### PR TITLE
ci: build iOS on PRs into main only when requested

### DIFF
--- a/.github/guidelines/E2E_DECISION_TREE.md
+++ b/.github/guidelines/E2E_DECISION_TREE.md
@@ -12,20 +12,70 @@ flowchart TD
     L2 -->|ignorable-only changes| NoBlock[No merge block]
     L2 -->|non-ignorable changes| Skip2[⛔️ Merge blocked]
     GR -->|PR ignorable-only changes| Ignorable[No E2E]
-    GR -->|PR test-only changes| TestOnly[E2E + Smart selection, reuse main builds]
+    GR -->|PR test-only changes| TestOnly[E2E needed - reuse main builds]
     GR -->|PR has Android-only changes| Android[Android Build + Tests needed]
     GR -->|PR has iOS-only changes| iOS[iOS Build + Test needed]
     GR -->|PR other files changed| Both[Both Build + Tests needed]
     GR -->|PR targets stable| StableSync[No E2E - synchronization only]
     GR -->|Scheduled or Push to main/release/*| Full[Run all E2E Suites for Both]
 
-    Android & iOS & Both --> LABEL{{PR label: skip-smart-e2e-selection ?}}
+    TestOnly & Android & iOS & Both --> BASE{{PR base branch ?}}
+    BASE -->|release/*| KeepIOS[Keep the platforms path filters selected]
+    BASE -->|main| IOSREQ{{iOS requested ?}}
+    IOSREQ -->|label: run-appium-ios-tests| OptIn[Build iOS + run Appium iOS]
+    IOSREQ -->|label: skip-smart-e2e-selection AND path filters selected iOS| OptIn
+    IOSREQ -->|no| StripIOS[Drop iOS - Android only, or no E2E at all on an iOS-only PR]
+    StripIOS & KeepIOS & OptIn --> LABEL{{PR label: skip-smart-e2e-selection ?}}
     LABEL -->|yes| AllTags[Run all E2E tags on platforms selected by path filters]
     LABEL -->|no| AI[🤖 AI selects test suites + confidence score]
     AI --> CONF{{Confidence >= 85% ?}}
     CONF -->|yes| SelectedTags[Run selected E2E suites]
     CONF -->|no| AllTagsFallback[Run all E2E needed]
 ```
+
+## iOS builds on PRs into `main` are on request only
+
+Path filters alone **never** build the iOS app on a pull request targeting
+`main`. iOS has to be requested, and there are exactly two ways to do it:
+
+| Request | Effect |
+| --- | --- |
+| `run-appium-ios-tests` label | Builds iOS and runs Appium iOS, **even when path filters selected Android only**. Widening is the whole point of this label. |
+| `skip-smart-e2e-selection` label | Builds iOS and runs Appium iOS with the full `ALL` tag set, **but only when path filters already selected iOS**. This label expands the tag set, not the platform list, so it never adds a platform path filters deliberately skipped. |
+
+Nothing else opts in. In particular, shared smoke/Appium infrastructure changes
+no longer pull in an iOS build on a `main` PR the way they do on `release/*`.
+
+**The app is only built when iOS E2E will actually run.** On PRs into `main`,
+`ios_e2e_needed` and `run_appium_ios` are driven by the same two requests above,
+so they are always equal — CI never spends a macOS build on an app nothing will
+test. A unit test asserts this invariant across every combination.
+
+Consequences when iOS is *not* requested:
+
+- A PR that touches shared or cross-platform code runs **Android only**.
+- A PR that touches **only** iOS files (`ios/**`, `Podfile`, native iOS code)
+  runs **no E2E at all** — there is no Android build to test either, so
+  `native_build_needed` and Smart E2E Selection both turn off. Adding either
+  label restores iOS *and* Smart E2E Selection.
+- `validate-e2e-fixtures` is iOS-only, so **fixture validation only runs on a
+  `main` PR when iOS was requested**. It still runs unconditionally on PRs into
+  `release/*` that build iOS.
+
+iOS coverage outside feature-branch PRs is unchanged. Every push to `main` and
+`release/*`, plus the hourly overnight schedule, builds iOS and runs Appium iOS
+with the full `ALL` tag set. PRs into `release/*` keep the Android-first policy:
+they build iOS when path filters select it, and Appium iOS stays opt-in — see
+[Appium smoke platform policy](#appium-smoke-platform-policy).
+
+So an unlabelled `main` PR that breaks iOS surfaces on `main` after merge rather
+than in the PR. Add `run-appium-ios-tests` when you are touching anything that
+could plausibly be iOS-specific.
+
+The rule is implemented in `.github/scripts/compute-e2e-platform-flags.cjs`:
+`computeE2EPlatformFlags` drops iOS while recording `iosByPathFilters`, and
+`applyE2ELabelOverrides` restores it for either request. `build-ios-apps` in
+`.github/workflows/ci.yml` then gates on the resulting `ios_e2e_needed`.
 
 ## Test-only PR changes
 
@@ -63,16 +113,21 @@ Runs only when all of the following are true:
 - No `skip-smart-e2e-selection` label
 - PR does not target `stable`
 
-For PRs targeting `main` or `release/*`, Smart E2E selects the test tags. Release
-cherry-pick PRs use the same Android-first platform policy as main PRs: Android
-is selected by path filters and iOS is opt-in through the Appium iOS label or
-shared smoke/Appium infrastructure changes.
+For PRs targeting `main` or `release/*`, Smart E2E selects the test tags. PRs
+into `main` are Android-only unless iOS is explicitly requested (see
+[iOS builds on PRs into `main` are on request only](#ios-builds-on-prs-into-main-are-on-request-only)). Release
+cherry-pick PRs are Android-first: Android is selected by path filters and iOS is
+opt-in through the Appium iOS label or shared smoke/Appium infrastructure
+changes.
 
 When `skip-smart-e2e-selection` is present, Smart E2E is bypassed and the full
 `ALL` tag set runs on each platform already required by path filters — it does
-not add platforms that path filters would skip. On PRs where path filters
-require iOS, this label also enables Appium iOS smoke (otherwise opt-in via
-`run-appium-ios-tests`).
+not add platforms that path filters would skip. Where path filters require iOS,
+this label also builds iOS and enables Appium iOS smoke — on PRs into `main` as
+well as `release/*`. It is the second of the two iOS requests described in
+[iOS builds on PRs into `main` are on request only](#ios-builds-on-prs-into-main-are-on-request-only);
+the non-widening rule is exactly why it cannot pull in iOS on an Android-only PR,
+where `run-appium-ios-tests` is the label to use instead.
 
 ## (Exceptional) skip builds and all E2E tests
 
@@ -82,8 +137,9 @@ require iOS, this label also enables Appium iOS smoke (otherwise opt-in via
 ## Appium smoke platform policy
 
 - Pull requests targeting `main` or `release/*` run Appium Android when Android E2E is required. Smart E2E controls the selected tags.
-- Appium iOS is skipped on PRs by default. It runs when `run-appium-ios-tests` is added (also opts into the iOS native build on Android-only PRs), when `skip-smart-e2e-selection` is added and path filters already require iOS, or when shared smoke/Appium infrastructure changes (`tests/page-objects/**`, `tests/selectors/**`, `tests/locators/**`, `tests/framework/**`, or `tests/smoke-appium/**`) and path filters require an iOS build.
-- Pushes to `main` and `release/*` run Appium Android and Appium iOS with the full `ALL` tag set.
+- On PRs into `main`, Appium iOS runs **only when iOS was requested** via `run-appium-ios-tests`, or via `skip-smart-e2e-selection` when path filters already require iOS. Path filters and smoke-infra changes alone do not trigger it, and the iOS app is not built unless it will be tested. See [iOS builds on PRs into `main` are on request only](#ios-builds-on-prs-into-main-are-on-request-only).
+- On PRs into `release/*`, Appium iOS is skipped by default. It runs when `run-appium-ios-tests` is added (also opts into the iOS native build on Android-only PRs), when `skip-smart-e2e-selection` is added and path filters already require iOS, or when shared smoke/Appium infrastructure changes (`tests/page-objects/**`, `tests/selectors/**`, `tests/locators/**`, `tests/framework/**`, or `tests/smoke-appium/**`) and path filters require an iOS build.
+- Pushes to `main` and `release/*` run Appium Android and Appium iOS with the full `ALL` tag set. This is where iOS coverage for merged feature work comes from.
 - PRs targeting `stable` from `release/*` are synchronization-only and run no E2E, including Appium.
 - Stable branch synchronization automation remains active; stable is not the release-build source.
 
@@ -100,7 +156,7 @@ Flakiness detection is applied to modified E2E test files in PRs:
 `release/*` branches are release candidates. Their E2E policy is:
 
 - Cherry-pick PRs from `main` use Smart E2E selection with the Android-first platform policy.
-- Release cherry-pick PRs do not automatically run iOS; use `run-appium-ios-tests` to opt into the iOS build and Appium iOS smoke when needed.
+- Release cherry-pick PRs do not automatically run iOS; use `run-appium-ios-tests` to opt into the iOS build and Appium iOS smoke when needed. Unlike PRs into `main`, path filters selecting iOS are enough to build it here, and shared smoke/Appium infrastructure changes still enable Appium iOS.
 - Every push to `release/*` runs Android and iOS Appium E2E with `ALL` tags.
 - PRs from `release/*` to `stable` are synchronization PRs and run no E2E.
 - The final release decision is based on the latest tested `release/*` SHA, which is also the source for the production build.

--- a/.github/guidelines/LABELING_GUIDELINES.md
+++ b/.github/guidelines/LABELING_GUIDELINES.md
@@ -37,7 +37,7 @@ Using any of these labels should be exceptional in case of CI friction and urgen
 
 ### Skip Smart E2E Selection
 
-- **skip-smart-e2e-selection**: Bypasses the AI-powered Smart E2E Selection (level 2) so that the full E2E test suite (`ALL` tags) runs instead of an AI-picked subset on whichever platforms path filters (level 1) already require. It does **not** override path filters: ignorable-only PRs (e.g. docs-only), `skip-e2e`, and `pr-not-ready-for-e2e` still skip E2E entirely, and Android-only or iOS-only PRs still run only the platform indicated by path filters. When path filters already require iOS, this label also enables Appium iOS smoke on PRs. Adding or removing this label re-triggers CI. Not honored on fork PRs.
+- **skip-smart-e2e-selection**: Bypasses the AI-powered Smart E2E Selection (level 2) so that the full E2E test suite (`ALL` tags) runs instead of an AI-picked subset on whichever platforms path filters (level 1) already require. It does **not** override path filters: ignorable-only PRs (e.g. docs-only), `skip-e2e`, and `pr-not-ready-for-e2e` still skip E2E entirely, and Android-only or iOS-only PRs still run only the platform indicated by path filters. When path filters already require iOS, this label also builds iOS and enables Appium iOS smoke — including on PRs into `main`, where it is one of the two ways to request iOS at all (see [E2E decision tree](./E2E_DECISION_TREE.md#ios-builds-on-prs-into-main-are-on-request-only)). Because it does not widen platforms, it cannot pull iOS into an Android-only PR; use `run-appium-ios-tests` for that. Adding or removing this label re-triggers CI. Not honored on fork PRs.
 
 ### Force Performance Tests
 
@@ -45,7 +45,7 @@ Using any of these labels should be exceptional in case of CI friction and urgen
 
 ### Force Appium iOS Smoke Tests
 
-- **run-appium-ios-tests**: Opts into the iOS native build and Appium iOS smoke tests on a PR targeting `main` or `release/*` when path filters would otherwise skip iOS (e.g. Android-only PRs). Uses the same Smart E2E Selection tags as Appium Android. Does not bypass ignorable-only, `skip-e2e`, or `pr-not-ready-for-e2e` gates, and it is ignored for synchronization PRs targeting `stable`. Pushes to `main` and `release/*` run iOS automatically with the full `ALL` tag set. Remove `pr-not-ready-for-e2e` when the PR is ready for E2E validation. Adding or removing this label re-triggers CI. Not honored on fork PRs.
+- **run-appium-ios-tests**: Opts into the iOS native build and Appium iOS smoke tests on a PR targeting `main` or `release/*` when path filters would otherwise skip iOS (e.g. Android-only PRs). Uses the same Smart E2E Selection tags as Appium Android. On PRs into `main` this is the **primary** way to get iOS CI at all: path filters alone never build iOS there, so add this label whenever your change could plausibly be iOS-specific (see [E2E decision tree](./E2E_DECISION_TREE.md#ios-builds-on-prs-into-main-are-on-request-only)). Does not bypass ignorable-only, `skip-e2e`, or `pr-not-ready-for-e2e` gates, and it is ignored for synchronization PRs targeting `stable`. Pushes to `main` and `release/*` run iOS automatically with the full `ALL` tag set. Remove `pr-not-ready-for-e2e` when the PR is ready for E2E validation. Adding or removing this label re-triggers CI. Not honored on fork PRs.
 
 ### Block merge if any is present
 

--- a/.github/scripts/compute-e2e-platform-flags.cjs
+++ b/.github/scripts/compute-e2e-platform-flags.cjs
@@ -44,6 +44,13 @@ function computeE2EPlatformFlags(input) {
   const isStableTarget =
     githubEventName === 'pull_request' && prBaseRef === 'stable';
 
+  // Feature-branch PRs into main do not build iOS from path filters alone. Two
+  // labels opt back in — see applyE2ELabelOverrides. Pushes to main/release/*,
+  // the nightly schedule, and PRs into release/* are unaffected, so iOS
+  // regressions are still caught before a release is cut.
+  const isMainTargetPullRequest =
+    githubEventName === 'pull_request' && prBaseRef === 'main';
+
   if (isStableTarget) {
     message = 'Skipping E2E (stable branch synchronization PR)';
   } else if (githubEventName === 'schedule' || githubEventName === 'push') {
@@ -91,6 +98,16 @@ function computeE2EPlatformFlags(input) {
     changed = changedSpecFiles;
   }
 
+  // Preserved so the skip-smart-e2e-selection opt-in can stay non-widening: it
+  // must know whether iOS was selected by path filters before the suppression
+  // below erased it.
+  const iosByPathFilters = ios;
+
+  if (isMainTargetPullRequest && ios) {
+    ios = false;
+    message = `${message} — iOS not requested for a PR into main (add run-appium-ios-tests or skip-smart-e2e-selection)`;
+  }
+
   const e2eNeeded = android || ios;
 
   const runSmartE2ESelection =
@@ -102,6 +119,7 @@ function computeE2EPlatformFlags(input) {
   return {
     android,
     ios,
+    iosByPathFilters,
     e2eNeeded,
     nativeBuildNeeded: e2eNeeded ? nativeBuildNeeded : false,
     runSmartE2ESelection,
@@ -121,6 +139,7 @@ function computeE2EPlatformFlags(input) {
 function applyE2ELabelOverrides(flags, input) {
   const {
     runAppiumIosLabel = false,
+    skipSmartSelection = false,
     githubEventName,
     prBaseRef = '',
     isFork,
@@ -136,7 +155,19 @@ function applyE2ELabelOverrides(flags, input) {
     !shouldSkipE2E &&
     !ignorableOnly;
 
-  if (!isEligiblePullRequest || !runAppiumIosLabel || flags.ios) {
+  // Two ways to request iOS. `run-appium-ios-tests` widens to iOS regardless of
+  // path filters — that is its whole purpose. `skip-smart-e2e-selection` runs the
+  // full ALL tag set on the platforms path filters already selected, so it opts
+  // into iOS only when iOS was one of them; it must not add a platform the path
+  // filters deliberately skipped.
+  let reason = null;
+  if (runAppiumIosLabel) {
+    reason = 'run-appium-ios-tests label';
+  } else if (skipSmartSelection && flags.iosByPathFilters) {
+    reason = 'skip-smart-e2e-selection label';
+  }
+
+  if (!isEligiblePullRequest || !reason || flags.ios) {
     return flags;
   }
 
@@ -148,7 +179,11 @@ function applyE2ELabelOverrides(flags, input) {
     ios,
     e2eNeeded,
     nativeBuildNeeded: e2eNeeded && !testOnlyChanges,
-    message: `${flags.message} + iOS build (run-appium-ios-tests label)`,
+    // An iOS-only PR into main is suppressed down to no platforms at all, which
+    // turns Smart E2E Selection off. Restoring iOS has to restore it too — and
+    // isEligiblePullRequest already guarantees every other conjunct here.
+    runSmartE2ESelection: true,
+    message: `${flags.message} + iOS build (${reason})`,
   };
 }
 
@@ -178,6 +213,14 @@ function resolveRunAppiumIos(flags, input) {
     return false;
   }
 
+  // No iOS app, nothing to run smoke against. Keeps the flag from advertising a
+  // run that cannot happen, and upholds the "only build when iOS E2E will run"
+  // invariant from the other side: on PRs into main, ios and runAppiumIos are
+  // driven by the same two opt-ins, so they are always equal.
+  if (!flags.ios) {
+    return false;
+  }
+
   if (runAppiumIosLabel) {
     return true;
   }
@@ -204,7 +247,10 @@ function resolveE2EPlatformRequirements(input) {
   } = input;
 
   const baseFlags = computeE2EPlatformFlags(pathFilterInput);
-  const flags = applyE2ELabelOverrides(baseFlags, labelOverrideInput);
+  const flags = applyE2ELabelOverrides(baseFlags, {
+    ...labelOverrideInput,
+    skipSmartSelection,
+  });
   const runAppiumIos = resolveRunAppiumIos(flags, {
     skipSmartSelection,
     runAppiumIosLabel: labelOverrideInput.runAppiumIosLabel,

--- a/.github/scripts/compute-e2e-platform-flags.test.ts
+++ b/.github/scripts/compute-e2e-platform-flags.test.ts
@@ -141,6 +141,94 @@ describe('computeE2EPlatformFlags', () => {
     expect(result.message).toContain('push to main/release/*');
     expect(result.runSmartE2ESelection).toBe(false);
   });
+
+  it('drops iOS from both-platform selection for PRs targeting main', () => {
+    const result = computeE2EPlatformFlags({
+      ...baseInput,
+      prBaseRef: 'main',
+      e2eTestFilesCount: 0,
+      e2eTestOrIgnorableCount: 0,
+      androidCount: 1,
+      iosCount: 1,
+      androidOrIgnorableCount: 1,
+      iosOrIgnorableCount: 1,
+    });
+
+    expect(result).toMatchObject({
+      android: true,
+      ios: false,
+      e2eNeeded: true,
+      nativeBuildNeeded: true,
+    });
+    expect(result.message).toContain('iOS not requested for a PR into main');
+    // Path filters selected iOS; only the main-PR rule removed it. The opt-ins
+    // rely on this being preserved.
+    expect(result.iosByPathFilters).toBe(true);
+  });
+
+  it('drops iOS from test-only selection for PRs targeting main', () => {
+    const result = computeE2EPlatformFlags({
+      ...baseInput,
+      prBaseRef: 'main',
+    });
+
+    expect(result).toMatchObject({
+      android: true,
+      ios: false,
+      e2eNeeded: true,
+      nativeBuildNeeded: false,
+    });
+  });
+
+  it('leaves no E2E to run when an iOS-only PR targets main', () => {
+    const result = computeE2EPlatformFlags({
+      ...baseInput,
+      prBaseRef: 'main',
+      e2eTestFilesCount: 0,
+      e2eTestOrIgnorableCount: 0,
+      iosCount: 1,
+      iosOrIgnorableCount: 1,
+    });
+
+    expect(result).toMatchObject({
+      android: false,
+      ios: false,
+      e2eNeeded: false,
+      nativeBuildNeeded: false,
+      runSmartE2ESelection: false,
+    });
+  });
+
+  it('still builds iOS for cherry-pick PRs targeting release/*', () => {
+    const result = computeE2EPlatformFlags({
+      ...baseInput,
+      prBaseRef: 'release/1.0.0',
+      e2eTestFilesCount: 0,
+      e2eTestOrIgnorableCount: 0,
+      androidCount: 1,
+      iosCount: 1,
+      androidOrIgnorableCount: 1,
+      iosOrIgnorableCount: 1,
+    });
+
+    expect(result).toMatchObject({
+      android: true,
+      ios: true,
+      e2eNeeded: true,
+    });
+    expect(result.message).not.toContain('iOS build disabled');
+  });
+
+  it('keys the main-PR iOS suppression off the event, not the ref', () => {
+    const result = computeE2EPlatformFlags({
+      ...baseInput,
+      githubEventName: 'push',
+      prBaseRef: 'main',
+    });
+
+    expect(result.android).toBe(true);
+    expect(result.ios).toBe(true);
+  });
 });
 
 describe('applyE2ELabelOverrides', () => {
@@ -154,23 +242,110 @@ describe('applyE2ELabelOverrides', () => {
     testOnlyChanges: false,
   };
 
-  it('opts into iOS build on Android-only PRs via run-appium-ios-tests', () => {
+  const androidOnlyPathFiltersFor = (prBaseRef: string) => ({
+    githubEventName: 'pull_request',
+    prBaseRef,
+    isFork: false,
+    shouldSkipE2E: false,
+    allChangesCount: 1,
+    ignorableCount: 0,
+    e2eTestFilesCount: 0,
+    e2eTestOrIgnorableCount: 0,
+    e2eWorkflowsCount: 0,
+    androidCount: 1,
+    iosCount: 0,
+    androidOrIgnorableCount: 1,
+    iosOrIgnorableCount: 0,
+  });
+
+  it('opts into iOS build via run-appium-ios-tests on PRs targeting main', () => {
+    const baseFlags = computeE2EPlatformFlags(androidOnlyPathFiltersFor('main'));
+
+    const result = applyE2ELabelOverrides(baseFlags, overrideInput);
+
+    // The label widens to iOS even though path filters selected Android only.
+    expect(result).toMatchObject({
+      android: true,
+      ios: true,
+      e2eNeeded: true,
+      nativeBuildNeeded: true,
+      message: expect.stringContaining('run-appium-ios-tests'),
+    });
+  });
+
+  it('opts into iOS build via skip-smart-e2e-selection when path filters selected iOS', () => {
     const baseFlags = computeE2EPlatformFlags({
-      githubEventName: 'pull_request',
-      isFork: false,
-      shouldSkipE2E: false,
-      allChangesCount: 1,
-      ignorableCount: 0,
-      e2eTestFilesCount: 0,
-      e2eTestOrIgnorableCount: 0,
-      e2eWorkflowsCount: 0,
-      androidCount: 1,
-      iosCount: 0,
-      androidOrIgnorableCount: 1,
-      iosOrIgnorableCount: 0,
+      ...androidOnlyPathFiltersFor('main'),
+      iosCount: 1,
+      iosOrIgnorableCount: 1,
+    });
+
+    const result = applyE2ELabelOverrides(baseFlags, {
+      ...overrideInput,
+      runAppiumIosLabel: false,
+      skipSmartSelection: true,
+    });
+
+    expect(result).toMatchObject({
+      android: true,
+      ios: true,
+      e2eNeeded: true,
+      message: expect.stringContaining('skip-smart-e2e-selection'),
+    });
+  });
+
+  it('keeps skip-smart-e2e-selection non-widening on an Android-only PR into main', () => {
+    const baseFlags = computeE2EPlatformFlags(androidOnlyPathFiltersFor('main'));
+
+    const result = applyE2ELabelOverrides(baseFlags, {
+      ...overrideInput,
+      runAppiumIosLabel: false,
+      skipSmartSelection: true,
+    });
+
+    // Path filters deliberately skipped iOS, so the ALL-tags label must not add
+    // the platform back.
+    expect(result).toMatchObject({ android: true, ios: false, e2eNeeded: true });
+    expect(result.message).not.toContain('skip-smart-e2e-selection');
+  });
+
+  it('restores Smart E2E selection when a label revives an iOS-only PR into main', () => {
+    const baseFlags = computeE2EPlatformFlags({
+      ...androidOnlyPathFiltersFor('main'),
+      androidCount: 0,
+      androidOrIgnorableCount: 0,
+      iosCount: 1,
+      iosOrIgnorableCount: 1,
+    });
+
+    // Suppressed all the way down to no platforms, which turns Smart E2E off.
+    expect(baseFlags).toMatchObject({
+      android: false,
+      ios: false,
+      e2eNeeded: false,
+      runSmartE2ESelection: false,
     });
 
     const result = applyE2ELabelOverrides(baseFlags, overrideInput);
+
+    expect(result).toMatchObject({
+      android: false,
+      ios: true,
+      e2eNeeded: true,
+      nativeBuildNeeded: true,
+      runSmartE2ESelection: true,
+    });
+  });
+
+  it('opts into iOS build on Android-only release/* PRs via run-appium-ios-tests', () => {
+    const baseFlags = computeE2EPlatformFlags(
+      androidOnlyPathFiltersFor('release/1.0.0'),
+    );
+
+    const result = applyE2ELabelOverrides(baseFlags, {
+      ...overrideInput,
+      prBaseRef: 'release/1.0.0',
+    });
 
     expect(result).toMatchObject({
       android: true,
@@ -221,8 +396,11 @@ describe('resolveE2EPlatformRequirements', () => {
     testOnlyChanges: false,
   };
 
+  // prBaseRef mirrors eligibleLabelInput — the GitHub Actions entrypoint passes
+  // the same base ref to both the path-filter and label-override stages.
   const androidOnlyPathFilters = {
     githubEventName: 'pull_request',
+    prBaseRef: 'main',
     isFork: false,
     shouldSkipE2E: false,
     allChangesCount: 1,
@@ -252,7 +430,7 @@ describe('resolveE2EPlatformRequirements', () => {
     });
   });
 
-  it('enables Appium iOS smoke when skip-smart-e2e-selection is applied and path filters require iOS', () => {
+  it('enables the iOS build and Appium iOS smoke on a main PR via skip-smart-e2e-selection', () => {
     const result = resolveE2EPlatformRequirements({
       pathFilterInput: {
         ...androidOnlyPathFilters,
@@ -269,6 +447,91 @@ describe('resolveE2EPlatformRequirements', () => {
       android: true,
       ios: true,
       runAppiumIos: true,
+    });
+  });
+
+  it('does not enable the iOS build on a main PR when nothing requests iOS', () => {
+    const result = resolveE2EPlatformRequirements({
+      pathFilterInput: {
+        ...androidOnlyPathFilters,
+        androidCount: 1,
+        iosCount: 1,
+        androidOrIgnorableCount: 1,
+        iosOrIgnorableCount: 1,
+      },
+      labelOverrideInput: eligibleLabelInput,
+    });
+
+    expect(result).toMatchObject({
+      android: true,
+      ios: false,
+      runAppiumIos: false,
+    });
+  });
+
+  // Stakeholder constraint: never build the iOS app unless iOS E2E will run.
+  // On PRs into main both are driven by the same two opt-ins, so they must be
+  // equal in every combination.
+  it.each([
+    ['nothing requested', { runAppiumIosLabel: false, skipSmartSelection: false, iosCount: 1 }],
+    ['run-appium-ios-tests', { runAppiumIosLabel: true, skipSmartSelection: false, iosCount: 1 }],
+    ['skip-smart-e2e-selection with iOS paths', { runAppiumIosLabel: false, skipSmartSelection: true, iosCount: 1 }],
+    ['skip-smart-e2e-selection without iOS paths', { runAppiumIosLabel: false, skipSmartSelection: true, iosCount: 0 }],
+    ['label on an Android-only PR', { runAppiumIosLabel: true, skipSmartSelection: false, iosCount: 0 }],
+    ['smoke-infra changes only', { runAppiumIosLabel: false, skipSmartSelection: false, iosCount: 1, e2eSmokeInfraCount: 4 }],
+  ])(
+    'keeps the iOS build and Appium iOS run in lockstep on a main PR (%s)',
+    (_label, { runAppiumIosLabel, skipSmartSelection, iosCount, e2eSmokeInfraCount = 0 }) => {
+      const result = resolveE2EPlatformRequirements({
+        pathFilterInput: {
+          ...androidOnlyPathFilters,
+          iosCount,
+          iosOrIgnorableCount: iosCount,
+        },
+        labelOverrideInput: { ...eligibleLabelInput, runAppiumIosLabel },
+        skipSmartSelection,
+        e2eSmokeInfraCount,
+      });
+
+      expect(result.ios).toBe(result.runAppiumIos);
+    },
+  );
+
+  it('enables Appium iOS smoke on release/* PRs when skip-smart-e2e-selection is applied and path filters require iOS', () => {
+    const result = resolveE2EPlatformRequirements({
+      pathFilterInput: {
+        ...androidOnlyPathFilters,
+        prBaseRef: 'release/1.0.0',
+        androidCount: 1,
+        iosCount: 1,
+        androidOrIgnorableCount: 1,
+        iosOrIgnorableCount: 1,
+      },
+      labelOverrideInput: {
+        ...eligibleLabelInput,
+        prBaseRef: 'release/1.0.0',
+      },
+      skipSmartSelection: true,
+    });
+
+    expect(result).toMatchObject({
+      android: true,
+      ios: true,
+      runAppiumIos: true,
+    });
+  });
+
+  it('suppresses Appium iOS smoke from smoke-infra changes on PRs targeting main', () => {
+    const result = resolveE2EPlatformRequirements({
+      pathFilterInput: androidOnlyPathFilters,
+      labelOverrideInput: eligibleLabelInput,
+      e2eSmokeInfraCount: 3,
+    });
+
+    expect(result).toMatchObject({
+      android: true,
+      ios: false,
+      runAppiumIos: false,
     });
   });
 

--- a/.github/scripts/run-compute-e2e-platform-flags.cjs
+++ b/.github/scripts/run-compute-e2e-platform-flags.cjs
@@ -72,7 +72,20 @@ const flags = resolveE2EPlatformRequirements({
   e2eSmokeInfraCount: readInt(process.env.E2E_SMOKE_INFRA_COUNT),
 });
 
-if (labelOverrideInput.runAppiumIosLabel) {
+const runAppiumIos = flags.runAppiumIos;
+
+// Only explain a run that is actually happening — flags.runAppiumIos is the
+// resolved value, and it is always false for PRs into main.
+if (!runAppiumIos) {
+  if (
+    labelOverrideInput.githubEventName === 'pull_request' &&
+    labelOverrideInput.prBaseRef === 'main'
+  ) {
+    console.log(
+      '-> RUN_APPIUM_IOS=false — iOS not requested for this PR into main. Add run-appium-ios-tests, or skip-smart-e2e-selection when path filters already require iOS.',
+    );
+  }
+} else if (labelOverrideInput.runAppiumIosLabel) {
   console.log(
     "-> RUN_APPIUM_IOS=true due to 'run-appium-ios-tests' label on PR",
   );
@@ -85,8 +98,6 @@ if (labelOverrideInput.runAppiumIosLabel) {
     '-> RUN_APPIUM_IOS=true due to e2e smoke infra changes (page-objects/selectors/locators/framework/smoke-appium)',
   );
 }
-
-const runAppiumIos = flags.runAppiumIos;
 
 let blockMerge = false;
 if (readBool(process.env.LABEL_BLOCKS_MERGE) && !ignorableOnly) {

--- a/.github/scripts/run-compute-e2e-platform-flags.test.ts
+++ b/.github/scripts/run-compute-e2e-platform-flags.test.ts
@@ -1,0 +1,260 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const ENTRYPOINT = path.join(
+  __dirname,
+  'run-compute-e2e-platform-flags.cjs',
+);
+
+/**
+ * Parse a GITHUB_OUTPUT file, including `key<<DELIMITER` heredoc blocks.
+ */
+function parseGithubOutput(raw: string): Record<string, string> {
+  const outputs: Record<string, string> = {};
+  const lines = raw.split('\n');
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!line) {
+      continue;
+    }
+
+    const heredoc = /^([^=<]+)<<(.+)$/u.exec(line);
+    if (heredoc) {
+      const [, key, delimiter] = heredoc;
+      const collected: string[] = [];
+      index += 1;
+      while (index < lines.length && lines[index] !== delimiter) {
+        collected.push(lines[index]);
+        index += 1;
+      }
+      outputs[key] = collected.join('\n');
+      continue;
+    }
+
+    const separator = line.indexOf('=');
+    if (separator > 0) {
+      outputs[line.slice(0, separator)] = line.slice(separator + 1);
+    }
+  }
+
+  return outputs;
+}
+
+/**
+ * Run the entrypoint in a child process with a controlled environment.
+ *
+ * The env is built from scratch rather than inheriting `process.env` — this
+ * suite runs inside GitHub Actions, where ambient `GITHUB_*` variables would
+ * otherwise leak in and make the scenarios non-deterministic.
+ */
+function runEntrypoint(scenarioEnv: Record<string, string>) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-flags-'));
+  const outputPath = path.join(tempDir, 'github-output');
+  fs.writeFileSync(outputPath, '');
+
+  const result = spawnSync(process.execPath, [ENTRYPOINT], {
+    encoding: 'utf8',
+    env: {
+      PATH: process.env.PATH ?? '',
+      HOME: process.env.HOME ?? '',
+      GITHUB_OUTPUT: outputPath,
+      ...scenarioEnv,
+    },
+  });
+
+  const outputs = parseGithubOutput(fs.readFileSync(outputPath, 'utf8'));
+  fs.rmSync(tempDir, { recursive: true, force: true });
+
+  return { status: result.status, stdout: result.stdout ?? '', outputs };
+}
+
+const bothPlatformsPR = {
+  ALL_CHANGES_COUNT: '1',
+  IGNORABLE_COUNT: '0',
+  E2E_TEST_FILES_COUNT: '0',
+  E2E_TEST_OR_IGNORABLE_COUNT: '0',
+  E2E_WORKFLOWS_COUNT: '0',
+  ANDROID_COUNT: '1',
+  IOS_COUNT: '1',
+  ANDROID_OR_IGNORABLE_COUNT: '1',
+  IOS_OR_IGNORABLE_COUNT: '1',
+};
+
+const androidOnlyPR = {
+  ...bothPlatformsPR,
+  IOS_COUNT: '0',
+  IOS_OR_IGNORABLE_COUNT: '0',
+};
+
+describe('run-compute-e2e-platform-flags entrypoint', () => {
+  describe('pull requests targeting main', () => {
+    it('emits ios_final=false and explains the suppression exactly once', () => {
+      const { status, stdout, outputs } = runEntrypoint({
+        GITHUB_EVENT_NAME: 'pull_request',
+        PR_BASE_REF: 'main',
+        ...bothPlatformsPR,
+      });
+
+      expect(status).toBe(0);
+      expect(outputs).toMatchObject({
+        android_final: 'true',
+        ios_final: 'false',
+        e2e_needed: 'true',
+        native_build_needed: 'true',
+        run_appium_ios: 'false',
+      });
+      expect(stdout).toContain('iOS not requested for a PR into main');
+      expect(stdout).toContain(
+        '-> RUN_APPIUM_IOS=false — iOS not requested for this PR into main.',
+      );
+      // The log must never contradict the emitted output.
+      expect(stdout).not.toContain('RUN_APPIUM_IOS=true');
+    });
+
+    it('builds iOS and runs Appium iOS when run-appium-ios-tests is applied', () => {
+      const { stdout, outputs } = runEntrypoint({
+        GITHUB_EVENT_NAME: 'pull_request',
+        PR_BASE_REF: 'main',
+        RUN_APPIUM_IOS_LABEL: 'true',
+        ...androidOnlyPR,
+      });
+
+      // The label widens to iOS even on an Android-only PR.
+      expect(outputs).toMatchObject({
+        android_final: 'true',
+        ios_final: 'true',
+        run_appium_ios: 'true',
+        native_build_needed: 'true',
+      });
+      expect(stdout).toContain(
+        "-> RUN_APPIUM_IOS=true due to 'run-appium-ios-tests' label on PR",
+      );
+    });
+
+    it('builds iOS and runs Appium iOS when skip-smart-e2e-selection is applied and paths require iOS', () => {
+      const { stdout, outputs } = runEntrypoint({
+        GITHUB_EVENT_NAME: 'pull_request',
+        PR_BASE_REF: 'main',
+        SKIP_SMART_SELECTION: 'true',
+        ...bothPlatformsPR,
+      });
+
+      expect(outputs).toMatchObject({
+        android_final: 'true',
+        ios_final: 'true',
+        run_appium_ios: 'true',
+      });
+      expect(stdout).toContain(
+        "-> RUN_APPIUM_IOS=true due to 'skip-smart-e2e-selection' label on PR (iOS already required by path filters)",
+      );
+    });
+
+    it('keeps skip-smart-e2e-selection non-widening on an Android-only PR', () => {
+      const { stdout, outputs } = runEntrypoint({
+        GITHUB_EVENT_NAME: 'pull_request',
+        PR_BASE_REF: 'main',
+        SKIP_SMART_SELECTION: 'true',
+        ...androidOnlyPR,
+      });
+
+      expect(outputs).toMatchObject({
+        android_final: 'true',
+        ios_final: 'false',
+        run_appium_ios: 'false',
+      });
+      expect(stdout).not.toContain('RUN_APPIUM_IOS=true');
+    });
+
+    it('does not claim an Appium iOS run for smoke-infra changes', () => {
+      const { stdout, outputs } = runEntrypoint({
+        GITHUB_EVENT_NAME: 'pull_request',
+        PR_BASE_REF: 'main',
+        E2E_SMOKE_INFRA_COUNT: '3',
+        ...androidOnlyPR,
+      });
+
+      expect(outputs.run_appium_ios).toBe('false');
+      expect(outputs.ios_final).toBe('false');
+      expect(stdout).not.toContain('RUN_APPIUM_IOS=true');
+    });
+
+    it('leaves no E2E to run for an iOS-only PR', () => {
+      const { outputs } = runEntrypoint({
+        GITHUB_EVENT_NAME: 'pull_request',
+        PR_BASE_REF: 'main',
+        ...bothPlatformsPR,
+        ANDROID_COUNT: '0',
+        ANDROID_OR_IGNORABLE_COUNT: '0',
+      });
+
+      expect(outputs).toMatchObject({
+        android_final: 'false',
+        ios_final: 'false',
+        e2e_needed: 'false',
+        native_build_needed: 'false',
+        run_smart_e2e_selection: 'false',
+        run_appium_ios: 'false',
+      });
+    });
+  });
+
+  describe('pull requests targeting release/*', () => {
+    it('still opts into iOS and Appium iOS via run-appium-ios-tests', () => {
+      const { stdout, outputs } = runEntrypoint({
+        GITHUB_EVENT_NAME: 'pull_request',
+        PR_BASE_REF: 'release/1.0.0',
+        RUN_APPIUM_IOS_LABEL: 'true',
+        ...androidOnlyPR,
+      });
+
+      expect(outputs).toMatchObject({
+        android_final: 'true',
+        ios_final: 'true',
+        run_appium_ios: 'true',
+      });
+      expect(stdout).toContain(
+        "-> RUN_APPIUM_IOS=true due to 'run-appium-ios-tests' label on PR",
+      );
+      expect(stdout).not.toContain('iOS build disabled for PRs into main');
+    });
+
+    it('still enables Appium iOS via skip-smart-e2e-selection when paths require iOS', () => {
+      const { stdout, outputs } = runEntrypoint({
+        GITHUB_EVENT_NAME: 'pull_request',
+        PR_BASE_REF: 'release/1.0.0',
+        SKIP_SMART_SELECTION: 'true',
+        ...bothPlatformsPR,
+      });
+
+      expect(outputs).toMatchObject({
+        android_final: 'true',
+        ios_final: 'true',
+        run_appium_ios: 'true',
+      });
+      expect(stdout).toContain(
+        "-> RUN_APPIUM_IOS=true due to 'skip-smart-e2e-selection' label on PR (iOS already required by path filters)",
+      );
+    });
+  });
+
+  describe('non-pull-request events', () => {
+    it('builds both platforms on a push and emits no main-PR suppression log', () => {
+      const { stdout, outputs } = runEntrypoint({
+        GITHUB_EVENT_NAME: 'push',
+        ...bothPlatformsPR,
+      });
+
+      expect(outputs).toMatchObject({
+        android_final: 'true',
+        ios_final: 'true',
+        e2e_needed: 'true',
+        run_appium_ios: 'false',
+      });
+      expect(stdout).not.toContain('iOS build disabled for PRs into main');
+      expect(stdout).not.toContain('RUN_APPIUM_IOS=true');
+    });
+  });
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1526,6 +1526,13 @@ jobs:
 
   build-ios-apps:
     name: 'Build iOS Apps'
+    # PRs into main do not build iOS from path filters alone — it has to be
+    # requested with run-appium-ios-tests, or with skip-smart-e2e-selection when
+    # path filters already require iOS. Both opt-ins are resolved into
+    # ios_e2e_needed by .github/scripts/compute-e2e-platform-flags.cjs, which also
+    # keeps ios_e2e_needed and run_appium_ios equal on those PRs so the app is
+    # only built when iOS E2E will actually run. Pushes to main/release/*, the
+    # nightly schedule, and PRs into release/* are unaffected.
     if: >-
       ${{
         !cancelled() &&
@@ -1662,6 +1669,10 @@ jobs:
     secrets: inherit
 
   # Fixture validation — ensures committed E2E fixtures match the live app state schema
+  # Runs on iOS only, so on PRs into main it runs only when iOS was requested via
+  # run-appium-ios-tests or skip-smart-e2e-selection. It still runs on PRs into
+  # release/* that build iOS. Moving this to Android would make it unconditional
+  # on PRs again — tracked separately.
   validate-e2e-fixtures:
     name: 'Validate E2E Fixtures'
     if: >-

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -15,7 +15,7 @@ on:
         description: 'Whether Android E2E tests and builds should run (true when Android-specific or shared files changed)'
         value: ${{ jobs.detect-changes.outputs.android_e2e_needed }}
       ios_e2e_needed:
-        description: 'Whether iOS E2E tests and builds should run (true when iOS-specific or shared files changed)'
+        description: 'Whether iOS E2E tests and builds should run (true when iOS-specific or shared files changed). On pull requests targeting main, path filters alone never enable it — iOS must be requested via the run-appium-ios-tests label, or via skip-smart-e2e-selection when path filters already require iOS. It then matches run_appium_ios, so the app is only built when iOS E2E will run.'
         value: ${{ jobs.detect-changes.outputs.ios_e2e_needed }}
       changed_spec_files:
         description: 'Space-separated list of changed E2E spec file paths only — never the full changed-file list, which overflows ARG_MAX and kills this job on large PRs. Smoke test workflows use this to run modified spec files twice for flakiness detection (catches flaky tests before they land on main)'
@@ -30,7 +30,7 @@ on:
         description: 'Whether performance E2E tests should be forced to run via the run-performance-tests PR label'
         value: ${{ jobs.detect-changes.outputs.run_performance }}
       run_appium_ios:
-        description: 'Whether Appium iOS smoke tests should also run on an eligible PR via the run-appium-ios-tests label (also opts into the iOS native build on Android-only PRs), skip-smart-e2e-selection when path filters require iOS, or e2e smoke infra / smoke-appium file changes'
+        description: 'Whether Appium iOS smoke tests should also run on an eligible PR via the run-appium-ios-tests label (also opts into the iOS native build on Android-only PRs), skip-smart-e2e-selection when path filters require iOS, or e2e smoke infra / smoke-appium file changes. Always false when no iOS app is built. The smoke-infra trigger applies to release/* PRs only; on PRs targeting main this equals ios_e2e_needed.'
         value: ${{ jobs.detect-changes.outputs.run_appium_ios }}
       native_build_needed:
         description: 'Whether fresh iOS/Android native E2E builds are required. False when only E2E/performance test files changed — CI reuses main branch builds instead.'

--- a/docs/testing/appium-smoke-testing.md
+++ b/docs/testing/appium-smoke-testing.md
@@ -10,7 +10,7 @@ Appium smoke is the mobile E2E path (Playwright + Appium). Specs live under `tes
 | **Build**               | **main-e2e release** (`HAS_TEST_OVERRIDES=true`)       |
 | **Local yarn commands** | `yarn appium-smoke:ios` / `yarn appium-smoke:android`  |
 
-Appium iOS on PRs remains opt-in via `run-appium-ios-tests` or when shared smoke infra / `tests/smoke-appium/**` paths change (see [E2E decision tree](../.github/guidelines/E2E_DECISION_TREE.md)). Dual-framework imports are ESLint errors: [tests/AGENTS.md](../tests/AGENTS.md).
+On PRs into `main`, iOS is built and Appium iOS runs **only on request** — add `run-appium-ios-tests`, or `skip-smart-e2e-selection` when path filters already require iOS. Path filters and smoke-infra changes alone do not trigger it, and the app is never built unless it will be tested. On PRs into `release/*` the older policy still applies: opt in via `run-appium-ios-tests`, via `skip-smart-e2e-selection` when path filters already require iOS, or when shared smoke infra / `tests/smoke-appium/**` paths change. Unrequested iOS coverage comes from pushes to `main`/`release/*` and the overnight schedule (see [E2E decision tree](../../.github/guidelines/E2E_DECISION_TREE.md#ios-builds-on-prs-into-main-are-on-request-only)). Dual-framework imports are ESLint errors: [tests/AGENTS.md](../../tests/AGENTS.md).
 
 ## Architecture
 
@@ -233,7 +233,7 @@ CI uploads per-suite artifacts as `appium-smoke-report-<suite>`, `appium-timings
 ## CI
 
 - **Build:** `build` workflow produces `main-e2e-MetaMask.app` and `main-e2e-release.apk`.
-- **Tests:** `appium-smoke-tests-ios` / `appium-smoke-tests-android` in PR CI (see [E2E decision tree](../../.github/guidelines/E2E_DECISION_TREE.md)).
+- **Tests:** `appium-smoke-tests-android` in PR CI; `appium-smoke-tests-ios` on pushes to `main`/`release/*`, the overnight schedule, opted-in `release/*` PRs, and PRs into `main` only when iOS was requested by label (see [E2E decision tree](../../.github/guidelines/E2E_DECISION_TREE.md#ios-builds-on-prs-into-main-are-on-request-only)).
 - **Reusable job:** `.github/workflows/run-appium-e2e-workflow.yml` — selects specs per fixed `split`/`total_splits` via `e2e-split-tags-shards.mjs` (qa-stats timing bin-pack when available), then runs Playwright with `--grep` and those files.
 - **Seedless:** `SmokeSeedlessOnboarding` uses **2** shards per platform (thin keep list in `tests/smoke-appium/seedless/`). Smart E2E selects this tag from `tests/tags.js` — prefer CV/unit for Account Already Exists, attribution props, and Import SRP UI.
 


### PR DESCRIPTION
## **Description**

Pull requests targeting `main` no longer build the iOS app from path filters alone. iOS must be **requested**, and there are exactly two ways to do it:

| Request | Effect |
| --- | --- |
| `run-appium-ios-tests` label | Builds iOS and runs Appium iOS, **even when path filters selected Android only**. Widening is this label's purpose. |
| `skip-smart-e2e-selection` label | Builds iOS and runs the full `ALL` tag set, **but only when path filters already selected iOS**. This label expands the tag set, not the platform list, so it never adds a platform path filters deliberately skipped. |

Nothing else opts in. Notably, shared smoke/Appium infrastructure changes no longer pull an iOS build into a `main` PR the way they still do on `release/*`.

**The app is only built when iOS E2E will actually run.** On PRs into `main`, `ios_e2e_needed` and `run_appium_ios` are driven by the same two requests, so they are always equal — CI never spends a macOS build on an app nothing will test. A parameterised test asserts `ios === runAppiumIos` across every combination.

Everything outside PRs into `main` is deliberately untouched:

| Trigger | iOS build | Appium iOS |
| --- | --- | --- |
| PR → `main`, no label | ❌ not built | ❌ not run |
| PR → `main` + `run-appium-ios-tests` | ✅ built (widens) | ✅ runs |
| PR → `main` + `skip-smart-e2e-selection` | ✅ built if paths selected iOS | ✅ runs, `ALL` tags |
| PR → `release/*` | ✅ unchanged (Android-first; label / paths / smoke-infra) | ✅ unchanged |
| PR → `stable` | unchanged (no E2E — sync only) | unchanged |
| Push to `main` / `release/*` | ✅ unchanged | ✅ unchanged (`ALL` tags) |
| Overnight schedule on `main` | ✅ unchanged | ✅ unchanged |
| `merge_group` | unchanged (no E2E) | unchanged |

### Implementation

`.github/scripts/compute-e2e-platform-flags.cjs` is the single source of truth for `ios_e2e_needed`:

- `computeE2EPlatformFlags` drops iOS for `pull_request` + base `main`, and returns `iosByPathFilters` recording what path filters chose before the suppression erased it — the non-widening rule needs that value after the fact.
- `applyE2ELabelOverrides` takes `skipSmartSelection`, resolves which of the two requests fired, and reports it in the message. It also restores `runSmartE2ESelection`: an iOS-only PR into `main` is suppressed down to no platforms, which turns Smart E2E off, so reviving iOS has to revive selection too. That could not happen before, because the old override only fired when E2E was already needed for Android.
- `resolveRunAppiumIos` gained an early `!flags.ios` return. This enforces the build⟺run invariant from the other side, and fixes a latent inconsistency where the label or a smoke-infra change could report `run_appium_ios=true` while no iOS app existed.

`build-ios-apps` in `ci.yml` keeps gating purely on `ios_e2e_needed`. Both requests are already resolved into that flag, so a second base-ref gate in the workflow would have to duplicate the label logic to stay correct — the decision belongs in one place.

### Consequences (deliberately accepted)

1. **An unlabelled PR touching only iOS files runs no E2E at all.** The "E2E iOS only" path yields no platforms, which also turns off `native_build_needed` and Smart E2E Selection. Adding either label restores iOS *and* Smart E2E Selection.
2. **`validate-e2e-fixtures` only runs on a `main` PR when iOS was requested.** It is iOS-only and PR-only. It still runs unconditionally on PRs into `release/*` that build iOS. Repointing it at Android would make it unconditional again — worth a follow-up, flagged in a comment on the job.
3. **Reviewer note, out of scope here:** PRs into `release/*` still violate the "only build when iOS E2E will run" principle. A release PR whose path filters select iOS builds the app while `run_appium_ios` stays false, so only fixture validation consumes it. Aligning that would change release behaviour, which the "feature branches only" scope explicitly excludes — raising it rather than changing it silently.

`check-all-jobs-pass` already treats skipped `build-ios-apps` / `appium-smoke-tests-ios` as an allowed skip via its `e2e-job-regex`, so the aggregate gate is unaffected.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: no ticket — CI cost/capacity change requested directly. Reverting the single commit fully restores the previous behaviour.

## **Manual testing steps**

### 1. Unit tests (fast, proves the whole decision matrix)

```bash
yarn jest .github/scripts/compute-e2e-platform-flags.test.ts .github/scripts/run-compute-e2e-platform-flags.test.ts
```

Expect **41 passed**. The ones worth reading:

- `opts into iOS build via run-appium-ios-tests on PRs targeting main` — the widening request.
- `opts into iOS build via skip-smart-e2e-selection when path filters selected iOS` — the non-widening request.
- `keeps skip-smart-e2e-selection non-widening on an Android-only PR into main` — proves it does **not** add a platform path filters skipped.
- `keeps the iOS build and Appium iOS run in lockstep on a main PR (...)` — 6 parameterised cases asserting `ios === runAppiumIos`, i.e. the "only build when iOS E2E will run" constraint.
- `restores Smart E2E selection when a label revives an iOS-only PR into main` — the suppress-to-nothing-then-revive edge case.
- `still builds iOS for cherry-pick PRs targeting release/*` — the `release/*` regression guard.

### 2. This PR's own CI run — the unrequested path ⚠️ read this first

This PR targets `main` and edits `.github/workflows/ci.yml` + `get-requirements.yml`, both in `e2e_relevant_workflows`, so path filters land on "E2E for both platforms". With no iOS label applied, iOS should be dropped.

**First remove the `pr-not-ready-for-e2e` label.** It was auto-applied on open (created inside the 13:00–17:00 UTC window). While present, *all* E2E is skipped and merge is blocked — you would see "iOS skipped" for the wrong reason and prove nothing. The giveaway is `Build Android APKs` being skipped too. Removing the label re-triggers CI.

Then on the `ci` run, confirm:

**a. `Get workflow and job requirements` → `Compute E2E flags` log**

```
E2E for both platforms — iOS not requested for a PR into main (add run-appium-ios-tests or skip-smart-e2e-selection)
-> RUN_APPIUM_IOS=false — iOS not requested for this PR into main. Add run-appium-ios-tests, or skip-smart-e2e-selection when path filters already require iOS.
```

with outputs `android_final=true`, `ios_final=false`, `native_build_needed=true`, `run_appium_ios=false`.

**b. Job outcomes**

| Job | Expected |
| --- | --- |
| `Build iOS Apps` | **skipped** |
| `iOS Tests Ready` / `Appium Smoke Tests (iOS)` | skipped |
| `Validate E2E Fixtures` | skipped (consequence #2) |
| `Build Android APKs` | runs and passes |
| `Appium Smoke Tests (Android)` | runs with `ALL` tags (workflow-change hard rule) |
| `Check workflows` | passes — the `actionlint` 1.7.1 gate on the `ci.yml` edit |
| `Check all jobs pass` | **success**, skipped iOS jobs shown as "skipped E2E jobs are allowed" |

No macOS/iOS runner minutes on this run is the headline result.

### 3. Verify both requests actually work — on this same PR

This is the new behaviour and the part most worth checking by hand. Do them one at a time; each label change re-triggers CI automatically.

**3a. `run-appium-ios-tests`**

```bash
gh pr edit 35329 --add-label run-appium-ios-tests
```

Expect `ios_final=true`, `run_appium_ios=true`, `Build iOS Apps` **runs**, `Appium Smoke Tests (iOS)` **runs**, and the log line `-> RUN_APPIUM_IOS=true due to 'run-appium-ios-tests' label on PR`. Then remove it:

```bash
gh pr edit 35329 --remove-label run-appium-ios-tests
```

**3b. `skip-smart-e2e-selection`**

```bash
gh pr edit 35329 --add-label skip-smart-e2e-selection
```

This PR's path filters do select iOS, so expect `ios_final=true`, `run_appium_ios=true`, `Build iOS Apps` **runs**, and `-> RUN_APPIUM_IOS=true due to 'skip-smart-e2e-selection' label on PR (iOS already required by path filters)`. Remove it afterwards.

**3c. Non-widening check (optional, needs a scratch PR)**

On a PR touching **only** `android/**`, `skip-smart-e2e-selection` must *not* build iOS, while `run-appium-ios-tests` must. Unit tests cover both; a scratch PR is the end-to-end proof if you want it.

### 4. Confirm `release/*` is genuinely untouched (the "only!" half)

Open a throwaway draft PR from this branch into the active RC and confirm the mirror image:

```bash
git fetch origin
git branch -r --list 'origin/release/*' | tail -3          # pick the active RC
gh pr create --draft --base release/<X.Y.Z> \
  --head ci/drop-ios-build-feature-branch-prs \
  --title "test: verify iOS still builds on release PRs (do not merge)"
```

Expect `ios_final=true` and `Build iOS Apps` **running with no labels at all** — on `release/*`, path filters selecting iOS are still sufficient. Close it without merging. If iOS is skipped there, this PR is wrong; do not approve.

### 5. Optional local probe of the pure decision logic

No CI needed — the module is dependency-free CommonJS:

```bash
node -e '
const { resolveE2EPlatformRequirements } = require("./.github/scripts/compute-e2e-platform-flags.cjs");
const paths = (prBaseRef, iosCount) => ({ githubEventName: "pull_request", prBaseRef, isFork: false,
  shouldSkipE2E: false, allChangesCount: 1, ignorableCount: 0, e2eTestFilesCount: 0,
  e2eTestOrIgnorableCount: 0, e2eWorkflowsCount: 0, androidCount: 1, iosCount,
  androidOrIgnorableCount: 1, iosOrIgnorableCount: iosCount });
const labels = (prBaseRef, runAppiumIosLabel) => ({ runAppiumIosLabel, githubEventName: "pull_request",
  prBaseRef, isFork: false, shouldSkipE2E: false, ignorableOnly: false, testOnlyChanges: false });
const show = (d, ref, iosPaths, label, skipSmart) => {
  const r = resolveE2EPlatformRequirements({ pathFilterInput: paths(ref, iosPaths),
    labelOverrideInput: labels(ref, label), skipSmartSelection: skipSmart });
  console.log(d.padEnd(46), "ios:", String(r.ios).padEnd(5), "appiumIos:", String(r.runAppiumIos).padEnd(5),
    "lockstep:", r.ios === r.runAppiumIos);
};
show("main, iOS paths, no label",        "main", 1, false, false);
show("main, iOS paths, ios label",       "main", 1, true,  false);
show("main, iOS paths, skip-smart",      "main", 1, false, true);
show("main, android-only, skip-smart",   "main", 0, false, true);
show("main, android-only, ios label",    "main", 0, true,  false);
show("release, iOS paths, no label",     "release/1.0.0", 1, false, false);'
```

Expect `lockstep: true` on every `main` row, iOS off only on the two unrequested/non-widening `main` rows, and the `release` row building iOS with no label.

### 6. Post-merge watch

The push-to-`main` path cannot be exercised from a PR. After merge, confirm the first `ci` run on `main` still **builds iOS** and runs `Appium Smoke Tests (iOS)` with `ALL` tags. If not, revert — that would mean iOS coverage was lost entirely rather than only becoming opt-in on feature-branch PRs.

### What I ran locally

`yarn jest` on both suites → **41 passed**. `yarn format:check` → clean. Both changed workflows parse as YAML. `actionlint` 1.7.1 has validated the workflow edits via this PR's own `Check workflows` job; I did not run `actionlint` locally, so step 2b relies on that job. I also mutation-tested the entrypoint suite by reverting its log gating — 3 of 7 tests caught it, so those assertions have teeth. The changed scripts sit under `.github/`, which ESLint ignores by default, so `yarn lint` does not cover them.

## **Screenshots/Recordings**

N/A — CI configuration change with no user-facing surface. The evidence is the job-outcome table in step 2b and the `Compute E2E flags` step log.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Not applicable: CI-only change, no app code touched. Android E2E on this PR's own run is the equivalent signal.
- [x] I've tested with a power user scenario
  - Not applicable: no app code paths changed.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Not applicable: no runtime code changed.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CI gating for iOS E2E and shifts some iOS validation from PRs to post-merge on main, but release branches and push/schedule coverage are preserved and behavior is heavily unit-tested.
> 
> **Overview**
> **PRs targeting `main` no longer build iOS or run Appium iOS from path filters alone.** Cross-platform or shared changes run **Android E2E only** unless iOS is explicitly requested. Pushes to `main`/`release/*`, the overnight schedule, and PRs into `release/*` keep the previous behavior.
> 
> **Two labels opt into iOS on `main` PRs:** `run-appium-ios-tests` (builds iOS and runs Appium even on Android-only path selection), and `skip-smart-e2e-selection` (builds iOS and runs full `ALL` tags **only** when path filters already selected iOS—it does not widen platforms). Shared smoke/Appium infra changes no longer trigger iOS on `main` PRs (they still can on `release/*`).
> 
> **Implementation** centers on `compute-e2e-platform-flags.cjs`: `computeE2EPlatformFlags` strips iOS for `pull_request` + base `main` while preserving `iosByPathFilters`; `applyE2ELabelOverrides` restores iOS from those labels and re-enables Smart E2E when an iOS-only PR was suppressed to zero platforms; `resolveRunAppiumIos` returns false when no iOS app will be built so **`ios_e2e_needed` and `run_appium_ios` stay aligned on `main` PRs**. `build-ios-apps` still gates on `ios_e2e_needed`; `validate-e2e-fixtures` only runs on `main` PRs when iOS was requested.
> 
> Docs (`E2E_DECISION_TREE`, labeling guidelines, Appium smoke doc) and workflow output descriptions are updated. Coverage includes expanded unit tests plus a new entrypoint test suite for `run-compute-e2e-platform-flags.cjs`.
> 
> **Accepted tradeoff:** unlabelled `main` PRs that touch only iOS-native paths may run **no E2E** until a label is added; iOS regressions from typical shared-code PRs surface after merge via `main` push CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 086058e7c874d9ecf6772bdde464eff3897d34c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->