### PR TITLE
ci: dual-upload Appium phase timings to GitHub Artifacts

### DIFF
--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -450,9 +450,6 @@ jobs:
           path: tests/test-reports/appium-timings/
           if-no-files-found: ignore
           retention-days: 7
-      # Weekly Appium timings review (and `gh run download`) read these through
-      # the GitHub Artifacts API. Namespace storage is invisible to that API, so
-      # keep this upload on Namespace runs as well as the Namespace-native copy.
       - name: Upload Appium phase timings (GitHub)
         if: ${{ always() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -450,8 +450,11 @@ jobs:
           path: tests/test-reports/appium-timings/
           if-no-files-found: ignore
           retention-days: 7
-      - name: Upload Appium phase timings (current)
-        if: ${{ always() && inputs.runner_provider != 'namespace' }}
+      # Weekly Appium timings review (and `gh run download`) read these through
+      # the GitHub Artifacts API. Namespace storage is invisible to that API, so
+      # keep this upload on Namespace runs as well as the Namespace-native copy.
+      - name: Upload Appium phase timings (GitHub)
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: appium-timings-${{ inputs.test-suite-name }}

--- a/docs/testing/appium-smoke-testing.md
+++ b/docs/testing/appium-smoke-testing.md
@@ -210,14 +210,14 @@ Helpers:
 
 ## Phase timing telemetry
 
-Appium smoke records phase ms via `PhaseTimer` (`servers_start`, soft-reload phases, `login`, `modal_dismissal`, `test_body`, `teardown`). Suites write `tests/test-reports/appium-timings/<suite>.json` (CI artifact `appium-timings-<suite>`). Aggregate with:
+Appium smoke records phase ms via `PhaseTimer` (`servers_start`, soft-reload phases, `login`, `modal_dismissal`, `test_body`, `teardown`). Suites write `tests/test-reports/appium-timings/<suite>.json` (CI artifact `appium-timings-<suite>`). On Namespace runners the same files are also published to GitHub Artifacts so `gh` / the GitHub API can download them. Aggregate with:
 
 ```bash
 yarn appium-smoke:aggregate-timings
 yarn appium-smoke:aggregate-timings -- --input /path/to/timings --markdown /tmp/trend.md
 ```
 
-Report: avg/p95 per phase, slowest shard, retry rate, session-reuse. Compare against timings downloaded from `main` once jobs upload them.
+Report: avg/p95 per phase, slowest shard, retry rate, session-reuse. Compare against timings downloaded from `main` (`gh run download <run> -n appium-timings-<suite>`).
 
 ## Reports and artifacts
 
@@ -228,7 +228,7 @@ Report: avg/p95 per phase, slowest shard, retry rate, session-reuse. Compare aga
 | Failure videos (when enabled) | `test-reports/appium-smoke-videos/`   |
 | Phase timings                 | `test-reports/appium-timings/`        |
 
-CI uploads per-suite artifacts as `appium-smoke-report-<suite>`, `appium-timings-<suite>`, and `appium-smoke-videos-<suite>`.
+CI uploads per-suite artifacts as `appium-smoke-report-<suite>`, `appium-timings-<suite>`, and `appium-smoke-videos-<suite>`. `appium-timings-<suite>` is always published to GitHub Artifacts (plus Namespace storage on Namespace runners).
 
 ## CI
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Namespace Appium smoke jobs were uploading `appium-timings-*` only with `namespace-actions/upload-artifact`. That store is invisible to the GitHub Artifacts API, so `gh run download` and the weekly Appium timings review could not see phase JSON from `main` / Namespace CI.

This keeps the Namespace-store copy for in-run consumers, and always publishes the same files to GitHub Artifacts (`actions/upload-artifact@v4` with `if: always()`), matching the Playwright JSON dual-upload in #35319.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: MMQA-2201

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Appium phase timings on GitHub Artifacts

  Scenario: Namespace Appium smoke publishes GitHub-visible timings
    Given an Appium smoke shard ran with runner_provider namespace
    When the GitHub Artifacts API lists that CI run
    Then an artifact named appium-timings-<suite> exists
    And gh run download can fetch tests/test-reports/appium-timings/*.json
```

N/A to exercise in the mobile app — CI workflow change. Confirm on the next Namespace Appium run after merge (or this PR's own Appium jobs if they run).

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — CI artifact-upload change; no UI.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

N/A — no app runtime change.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2b5023d-4779-4fb9-8559-e4ab14100969?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2b5023d-4779-4fb9-8559-e4ab14100969&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

