### PR TITLE
fix(ramps): move UB2 Buy onto the shared context payment-method call (TRAM-3838) [2/2]

### DIFF
--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.view.test.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.view.test.tsx
@@ -198,10 +198,11 @@ function setupV2Hooks(
   (Engine.context.RampsController.getProviders as jest.Mock)
     .mockReset()
     .mockResolvedValue({ providers });
-  (Engine.context.RampsController.getPaymentMethods as jest.Mock)
+  (Engine.context.RampsController.getPaymentMethodsForContext as jest.Mock)
     .mockReset()
     .mockResolvedValue({
-      payments: [DEBIT_CARD_PAYMENT_METHOD, APPLE_PAY_PAYMENT_METHOD],
+      methods: [DEBIT_CARD_PAYMENT_METHOD, APPLE_PAY_PAYMENT_METHOD],
+      selected: DEBIT_CARD_PAYMENT_METHOD,
     });
 
   const getQuotesMock = Engine.context.RampsController.getQuotes as jest.Mock;

--- a/app/components/UI/Ramp/hooks/useRampsPaymentMethods.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsPaymentMethods.test.ts
@@ -12,9 +12,7 @@ import { rampsPaymentMethodsOptions } from '../queries/paymentMethods';
 notifyManager.setBatchNotifyFunction((callback: () => void) => {
   callback();
 });
-notifyManager.setNotifyFunction((callback) => {
-  act(callback);
-});
+notifyManager.setNotifyFunction(act);
 
 jest.mock('../../../../../locales/i18n', () => ({
   strings: (key: string) => key,
@@ -96,7 +94,13 @@ const baseRampsState = {
 };
 
 type RampsState = typeof baseRampsState;
-type RampsOverrides = Partial<RampsState>;
+// Every slice member is nullable in real controller state, so overrides must be
+// able to clear `selected` even though `baseRampsState` seeds it with a value.
+type RampsOverrides = {
+  [K in keyof RampsState]?: {
+    [P in keyof RampsState[K]]: RampsState[K][P] | null;
+  };
+};
 
 const createMockStore = (rampsControllerOverrides: RampsOverrides = {}) => {
   const initialRampsState = {
@@ -205,27 +209,10 @@ describe('useRampsPaymentMethods', () => {
     });
   });
 
-  it.each([
-    [
-      'region',
-      {
-        userRegion: { ...baseRampsState.userRegion, regionCode: '' },
-      },
-    ],
-    [
-      'asset',
-      {
-        tokens: { ...baseRampsState.tokens, selected: null },
-      },
-    ],
-    [
-      'provider',
-      {
-        providers: { ...baseRampsState.providers, selected: null },
-      },
-    ],
-  ])('is idle when %s is missing', (_label, overrides) => {
-    const store = createMockStore(overrides as RampsOverrides);
+  it('returns idle when no provider is selected', () => {
+    const store = createMockStore({
+      providers: { ...baseRampsState.providers, selected: null },
+    });
     const { Wrapper } = createWrapper(store);
 
     const { result } = renderHook(() => useRampsPaymentMethods(), {
@@ -238,6 +225,7 @@ describe('useRampsPaymentMethods', () => {
       isLoading: false,
       status: 'idle',
       isSuccess: false,
+      error: null,
     });
     expect(getPaymentMethodsForContextMock).not.toHaveBeenCalled();
   });
@@ -606,9 +594,31 @@ describe('useRampsPaymentMethods', () => {
     expect(setSelectedPaymentMethodMock).not.toHaveBeenCalled();
   });
 
-  it('preserves localized circuit-breaker errors', async () => {
+  it('returns error when the request rejects', async () => {
     const store = createMockStore();
     const { Wrapper } = createWrapper(store);
+
+    getPaymentMethodsForContextMock.mockRejectedValue(
+      new Error('Network error'),
+    );
+
+    const { result } = renderHook(() => useRampsPaymentMethods(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error');
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.paymentMethods).toEqual([]);
+  });
+
+  it('returns localized fallback when the payment methods query trips the circuit breaker', async () => {
+    const store = createMockStore();
+    const { Wrapper } = createWrapper(store);
+
     getPaymentMethodsForContextMock.mockRejectedValue(
       Object.assign(
         new Error('Execution prevented because the circuit breaker is open'),
@@ -620,47 +630,100 @@ describe('useRampsPaymentMethods', () => {
       wrapper: Wrapper,
     });
 
-    await waitFor(() => expect(result.current.status).toBe('error'));
+    await waitFor(() => {
+      expect(result.current.status).toBe('error');
+    });
+
     expect(result.current.error).toBe('fiat_on_ramp.circuit_breaker_open');
   });
 
-  it('preserves ordinary request errors', async () => {
-    const store = createMockStore();
+  it('calls Engine.context.RampsController.setSelectedPaymentMethod with full payment method object', () => {
+    const store = createMockStore({
+      providers: { ...baseRampsState.providers, selected: null },
+    });
     const { Wrapper } = createWrapper(store);
-    getPaymentMethodsForContextMock.mockRejectedValue(
-      new Error('Network error'),
-    );
 
     const { result } = renderHook(() => useRampsPaymentMethods(), {
       wrapper: Wrapper,
     });
 
-    await waitFor(() => expect(result.current.status).toBe('error'));
-    expect(result.current.error).toBe('Network error');
+    act(() => {
+      result.current.setSelectedPaymentMethod(mockPaymentMethods[0]);
+    });
+
+    expect(
+      Engine.context.RampsController.setSelectedPaymentMethod,
+    ).toHaveBeenCalledWith(mockPaymentMethods[0]);
   });
 
-  it('keeps the manual setter unchanged', async () => {
-    const store = createMockStore();
+  it('calls Engine.context.RampsController.setSelectedPaymentMethod with null when payment method is null', () => {
+    const store = createMockStore({
+      providers: { ...baseRampsState.providers, selected: null },
+    });
     const { Wrapper } = createWrapper(store);
-    const deferred = createDeferred<ReturnType<typeof contextResponse>>();
-    getPaymentMethodsForContextMock.mockReturnValue(deferred.promise);
+
     const { result } = renderHook(() => useRampsPaymentMethods(), {
       wrapper: Wrapper,
     });
 
-    await act(async () =>
-      result.current.setSelectedPaymentMethod(mockPaymentMethods[0]),
-    );
-
-    expect(setSelectedPaymentMethodMock).toHaveBeenCalledWith(
-      mockPaymentMethods[0],
-    );
-
-    await act(async () => {
-      deferred.resolve(contextResponse());
-      await deferred.promise;
+    act(() => {
+      result.current.setSelectedPaymentMethod(null);
     });
-    await waitFor(() => expect(result.current.status).toBe('success'));
+
+    expect(
+      Engine.context.RampsController.setSelectedPaymentMethod,
+    ).toHaveBeenCalledWith(null);
+  });
+
+  it('setSelectedPaymentMethod is stable across re-renders', async () => {
+    const store = createMockStore();
+    const { Wrapper } = createWrapper(store);
+
+    getPaymentMethodsForContextMock.mockResolvedValue(contextResponse());
+
+    const { result, rerender } = renderHook(() => useRampsPaymentMethods(), {
+      wrapper: Wrapper,
+    });
+
+    const firstRef = result.current.setSelectedPaymentMethod;
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('success');
+    });
+
+    rerender({});
+
+    expect(result.current.setSelectedPaymentMethod).toBe(firstRef);
+  });
+
+  it('disables query when userRegion is missing', () => {
+    const store = createMockStore({
+      userRegion: { ...baseRampsState.userRegion, regionCode: '' },
+    });
+    const { Wrapper } = createWrapper(store);
+
+    const { result } = renderHook(() => useRampsPaymentMethods(), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.isLoading).toBe(false);
+    expect(getPaymentMethodsForContextMock).not.toHaveBeenCalled();
+  });
+
+  it('disables query when no asset is selected', () => {
+    const store = createMockStore({
+      tokens: { ...baseRampsState.tokens, selected: null },
+    });
+    const { Wrapper } = createWrapper(store);
+
+    const { result } = renderHook(() => useRampsPaymentMethods(), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.isLoading).toBe(false);
+    expect(getPaymentMethodsForContextMock).not.toHaveBeenCalled();
   });
 
   it('deduplicates same-key concurrent consumers safely', async () => {

--- a/app/components/UI/Ramp/hooks/useRampsPaymentMethods.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsPaymentMethods.test.ts
@@ -1,11 +1,20 @@
-import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { notifyManager } from '@tanstack/query-core';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import React from 'react';
-import { useRampsPaymentMethods } from './useRampsPaymentMethods';
 import { type PaymentMethod } from '@metamask/ramps-controller';
+import { useRampsPaymentMethods } from './useRampsPaymentMethods';
 import Engine from '../../../../core/Engine';
+import { rampsPaymentMethodsOptions } from '../queries/paymentMethods';
+
+notifyManager.setBatchNotifyFunction((callback: () => void) => {
+  callback();
+});
+notifyManager.setNotifyFunction((callback) => {
+  act(callback);
+});
 
 jest.mock('../../../../../locales/i18n', () => ({
   strings: (key: string) => key,
@@ -15,7 +24,7 @@ jest.mock('../../../../../locales/i18n', () => ({
 jest.mock('../../../../core/Engine', () => ({
   context: {
     RampsController: {
-      getPaymentMethods: jest.fn(),
+      getPaymentMethodsForContext: jest.fn(),
       setSelectedPaymentMethod: jest.fn(),
     },
   },
@@ -37,6 +46,14 @@ const mockPaymentMethods: PaymentMethod[] = [
     icon: 'bank',
   },
 ];
+
+const staleMethod: PaymentMethod = {
+  id: '/payments/stale',
+  paymentType: 'stale',
+  name: 'Stale',
+  score: 0,
+  icon: 'stale',
+};
 
 const baseRampsState = {
   userRegion: {
@@ -71,36 +88,71 @@ const baseRampsState = {
     error: null,
   },
   paymentMethods: {
-    data: [],
-    selected: null,
+    data: [] as PaymentMethod[],
+    selected: null as PaymentMethod | null,
     isLoading: false,
     error: null,
   },
 };
 
-const createMockStore = (rampsControllerOverrides = {}) =>
-  configureStore({
-    reducer: {
-      engine: () => ({
-        backgroundState: {
-          RampsController: {
-            ...baseRampsState,
-            ...rampsControllerOverrides,
+type RampsState = typeof baseRampsState;
+type RampsOverrides = Partial<RampsState>;
+
+const createMockStore = (rampsControllerOverrides: RampsOverrides = {}) => {
+  const initialRampsState = {
+    ...baseRampsState,
+    ...rampsControllerOverrides,
+  };
+  const initialState = {
+    engine: {
+      backgroundState: {
+        RampsController: initialRampsState,
+      },
+    },
+  };
+
+  return configureStore({
+    reducer: (
+      state: typeof initialState | undefined,
+      action: { type: string; payload?: RampsOverrides },
+    ) => {
+      const currentState = state ?? initialState;
+      if (action.type !== 'test/updateRamps' || !action.payload) {
+        return currentState;
+      }
+      return {
+        engine: {
+          backgroundState: {
+            RampsController: {
+              ...currentState.engine.backgroundState.RampsController,
+              ...action.payload,
+            },
           },
         },
-      }),
+      };
     },
   });
+};
+
+const updateRampsState = (
+  store: ReturnType<typeof createMockStore>,
+  payload: RampsOverrides,
+) => {
+  store.dispatch({ type: 'test/updateRamps', payload });
+};
+
+const queryClients: QueryClient[] = [];
 
 const createWrapper = (store: ReturnType<typeof createMockStore>) => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
         retry: false,
+        cacheTime: Infinity,
       },
     },
   });
-
+  queryClients.push(queryClient);
   const Wrapper = ({ children }: { children: React.ReactNode }) =>
     React.createElement(
       Provider,
@@ -115,15 +167,65 @@ const createWrapper = (store: ReturnType<typeof createMockStore>) => {
   return { Wrapper, queryClient };
 };
 
+const contextResponse = (
+  methods = mockPaymentMethods,
+  selected: PaymentMethod | null = methods[0] ?? null,
+) => ({
+  methods,
+  selected,
+  providerIds: ['/providers/transak'],
+});
+
+const createDeferred = <T>() => {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+};
+
+const getPaymentMethodsForContextMock = jest.mocked(
+  Engine.context.RampsController.getPaymentMethodsForContext,
+);
+const setSelectedPaymentMethodMock = jest.mocked(
+  Engine.context.RampsController.setSelectedPaymentMethod,
+);
+
 describe('useRampsPaymentMethods', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('returns idle when no provider is selected', () => {
-    const store = createMockStore({
-      providers: { ...baseRampsState.providers, selected: null },
+  afterEach(async () => {
+    await act(async () => {
+      for (const queryClient of queryClients.splice(0)) {
+        await queryClient.cancelQueries();
+        queryClient.clear();
+      }
     });
+  });
+
+  it.each([
+    [
+      'region',
+      {
+        userRegion: { ...baseRampsState.userRegion, regionCode: '' },
+      },
+    ],
+    [
+      'asset',
+      {
+        tokens: { ...baseRampsState.tokens, selected: null },
+      },
+    ],
+    [
+      'provider',
+      {
+        providers: { ...baseRampsState.providers, selected: null },
+      },
+    ],
+  ])('is idle when %s is missing', (_label, overrides) => {
+    const store = createMockStore(overrides as RampsOverrides);
     const { Wrapper } = createWrapper(store);
 
     const { result } = renderHook(() => useRampsPaymentMethods(), {
@@ -136,107 +238,378 @@ describe('useRampsPaymentMethods', () => {
       isLoading: false,
       status: 'idle',
       isSuccess: false,
-      error: null,
     });
-    expect(
-      Engine.context.RampsController.getPaymentMethods,
-    ).not.toHaveBeenCalled();
+    expect(getPaymentMethodsForContextMock).not.toHaveBeenCalled();
   });
 
-  it('returns loading while the query is in flight', () => {
+  it('passes normalized region, EVM asset, and provider context', async () => {
+    const checksummedAssetId =
+      'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+    const store = createMockStore({
+      userRegion: { ...baseRampsState.userRegion, regionCode: ' US ' },
+      tokens: {
+        ...baseRampsState.tokens,
+        selected: {
+          ...baseRampsState.tokens.selected,
+          assetId: ` ${checksummedAssetId} `,
+        },
+      },
+      providers: {
+        ...baseRampsState.providers,
+        selected: {
+          ...baseRampsState.providers.selected,
+          id: ' /providers/transak ',
+        },
+      },
+    });
+    const { Wrapper } = createWrapper(store);
+    getPaymentMethodsForContextMock.mockResolvedValue(contextResponse());
+
+    renderHook(() => useRampsPaymentMethods(), { wrapper: Wrapper });
+
+    await waitFor(() =>
+      expect(getPaymentMethodsForContextMock).toHaveBeenCalledWith({
+        region: 'us',
+        assetId: checksummedAssetId.toLowerCase(),
+        providers: ['/providers/transak'],
+        updateState: true,
+      }),
+    );
+  });
+
+  it('preserves non-EVM asset case', async () => {
+    const assetId =
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm';
+    const store = createMockStore({
+      tokens: {
+        ...baseRampsState.tokens,
+        selected: { ...baseRampsState.tokens.selected, assetId },
+      },
+    });
+    const { Wrapper } = createWrapper(store);
+    getPaymentMethodsForContextMock.mockResolvedValue(contextResponse());
+
+    renderHook(() => useRampsPaymentMethods(), { wrapper: Wrapper });
+
+    await waitFor(() =>
+      expect(getPaymentMethodsForContextMock).toHaveBeenCalledWith(
+        expect.objectContaining({ assetId }),
+      ),
+    );
+  });
+
+  it('refetches when token changes', async () => {
     const store = createMockStore();
     const { Wrapper } = createWrapper(store);
+    getPaymentMethodsForContextMock.mockResolvedValue(contextResponse());
+    renderHook(() => useRampsPaymentMethods(), { wrapper: Wrapper });
+    await waitFor(() =>
+      expect(getPaymentMethodsForContextMock).toHaveBeenCalledTimes(1),
+    );
 
-    (
-      Engine.context.RampsController.getPaymentMethods as jest.Mock
-    ).mockImplementation(() => new Promise(() => undefined));
+    await act(async () => {
+      updateRampsState(store, {
+        tokens: {
+          ...baseRampsState.tokens,
+          selected: {
+            ...baseRampsState.tokens.selected,
+            assetId: 'eip155:1/erc20:0x1234',
+          },
+        },
+      });
+    });
+
+    await waitFor(() =>
+      expect(getPaymentMethodsForContextMock).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it('refetches when provider changes', async () => {
+    const store = createMockStore();
+    const { Wrapper } = createWrapper(store);
+    getPaymentMethodsForContextMock.mockResolvedValue(contextResponse());
+    renderHook(() => useRampsPaymentMethods(), { wrapper: Wrapper });
+    await waitFor(() =>
+      expect(getPaymentMethodsForContextMock).toHaveBeenCalledTimes(1),
+    );
+
+    await act(async () => {
+      updateRampsState(store, {
+        providers: {
+          ...baseRampsState.providers,
+          selected: { id: '/providers/moonpay', name: 'MoonPay' },
+        },
+      });
+    });
+
+    await waitFor(() =>
+      expect(getPaymentMethodsForContextMock).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it('rehydrates controller state when returning to a cached context', async () => {
+    const store = createMockStore();
+    const { Wrapper } = createWrapper(store);
+    getPaymentMethodsForContextMock.mockResolvedValue(contextResponse());
+    renderHook(() => useRampsPaymentMethods(), { wrapper: Wrapper });
+    await waitFor(() =>
+      expect(getPaymentMethodsForContextMock).toHaveBeenCalledTimes(1),
+    );
+
+    await act(async () => {
+      updateRampsState(store, {
+        providers: {
+          ...baseRampsState.providers,
+          selected: { id: '/providers/moonpay', name: 'MoonPay' },
+        },
+      });
+    });
+    await waitFor(() =>
+      expect(getPaymentMethodsForContextMock).toHaveBeenCalledTimes(2),
+    );
+
+    await act(async () => {
+      updateRampsState(store, { providers: baseRampsState.providers });
+    });
+
+    await waitFor(() =>
+      expect(getPaymentMethodsForContextMock).toHaveBeenCalledTimes(3),
+    );
+  });
+
+  it('keeps cached active-context methods visible during a background refetch', async () => {
+    const store = createMockStore();
+    const { Wrapper, queryClient } = createWrapper(store);
+    const cachedResponse = contextResponse();
+    queryClient.setQueryData(
+      rampsPaymentMethodsOptions({
+        regionCode: 'us',
+        assetId: 'eip155:1/slip44:60',
+        providerId: '/providers/transak',
+      }).queryKey,
+      cachedResponse,
+    );
+    const deferred = createDeferred<ReturnType<typeof contextResponse>>();
+    getPaymentMethodsForContextMock.mockReturnValue(deferred.promise);
 
     const { result } = renderHook(() => useRampsPaymentMethods(), {
       wrapper: Wrapper,
     });
 
-    expect(result.current.isLoading).toBe(true);
-    expect(result.current.status).toBe('loading');
+    await waitFor(() => expect(result.current.isFetching).toBe(true));
+    expect(result.current.paymentMethods).toEqual(mockPaymentMethods);
+    expect(result.current.selectedPaymentMethod).toEqual(mockPaymentMethods[0]);
+    expect(result.current.status).toBe('success');
+    expect(result.current.isLoading).toBe(false);
+
+    await act(async () => {
+      deferred.resolve(cachedResponse);
+      await deferred.promise;
+    });
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
   });
 
-  it('returns success with data and preserves controller-backed selection', async () => {
+  it('does not show context A methods while uncached context B loads', async () => {
     const store = createMockStore({
       paymentMethods: {
         ...baseRampsState.paymentMethods,
+        data: mockPaymentMethods,
         selected: mockPaymentMethods[0],
       },
     });
     const { Wrapper } = createWrapper(store);
+    const contextBMethod: PaymentMethod = {
+      ...staleMethod,
+      id: '/payments/context-b',
+      name: 'Context B',
+    };
+    const contextBResponse = contextResponse([contextBMethod], contextBMethod);
+    const contextBDeferred =
+      createDeferred<ReturnType<typeof contextResponse>>();
+    getPaymentMethodsForContextMock.mockImplementation(
+      async ({ providers }) => {
+        if (providers?.[0] === '/providers/moonpay') {
+          return contextBDeferred.promise;
+        }
+        return contextResponse();
+      },
+    );
 
-    (
-      Engine.context.RampsController.getPaymentMethods as jest.Mock
-    ).mockResolvedValue({
-      payments: mockPaymentMethods,
+    const { result } = renderHook(() => useRampsPaymentMethods(), {
+      wrapper: Wrapper,
     });
+    await waitFor(() => expect(result.current.status).toBe('success'));
+
+    await act(async () => {
+      updateRampsState(store, {
+        providers: {
+          ...baseRampsState.providers,
+          selected: { id: '/providers/moonpay', name: 'MoonPay' },
+        },
+      });
+    });
+
+    expect(result.current.paymentMethods).toEqual([]);
+    expect(result.current.selectedPaymentMethod).toBeNull();
+    expect(result.current.status).toBe('loading');
+
+    await act(async () => {
+      contextBDeferred.resolve(contextBResponse);
+      await contextBDeferred.promise;
+    });
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.paymentMethods).toEqual([contextBMethod]);
+  });
+
+  it('reuses and settles the original A request across A-B-A', async () => {
+    const store = createMockStore();
+    const { Wrapper } = createWrapper(store);
+    const contextADeferred =
+      createDeferred<ReturnType<typeof contextResponse>>();
+    const contextBDeferred =
+      createDeferred<ReturnType<typeof contextResponse>>();
+    getPaymentMethodsForContextMock.mockImplementation(async ({ providers }) =>
+      providers?.[0] === '/providers/transak'
+        ? contextADeferred.promise
+        : contextBDeferred.promise,
+    );
+
+    const { result } = renderHook(() => useRampsPaymentMethods(), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() =>
+      expect(getPaymentMethodsForContextMock).toHaveBeenCalledTimes(1),
+    );
+    await act(async () => {
+      updateRampsState(store, {
+        providers: {
+          ...baseRampsState.providers,
+          selected: { id: '/providers/moonpay', name: 'MoonPay' },
+        },
+      });
+    });
+    await waitFor(() =>
+      expect(getPaymentMethodsForContextMock).toHaveBeenCalledTimes(2),
+    );
+    await act(async () => {
+      updateRampsState(store, { providers: baseRampsState.providers });
+    });
+
+    expect(getPaymentMethodsForContextMock).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      contextBDeferred.resolve(contextResponse([staleMethod], staleMethod));
+      await contextBDeferred.promise;
+      contextADeferred.resolve(contextResponse());
+      await contextADeferred.promise;
+    });
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.paymentMethods).toEqual(mockPaymentMethods);
+  });
+
+  it('finishes loading after the controller commits catalog and selection', async () => {
+    const store = createMockStore();
+    const { Wrapper } = createWrapper(store);
+    const deferred = createDeferred<ReturnType<typeof contextResponse>>();
+    getPaymentMethodsForContextMock.mockReturnValue(deferred.promise);
 
     const { result } = renderHook(() => useRampsPaymentMethods(), {
       wrapper: Wrapper,
     });
 
-    await waitFor(() => {
-      expect(result.current.status).toBe('success');
+    await act(async () => {
+      updateRampsState(store, {
+        paymentMethods: {
+          ...baseRampsState.paymentMethods,
+          data: mockPaymentMethods,
+          selected: mockPaymentMethods[0],
+        },
+      });
+      deferred.resolve(contextResponse());
+      await deferred.promise;
     });
 
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.isLoading).toBe(false);
     expect(result.current.paymentMethods).toEqual(mockPaymentMethods);
     expect(result.current.selectedPaymentMethod).toEqual(mockPaymentMethods[0]);
-    expect(result.current.isSuccess).toBe(true);
   });
 
-  it('returns success with an empty array when the request completes empty', async () => {
-    const store = createMockStore();
-    const { Wrapper } = createWrapper(store);
-
-    (
-      Engine.context.RampsController.getPaymentMethods as jest.Mock
-    ).mockResolvedValue({
-      payments: [],
+  it('preserves a valid controller selection without manual auto-selection', async () => {
+    const store = createMockStore({
+      paymentMethods: {
+        ...baseRampsState.paymentMethods,
+        data: mockPaymentMethods,
+        selected: mockPaymentMethods[1],
+      },
     });
+    const { Wrapper } = createWrapper(store);
+    getPaymentMethodsForContextMock.mockResolvedValue(
+      contextResponse(mockPaymentMethods, mockPaymentMethods[1]),
+    );
 
     const { result } = renderHook(() => useRampsPaymentMethods(), {
       wrapper: Wrapper,
     });
 
-    await waitFor(() => {
-      expect(result.current.status).toBe('success');
-    });
-
-    expect(result.current.paymentMethods).toEqual([]);
-    expect(result.current.error).toBeNull();
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.selectedPaymentMethod).toEqual(mockPaymentMethods[1]);
+    expect(setSelectedPaymentMethodMock).not.toHaveBeenCalled();
   });
 
-  it('returns error when the request rejects', async () => {
-    const store = createMockStore();
+  it('uses the controller-selected fallback for a stale selection', async () => {
+    const store = createMockStore({
+      paymentMethods: {
+        ...baseRampsState.paymentMethods,
+        data: [staleMethod],
+        selected: staleMethod,
+      },
+    });
     const { Wrapper } = createWrapper(store);
-
-    (
-      Engine.context.RampsController.getPaymentMethods as jest.Mock
-    ).mockRejectedValue(new Error('Network error'));
+    const deferred = createDeferred<ReturnType<typeof contextResponse>>();
+    getPaymentMethodsForContextMock.mockReturnValue(deferred.promise);
 
     const { result } = renderHook(() => useRampsPaymentMethods(), {
       wrapper: Wrapper,
     });
 
-    await waitFor(() => {
-      expect(result.current.status).toBe('error');
+    await act(async () => {
+      updateRampsState(store, {
+        paymentMethods: {
+          ...baseRampsState.paymentMethods,
+          data: mockPaymentMethods,
+          selected: mockPaymentMethods[0],
+        },
+      });
+      deferred.resolve(contextResponse());
+      await deferred.promise;
     });
 
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.error).toBe('Network error');
-    expect(result.current.paymentMethods).toEqual([]);
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.selectedPaymentMethod).toEqual(mockPaymentMethods[0]);
+    expect(setSelectedPaymentMethodMock).not.toHaveBeenCalled();
   });
 
-  it('returns localized fallback when the payment methods query trips the circuit breaker', async () => {
+  it('returns empty success without automatic selection', async () => {
     const store = createMockStore();
     const { Wrapper } = createWrapper(store);
+    getPaymentMethodsForContextMock.mockResolvedValue(
+      contextResponse([], null),
+    );
 
-    (
-      Engine.context.RampsController.getPaymentMethods as jest.Mock
-    ).mockRejectedValue(
+    const { result } = renderHook(() => useRampsPaymentMethods(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.paymentMethods).toEqual([]);
+    expect(result.current.selectedPaymentMethod).toBeNull();
+    expect(setSelectedPaymentMethodMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves localized circuit-breaker errors', async () => {
+    const store = createMockStore();
+    const { Wrapper } = createWrapper(store);
+    getPaymentMethodsForContextMock.mockRejectedValue(
       Object.assign(
         new Error('Execution prevented because the circuit breaker is open'),
         { errorKey: 'CIRCUIT_BREAKER_OPEN' },
@@ -247,380 +620,63 @@ describe('useRampsPaymentMethods', () => {
       wrapper: Wrapper,
     });
 
-    await waitFor(() => {
-      expect(result.current.status).toBe('error');
-    });
-
+    await waitFor(() => expect(result.current.status).toBe('error'));
     expect(result.current.error).toBe('fiat_on_ramp.circuit_breaker_open');
   });
 
-  it('calls Engine.context.RampsController.setSelectedPaymentMethod with full payment method object', () => {
-    const store = createMockStore({
-      providers: { ...baseRampsState.providers, selected: null },
-    });
-    const { Wrapper } = createWrapper(store);
-
-    const { result } = renderHook(() => useRampsPaymentMethods(), {
-      wrapper: Wrapper,
-    });
-
-    act(() => {
-      result.current.setSelectedPaymentMethod(mockPaymentMethods[0]);
-    });
-
-    expect(
-      Engine.context.RampsController.setSelectedPaymentMethod,
-    ).toHaveBeenCalledWith(mockPaymentMethods[0]);
-  });
-
-  it('calls Engine.context.RampsController.setSelectedPaymentMethod with null when payment method is null', () => {
-    const store = createMockStore({
-      providers: { ...baseRampsState.providers, selected: null },
-    });
-    const { Wrapper } = createWrapper(store);
-
-    const { result } = renderHook(() => useRampsPaymentMethods(), {
-      wrapper: Wrapper,
-    });
-
-    act(() => {
-      result.current.setSelectedPaymentMethod(null);
-    });
-
-    expect(
-      Engine.context.RampsController.setSelectedPaymentMethod,
-    ).toHaveBeenCalledWith(null);
-  });
-
-  it('normalizes EVM checksummed assetId case before passing to getPaymentMethods', async () => {
-    const checksummedAssetId =
-      'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
-    const store = createMockStore({
-      tokens: {
-        ...baseRampsState.tokens,
-        selected: {
-          assetId: checksummedAssetId,
-          chainId: 'eip155:1',
-          name: 'USDC',
-          symbol: 'USDC',
-          decimals: 6,
-          iconUrl: '',
-          tokenSupported: true,
-        },
-      },
-    });
-    const { Wrapper, queryClient } = createWrapper(store);
-
-    (
-      Engine.context.RampsController.getPaymentMethods as jest.Mock
-    ).mockResolvedValue({ payments: mockPaymentMethods });
-
-    const { unmount } = renderHook(() => useRampsPaymentMethods(), {
-      wrapper: Wrapper,
-    });
-
-    await waitFor(() => {
-      expect(
-        Engine.context.RampsController.getPaymentMethods,
-      ).toHaveBeenCalled();
-    });
-
-    const callArgs = (
-      Engine.context.RampsController.getPaymentMethods as jest.Mock
-    ).mock.calls[0];
-    expect(callArgs[1].assetId).toBe(checksummedAssetId.toLowerCase());
-
-    queryClient.cancelQueries();
-    unmount();
-    queryClient.clear();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  });
-
-  it('preserves non-EVM (Solana) assetId case when passing to getPaymentMethods', async () => {
-    const solanaAssetId =
-      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm';
-    const store = createMockStore({
-      tokens: {
-        ...baseRampsState.tokens,
-        selected: {
-          assetId: solanaAssetId,
-          chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-          name: 'dogwifhat',
-          symbol: 'WIF',
-          decimals: 6,
-          iconUrl: '',
-          tokenSupported: true,
-        },
-      },
-    });
-    const { Wrapper, queryClient } = createWrapper(store);
-
-    (
-      Engine.context.RampsController.getPaymentMethods as jest.Mock
-    ).mockResolvedValue({ payments: mockPaymentMethods });
-
-    const { unmount } = renderHook(() => useRampsPaymentMethods(), {
-      wrapper: Wrapper,
-    });
-
-    await waitFor(() => {
-      expect(
-        Engine.context.RampsController.getPaymentMethods,
-      ).toHaveBeenCalled();
-    });
-
-    const callArgs = (
-      Engine.context.RampsController.getPaymentMethods as jest.Mock
-    ).mock.calls[0];
-    expect(callArgs[1].assetId).toBe(solanaAssetId);
-
-    queryClient.cancelQueries();
-    unmount();
-    queryClient.clear();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  });
-
-  it('transitions from loading to success when query resolves', async () => {
+  it('preserves ordinary request errors', async () => {
     const store = createMockStore();
     const { Wrapper } = createWrapper(store);
-
-    let resolveQuery: (value: { payments: PaymentMethod[] }) => void = () => {
-      // noop, overwritten by mock
-    };
-    (
-      Engine.context.RampsController.getPaymentMethods as jest.Mock
-    ).mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveQuery = resolve;
-        }),
+    getPaymentMethodsForContextMock.mockRejectedValue(
+      new Error('Network error'),
     );
 
     const { result } = renderHook(() => useRampsPaymentMethods(), {
       wrapper: Wrapper,
     });
 
-    expect(result.current.isLoading).toBe(true);
-    expect(result.current.status).toBe('loading');
-    expect(result.current.isSuccess).toBe(false);
-
-    await act(async () => {
-      resolveQuery({ payments: mockPaymentMethods });
-    });
-
-    await waitFor(() => {
-      expect(result.current.status).toBe('success');
-    });
-
-    // isLoading remains true because no payment method is selected yet
-    // (auto-selection was triggered but Redux hasn't updated in this test)
-    expect(result.current.isLoading).toBe(true);
-    expect(result.current.isSuccess).toBe(true);
-    expect(result.current.paymentMethods).toEqual(mockPaymentMethods);
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.error).toBe('Network error');
   });
 
-  it('returns selectedPaymentMethod from Redux state', async () => {
-    const store = createMockStore({
-      paymentMethods: {
-        ...baseRampsState.paymentMethods,
-        selected: mockPaymentMethods[1],
-      },
-    });
-    const { Wrapper } = createWrapper(store);
-
-    (
-      Engine.context.RampsController.getPaymentMethods as jest.Mock
-    ).mockResolvedValue({ payments: mockPaymentMethods });
-
-    const { result } = renderHook(() => useRampsPaymentMethods(), {
-      wrapper: Wrapper,
-    });
-
-    await waitFor(() => {
-      expect(result.current.status).toBe('success');
-    });
-
-    expect(result.current.selectedPaymentMethod).toEqual(mockPaymentMethods[1]);
-  });
-
-  it('setSelectedPaymentMethod is stable across re-renders', async () => {
+  it('keeps the manual setter unchanged', async () => {
     const store = createMockStore();
     const { Wrapper } = createWrapper(store);
-
-    (
-      Engine.context.RampsController.getPaymentMethods as jest.Mock
-    ).mockResolvedValue({ payments: mockPaymentMethods });
-
-    const { result, rerender } = renderHook(() => useRampsPaymentMethods(), {
-      wrapper: Wrapper,
-    });
-
-    const firstRef = result.current.setSelectedPaymentMethod;
-
-    await waitFor(() => {
-      expect(result.current.status).toBe('success');
-    });
-
-    rerender({});
-
-    expect(result.current.setSelectedPaymentMethod).toBe(firstRef);
-  });
-
-  it('disables query when userRegion is missing', () => {
-    const store = createMockStore({
-      userRegion: { country: null, state: null, regionCode: null },
-    });
-    const { Wrapper } = createWrapper(store);
-
+    const deferred = createDeferred<ReturnType<typeof contextResponse>>();
+    getPaymentMethodsForContextMock.mockReturnValue(deferred.promise);
     const { result } = renderHook(() => useRampsPaymentMethods(), {
       wrapper: Wrapper,
     });
 
-    expect(result.current.status).toBe('idle');
-    expect(result.current.isLoading).toBe(false);
-    expect(
-      Engine.context.RampsController.getPaymentMethods,
-    ).not.toHaveBeenCalled();
+    await act(async () =>
+      result.current.setSelectedPaymentMethod(mockPaymentMethods[0]),
+    );
+
+    expect(setSelectedPaymentMethodMock).toHaveBeenCalledWith(
+      mockPaymentMethods[0],
+    );
+
+    await act(async () => {
+      deferred.resolve(contextResponse());
+      await deferred.promise;
+    });
+    await waitFor(() => expect(result.current.status).toBe('success'));
   });
 
-  describe('auto-selection', () => {
-    it('auto-selects first payment method when data loads and none is selected', async () => {
-      const store = createMockStore();
-      const { Wrapper } = createWrapper(store);
+  it('deduplicates same-key concurrent consumers safely', async () => {
+    const store = createMockStore();
+    const { Wrapper } = createWrapper(store);
+    getPaymentMethodsForContextMock.mockResolvedValue(contextResponse());
 
-      (
-        Engine.context.RampsController.getPaymentMethods as jest.Mock
-      ).mockResolvedValue({ payments: mockPaymentMethods });
-
-      const { result } = renderHook(() => useRampsPaymentMethods(), {
-        wrapper: Wrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.status).toBe('success');
-      });
-
-      expect(
-        Engine.context.RampsController.setSelectedPaymentMethod,
-      ).toHaveBeenCalledWith(mockPaymentMethods[0]);
+    const first = renderHook(() => useRampsPaymentMethods(), {
+      wrapper: Wrapper,
+    });
+    const second = renderHook(() => useRampsPaymentMethods(), {
+      wrapper: Wrapper,
     });
 
-    it('preserves existing selection if it is still in the new list', async () => {
-      const store = createMockStore({
-        paymentMethods: {
-          ...baseRampsState.paymentMethods,
-          selected: mockPaymentMethods[1],
-        },
-      });
-      const { Wrapper } = createWrapper(store);
-
-      (
-        Engine.context.RampsController.getPaymentMethods as jest.Mock
-      ).mockResolvedValue({ payments: mockPaymentMethods });
-
-      const { result } = renderHook(() => useRampsPaymentMethods(), {
-        wrapper: Wrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.status).toBe('success');
-      });
-
-      expect(
-        Engine.context.RampsController.setSelectedPaymentMethod,
-      ).not.toHaveBeenCalled();
-      expect(result.current.selectedPaymentMethod).toEqual(
-        mockPaymentMethods[1],
-      );
-    });
-
-    it('does not auto-select when payment methods list is empty', async () => {
-      const store = createMockStore();
-      const { Wrapper } = createWrapper(store);
-
-      (
-        Engine.context.RampsController.getPaymentMethods as jest.Mock
-      ).mockResolvedValue({ payments: [] });
-
-      const { result } = renderHook(() => useRampsPaymentMethods(), {
-        wrapper: Wrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.status).toBe('success');
-      });
-
-      expect(
-        Engine.context.RampsController.setSelectedPaymentMethod,
-      ).not.toHaveBeenCalled();
-      expect(result.current.selectedPaymentMethod).toBeNull();
-    });
-
-    it('falls back to first method when current selection is not in the new list', async () => {
-      const removedMethod: PaymentMethod = {
-        id: '/payments/removed',
-        paymentType: 'removed',
-        name: 'Removed',
-        score: 0,
-        icon: 'removed',
-      };
-      const store = createMockStore({
-        paymentMethods: {
-          ...baseRampsState.paymentMethods,
-          selected: removedMethod,
-        },
-      });
-      const { Wrapper } = createWrapper(store);
-
-      (
-        Engine.context.RampsController.getPaymentMethods as jest.Mock
-      ).mockResolvedValue({ payments: mockPaymentMethods });
-
-      const { result } = renderHook(() => useRampsPaymentMethods(), {
-        wrapper: Wrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.status).toBe('success');
-      });
-
-      expect(
-        Engine.context.RampsController.setSelectedPaymentMethod,
-      ).toHaveBeenCalledWith(mockPaymentMethods[0]);
-    });
-
-    it('keeps isLoading true during stale-selection fallback to prevent UI flash', async () => {
-      const removedMethod: PaymentMethod = {
-        id: '/payments/removed',
-        paymentType: 'removed',
-        name: 'Removed',
-        score: 0,
-        icon: 'removed',
-      };
-      const store = createMockStore({
-        paymentMethods: {
-          ...baseRampsState.paymentMethods,
-          selected: removedMethod,
-        },
-      });
-      const { Wrapper } = createWrapper(store);
-
-      (
-        Engine.context.RampsController.getPaymentMethods as jest.Mock
-      ).mockResolvedValue({ payments: mockPaymentMethods });
-
-      const { result } = renderHook(() => useRampsPaymentMethods(), {
-        wrapper: Wrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.status).toBe('success');
-      });
-
-      // isLoading should remain true because the stale selection is not in the
-      // new list — the useEffect will correct it, but until Redux updates,
-      // isLoading must stay true to prevent the stale name from flashing.
-      expect(result.current.isLoading).toBe(true);
-    });
+    await waitFor(() => expect(first.result.current.status).toBe('success'));
+    await waitFor(() => expect(second.result.current.status).toBe('success'));
+    expect(getPaymentMethodsForContextMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Ramp/hooks/useRampsPaymentMethods.ts
+++ b/app/components/UI/Ramp/hooks/useRampsPaymentMethods.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
@@ -58,9 +58,8 @@ export interface UseRampsPaymentMethodsResult {
 /**
  * Hook to get payment methods via React Query.
  *
- * The query fires only when a provider is selected (provider change is the
- * sole trigger). Token is passed to the API call but is NOT part of the query
- * key, so changing it does not cause a refetch.
+ * The query executes for the active region, asset, and provider context.
+ * RampsController owns catalog writes and automatic selection.
  *
  * @returns Payment methods state.
  */
@@ -70,13 +69,16 @@ export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
   const { selected: selectedToken } = useSelector(selectTokens);
   const userRegion = useSelector(selectUserRegion);
 
-  const queryEnabled = Boolean(userRegion?.regionCode && selectedProvider?.id);
+  const regionCode = userRegion?.regionCode?.trim().toLowerCase() ?? '';
+  const assetId = normalizeAssetIdForApi(selectedToken?.assetId?.trim() ?? '');
+  const providerId = selectedProvider?.id?.trim() ?? '';
+  const queryEnabled = Boolean(regionCode && assetId && providerId);
 
   const paymentMethodsQuery = useQuery({
     ...rampsQueries.paymentMethods.options({
-      regionCode: userRegion?.regionCode ?? '',
-      assetId: normalizeAssetIdForApi(selectedToken?.assetId),
-      providerId: selectedProvider?.id ?? '',
+      regionCode,
+      assetId,
+      providerId,
     }),
     enabled: queryEnabled,
   });
@@ -93,69 +95,53 @@ export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
     [],
   );
 
-  useEffect(() => {
-    const methods = paymentMethodsQuery.data;
-    if (!methods || methods.length === 0) return;
-
-    let target: PaymentMethod | null = null;
-
-    if (selectedPaymentMethod) {
-      target = methods.find((m) => m.id === selectedPaymentMethod.id) ?? null;
-    }
-
-    if (!target) {
-      target = methods[0];
-    }
-
-    if (target.id !== selectedPaymentMethod?.id) {
-      setSelectedPaymentMethod(target);
-    }
-  }, [
-    paymentMethodsQuery.data,
-    selectedPaymentMethod,
-    setSelectedPaymentMethod,
-  ]);
-
-  const isAutoSelecting = Boolean(
-    paymentMethodsQuery.data?.length &&
-      (!selectedPaymentMethod ||
-        paymentMethodsQuery.data.every(
-          (m) => m.id !== selectedPaymentMethod.id,
-        )),
-  );
+  const activeResponse = queryEnabled ? paymentMethodsQuery.data : undefined;
+  const paymentMethods = activeResponse?.methods ?? [];
+  const activeSelectedPaymentMethod =
+    (selectedPaymentMethod
+      ? (paymentMethods.find(
+          (method) => method.id === selectedPaymentMethod.id,
+        ) ?? null)
+      : null) ??
+    (activeResponse?.selected
+      ? (paymentMethods.find(
+          (method) => method.id === activeResponse.selected?.id,
+        ) ?? null)
+      : null);
 
   const status = useMemo<RampsQueryStatus>(() => {
     if (!queryEnabled) {
       return 'idle';
     }
-    if (paymentMethodsQuery.isLoading) {
-      return 'loading';
-    }
     if (paymentMethodsQuery.isError) {
       return 'error';
     }
-    return 'success';
-  }, [
-    paymentMethodsQuery.isError,
-    paymentMethodsQuery.isLoading,
-    queryEnabled,
-  ]);
+    if (paymentMethodsQuery.data !== undefined) {
+      return 'success';
+    }
+    return 'loading';
+  }, [paymentMethodsQuery.data, paymentMethodsQuery.isError, queryEnabled]);
 
-  return {
-    paymentMethods: paymentMethodsQuery.data ?? [],
-    selectedPaymentMethod,
-    setSelectedPaymentMethod,
-    isLoading: status === 'loading' || isAutoSelecting,
-    isFetching: paymentMethodsQuery.isFetching,
-    status,
-    isSuccess: status === 'success',
-    error:
+  const error = useMemo(
+    () =>
       paymentMethodsQuery.error != null
         ? parseUserFacingError(
             paymentMethodsQuery.error,
             strings('fiat_on_ramp.payment_error'),
           )
         : null,
+    [paymentMethodsQuery.error],
+  );
+
+  return {
+    paymentMethods,
+    selectedPaymentMethod: activeSelectedPaymentMethod,
+    setSelectedPaymentMethod,
+    isLoading: status === 'loading',
+    isFetching: paymentMethodsQuery.isFetching,
+    status,
+    isSuccess: status === 'success',
+    error,
   };
 }
 

--- a/app/components/UI/Ramp/hooks/useRampsPaymentMethods.ts
+++ b/app/components/UI/Ramp/hooks/useRampsPaymentMethods.ts
@@ -122,17 +122,6 @@ export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
     return 'loading';
   }, [paymentMethodsQuery.data, paymentMethodsQuery.isError, queryEnabled]);
 
-  const error = useMemo(
-    () =>
-      paymentMethodsQuery.error != null
-        ? parseUserFacingError(
-            paymentMethodsQuery.error,
-            strings('fiat_on_ramp.payment_error'),
-          )
-        : null,
-    [paymentMethodsQuery.error],
-  );
-
   return {
     paymentMethods,
     selectedPaymentMethod: activeSelectedPaymentMethod,
@@ -141,7 +130,13 @@ export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
     isFetching: paymentMethodsQuery.isFetching,
     status,
     isSuccess: status === 'success',
-    error,
+    error:
+      paymentMethodsQuery.error != null
+        ? parseUserFacingError(
+            paymentMethodsQuery.error,
+            strings('fiat_on_ramp.payment_error'),
+          )
+        : null,
   };
 }
 

--- a/app/components/UI/Ramp/queries/paymentMethods.test.ts
+++ b/app/components/UI/Ramp/queries/paymentMethods.test.ts
@@ -2,18 +2,39 @@ import {
   rampsPaymentMethodsKeys,
   rampsPaymentMethodsOptions,
 } from './paymentMethods';
+import Engine from '../../../../core/Engine';
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    RampsController: {
+      getPaymentMethods: jest.fn(),
+      getPaymentMethodsForContext: jest.fn(),
+    },
+  },
+}));
 
 describe('rampsPaymentMethodsOptions', () => {
-  it('creates a stable normalized query key from regionCode and providerId only', () => {
-    expect(
-      rampsPaymentMethodsKeys.detail({
-        regionCode: 'US ',
-        providerId: '/providers/transak',
-      }),
-    ).toEqual(['ramps', 'paymentMethods', 'us', '/providers/transak']);
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('builds query options with provider-scoped key and 5min staleTime', () => {
+  it('keys by normalized region, asset, and provider without payment-method selection', () => {
+    expect(
+      rampsPaymentMethodsKeys.detail({
+        regionCode: ' US ',
+        assetId: ' eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 ',
+        providerId: ' /providers/transak ',
+      }),
+    ).toEqual([
+      'ramps',
+      'paymentMethods',
+      'us',
+      'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      '/providers/transak',
+    ]);
+  });
+
+  it('builds context query options with staleTime zero', () => {
     const opts = rampsPaymentMethodsOptions({
       regionCode: 'us',
       assetId: 'eip155:1/slip44:60',
@@ -24,9 +45,45 @@ describe('rampsPaymentMethodsOptions', () => {
       'ramps',
       'paymentMethods',
       'us',
+      'eip155:1/slip44:60',
       '/providers/transak',
     ]);
     expect(typeof opts.queryFn).toBe('function');
-    expect(opts.staleTime).toBe(5 * 60 * 1000);
+    expect(opts.staleTime).toBe(0);
+  });
+
+  it('requests and returns the exact normalized explicit context', async () => {
+    const response = {
+      methods: [],
+      selected: null,
+      providerIds: ['/providers/transak'],
+    };
+    jest
+      .mocked(
+        Engine.context.RampsController.getPaymentMethodsForContext as jest.Mock,
+      )
+      .mockResolvedValue(response);
+    const opts = rampsPaymentMethodsOptions({
+      regionCode: ' US ',
+      assetId: ' eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 ',
+      providerId: ' /providers/transak ',
+    });
+
+    const result = await opts.queryFn?.({} as never);
+
+    expect(
+      Engine.context.RampsController.getPaymentMethodsForContext,
+    ).toHaveBeenCalledWith({
+      region: 'us',
+      assetId: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      providers: ['/providers/transak'],
+      updateState: true,
+    });
+    expect(
+      Engine.context.RampsController.getPaymentMethodsForContext,
+    ).not.toHaveBeenCalledWith(
+      expect.objectContaining({ preferPaymentMethodId: expect.anything() }),
+    );
+    expect(result).toBe(response);
   });
 });

--- a/app/components/UI/Ramp/queries/paymentMethods.test.ts
+++ b/app/components/UI/Ramp/queries/paymentMethods.test.ts
@@ -52,16 +52,10 @@ describe('rampsPaymentMethodsOptions', () => {
   });
 
   it('requests and returns the exact normalized explicit context', async () => {
-    const response = {
-      methods: [],
-      selected: null,
-      providerIds: ['/providers/transak'],
-    };
-    jest
-      .mocked(
-        Engine.context.RampsController.getPaymentMethodsForContext as jest.Mock,
-      )
-      .mockResolvedValue(response);
+    const response = { methods: [], selected: null };
+    (
+      Engine.context.RampsController.getPaymentMethodsForContext as jest.Mock
+    ).mockResolvedValue(response);
     const opts = rampsPaymentMethodsOptions({
       regionCode: ' US ',
       assetId: ' eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 ',

--- a/app/components/UI/Ramp/queries/paymentMethods.test.ts
+++ b/app/components/UI/Ramp/queries/paymentMethods.test.ts
@@ -7,7 +7,6 @@ import Engine from '../../../../core/Engine';
 jest.mock('../../../../core/Engine', () => ({
   context: {
     RampsController: {
-      getPaymentMethods: jest.fn(),
       getPaymentMethodsForContext: jest.fn(),
     },
   },
@@ -79,11 +78,6 @@ describe('rampsPaymentMethodsOptions', () => {
       providers: ['/providers/transak'],
       updateState: true,
     });
-    expect(
-      Engine.context.RampsController.getPaymentMethodsForContext,
-    ).not.toHaveBeenCalledWith(
-      expect.objectContaining({ preferPaymentMethodId: expect.anything() }),
-    );
     expect(result).toBe(response);
   });
 });

--- a/app/components/UI/Ramp/queries/paymentMethods.ts
+++ b/app/components/UI/Ramp/queries/paymentMethods.ts
@@ -1,9 +1,7 @@
 import { queryOptions } from '@tanstack/react-query';
-import type {
-  PaymentMethod,
-  PaymentMethodsResponse,
-} from '@metamask/ramps-controller';
+import type { PaymentMethodsForContextResponse } from '@metamask/ramps-controller';
 import Engine from '../../../../core/Engine';
+import { normalizeAssetIdForApi } from '../utils/normalizeAssetIdForApi';
 
 interface PaymentMethodsQueryParams {
   regionCode: string;
@@ -11,33 +9,45 @@ interface PaymentMethodsQueryParams {
   providerId: string;
 }
 
+const normalizePaymentMethodsContext = ({
+  regionCode,
+  assetId,
+  providerId,
+}: PaymentMethodsQueryParams): PaymentMethodsQueryParams => ({
+  regionCode: regionCode.trim().toLowerCase(),
+  assetId: normalizeAssetIdForApi(assetId.trim()),
+  providerId: providerId.trim(),
+});
+
 export const rampsPaymentMethodsKeys = {
   all: () => ['ramps', 'paymentMethods'] as const,
-  detail: ({
-    regionCode,
-    providerId,
-  }: Pick<PaymentMethodsQueryParams, 'regionCode' | 'providerId'>) =>
-    [
+  detail: (params: PaymentMethodsQueryParams) => {
+    const { regionCode, assetId, providerId } =
+      normalizePaymentMethodsContext(params);
+    return [
       ...rampsPaymentMethodsKeys.all(),
-      regionCode.trim().toLowerCase(),
+      regionCode,
+      assetId,
       providerId,
-    ] as const,
+    ] as const;
+  },
 };
 
-export const rampsPaymentMethodsOptions = (params: PaymentMethodsQueryParams) =>
-  queryOptions({
-    queryKey: rampsPaymentMethodsKeys.detail(params),
-    queryFn: async (): Promise<PaymentMethod[]> => {
-      const response: PaymentMethodsResponse =
-        await Engine.context.RampsController.getPaymentMethods(
-          params.regionCode,
-          {
-            assetId: params.assetId,
-            provider: params.providerId,
-          },
-        );
+export const rampsPaymentMethodsOptions = (
+  params: PaymentMethodsQueryParams,
+) => {
+  const { regionCode, assetId, providerId } =
+    normalizePaymentMethodsContext(params);
 
-      return response.payments;
-    },
-    staleTime: 5 * 60 * 1000, // 5 minutes
+  return queryOptions({
+    queryKey: rampsPaymentMethodsKeys.detail(params),
+    queryFn: async (): Promise<PaymentMethodsForContextResponse> =>
+      Engine.context.RampsController.getPaymentMethodsForContext({
+        region: regionCode,
+        assetId,
+        providers: [providerId],
+        updateState: true,
+      }),
+    staleTime: 0,
   });
+};

--- a/tests/component-view/mocks.ts
+++ b/tests/component-view/mocks.ts
@@ -276,6 +276,9 @@ jest.mock('../../app/core/Engine', () => {
         // react-query layers run for real in component-view tests.
         getProviders: jest.fn().mockResolvedValue({ providers: [] }),
         getPaymentMethods: jest.fn().mockResolvedValue({ payments: [] }),
+        getPaymentMethodsForContext: jest
+          .fn()
+          .mockResolvedValue({ methods: [], selected: null }),
         getQuotes: jest.fn().mockResolvedValue({ success: [], error: [] }),
         getBuyWidgetData: jest.fn().mockResolvedValue(null),
       },


### PR DESCRIPTION
## **Description**

> **Do not merge this before PR A (https://github.com/MetaMask/metamask-mobile/pull/35339).** The base branch of this PR is set to PR A's branch so GitHub enforces the stack. PR B makes Buy's payment-method query require a selected asset, and the Money account deposit screen has no selected asset until the user taps Continue. Landing B on its own would therefore hide the fiat row on the deposit screen. PR A is what gives the deposit screen its own asset-scoped query, so A has to be in first.

PR A gave MM Pay its own deposit-scoped payment-method request. This PR is the DRY half of the ticket: UB2's Buy flow moves onto the same `RampsController.getPaymentMethodsForContext` call, so both surfaces resolve payment methods through one context-scoped path instead of two.

What changes for Buy:

- The query key now includes the selected asset and provider, so changing either refetches instead of serving a catalog resolved for a different context.
- Region, asset, and provider are normalised once, in `rampsPaymentMethodsKeys.detail`, so the same context always produces the same key.
- The controller owns catalog writes and automatic selection. The hook's client-side auto-select `useEffect` is gone; the response's `selected` is used as the fallback when the stored selection is not in the new list.
- While an uncached context loads, the previous context's methods are no longer shown.

### Test churn

The original commit rewrote `useRampsPaymentMethods.test.ts` wholesale: 800 lines of churn for a roughly 160 line production change, with every test renamed and some coverage quietly dropped. The rewrite is unwound where it was pure restructuring. The original idle, setter, setter-stability and error tests are back under their original names and assertions, and only the genuinely new missing-asset case was added. The new context tests (refetch on token or provider change, cache rehydration, background refetch, uncached context switching, A-B-A request reuse, controller commit ordering, request dedup) are all kept.

### Component-view mocks

`tests/component-view/mocks.ts` and the UB2 `BuildQuote.view.test.tsx` setup stubbed the old `RampsController.getPaymentMethods`. With the query moved to `getPaymentMethodsForContext` those stubs resolved nothing, so the view test never reached the quote request. Both now stub the context API. The old `getPaymentMethods` stub is left in place for anything still relying on it.

### Split from #34469

This was split out of https://github.com/MetaMask/metamask-mobile/pull/34469, which was over the 1,000 line `check-pr-max-lines` limit.

### Ramps controller preview pin

Inherited from PR A: `@metamask/ramps-controller` is pinned to the preview build `20.0.0-preview-a2a428472` from MetaMask/core#9801. That pin must be replaced with a real published version before either PR merges.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3838
Refs: https://github.com/MetaMask/metamask-mobile/issues/34109
Refs: https://github.com/MetaMask/core/pull/9801
Refs: https://github.com/MetaMask/metamask-mobile/pull/34469

## **Manual testing steps**

```gherkin
Feature: Buy payment methods follow the active region, asset, and provider

  Scenario: switching the token refetches the payment methods
    Given the user is on the Buy amount screen with a token and provider selected

    When user changes the selected token to one the provider serves differently
    Then the payment method list refetches for the new token
    And no payment method from the previous token is shown while the new list loads

  Scenario: switching the provider refetches the payment methods
    Given the user is on the Buy amount screen

    When user changes the provider
    Then the payment method list refetches for the new provider
    And the selected payment method is one the new provider supports

  Scenario: returning to a previous context does not refetch from scratch
    Given the user switched from provider A to provider B and back to provider A

    When the Buy amount screen settles
    Then provider A's payment methods are shown again without a loading flash

  Scenario: MM Pay is unaffected
    Given the user opens the Money account and taps Add

    When user taps "Pay with"
    Then the deposit payment methods are still scoped to the deposit asset
    And Revolut Pay is not listed when the deposit provider cannot serve it
```

## **Screenshots/Recordings**

N/A. No visible UI change in Buy; the fix is which payment methods the query resolves and when it refetches. The user-facing before/after for this ticket is on PR A.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
