### PR TITLE
perf(homepage): defer Perps connection polling until needed

### DIFF
--- a/app/components/UI/Perps/providers/PerpsConnectionProvider.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsConnectionProvider.test.tsx
@@ -157,6 +157,66 @@ describe('PerpsConnectionProvider', () => {
     expect(jest.getTimerCount()).toBe(0);
   });
 
+  it('reuses the initial connection snapshot when polling starts enabled', () => {
+    render(
+      <PerpsConnectionProvider suppressErrorView>
+        <TestComponent />
+      </PerpsConnectionProvider>,
+    );
+
+    expect(mockGetConnectionState).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs connection state immediately when polling becomes enabled', () => {
+    const { getByTestId, rerender } = render(
+      <PerpsConnectionProvider isEnabled={false} suppressErrorView>
+        <TestComponent />
+      </PerpsConnectionProvider>,
+    );
+    mockGetConnectionState.mockReturnValue({
+      isConnected: true,
+      isConnecting: false,
+      isInitialized: true,
+      error: null,
+    });
+
+    rerender(
+      <PerpsConnectionProvider isEnabled suppressErrorView>
+        <TestComponent />
+      </PerpsConnectionProvider>,
+    );
+
+    expect(getByTestId('connection-status')).toHaveTextContent('Connected');
+  });
+
+  it('resyncs after active polling is disabled and re-enabled', () => {
+    const { getByTestId, rerender } = render(
+      <PerpsConnectionProvider isEnabled suppressErrorView>
+        <TestComponent />
+      </PerpsConnectionProvider>,
+    );
+    rerender(
+      <PerpsConnectionProvider isEnabled={false} suppressErrorView>
+        <TestComponent />
+      </PerpsConnectionProvider>,
+    );
+    mockGetConnectionState.mockReturnValue({
+      isConnected: true,
+      isConnecting: false,
+      isInitialized: true,
+      error: null,
+    });
+
+    rerender(
+      <PerpsConnectionProvider isEnabled suppressErrorView>
+        <TestComponent />
+      </PerpsConnectionProvider>,
+    );
+
+    expect(getByTestId('connection-status')).toHaveTextContent('Connected');
+    expect(jest.getTimerCount()).toBe(1);
+  });
+
   it('renders children immediately even while connecting', () => {
     // Children should render even when isInitialized is false and isConnecting is true
     // Individual sections handle their own loading states with per-row skeletons

--- a/app/components/UI/Perps/providers/PerpsConnectionProvider.tsx
+++ b/app/components/UI/Perps/providers/PerpsConnectionProvider.tsx
@@ -2,6 +2,7 @@ import React, {
   createContext,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useState,
   useRef,
@@ -59,11 +60,14 @@ export const PerpsConnectionProvider: React.FC<
     PerpsConnectionManager.getConnectionState(),
   );
   const [retryAttempts, setRetryAttempts] = useState(0);
-  const pollIntervalRef = useRef<NodeJS.Timeout | undefined>(undefined);
+  const wasPollingEnabledRef = useRef(isEnabled);
   const lastErrorBreadcrumbRef = useRef<string | null>(null);
 
   // Poll connection state to sync with singleton
-  useEffect(() => {
+  useLayoutEffect(() => {
+    const wasPollingEnabled = wasPollingEnabledRef.current;
+    wasPollingEnabledRef.current = isEnabled;
+
     if (!isEnabled) {
       return;
     }
@@ -100,14 +104,16 @@ export const PerpsConnectionProvider: React.FC<
       });
     };
 
-    // Poll every 100ms for state changes
-    pollIntervalRef.current = setInterval(updateState, 100);
+    // The state initializer already captures the current snapshot for an
+    // initially enabled provider. Only re-sync after an idle → active transition.
+    if (!wasPollingEnabled) {
+      updateState();
+    }
 
-    return () => {
-      if (pollIntervalRef.current) {
-        clearInterval(pollIntervalRef.current);
-      }
-    };
+    // Poll every 100ms for state changes
+    const pollInterval = setInterval(updateState, 100);
+
+    return () => clearInterval(pollInterval);
   }, [isEnabled]);
 
   useEffect(() => {

--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -64,7 +64,7 @@ jest.mock('../../UI/Perps', () => ({
 const mockPerpsConnectionProvider = jest.fn();
 jest.mock('../../UI/Perps/providers/PerpsConnectionProvider', () => {
   const ReactLib = jest.requireActual<typeof import('react')>('react');
-  const PerpsConnectionContext = ReactLib.createContext({
+  const contextValue = {
     isConnected: true,
     isConnecting: false,
     isInitialized: true,
@@ -73,7 +73,10 @@ jest.mock('../../UI/Perps/providers/PerpsConnectionProvider', () => {
     disconnect: jest.fn(),
     resetError: jest.fn(),
     reconnectWithNewContext: jest.fn().mockResolvedValue(undefined),
-  });
+  };
+  const PerpsConnectionContext = ReactLib.createContext<
+    typeof contextValue | null
+  >(null);
 
   return {
     PerpsConnectionContext,
@@ -85,18 +88,35 @@ jest.mock('../../UI/Perps/providers/PerpsConnectionProvider', () => {
       isEnabled?: boolean;
     }) => {
       mockPerpsConnectionProvider({ isEnabled });
-      return children;
+      return ReactLib.createElement(
+        PerpsConnectionContext.Provider,
+        { value: contextValue },
+        children,
+      );
     },
   };
 });
 
-jest.mock('../../UI/Perps/providers/PerpsStreamManager', () => ({
-  PerpsStreamProvider: ({ children }: { children: React.ReactNode }) =>
-    children,
-  usePerpsStream: jest.fn(() => ({
+jest.mock('../../UI/Perps/providers/PerpsStreamManager', () => {
+  const ReactLib = jest.requireActual<typeof import('react')>('react');
+  const contextValue = {
     candles: { subscribe: jest.fn(() => jest.fn()) },
-  })),
-}));
+  };
+  const PerpsStreamContext = ReactLib.createContext<typeof contextValue | null>(
+    null,
+  );
+
+  return {
+    PerpsStreamContext,
+    PerpsStreamProvider: ({ children }: { children: React.ReactNode }) =>
+      ReactLib.createElement(
+        PerpsStreamContext.Provider,
+        { value: contextValue },
+        children,
+      ),
+    usePerpsStream: () => ReactLib.useContext(PerpsStreamContext),
+  };
+});
 
 jest.mock('../../UI/Perps/hooks', () => ({
   usePerpsLivePositions: jest.fn(() => ({
@@ -136,12 +156,13 @@ jest.mock('../../UI/Perps/hooks/usePerpsConnection', () => ({
   })),
 }));
 
+const mockRefreshPerpsSparklines = jest.fn();
 jest.mock(
   '../Homepage/Sections/Perpetuals/hooks/useHomepageSparklines',
   () => ({
     useHomepageSparklines: jest.fn(() => ({
       sparklines: {},
-      refresh: jest.fn(),
+      refresh: mockRefreshPerpsSparklines,
     })),
   }),
 );
@@ -236,11 +257,27 @@ jest.mock('../../UI/Assets/watchlist/hooks/useTokenWatchlistQuery', () => ({
 }));
 
 const mockBalanceBreakdownSection = jest.fn();
+const mockBalanceBreakdownPerpsContexts = jest.fn();
 jest.mock('./Sections/BalanceBreakdown', () => {
+  const ReactLib = jest.requireActual<typeof import('react')>('react');
   const { View } = jest.requireActual('react-native');
+  const { PerpsConnectionContext } = jest.requireMock(
+    '../../UI/Perps/providers/PerpsConnectionProvider',
+  ) as typeof import('../../UI/Perps/providers/PerpsConnectionProvider');
+  const { PerpsStreamContext } = jest.requireMock(
+    '../../UI/Perps/providers/PerpsStreamManager',
+  ) as {
+    PerpsStreamContext: React.Context<unknown>;
+  };
+
   return {
     __esModule: true,
     default: (props: unknown) => {
+      mockBalanceBreakdownPerpsContexts({
+        hasConnectionContext:
+          ReactLib.useContext(PerpsConnectionContext) !== null,
+        hasStreamContext: ReactLib.useContext(PerpsStreamContext) !== null,
+      });
       mockBalanceBreakdownSection(props);
       return <View testID="balance-breakdown-section-mock" />;
     },
@@ -282,6 +319,15 @@ jest.mock('./hooks/useHomeViewedEvent', () => ({
     PREDICT: 'predict',
     NFTS: 'nfts',
   },
+}));
+
+const mockUseSectionViewportVisible = jest.fn(() => ({
+  isVisible: false,
+  onLayout: jest.fn(),
+}));
+jest.mock('./hooks/useSectionViewportVisible', () => ({
+  __esModule: true,
+  default: () => mockUseSectionViewportVisible(),
 }));
 
 /** Returns mock useHomeViewedEvent calls with typed first argument. */
@@ -392,18 +438,46 @@ describe('Homepage', () => {
     mockUseOwnedNfts.mockReturnValue([]);
     mockPopularNetworks = [];
     mockIsNetworkEnabled.mockReturnValue(true);
+    mockUseSectionViewportVisible.mockReturnValue({
+      isVisible: false,
+      onLayout: jest.fn(),
+    });
   });
 
-  it('uses one enabled Perps connection provider for the homepage', () => {
+  it('keeps Perps connection polling idle before section visibility is known', () => {
     renderWithProvider(<Homepage />, { state: stateWithPreferences });
 
     expect(mockPerpsConnectionProvider).toHaveBeenCalledTimes(1);
     expect(mockPerpsConnectionProvider).toHaveBeenCalledWith({
+      isEnabled: false,
+    });
+  });
+
+  it('keeps Perps connection polling active after first visibility', () => {
+    const { rerender } = renderWithProvider(<Homepage />, {
+      state: stateWithPreferences,
+    });
+    mockUseSectionViewportVisible.mockReturnValue({
+      isVisible: true,
+      onLayout: jest.fn(),
+    });
+    rerender(<Homepage />);
+    expect(mockPerpsConnectionProvider).toHaveBeenLastCalledWith({
+      isEnabled: true,
+    });
+    mockUseSectionViewportVisible.mockReturnValue({
+      isVisible: false,
+      onLayout: jest.fn(),
+    });
+
+    rerender(<Homepage />);
+
+    expect(mockPerpsConnectionProvider).toHaveBeenLastCalledWith({
       isEnabled: true,
     });
   });
 
-  it('keeps the shared provider inert when Perps is disabled', () => {
+  it('keeps the shared Perps context provider inert when Perps is disabled', () => {
     jest
       .requireMock('../../UI/Perps')
       .selectPerpsEnabledFlag.mockReturnValue(false);
@@ -413,6 +487,23 @@ describe('Homepage', () => {
     expect(mockPerpsConnectionProvider).toHaveBeenCalledTimes(1);
     expect(mockPerpsConnectionProvider).toHaveBeenCalledWith({
       isEnabled: false,
+    });
+  });
+
+  it('enables Perps connection polling for the visible balance breakdown', () => {
+    const balanceBreakdownSectionProps = {
+      accountGroupBalanceProps: {},
+      hideRows: false,
+      layout: 'icons' as const,
+    };
+
+    renderWithProvider(
+      <Homepage balanceBreakdownSectionProps={balanceBreakdownSectionProps} />,
+      { state: stateWithPreferences },
+    );
+
+    expect(mockPerpsConnectionProvider).toHaveBeenCalledWith({
+      isEnabled: true,
     });
   });
 
@@ -434,6 +525,24 @@ describe('Homepage', () => {
     expect(mockBalanceBreakdownSection).toHaveBeenCalledWith(
       balanceBreakdownSectionProps,
     );
+  });
+
+  it('provides Perps contexts to the treatment balance breakdown', () => {
+    const balanceBreakdownSectionProps = {
+      accountGroupBalanceProps: {},
+      hideRows: false,
+      layout: 'icons' as const,
+    };
+
+    renderWithProvider(
+      <Homepage balanceBreakdownSectionProps={balanceBreakdownSectionProps} />,
+      { state: stateWithPreferences },
+    );
+
+    expect(mockBalanceBreakdownPerpsContexts).toHaveBeenCalledWith({
+      hasConnectionContext: true,
+      hasStreamContext: true,
+    });
   });
 
   it('does not render a breakdown section for control', () => {
@@ -503,6 +612,17 @@ describe('Homepage', () => {
     const result = ref.current?.refresh();
 
     await expect(result).resolves.toBeUndefined();
+  });
+
+  it('skips Perps refresh before the section is activated', async () => {
+    const ref = createRef<SectionRefreshHandle>();
+    renderWithProvider(<Homepage ref={ref} />, { state: stateWithPreferences });
+
+    await act(async () => {
+      await ref.current?.refresh();
+    });
+
+    expect(mockRefreshPerpsSparklines).not.toHaveBeenCalled();
   });
 
   describe('section indices — all flags enabled', () => {

--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -4,6 +4,7 @@ import React, {
   useImperativeHandle,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
@@ -56,6 +57,8 @@ const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
     const defiSectionRef = useRef<SectionRefreshHandle>(null);
     const nftsSectionRef = useRef<SectionRefreshHandle>(null);
     const watchlistSectionRef = useRef<SectionRefreshHandle>(null);
+    const [hasActivatedPerpsSection, setHasActivatedPerpsSection] =
+      useState(false);
 
     const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
     const isPredictEnabled = useSelector(selectPredictEnabledFlag);
@@ -65,6 +68,12 @@ const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
     const isTopTradersEnabled = useSelector(selectSocialLeaderboardEnabled);
     const isWatchlistEnabled = useSelector(selectTokenWatchlistEnabled);
     const isEarnSectionEnabled = useSelector(selectEarnHomeSectionEnabledFlag);
+    // Balance Breakdown consumes live Perps context immediately. Otherwise,
+    // defer polling until the Perps section is first visible, then keep it
+    // active so offscreen pull-to-refresh uses current connection state.
+    const isPerpsConnectionPollingEnabled =
+      isPerpsEnabled &&
+      (balanceBreakdownSectionProps !== undefined || hasActivatedPerpsSection);
 
     const { enableAllPopularNetworks, isNetworkEnabled, popularNetworks } =
       useNetworkEnablement();
@@ -134,7 +143,9 @@ const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
     const refresh = useCallback(async () => {
       await Promise.allSettled([
         tokensSectionRef.current?.refresh(),
-        perpsSectionRef.current?.refresh(),
+        isPerpsConnectionPollingEnabled
+          ? perpsSectionRef.current?.refresh()
+          : undefined,
         earnSectionRef.current?.refresh(),
         predictionsSectionRef.current?.refresh(),
         watchlistSectionRef.current?.refresh(),
@@ -142,12 +153,19 @@ const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
         defiSectionRef.current?.refresh(),
         nftsSectionRef.current?.refresh(),
       ]);
+    }, [isPerpsConnectionPollingEnabled]);
+
+    const activatePerpsSection = useCallback(() => {
+      setHasActivatedPerpsSection(true);
     }, []);
 
     useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 
     return (
-      <PerpsConnectionProvider isEnabled={isPerpsEnabled} suppressErrorView>
+      <PerpsConnectionProvider
+        isEnabled={isPerpsConnectionPollingEnabled}
+        suppressErrorView
+      >
         <PerpsStreamProvider>
           <Box
             marginBottom={8}
@@ -167,6 +185,7 @@ const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
                 ref={perpsSectionRef}
                 sectionIndex={getSectionIndex(HomeSectionNames.PERPS)}
                 totalSectionsLoaded={totalSectionsLoaded}
+                onVisible={activatePerpsSection}
               />
             )}
             {isEarnSectionEnabled && (

--- a/app/components/Views/Homepage/Sections/Perpetuals/HomepagePerpsHomeSlot.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/HomepagePerpsHomeSlot.test.tsx
@@ -24,6 +24,15 @@ jest.mock('../../../../../hooks', () => ({
     Reflect.apply(mockUseABTest, undefined, args),
 }));
 
+const mockUseSectionViewportVisible = jest.fn(() => ({
+  isVisible: false,
+  onLayout: jest.fn(),
+}));
+jest.mock('../../hooks/useSectionViewportVisible', () => ({
+  __esModule: true,
+  default: () => mockUseSectionViewportVisible(),
+}));
+
 jest.mock('./PerpsSection', () => {
   const ReactLib = jest.requireActual('react');
   const RN = jest.requireActual('react-native');
@@ -59,6 +68,10 @@ jest.mock('./PerpsSection', () => {
 describe('HomepagePerpsHomeSlot', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseSectionViewportVisible.mockReturnValue({
+      isVisible: false,
+      onLayout: jest.fn(),
+    });
   });
 
   it('renders PerpsSection when experiment is control', () => {
@@ -115,5 +128,36 @@ describe('HomepagePerpsHomeSlot', () => {
     expect(screen.getByText('PerpsSection')).toBeOnTheScreen();
     expect(screen.getByText('emptyStateContent:pills')).toBeOnTheScreen();
     expect(screen.getByText('emptyStateTitle:Perps movers')).toBeOnTheScreen();
+  });
+
+  it('notifies Homepage when the Perps section enters the viewport', () => {
+    const onVisible = jest.fn();
+    mockUseSectionViewportVisible.mockReturnValue({
+      isVisible: true,
+      onLayout: jest.fn(),
+    });
+    mockUseABTest.mockImplementation((key: string) => {
+      if (key === HOMEPAGE_PERPS_PILLS_EMPTY_AB_KEY) {
+        return {
+          variant:
+            HOMEPAGE_PERPS_PILLS_EMPTY_VARIANTS[
+              HomepagePerpsPillsEmptyVariant.Control
+            ],
+          variantName: HomepagePerpsPillsEmptyVariant.Control,
+          isActive: true,
+        };
+      }
+      return { variant: {}, variantName: 'control', isActive: false };
+    });
+
+    renderWithProvider(
+      <HomepagePerpsHomeSlot
+        sectionIndex={1}
+        totalSectionsLoaded={5}
+        onVisible={onVisible}
+      />,
+    );
+
+    expect(onVisible).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/Views/Homepage/Sections/Perpetuals/HomepagePerpsHomeSlot.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/HomepagePerpsHomeSlot.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useLayoutEffect, useRef } from 'react';
+import { View } from 'react-native';
 import { useABTest } from '../../../../../hooks';
 import {
   HOMEPAGE_PERPS_PILLS_EMPTY_AB_KEY,
@@ -9,6 +10,11 @@ import type { SectionRefreshHandle } from '../../types';
 import type { PerpsSectionProps } from './PerpsSectionWithProvider';
 import PerpsSection from './PerpsSection';
 import { strings } from '../../../../../../locales/i18n';
+import useSectionViewportVisible from '../../hooks/useSectionViewportVisible';
+
+interface HomepagePerpsHomeSlotProps extends PerpsSectionProps {
+  onVisible?: () => void;
+}
 
 /**
  * Chooses the empty-state content for the homepage Perps section.
@@ -17,8 +23,9 @@ import { strings } from '../../../../../../locales/i18n';
  */
 const HomepagePerpsHomeSlot = forwardRef<
   SectionRefreshHandle,
-  PerpsSectionProps
->((props, ref) => {
+  HomepagePerpsHomeSlotProps
+>(({ onVisible, ...props }, ref) => {
+  const sectionViewRef = useRef<View>(null);
   const { variant: perpsPillsEmptyAbVariant } = useABTest(
     HOMEPAGE_PERPS_PILLS_EMPTY_AB_KEY,
     HOMEPAGE_PERPS_PILLS_EMPTY_VARIANTS,
@@ -28,17 +35,29 @@ const HomepagePerpsHomeSlot = forwardRef<
   const emptyStateUsesExplorePills =
     perpsPillsEmptyAbVariant.showExplorePillsWhenEmpty;
 
-  if (!emptyStateUsesExplorePills) {
-    return <PerpsSection ref={ref} {...props} />;
-  }
+  const { isVisible, onLayout } = useSectionViewportVisible(sectionViewRef, {
+    once: true,
+  });
+
+  useLayoutEffect(() => {
+    if (isVisible) {
+      onVisible?.();
+    }
+  }, [isVisible, onVisible]);
 
   return (
-    <PerpsSection
-      ref={ref}
-      {...props}
-      emptyStateContent="pills"
-      emptyStateTitleOverride={strings('trending.perps_movers')}
-    />
+    <View ref={sectionViewRef} onLayout={onLayout}>
+      {emptyStateUsesExplorePills ? (
+        <PerpsSection
+          ref={ref}
+          {...props}
+          emptyStateContent="pills"
+          emptyStateTitleOverride={strings('trending.perps_movers')}
+        />
+      ) : (
+        <PerpsSection ref={ref} {...props} />
+      )}
+    </View>
   );
 });
 

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionWithProvider.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionWithProvider.test.tsx
@@ -31,7 +31,7 @@ jest.mock('./PerpsSection', () => {
   const RN = jest.requireActual('react-native');
   const ReactActual = jest.requireActual('react');
   const MockPerpsSection = () =>
-    ReactActual.createElement(RN.Text, null, 'PerpsSection');
+    ReactActual.createElement(RN.View, { testID: 'perps-section' });
   return {
     __esModule: true,
     PerpsSection: MockPerpsSection,
@@ -52,7 +52,7 @@ describe('PerpsSectionWithProvider', () => {
       <PerpsSectionWithProvider sectionIndex={0} totalSectionsLoaded={5} />,
     );
 
-    expect(screen.getByText('PerpsSection')).toBeOnTheScreen();
+    expect(screen.getByTestId('perps-section')).toBeOnTheScreen();
   });
 
   it('returns null when perps is disabled', () => {

--- a/app/components/Views/Homepage/hooks/useSectionViewportVisible.test.tsx
+++ b/app/components/Views/Homepage/hooks/useSectionViewportVisible.test.tsx
@@ -4,7 +4,8 @@ import { View } from 'react-native';
 import { HomepageScrollContext } from '../context/HomepageScrollContext';
 import useSectionViewportVisible from './useSectionViewportVisible';
 
-const mockSubscribeToScroll = jest.fn(() => jest.fn());
+const mockUnsubscribeFromScroll = jest.fn();
+const mockSubscribeToScroll = jest.fn(() => mockUnsubscribeFromScroll);
 
 const createWrapper =
   (
@@ -92,6 +93,31 @@ describe('useSectionViewportVisible', () => {
     expect(result.current.isVisible).toBe(false);
   });
 
+  it('clears visibility when a visible section collapses to zero height', () => {
+    const sectionRef = createRef<View>();
+    let sectionHeight = 200;
+    const measureInWindow = jest.fn(
+      (
+        callback: (x: number, y: number, width: number, height: number) => void,
+      ) => {
+        callback(0, 150, 100, sectionHeight);
+      },
+    );
+    sectionRef.current = { measureInWindow } as unknown as View;
+    const { result } = renderHook(
+      () => useSectionViewportVisible(sectionRef, { isLoading: false }),
+      { wrapper: createWrapper() },
+    );
+    expect(result.current.isVisible).toBe(true);
+    sectionHeight = 0;
+
+    act(() => {
+      result.current.onLayout();
+    });
+
+    expect(result.current.isVisible).toBe(false);
+  });
+
   it('subscribes to homepage scroll events', () => {
     const sectionRef = createRef<View>();
     sectionRef.current = {
@@ -117,6 +143,89 @@ describe('useSectionViewportVisible', () => {
     );
 
     expect(mockSubscribeToScroll).toHaveBeenCalled();
+  });
+
+  it('stops measuring after first visibility when once is enabled', () => {
+    const sectionRef = createRef<View>();
+    let sectionY = 1200;
+    const measureInWindow = jest.fn(
+      (
+        callback: (x: number, y: number, width: number, height: number) => void,
+      ) => {
+        callback(0, sectionY, 100, 200);
+      },
+    );
+    sectionRef.current = { measureInWindow } as unknown as View;
+    const { result } = renderHook(
+      () =>
+        useSectionViewportVisible(sectionRef, {
+          isLoading: false,
+          once: true,
+        }),
+      { wrapper: createWrapper() },
+    );
+    const scrollCallback = (
+      mockSubscribeToScroll.mock.calls as unknown as [[() => void]]
+    )[0][0];
+    sectionY = 150;
+
+    act(() => {
+      scrollCallback();
+    });
+    measureInWindow.mockClear();
+    act(() => {
+      scrollCallback();
+    });
+
+    expect(result.current.isVisible).toBe(true);
+    expect(mockUnsubscribeFromScroll).toHaveBeenCalledTimes(1);
+    expect(measureInWindow).not.toHaveBeenCalled();
+  });
+
+  it('ignores stale measurements after one-shot visibility is reached', () => {
+    type MeasurementCallback = (
+      x: number,
+      y: number,
+      width: number,
+      height: number,
+    ) => void;
+    const sectionRef = createRef<View>();
+    const pendingMeasurements: MeasurementCallback[] = [];
+    const measureInWindow = jest.fn((callback: MeasurementCallback) => {
+      pendingMeasurements.push(callback);
+    });
+    sectionRef.current = { measureInWindow } as unknown as View;
+    const { result } = renderHook(
+      () =>
+        useSectionViewportVisible(sectionRef, {
+          isLoading: false,
+          once: true,
+        }),
+      { wrapper: createWrapper() },
+    );
+    const scrollCallback = (
+      mockSubscribeToScroll.mock.calls as unknown as [[() => void]]
+    )[0][0];
+    act(() => {
+      scrollCallback();
+    });
+    const [staleMeasurement, visibleMeasurement] = pendingMeasurements as [
+      MeasurementCallback,
+      MeasurementCallback,
+    ];
+
+    act(() => {
+      visibleMeasurement(0, 150, 100, 200);
+      staleMeasurement(0, 1200, 100, 200);
+    });
+    measureInWindow.mockClear();
+    act(() => {
+      result.current.onLayout();
+    });
+
+    expect(result.current.isVisible).toBe(true);
+    expect(mockUnsubscribeFromScroll).toHaveBeenCalledTimes(1);
+    expect(measureInWindow).not.toHaveBeenCalled();
   });
 
   it('re-measures visibility when visitId increments on homepage revisit', () => {

--- a/app/components/Views/Homepage/hooks/useSectionViewportVisible.ts
+++ b/app/components/Views/Homepage/hooks/useSectionViewportVisible.ts
@@ -11,13 +11,15 @@ import { useHomepageScrollContext } from '../context/HomepageScrollContext';
 interface UseSectionViewportVisibleOptions {
   /** Defer visibility checks until section data has loaded. */
   isLoading?: boolean;
+  /** Preserve true and stop observing after the section is first visible. */
+  once?: boolean;
 }
 
 /**
  * Tracks whether a homepage section is vertically visible (≥ 30 % of the
  * section intersects the homepage scroll viewport). Unlike
- * `useHomeViewedEvent`, this exposes continuous on/off state for features
- * such as background prefetching.
+ * `useHomeViewedEvent`, this exposes on/off state for features such as
+ * background prefetching, or a sticky first-visible state with `once`.
  */
 export const useSectionViewportVisible = (
   sectionRef: RefObject<View | null>,
@@ -28,11 +30,18 @@ export const useSectionViewportVisible = (
   const [isVisible, setIsVisible] = useState(false);
   const isVisibleRef = useRef(false);
   const isLoading = options?.isLoading ?? false;
+  const once = options?.once ?? false;
 
   const checkVisibilityRef = useRef<() => void>(() => undefined);
 
   useEffect(() => {
+    if (once && isVisibleRef.current) {
+      checkVisibilityRef.current = () => undefined;
+      return;
+    }
+
     if (isLoading || !sectionRef.current || viewportHeight === 0) {
+      checkVisibilityRef.current = () => undefined;
       if (isVisibleRef.current) {
         isVisibleRef.current = false;
         setIsVisible(false);
@@ -40,9 +49,32 @@ export const useSectionViewportVisible = (
       return;
     }
 
+    let unsubscribe: (() => void) | undefined;
+    const stopObserving = () => {
+      unsubscribe?.();
+      unsubscribe = undefined;
+    };
+
+    const updateVisibility = (nextVisible: boolean) => {
+      if (once && isVisibleRef.current) {
+        return;
+      }
+      if (nextVisible !== isVisibleRef.current) {
+        isVisibleRef.current = nextVisible;
+        setIsVisible(nextVisible);
+      }
+      if (nextVisible && once) {
+        stopObserving();
+      }
+    };
+
     const checkVisibility = () => {
+      if (once && isVisibleRef.current) {
+        return;
+      }
       sectionRef.current?.measureInWindow((_x, y, _width, height) => {
         if (height === 0) {
+          updateVisibility(false);
           return;
         }
 
@@ -53,20 +85,20 @@ export const useSectionViewportVisible = (
         const threshold = Math.min(height * 0.3, viewportHeight * 0.3);
         const nextVisible = visiblePx >= threshold;
 
-        if (nextVisible !== isVisibleRef.current) {
-          isVisibleRef.current = nextVisible;
-          setIsVisible(nextVisible);
-        }
+        updateVisibility(nextVisible);
       });
     };
 
     checkVisibilityRef.current = checkVisibility;
     checkVisibility();
 
-    const unsubscribe = subscribeToScroll(checkVisibility);
-    return unsubscribe;
+    if (!(once && isVisibleRef.current)) {
+      unsubscribe = subscribeToScroll(checkVisibility);
+    }
+    return stopObserving;
   }, [
     isLoading,
+    once,
     viewportHeight,
     containerScreenY,
     sectionRef,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Defers the Homepage Perps connection-state polling until a Homepage consumer
needs current connection state. Without the Balance Breakdown treatment,
opening the wallet and remaining on Tokens no longer starts the 100 ms polling
interval. Polling starts when the Perps section first enters the viewport and
stays active for the remainder of the Homepage mount so pull-to-refresh always
uses current connection state.

The shared `PerpsConnectionProvider` and `PerpsStreamProvider` remain above the
Homepage subtree because Balance Breakdown also consumes both contexts. When
Balance Breakdown is rendered, polling starts immediately to keep its Perps
slice current.

The viewport observer is one-shot for this use case: it unsubscribes after the
first visible measurement and ignores stale asynchronous measurements. The
connection provider synchronizes immediately when polling is re-enabled while
avoiding a duplicate connection-state read when initially enabled.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1259

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Defer Homepage Perps connection polling

  Scenario: polling remains idle while Perps is offscreen
    Given Perps is enabled
    And the Homepage Balance Breakdown treatment is disabled
    When the user opens the Wallet Homepage and remains on Tokens
    Then Perps connection-state polling does not start

  Scenario: polling starts when Perps first becomes visible
    Given Perps is enabled
    And the Homepage Balance Breakdown treatment is disabled
    When the user scrolls until at least 30 percent of the Perps section is visible
    Then Perps connection-state polling starts
    And scrolling away does not restart the viewport observer
    And pull-to-refresh uses the current Perps connection state

  Scenario: Balance Breakdown retains Perps context
    Given Perps is enabled
    And the Homepage Balance Breakdown treatment is enabled
    When the user opens the Wallet Homepage
    Then Balance Breakdown renders without a missing Perps context error
    And Perps connection-state polling starts immediately
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-focused gating of existing polling with sticky activation; no auth or payment changes, though Perps connection UX timing on Homepage shifts slightly until scroll or Balance Breakdown.
> 
> **Overview**
> **Defers Homepage Perps connection-state polling** so opening the wallet on Tokens no longer starts the 100ms `PerpsConnectionProvider` interval until something needs live connection state.
> 
> `Homepage` now drives `PerpsConnectionProvider` with `isEnabled` only when Perps is on **and** either the Balance Breakdown treatment is mounted (immediate polling for that UI) or the Perps section has been **activated** after first viewport visibility. `HomepagePerpsHomeSlot` uses `useSectionViewportVisible` with `once: true` and fires `onVisible` to latch activation; scrolling away does not turn polling off. Pull-to-refresh skips Perps section refresh until that latch is set.
> 
> `PerpsConnectionProvider` moves polling to `useLayoutEffect`, re-syncs on idle→active transitions without a duplicate initial `getConnectionState`, and keeps a single interval lifecycle.
> 
> `useSectionViewportVisible` gains a **`once`** mode (unsubscribe after first visible, ignore stale async measurements, clear visibility on zero-height collapse), with matching unit and Homepage integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 803908e3f99ef5a5cb82868622c7a6014380254c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->