### PR TITLE
perf(perps): open deposit confirmation without waiting for tx prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a delay when tapping Add funds in Perps so the confirmation opens immediately (#35326)
+
 ## [8.9.1]
 
 ### Fixed

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -1826,10 +1826,58 @@ describe('PerpsMarketDetailsView', () => {
 
       await waitFor(() => {
         expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
+          loader: 'customAmount',
           stack: 'Perps',
         });
         expect(mockDepositWithConfirmation).toHaveBeenCalled();
+        expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
       });
+    });
+
+    it('navigates to confirmation without waiting for deposit preparation', async () => {
+      mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(null);
+      mockUsePerpsAccount.mockReturnValue({
+        account: {
+          spendableBalance: '0.00',
+          withdrawableBalance: '0.00',
+          marginUsed: '0.00',
+          unrealizedPnl: '0.00',
+          returnOnEquity: '0.00',
+          totalBalance: '0.00',
+        },
+        isInitialLoading: false,
+      });
+      mockUsePerpsLiveAccount.mockReturnValue({
+        account: {
+          spendableBalance: '0',
+          withdrawableBalance: '0',
+          marginUsed: '0',
+          unrealizedPnl: '0',
+          returnOnEquity: '0',
+          totalBalance: '0',
+        },
+        isInitialLoading: false,
+      });
+      mockNavigateToConfirmation.mockClear();
+      mockDepositWithConfirmation.mockClear();
+      mockDepositWithConfirmation.mockReturnValue(new Promise(() => undefined));
+
+      const { getByTestId } = renderWithProvider(
+        <PerpsConnectionProvider>
+          <PerpsMarketDetailsView />
+        </PerpsConnectionProvider>,
+        { state: initialState },
+      );
+
+      const addFundsButton = getByTestId(
+        PerpsMarketDetailsViewSelectorsIDs.ADD_FUNDS_BUTTON,
+      );
+      await act(async () => {
+        fireEvent.press(addFundsButton);
+      });
+
+      expect(mockNavigateToConfirmation).toHaveBeenCalledTimes(1);
+      expect(mockDepositWithConfirmation).toHaveBeenCalledTimes(1);
     });
 
     it('handles depositWithConfirmation rejection without throwing', async () => {
@@ -1875,6 +1923,7 @@ describe('PerpsMarketDetailsView', () => {
       });
       await waitFor(() => {
         expect(mockDepositWithConfirmation).toHaveBeenCalled();
+        expect(mockGoBack).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -243,6 +243,7 @@ const mockGoBack = jest.fn();
 const mockCanGoBack = jest.fn();
 const mockReset = jest.fn();
 const mockGetState = jest.fn();
+const mockAddListener = jest.fn(() => jest.fn());
 const mockSetPerpsMode = jest.fn();
 // Mutable active mode surfaced by the mocked usePerpsMode hook.
 let mockPerpsModeValue = 'lite';
@@ -306,6 +307,7 @@ jest.mock('@react-navigation/native', () => {
       canGoBack: mockCanGoBack,
       setOptions: jest.fn(),
       getState: mockGetState,
+      addListener: mockAddListener,
       reset: mockReset,
     }),
     useRoute: () => ({
@@ -972,6 +974,7 @@ describe('PerpsMarketDetailsView', () => {
         { name: Routes.PERPS.MARKET_DETAILS, key: 'market-1' },
       ],
     });
+    mockAddListener.mockReturnValue(jest.fn());
 
     // Default eligibility mock
     const { useSelector } = jest.requireMock('react-redux');
@@ -1907,6 +1910,15 @@ describe('PerpsMarketDetailsView', () => {
       mockDepositWithConfirmation.mockRejectedValueOnce(
         new Error('Deposit failed'),
       );
+      mockGetState.mockReturnValue({
+        index: 0,
+        routes: [
+          {
+            name: Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
+            key: 'confirm-1',
+          },
+        ],
+      });
 
       const { getByTestId } = renderWithProvider(
         <PerpsConnectionProvider>
@@ -1924,6 +1936,53 @@ describe('PerpsMarketDetailsView', () => {
       await waitFor(() => {
         expect(mockDepositWithConfirmation).toHaveBeenCalled();
         expect(mockGoBack).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('does not dismiss Perps when deposit prep fails before confirmation is shown', async () => {
+      mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(null);
+      mockUsePerpsAccount.mockReturnValue({
+        account: {
+          spendableBalance: '0.00',
+          withdrawableBalance: '0.00',
+          marginUsed: '0.00',
+          unrealizedPnl: '0.00',
+          returnOnEquity: '0.00',
+          totalBalance: '0.00',
+        },
+        isInitialLoading: false,
+      });
+      mockUsePerpsLiveAccount.mockReturnValue({
+        account: {
+          spendableBalance: '0',
+          withdrawableBalance: '0',
+          marginUsed: '0',
+          unrealizedPnl: '0',
+          returnOnEquity: '0',
+          totalBalance: '0',
+        },
+        isInitialLoading: false,
+      });
+      mockDepositWithConfirmation.mockRejectedValueOnce(
+        new Error('Deposit failed'),
+      );
+
+      const { getByTestId } = renderWithProvider(
+        <PerpsConnectionProvider>
+          <PerpsMarketDetailsView />
+        </PerpsConnectionProvider>,
+        { state: initialState },
+      );
+
+      const addFundsButton = getByTestId(
+        PerpsMarketDetailsViewSelectorsIDs.ADD_FUNDS_BUTTON,
+      );
+      await act(async () => {
+        fireEvent.press(addFundsButton);
+      });
+      await waitFor(() => {
+        expect(mockDepositWithConfirmation).toHaveBeenCalled();
+        expect(mockGoBack).not.toHaveBeenCalled();
       });
     });
 

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -56,6 +56,7 @@ import { Skeleton } from '../../../../../component-library/components-temp/Skele
 import { useStyles } from '../../../../../component-library/hooks';
 import Routes from '../../../../../constants/navigation/Routes';
 import Logger from '../../../../../util/Logger';
+import { ImpactMoment, playImpact } from '../../../../../util/haptics';
 import { isNotificationsFeatureEnabled } from '../../../../../util/notifications';
 import { trace, TraceName, TraceOperation } from '../../../../../util/trace';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
@@ -119,6 +120,7 @@ import {
 } from '../../hooks';
 import { usePerpsMarketHeaderActions } from '../../hooks/usePerpsMarketHeaderActions';
 import { useConfirmNavigation } from '../../../../Views/confirmations/hooks/useConfirmNavigation';
+import { ConfirmationLoader } from '../../../../Views/confirmations/components/confirm/confirm-component';
 import { useDefaultPayWithTokenWhenNoPerpsBalance } from '../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance';
 import {
   usePerpsLiveAccount,
@@ -690,7 +692,9 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
     (spendableBalance >= PERPS_MIN_BALANCE_THRESHOLD ||
       defaultPayTokenWhenNoPerpsBalance !== null);
 
-  const handleAddFunds = useCallback(async () => {
+  const handleAddFunds = useCallback(() => {
+    playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
+
     if (!isEligible) {
       track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
         [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
@@ -702,10 +706,22 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
       return;
     }
     try {
-      navigateToConfirmation({ stack: Routes.PERPS.ROOT });
-      await withPendingTransactionActiveAbTests(transactionActiveAbTests, () =>
+      navigateToConfirmation({
+        loader: ConfirmationLoader.CustomAmount,
+        stack: Routes.PERPS.ROOT,
+      });
+      // Do not await deposit prep — keep the skeleton on screen immediately.
+      withPendingTransactionActiveAbTests(transactionActiveAbTests, () =>
         depositWithConfirmation(),
-      );
+      ).catch((err: unknown) => {
+        Logger.error(
+          ensureError(err, 'PerpsMarketDetailsView.handleAddFunds'),
+          {
+            tags: { feature: PERPS_CONSTANTS.FeatureName },
+          },
+        );
+        navigation.goBack();
+      });
     } catch (err) {
       Logger.error(ensureError(err, 'PerpsMarketDetailsView.handleAddFunds'), {
         tags: { feature: PERPS_CONSTANTS.FeatureName },
@@ -716,6 +732,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
     track,
     navigateToConfirmation,
     depositWithConfirmation,
+    navigation,
     transactionActiveAbTests,
   ]);
 

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -183,6 +183,7 @@ import {
 } from '../../abTestConfig';
 import { getMarketHoursStatus, isEquityAsset } from '../../utils/marketHours';
 import { toPerpsEntryAttribution } from '../../utils/perpsAnalyticsAttribution';
+import { createDepositConfirmationGuard } from '../../utils/depositConfirmationGuard';
 import { normalizeMarketDetailsOrders } from '../../normalization/normalizeMarketDetailsOrders';
 import { ensureError } from '../../../../../util/errorUtils';
 import {
@@ -367,6 +368,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
   // This prevents stale closure issues where the captured position is outdated
   // Initialized to null, will be updated via useEffect when existingPosition is available
   const currentPositionRef = useRef<Position | null>(null);
+  const confirmationGuardCancelRef = useRef<(() => void) | null>(null);
   const scrollViewRef = useRef<Animated.ScrollView>(null);
 
   const isEligible = useSelector(selectPerpsEligibility);
@@ -692,6 +694,13 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
     (spendableBalance >= PERPS_MIN_BALANCE_THRESHOLD ||
       defaultPayTokenWhenNoPerpsBalance !== null);
 
+  const clearConfirmationGuard = useCallback(() => {
+    confirmationGuardCancelRef.current?.();
+    confirmationGuardCancelRef.current = null;
+  }, []);
+
+  useEffect(() => clearConfirmationGuard, [clearConfirmationGuard]);
+
   const handleAddFunds = useCallback(() => {
     playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
 
@@ -710,18 +719,25 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
         loader: ConfirmationLoader.CustomAmount,
         stack: Routes.PERPS.ROOT,
       });
+      clearConfirmationGuard();
+      const confirmationGuard = createDepositConfirmationGuard(navigation);
+      confirmationGuardCancelRef.current = confirmationGuard.cancel;
       // Do not await deposit prep — keep the skeleton on screen immediately.
       withPendingTransactionActiveAbTests(transactionActiveAbTests, () =>
         depositWithConfirmation(),
-      ).catch((err: unknown) => {
-        Logger.error(
-          ensureError(err, 'PerpsMarketDetailsView.handleAddFunds'),
-          {
-            tags: { feature: PERPS_CONSTANTS.FeatureName },
-          },
-        );
-        navigation.goBack();
-      });
+      )
+        .then(() => {
+          clearConfirmationGuard();
+        })
+        .catch((err: unknown) => {
+          Logger.error(
+            ensureError(err, 'PerpsMarketDetailsView.handleAddFunds'),
+            {
+              tags: { feature: PERPS_CONSTANTS.FeatureName },
+            },
+          );
+          confirmationGuard.onDepositFailed();
+        });
     } catch (err) {
       Logger.error(ensureError(err, 'PerpsMarketDetailsView.handleAddFunds'), {
         tags: { feature: PERPS_CONSTANTS.FeatureName },
@@ -734,6 +750,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
     depositWithConfirmation,
     navigation,
     transactionActiveAbTests,
+    clearConfirmationGuard,
   ]);
 
   // Keep current position ref in sync for callbacks stored in route params

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -17,11 +17,7 @@ import { strings } from '../../../../../../../../locales/i18n';
 import { getPerpsProInputAccessoryID } from './PerpsProCompactInput';
 import PerpsProOrderForm from './PerpsProOrderForm';
 import type { PerpsProOrderFormProps } from './PerpsProOrderForm.types';
-import {
-  ImpactMoment,
-  playImpact,
-  playSelection,
-} from '../../../../../../../util/haptics';
+import { playImpact, playSelection } from '../../../../../../../util/haptics';
 
 const mockInputFocus = jest.fn();
 let mockInputHandlesActive = true;
@@ -969,7 +965,7 @@ describe('PerpsProOrderForm', () => {
       fireEvent.press(screen.getByTestId(ids.AVAILABLE_BALANCE));
 
       expect(onAddFundsPress).toHaveBeenCalledTimes(1);
-      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('does not play Add funds haptics when the action is disabled', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProSizeInput.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProSizeInput.test.tsx
@@ -2,11 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import { StyleSheet } from 'react-native';
 import { TextVariant } from '@metamask/design-system-react-native';
-import {
-  ImpactMoment,
-  playImpact,
-  playSelection,
-} from '../../../../../../../util/haptics';
+import { playImpact, playSelection } from '../../../../../../../util/haptics';
 import { PerpsProOrderFormSelectorsIDs } from '../../../../Perps.testIds';
 import { getPerpsProInputAccessoryID } from './PerpsProCompactInput';
 import PerpsProSizeInput, {
@@ -95,14 +91,14 @@ describe('PerpsProSizeInput', () => {
     expect(playSelection).toHaveBeenCalledTimes(1);
   });
 
-  it('plays PrimaryCTA when Add funds is pressed', () => {
+  it('calls onAddFundsPress when Add funds is pressed', () => {
     const onAddFundsPress = jest.fn();
     renderInput({ onAddFundsPress });
 
     fireEvent.press(screen.getByTestId(ids.ADD_FUNDS_BUTTON));
 
     expect(onAddFundsPress).toHaveBeenCalledTimes(1);
-    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
+    expect(playImpact).not.toHaveBeenCalled();
   });
 
   it('does not play Add funds haptics when the action is disabled', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProSizeInput.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProSizeInput.tsx
@@ -17,7 +17,7 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React, { useCallback, useRef } from 'react';
 import { Platform, type TextInput, type View } from 'react-native';
 import { strings } from '../../../../../../../../locales/i18n';
-import { ImpactMoment, useHaptics } from '../../../../../../../util/haptics';
+import { useHaptics } from '../../../../../../../util/haptics';
 import { PerpsProOrderFormSelectorsIDs } from '../../../../Perps.testIds';
 import PerpsSlider from '../../../../components/PerpsSlider';
 import { getPerpsProInputAccessoryID } from './PerpsProCompactInput';
@@ -71,7 +71,7 @@ const PerpsProSizeInput = ({
   isDisabled = false,
 }: PerpsProSizeInputProps) => {
   const tw = useTailwind();
-  const { playImpact, playSelection } = useHaptics();
+  const { playSelection } = useHaptics();
   const internalInputRef = useRef<TextInput>(null);
   const inputRef = externalInputRef ?? internalInputRef;
   const unitLabel = getUnitLabel(denomination);
@@ -159,9 +159,8 @@ const PerpsProSizeInput = ({
       return;
     }
 
-    playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
     onAddFundsPress();
-  }, [isDisabled, onAddFundsPress, playImpact]);
+  }, [isDisabled, onAddFundsPress]);
 
   return (
     <Box

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
@@ -4,6 +4,8 @@ import { useSelector } from 'react-redux';
 import { usePerpsHomeActions } from './usePerpsHomeActions';
 import { usePerpsTrading } from './usePerpsTrading';
 import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
+import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
+import { ImpactMoment } from '../../../../util/haptics';
 import Routes from '../../../../constants/navigation/Routes';
 import { MetaMetricsEvents } from '../../../../core/Analytics/MetaMetrics.events';
 import {
@@ -15,6 +17,7 @@ import {
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(() => ({
     navigate: jest.fn(),
+    goBack: jest.fn(),
   })),
 }));
 
@@ -59,19 +62,26 @@ jest.mock('./usePerpsWithdrawConfirmation', () => ({
 const mockComplianceGate = jest.fn((action: () => Promise<unknown>) =>
   action(),
 );
-
 jest.mock('../../Compliance', () => ({
   useComplianceGate: () => ({
     gate: mockComplianceGate,
-    isBlocked: false,
     isComplianceEnabled: false,
     checkCompliance: jest.fn(),
+  }),
+}));
+
+const mockPlayImpact = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../../util/haptics', () => ({
+  ImpactMoment: { PrimaryCTA: 'primaryCta' },
+  useHaptics: () => ({
+    playImpact: mockPlayImpact,
   }),
 }));
 
 describe('usePerpsHomeActions', () => {
   const mockNavigation = {
     navigate: jest.fn(),
+    goBack: jest.fn(),
   };
 
   const mockDepositWithConfirmation = jest
@@ -83,6 +93,8 @@ describe('usePerpsHomeActions', () => {
     jest.clearAllMocks();
     mockTrack.mockClear();
     mockWithdrawWithConfirmation.mockResolvedValue(undefined);
+    mockDepositWithConfirmation.mockReset();
+    mockDepositWithConfirmation.mockReturnValue(Promise.resolve());
     mockComplianceGate.mockImplementation((action: () => Promise<unknown>) =>
       action(),
     );
@@ -148,8 +160,23 @@ describe('usePerpsHomeActions', () => {
       });
 
       expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
+        loader: ConfirmationLoader.CustomAmount,
         stack: Routes.PERPS.ROOT,
       });
+      expect(mockDepositWithConfirmation).toHaveBeenCalledTimes(1);
+      expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
+    });
+
+    it('navigates to confirmation without waiting for deposit preparation', async () => {
+      mockDepositWithConfirmation.mockReturnValue(new Promise(() => undefined));
+
+      const { result } = renderHook(() => usePerpsHomeActions());
+
+      await act(async () => {
+        await result.current.handleAddFunds();
+      });
+
+      expect(mockNavigateToConfirmation).toHaveBeenCalledTimes(1);
       expect(mockDepositWithConfirmation).toHaveBeenCalledTimes(1);
     });
 
@@ -194,6 +221,7 @@ describe('usePerpsHomeActions', () => {
       await waitFor(() => {
         expect(result.current.error).toEqual(depositError);
         expect(onError).toHaveBeenCalledWith(depositError, 'deposit');
+        expect(mockNavigation.goBack).toHaveBeenCalledTimes(1);
       });
     });
   });
@@ -243,7 +271,9 @@ describe('usePerpsHomeActions', () => {
         await result.current.handleAddFunds();
       });
 
+      expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
       expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
+      expect(mockNavigateToConfirmation).not.toHaveBeenCalled();
       expect(mockComplianceGate).toHaveBeenCalledTimes(1);
     });
 

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
@@ -18,6 +18,8 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(() => ({
     navigate: jest.fn(),
     goBack: jest.fn(),
+    getState: jest.fn(),
+    addListener: jest.fn(() => jest.fn()),
   })),
 }));
 
@@ -82,6 +84,8 @@ describe('usePerpsHomeActions', () => {
   const mockNavigation = {
     navigate: jest.fn(),
     goBack: jest.fn(),
+    getState: jest.fn(),
+    addListener: jest.fn(() => jest.fn()),
   };
 
   const mockDepositWithConfirmation = jest
@@ -106,6 +110,15 @@ describe('usePerpsHomeActions', () => {
     (useConfirmNavigation as jest.Mock).mockReturnValue({
       navigateToConfirmation: mockNavigateToConfirmation,
     });
+    mockNavigation.getState.mockReturnValue({
+      index: 0,
+      routes: [
+        {
+          name: Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
+        },
+      ],
+    });
+    mockNavigation.addListener.mockReturnValue(jest.fn());
   });
 
   describe('initialization', () => {
@@ -222,6 +235,26 @@ describe('usePerpsHomeActions', () => {
         expect(result.current.error).toEqual(depositError);
         expect(onError).toHaveBeenCalledWith(depositError, 'deposit');
         expect(mockNavigation.goBack).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('does not go back when confirmation was never presented', async () => {
+      mockNavigation.getState.mockReturnValue({
+        index: 0,
+        routes: [{ name: Routes.PERPS.PERPS_HOME }],
+      });
+      const depositError = new Error('Deposit failed');
+      mockDepositWithConfirmation.mockRejectedValueOnce(depositError);
+
+      const { result } = renderHook(() => usePerpsHomeActions());
+
+      await act(async () => {
+        await result.current.handleAddFunds();
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toEqual(depositError);
+        expect(mockNavigation.goBack).not.toHaveBeenCalled();
       });
     });
   });

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
@@ -5,9 +5,11 @@ import type { AppNavigationProp } from '../../../../core/NavigationService/types
 import { useSelector } from 'react-redux';
 import Logger from '../../../../util/Logger';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import { ImpactMoment, useHaptics } from '../../../../util/haptics';
 import Routes from '../../../../constants/navigation/Routes';
 import { selectPerpsEligibility } from '../selectors/perpsController';
 import { usePerpsTrading } from './usePerpsTrading';
+import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
 import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
 import {
   PERPS_CONSTANTS,
@@ -64,7 +66,7 @@ export interface UsePerpsHomeActionsReturn {
  * Handles:
  * - Eligibility checks and modal display
  * - Network validation (Arbitrum)
- * - Add funds flow with confirmation navigation
+ * - Add funds flow: haptic + skeleton immediately, then fire-and-forget deposit prep
  * - Withdraw navigation
  * - Error handling with Sentry tracking
  * - Loading state management
@@ -85,6 +87,7 @@ export const usePerpsHomeActions = (
   );
   const { withdrawWithConfirmation } = usePerpsWithdrawConfirmation();
   const { gate } = useComplianceGate(selectedAddress);
+  const { playImpact } = useHaptics();
 
   const [isEligibilityModalVisible, setIsEligibilityModalVisible] =
     useState(false);
@@ -110,43 +113,44 @@ export const usePerpsHomeActions = (
     [track],
   );
 
-  const handleAddFunds = useCallback(
-    () =>
-      gate(async () => {
-        track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
-          [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
-            PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
-          [PERPS_EVENT_PROPERTY.BUTTON_CLICKED]:
-            PERPS_EVENT_VALUE.BUTTON_CLICKED.DEPOSIT,
-          [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
-            buttonLocation || PERPS_EVENT_VALUE.BUTTON_LOCATION.PERPS_HOME,
-        });
+  const handleAddFunds = useCallback(() => {
+    // Immediate feedback so the tap is not gated on compliance or deposit prep.
+    playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
 
-        if (!isEligible) {
-          DevLogger.log('[usePerpsHomeActions] User not eligible for deposit');
-          showEligibilityModal(PERPS_EVENT_VALUE.SOURCE.DEPOSIT_BUTTON);
-          return;
-        }
+    return gate(async () => {
+      track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
+        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+          PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+        [PERPS_EVENT_PROPERTY.BUTTON_CLICKED]:
+          PERPS_EVENT_VALUE.BUTTON_CLICKED.DEPOSIT,
+        [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
+          buttonLocation || PERPS_EVENT_VALUE.BUTTON_LOCATION.PERPS_HOME,
+      });
 
-        setIsProcessing(true);
-        setError(null);
+      if (!isEligible) {
+        DevLogger.log('[usePerpsHomeActions] User not eligible for deposit');
+        showEligibilityModal(PERPS_EVENT_VALUE.SOURCE.DEPOSIT_BUTTON);
+        return;
+      }
 
-        DevLogger.log('[usePerpsHomeActions] Starting add funds flow');
+      setError(null);
 
-        try {
-          navigateToConfirmation({ stack: Routes.PERPS.ROOT });
+      DevLogger.log('[usePerpsHomeActions] Starting add funds flow');
 
-          // Wait for deposit confirmation to complete before calling success callback
-          await depositWithConfirmation();
+      navigateToConfirmation({
+        loader: ConfirmationLoader.CustomAmount,
+        stack: Routes.PERPS.ROOT,
+      });
 
+      // Do not await: preparing the unapproved tx must not block the skeleton.
+      depositWithConfirmation()
+        .then(() => {
           DevLogger.log(
             '[usePerpsHomeActions] Add funds flow completed successfully',
           );
-
-          if (onAddFundsSuccess) {
-            onAddFundsSuccess();
-          }
-        } catch (err) {
+          onAddFundsSuccess?.();
+        })
+        .catch((err: unknown) => {
           const errorObj = ensureError(
             err,
             'usePerpsHomeActions.handleAddFunds',
@@ -159,25 +163,23 @@ export const usePerpsHomeActions = (
             },
           });
 
-          if (onError) {
-            onError(errorObj, 'deposit');
-          }
-        } finally {
-          setIsProcessing(false);
-        }
-      }),
-    [
-      gate,
-      isEligible,
-      navigateToConfirmation,
-      depositWithConfirmation,
-      onAddFundsSuccess,
-      onError,
-      track,
-      buttonLocation,
-      showEligibilityModal,
-    ],
-  );
+          onError?.(errorObj, 'deposit');
+          navigation.goBack();
+        });
+    });
+  }, [
+    gate,
+    isEligible,
+    navigateToConfirmation,
+    depositWithConfirmation,
+    navigation,
+    onAddFundsSuccess,
+    onError,
+    playImpact,
+    track,
+    buttonLocation,
+    showEligibilityModal,
+  ]);
 
   const handleWithdraw = useCallback(async () => {
     // Track withdrawal button click with geo-block status for monitoring (TAT-2337)

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../core/NavigationService/types';
 
@@ -24,6 +24,7 @@ import { RootState } from '../../../../reducers';
 import { usePerpsWithdrawConfirmation } from './usePerpsWithdrawConfirmation';
 import { useComplianceGate } from '../../Compliance';
 import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
+import { createDepositConfirmationGuard } from '../utils/depositConfirmationGuard';
 
 export type PerpsHomeActionType = 'deposit' | 'withdraw';
 
@@ -97,6 +98,14 @@ export const usePerpsHomeActions = (
 
   const { onAddFundsSuccess, onWithdrawSuccess, onError, buttonLocation } =
     options || {};
+  const confirmationGuardCancelRef = useRef<(() => void) | null>(null);
+
+  const clearConfirmationGuard = useCallback(() => {
+    confirmationGuardCancelRef.current?.();
+    confirmationGuardCancelRef.current = null;
+  }, []);
+
+  useEffect(() => clearConfirmationGuard, [clearConfirmationGuard]);
 
   const showEligibilityModal = useCallback(
     (source: string) => {
@@ -142,12 +151,17 @@ export const usePerpsHomeActions = (
         stack: Routes.PERPS.ROOT,
       });
 
+      clearConfirmationGuard();
+      const confirmationGuard = createDepositConfirmationGuard(navigation);
+      confirmationGuardCancelRef.current = confirmationGuard.cancel;
+
       // Do not await: preparing the unapproved tx must not block the skeleton.
       depositWithConfirmation()
         .then(() => {
           DevLogger.log(
             '[usePerpsHomeActions] Add funds flow completed successfully',
           );
+          clearConfirmationGuard();
           onAddFundsSuccess?.();
         })
         .catch((err: unknown) => {
@@ -164,7 +178,7 @@ export const usePerpsHomeActions = (
           });
 
           onError?.(errorObj, 'deposit');
-          navigation.goBack();
+          confirmationGuard.onDepositFailed();
         });
     });
   }, [
@@ -179,6 +193,7 @@ export const usePerpsHomeActions = (
     track,
     buttonLocation,
     showEligibilityModal,
+    clearConfirmationGuard,
   ]);
 
   const handleWithdraw = useCallback(async () => {

--- a/app/components/UI/Perps/utils/depositConfirmationGuard.test.ts
+++ b/app/components/UI/Perps/utils/depositConfirmationGuard.test.ts
@@ -1,0 +1,121 @@
+import Routes from '../../../../constants/navigation/Routes';
+import {
+  createDepositConfirmationGuard,
+  getFocusedRouteName,
+  isRedesignedConfirmationFocused,
+  type NestedNavigationState,
+} from './depositConfirmationGuard';
+
+const CONFIRMATION_ROUTE =
+  Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS;
+
+const createState = (
+  focusedName: string,
+  nested?: NestedNavigationState,
+): NestedNavigationState => ({
+  index: 1,
+  routes: [
+    { name: Routes.PERPS.PERPS_HOME },
+    { name: focusedName, ...(nested ? { state: nested } : {}) },
+  ],
+});
+
+const createNavigation = (initialState: NestedNavigationState) => {
+  let state = initialState;
+  const listeners = new Set<() => void>();
+
+  return {
+    getState: jest.fn(() => state),
+    goBack: jest.fn(),
+    addListener: jest.fn((_event: 'state', callback: () => void) => {
+      listeners.add(callback);
+      return () => {
+        listeners.delete(callback);
+      };
+    }),
+    emitState: (nextState: NestedNavigationState) => {
+      state = nextState;
+      listeners.forEach((listener) => listener());
+    },
+  };
+};
+
+describe('getFocusedRouteName', () => {
+  it('returns undefined for empty state', () => {
+    expect(getFocusedRouteName(undefined)).toBeUndefined();
+    expect(getFocusedRouteName({ index: 0, routes: [] })).toBeUndefined();
+  });
+
+  it('returns the focused leaf route name from nested stacks', () => {
+    const state = createState(Routes.PERPS.ROOT, {
+      index: 0,
+      routes: [{ name: CONFIRMATION_ROUTE }],
+    });
+
+    expect(getFocusedRouteName(state)).toBe(CONFIRMATION_ROUTE);
+  });
+});
+
+describe('isRedesignedConfirmationFocused', () => {
+  it('returns true when a confirmation route is focused', () => {
+    const navigation = createNavigation(createState(CONFIRMATION_ROUTE));
+
+    expect(isRedesignedConfirmationFocused(navigation)).toBe(true);
+  });
+
+  it('returns false when Perps is focused', () => {
+    const navigation = createNavigation(
+      createState(Routes.PERPS.MARKET_DETAILS),
+    );
+
+    expect(isRedesignedConfirmationFocused(navigation)).toBe(false);
+  });
+});
+
+describe('createDepositConfirmationGuard', () => {
+  it('goes back when deposit fails while confirmation is focused', () => {
+    const navigation = createNavigation(createState(CONFIRMATION_ROUTE));
+    const guard = createDepositConfirmationGuard(navigation);
+
+    guard.onDepositFailed();
+
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not go back when the user already left confirmation', () => {
+    const navigation = createNavigation(createState(CONFIRMATION_ROUTE));
+    const guard = createDepositConfirmationGuard(navigation);
+
+    navigation.emitState(createState(Routes.PERPS.MARKET_DETAILS));
+    guard.onDepositFailed();
+
+    expect(navigation.goBack).not.toHaveBeenCalled();
+  });
+
+  it('goes back once confirmation appears after deferred navigation', () => {
+    const navigation = createNavigation(
+      createState(Routes.PERPS.MARKET_DETAILS),
+    );
+    const guard = createDepositConfirmationGuard(navigation);
+
+    guard.onDepositFailed();
+    expect(navigation.goBack).not.toHaveBeenCalled();
+
+    navigation.emitState(createState(CONFIRMATION_ROUTE));
+
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not go back for a later confirmation after cancel', () => {
+    const navigation = createNavigation(
+      createState(Routes.PERPS.MARKET_DETAILS),
+    );
+    const guard = createDepositConfirmationGuard(navigation);
+
+    guard.onDepositFailed();
+    guard.cancel();
+    navigation.emitState(createState(CONFIRMATION_ROUTE));
+
+    expect(navigation.goBack).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Perps/utils/depositConfirmationGuard.ts
+++ b/app/components/UI/Perps/utils/depositConfirmationGuard.ts
@@ -1,0 +1,126 @@
+import Routes from '../../../../constants/navigation/Routes';
+
+const CONFIRMATION_ROUTE_NAMES = new Set([
+  Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
+  Routes.FULL_SCREEN_CONFIRMATIONS.NO_HEADER,
+]);
+
+export interface NestedNavigationState {
+  index: number;
+  routes: { name: string; state?: NestedNavigationState }[];
+}
+
+export interface DepositConfirmationNavigation {
+  getState: () => NestedNavigationState | undefined;
+  goBack: () => void;
+  addListener: (event: 'state', callback: () => void) => () => void;
+}
+
+export interface DepositConfirmationGuard {
+  /**
+   * Dismiss confirmation if it is focused, or once it appears if navigation
+   * was deferred. No-ops when the user already left confirmation.
+   */
+  onDepositFailed: () => void;
+  /** Stop watching navigation. Call on success or unmount. */
+  cancel: () => void;
+}
+
+/**
+ * Returns the focused leaf route name from a (possibly nested) navigation state.
+ *
+ * @param state - React Navigation state, including nested stack state.
+ * @returns The focused route name, or undefined when state is empty.
+ */
+export function getFocusedRouteName(
+  state: NestedNavigationState | undefined,
+): string | undefined {
+  if (!state?.routes?.length) {
+    return undefined;
+  }
+
+  const route = state.routes[state.index];
+  if (route.state) {
+    return getFocusedRouteName(route.state) ?? route.name;
+  }
+
+  return route.name;
+}
+
+/**
+ * Whether the redesigned confirmation screen is the focused route.
+ *
+ * @param navigation - Navigation object exposing `getState`.
+ * @returns True when a confirmation route is focused.
+ */
+export function isRedesignedConfirmationFocused(
+  navigation: Pick<DepositConfirmationNavigation, 'getState'>,
+): boolean {
+  const focused = getFocusedRouteName(navigation.getState());
+  return focused !== undefined && CONFIRMATION_ROUTE_NAMES.has(focused);
+}
+
+/**
+ * Guards `goBack` after fire-and-forget deposit prep so we only dismiss the
+ * confirmation we opened — not Perps, and not a confirmation the user already
+ * closed. If `useConfirmNavigation` deferred the push, we wait until it
+ * appears and then dismiss it.
+ *
+ * @param navigation - Navigation object with state, goBack, and state listener.
+ * @returns Guard with `onDepositFailed` and `cancel`.
+ */
+export function createDepositConfirmationGuard(
+  navigation: DepositConfirmationNavigation,
+): DepositConfirmationGuard {
+  let cancelled = false;
+  let presented = isRedesignedConfirmationFocused(navigation);
+  let dismissWhenShown = false;
+
+  const unsubscribe = navigation.addListener('state', () => {
+    if (cancelled) {
+      return;
+    }
+
+    const focused = isRedesignedConfirmationFocused(navigation);
+    if (!focused) {
+      return;
+    }
+
+    presented = true;
+    if (dismissWhenShown) {
+      cancelled = true;
+      unsubscribe();
+      navigation.goBack();
+    }
+  });
+
+  return {
+    onDepositFailed: () => {
+      if (cancelled) {
+        return;
+      }
+
+      if (isRedesignedConfirmationFocused(navigation)) {
+        cancelled = true;
+        unsubscribe();
+        navigation.goBack();
+        return;
+      }
+
+      if (presented) {
+        cancelled = true;
+        unsubscribe();
+        return;
+      }
+
+      dismissWhenShown = true;
+    },
+    cancel: () => {
+      if (cancelled) {
+        return;
+      }
+      cancelled = true;
+      unsubscribe();
+    },
+  };
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Tapping Add funds in Perps felt laggy because the tap handler awaited `depositWithConfirmation()` (Arbitrum network ensure + unapproved tx simulation) and also called `setIsProcessing(true)`, which re-rendered the Pro market tree (chart, order book, live prices) on the same tick as navigation. Predict already navigates to a confirmation skeleton first and prepares the transaction afterward.

This PR matches that pattern for Perps home, Pro, and Lite:
- Play a Primary CTA haptic immediately on tap
- Navigate to the redesigned confirmation with the Custom Amount loader without awaiting deposit prep
- Fire-and-forget `depositWithConfirmation()`; dismiss confirmation on failure
- Move the Pro Add funds haptic into `usePerpsHomeActions` so the size input does not double-fire it

Pay with token-list lag on first open is confirmations-owned (`useAccountTokens`) and is not addressed here.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a delay when tapping Add funds in Perps so the confirmation opens immediately

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
Refs: TAT-3772

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps Add funds tap responsiveness

  Background:
    Given I am logged into MetaMask Mobile
    And I am eligible for Perps
    And I have a funded Perps account

  Scenario: user adds funds from the Pro order form
    Given I am on a Perps Pro market (e.g. BTC-USD)

    When user taps the available balance Add funds control
    Then I should feel haptic feedback immediately
    And the Add funds confirmation should appear without waiting on the Pro screen
    And the Custom Amount confirmation should load (amount + Pay with)

  Scenario: user adds funds from Perps home
    Given I am on the Perps home screen

    When user taps Add funds
    Then I should feel haptic feedback immediately
    And the Add funds confirmation should appear without a multi-second dead tap

  Scenario: user adds funds from Lite market details with no spendable balance
    Given I am on a Perps Lite market details screen
    And I do not have a direct order funding path

    When user taps Add funds
    Then the Add funds confirmation should appear immediately
    And deposit preparation should continue in the background

  Scenario: deposit preparation fails
    Given Add funds navigation has started
    And deposit preparation rejects

    Then the confirmation should dismiss back to the previous Perps screen
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — latency change; confirmation UI is unchanged

### **After**

N/A — latency change; confirmation UI is unchanged. Verified on iPhone 17 simulator: tapping `$20.36 available` opened Add funds with amount and Pay with already populated.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deposit navigation timing and failure recovery across Perps entry points; incorrect guard logic could dismiss the wrong screen, though behavior is covered by new unit tests.
> 
> **Overview**
> **Add funds in Perps** now responds on tap instead of waiting on Arbitrum setup and unapproved-tx preparation. Tapping plays **Primary CTA haptic** right away, navigates to the redesigned confirmation with the **Custom Amount** loader, and runs `depositWithConfirmation()` in the background (same pattern as Predict).
> 
> **Perps home** (`usePerpsHomeActions`) and **Lite market details** share this flow; **Pro** routes Add funds through the home-actions hook so haptics are not double-fired from `PerpsProSizeInput`. Home no longer toggles `isProcessing` around deposit prep for this path.
> 
> A new **`depositConfirmationGuard`** utility watches navigation and calls `goBack` only when deposit prep fails while the confirmation screen is (or becomes) focused—so Perps is not popped if prep fails before confirmation appears or the user already left.
> 
> Tests cover immediate navigation, failure dismiss behavior, and guard edge cases; changelog notes the user-facing latency fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca091a8c98e3a78e839ec5d881c6b4e7a3ba937c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->