### PR TITLE
ci: pass Langfuse secrets to AI PR risk analysis

### DIFF
--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: MetaMask/ai-analyzer
-          ref: 9ff2c43af75a27192a4d9c7ae6da00919391b2fd
+          ref: b493a7c49c0b151c34b613dbf8df873f2f16f726
           path: .ai-analyzer-action
           token: ${{ secrets.AI_ANALYZER_TOKEN }}
 
@@ -48,6 +48,9 @@ jobs:
           add-label: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           litellm-api-key: ${{ secrets.AI_ANALYZER_LITELLM_KEY }}
+          # Opt-in Langfuse tracing (redacted source; host is hardcoded in the analyzer)
+          langfuse-public-key: ${{ secrets.AI_ANALYZER_LANGFUSE_PUBLIC_KEY }}
+          langfuse-secret-key: ${{ secrets.AI_ANALYZER_LANGFUSE_SECRET_KEY }}
           # Gate override for Runway release-branch cherry-picks
           gate-override-risk-threshold: medium
           gate-override-base-pattern: '^release/'

--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: MetaMask/ai-analyzer
-          ref: b493a7c49c0b151c34b613dbf8df873f2f16f726
+          ref: 68870b76360431110ae00b27a0072d3011e6238c
           path: .ai-analyzer-action
           token: ${{ secrets.AI_ANALYZER_TOKEN }}
 


### PR DESCRIPTION
## **Description**

Opt in AI PR risk analysis to Langfuse observability now that [MetaMask/ai-analyzer#42](https://github.com/MetaMask/ai-analyzer/pull/42) has shipped.

The workflow pins `MetaMask/ai-analyzer` to commit `b493a7c49c0b151c34b613dbf8df873f2f16f726` (v2.2.0) so the new Action inputs exist, and forwards the org-level Langfuse keys on the analysis step:

- `langfuse-public-key` ← `secrets.AI_ANALYZER_LANGFUSE_PUBLIC_KEY`
- `langfuse-secret-key` ← `secrets.AI_ANALYZER_LANGFUSE_SECRET_KEY`

Tracing stays off if either secret is empty. Diffs, file bodies, and grep matches are redacted by the analyzer; the Langfuse host is hardcoded there (`https://langfuse.svc.consensys.info`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/ai-analyzer/pull/42

## **Manual testing steps**

N/A — CI workflow only. After merge (or when this PR is marked ready for review):

1. Confirm the **AI PR risk analysis** job checks out `b493a7c49c0b151c34b613dbf8df873f2f16f726`.
2. Confirm the job logs show Langfuse tracing enabled when both org secrets are set.
3. Open the corresponding trace in the MetaMask/ai-analyzer Langfuse project and confirm source is redacted with a link back to the Actions run.

## **Screenshots/Recordings**

### **Before**

N/A — CI workflow change only

### **After**

N/A — CI workflow change only

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change wiring optional observability secrets; no app runtime, auth, or data-path changes.
> 
> **Overview**
> **Opts the AI PR risk analysis workflow into Langfuse tracing** by forwarding org secrets `AI_ANALYZER_LANGFUSE_PUBLIC_KEY` and `AI_ANALYZER_LANGFUSE_SECRET_KEY` to the analyzer action as `langfuse-public-key` and `langfuse-secret-key`. Tracing remains off when either secret is missing; the workflow comment notes that source is redacted in the analyzer and the Langfuse host is fixed there.
> 
> The workflow also **bumps the pinned `MetaMask/ai-analyzer` checkout** from `9ff2c43…` to `68870b76…` so the action supports those inputs (aligned with ai-analyzer Langfuse support).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f35d780b8ab164b88e19f71aa61d55ca9ba37d22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->