### PR TITLE
fix(social): update trader bell state for notification delivery

### DIFF
--- a/app/components/Views/SocialLeaderboard/hooks/useTraderMuteActions.test.ts
+++ b/app/components/Views/SocialLeaderboard/hooks/useTraderMuteActions.test.ts
@@ -4,8 +4,13 @@ import { useOpenTradingSignalsSetup } from './useOpenTradingSignalsSetup';
 import { useNotificationPreferences } from '../NotificationPreferences/hooks';
 import { ImpactMoment, playImpact } from '../../../../util/haptics';
 
+let mockIsMasterEnabled = true;
+
 jest.mock('../NotificationPreferences/hooks');
 jest.mock('./useOpenTradingSignalsSetup');
+jest.mock('react-redux', () => ({
+  useSelector: () => mockIsMasterEnabled,
+}));
 jest.mock('../../../../util/haptics', () => ({
   ImpactMoment: { FollowToggle: 'FollowToggle' },
   playImpact: jest.fn(),
@@ -51,7 +56,10 @@ const setGate = (intercepts: boolean) => {
 };
 
 describe('useTraderMuteActions', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsMasterEnabled = true;
+  });
 
   it('reports a trader as muted when their notifications are off', () => {
     mockUseNotificationPreferences.mockReturnValue(
@@ -112,6 +120,20 @@ describe('useTraderMuteActions', () => {
 
     // The trader itself is not paused, but with both channels off nothing can
     // be heard, so the bell still reads as muted.
+    expect(result.current.isChipMuted('trader-1')).toBe(true);
+  });
+
+  it('shows the chip as muted when master notifications are off', () => {
+    mockIsMasterEnabled = false;
+    mockUseNotificationPreferences.mockReturnValue(
+      buildPreferences({
+        isTraderNotificationEnabled: jest.fn(() => true),
+      }),
+    );
+    setGate(false);
+
+    const { result } = renderHook(() => useTraderMuteActions());
+
     expect(result.current.isChipMuted('trader-1')).toBe(true);
   });
 

--- a/app/components/Views/SocialLeaderboard/hooks/useTraderMuteActions.ts
+++ b/app/components/Views/SocialLeaderboard/hooks/useTraderMuteActions.ts
@@ -1,5 +1,7 @@
 import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
 import { ImpactMoment, playImpact } from '../../../../util/haptics';
+import { selectIsMetamaskNotificationsEnabled } from '../../../../selectors/notifications';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { useNotificationPreferences } from '../NotificationPreferences/hooks';
 import { areTradingSignalsChannelsDisabled } from '../NotificationPreferences/hooks/tradingSignalsChannels';
@@ -13,16 +15,16 @@ export interface UseTraderMuteActionsResult {
    */
   showMuteChip: boolean;
   /**
-   * Visual mute state for a trader's bell: muted when that trader's alerts are
-   * paused, OR when both trading-signal channels are disabled globally (in
-   * which case no trader can be heard).
+   * Visual state for a trader's bell: barred when the trader is muted, the
+   * global notification toggle is off, or both trading-signal channels are
+   * disabled (in which case no trader can be heard).
    */
   isChipMuted: (traderId: string) => boolean;
   /**
-   * Bell tap handler. When both channels are off the bell only *looks* disabled,
-   * so a tap means "enable": setup is opened and an idempotent unmute is
-   * deferred to it rather than a blind toggle, so completing setup can never
-   * leave the trader muted. Otherwise it toggles directly.
+   * Bell tap handler. When delivery is unavailable the bell only *looks*
+   * disabled, so a tap means "enable": setup is opened and an idempotent
+   * unmute is deferred to it rather than a blind toggle. Otherwise it toggles
+   * directly.
    */
   onMutePress: (traderId: string) => void;
 }
@@ -40,6 +42,7 @@ export interface UseTraderMuteActionsResult {
  * single id.
  */
 export const useTraderMuteActions = (): UseTraderMuteActionsResult => {
+  const isMasterEnabled = useSelector(selectIsMetamaskNotificationsEnabled);
   const {
     preferences,
     hasNotificationPreferences,
@@ -50,7 +53,7 @@ export const useTraderMuteActions = (): UseTraderMuteActionsResult => {
 
   const needsNotificationSetup =
     hasNotificationPreferences &&
-    areTradingSignalsChannelsDisabled(preferences);
+    (!isMasterEnabled || areTradingSignalsChannelsDisabled(preferences));
 
   const isChipMuted = useCallback(
     (traderId: string) =>


### PR DESCRIPTION
## **Description**

The trader notification bell previously represented only the trader mute state and trading-signal channel state. When global notifications were disabled, the bell could appear unbarred even though notifications could not be delivered.

The bell now appears barred whenever any notification-delivery requirement is unavailable: global notifications are disabled, trading-signal channels are disabled, or the trader is muted. The existing setup flow remains responsible for enabling the required notification settings when a barred bell is tapped.

Global notifications disabled:
https://github.com/user-attachments/assets/beac124e-ad35-4694-b8c2-a8870366cab7

Trading Signals disabled:
https://github.com/user-attachments/assets/3ae0af9e-cc45-4bc6-8a34-5a26bdf1534f

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: TSA-1034

## **Manual testing steps**

```gherkin
Feature: Trader notification bell state

  Background:
    Given I am logged into MetaMask Mobile
    And I have notification preferences configured
    And I am viewing a followed trader

  Scenario: global notifications are disabled
    Given Allow notifications is disabled
    And trading-signal channels are enabled
    And the trader is not muted
    When user views the trader notification bell
    Then the bell is barred
    When user taps the bell
    Then the global notification setup sheet opens

  Scenario: trading-signal channels are disabled
    Given Allow notifications is enabled
    And both Trading signals channels are disabled
    And the trader is not muted
    When user views the trader notification bell
    Then the bell is barred
    When user taps the bell
    Then the Trading signals setup sheet opens
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

NA

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small hook change in social UI with unit tests; reuses existing setup gating rather than new notification delivery logic.
> 
> **Overview**
> The social leaderboard trader notification bell now treats **global MetaMask notifications disabled** the same as muted traders or disabled trading-signal channels: it renders **barred** and taps go through the existing setup flow instead of looking active when nothing can be delivered.
> 
> `useTraderMuteActions` reads `selectIsMetamaskNotificationsEnabled` from Redux and folds `!isMasterEnabled` into `needsNotificationSetup`, which drives both `isChipMuted` and when `onMutePress` defers to `openSetupIfNeeded`. JSDoc is updated to describe delivery requirements in those terms. Tests mock `react-redux` and add coverage for master notifications off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf2598aedb52dc98c25863d7af1548fd2d2b4d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->