### PR TITLE
fix: handle tron the same way as all other non evm networks in post trade modal cp-8.9.0

### DIFF
--- a/app/components/UI/Bridge/components/PostTradeBottomSheet/usePostTradeTxStatus.test.ts
+++ b/app/components/UI/Bridge/components/PostTradeBottomSheet/usePostTradeTxStatus.test.ts
@@ -1,7 +1,12 @@
 import { renderHook } from '@testing-library/react-native';
-import { StatusTypes as BridgeStatus } from '@metamask/bridge-controller';
 import {
+  ChainId,
+  StatusTypes as BridgeStatus,
+} from '@metamask/bridge-controller';
+import {
+  BtcScope,
   SolScope,
+  TrxScope,
   XlmScope,
   TransactionStatus as KeyringTransactionStatus,
 } from '@metamask/keyring-api';
@@ -9,8 +14,10 @@ import { TransactionStatus as TxStatus } from '@metamask/transaction-controller'
 import { PostTradeStatus as Status } from './PostTradeBottomSheet.types';
 import { usePostTradeTxStatus } from './usePostTradeTxStatus';
 
-const SOLANA_MAINNET_CHAIN_ID = 1151111081099710;
-const STELLAR_MAINNET_CHAIN_ID = 20000000000002;
+const SOLANA_MAINNET_CHAIN_ID = ChainId.SOLANA;
+const STELLAR_MAINNET_CHAIN_ID = ChainId.STELLAR;
+const TRON_MAINNET_CHAIN_ID = ChainId.TRON;
+const BITCOIN_MAINNET_CHAIN_ID = ChainId.BTC;
 
 let mockTransactionMeta: { status?: TxStatus; hash?: string } | undefined;
 let mockBridgeHistory = {};
@@ -99,6 +106,22 @@ const stellarTx = (status: KeyringTransactionStatus, id = 'stellar-sig') => ({
   },
 });
 
+const tronTx = (status: KeyringTransactionStatus, id = 'tron-txid') => ({
+  'account-1': {
+    [TrxScope.Mainnet]: {
+      transactions: [{ id, status }],
+    },
+  },
+});
+
+const bitcoinTx = (status: KeyringTransactionStatus, id = 'btc-txid') => ({
+  'account-1': {
+    [BtcScope.Mainnet]: {
+      transactions: [{ id, status }],
+    },
+  },
+});
+
 describe('usePostTradeTxStatus', () => {
   it('maps transaction and bridge statuses', () => {
     expect(statusOf(TxStatus.confirmed)).toBe(Status.Success);
@@ -130,6 +153,18 @@ describe('usePostTradeTxStatus', () => {
       chainName: 'Stellar',
       txHash: 'stellar-sig',
       txnGenerator: stellarTx,
+    },
+    {
+      chainId: TRON_MAINNET_CHAIN_ID,
+      chainName: 'Tron',
+      txHash: 'tron-txid',
+      txnGenerator: tronTx,
+    },
+    {
+      chainId: BITCOIN_MAINNET_CHAIN_ID,
+      chainName: 'Bitcoin',
+      txHash: 'btc-txid',
+      txnGenerator: bitcoinTx,
     },
   ])(
     'resolves same-chain $chainName swaps from multichain transactions',

--- a/app/components/UI/Bridge/components/PostTradeBottomSheet/usePostTradeTxStatus.ts
+++ b/app/components/UI/Bridge/components/PostTradeBottomSheet/usePostTradeTxStatus.ts
@@ -1,8 +1,7 @@
 import { useSelector } from 'react-redux';
 import {
   formatChainIdToCaip,
-  isSolanaChainId,
-  isStellarChainId,
+  isNonEvmChainId,
   StatusTypes,
 } from '@metamask/bridge-controller';
 import {
@@ -90,12 +89,12 @@ export const usePostTradeTxStatus = ({
     ? quote.srcChainId !== quote.destChainId
     : false;
   const isBridgeTx = isBridge || isCrossChainQuote;
-  // Same-chain Solana swaps never terminalize in `BridgeStatusController`, so
-  // resolve them from `MultichainTransactionsController` instead
+  // Same-chain non-EVM swaps are not reliably terminalized by
+  // `BridgeStatusController` or `TransactionController` (Tron is polled in
+  // Core, but that poll often never reaches COMPLETE), so resolve them from
+  // `MultichainTransactionsController` instead.
   const shouldResolveFromMultichain = Boolean(
-    !isBridgeTx &&
-      quote &&
-      (isSolanaChainId(quote.srcChainId) || isStellarChainId(quote.srcChainId)),
+    !isBridgeTx && quote && isNonEvmChainId(quote.srcChainId),
   );
 
   const multichainStatus = useSelector((state: RootState) =>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Same-chain Tron swaps left the post-trade modal on "Swap in progress" after the transaction confirmed. `usePostTradeTxStatus` only resolved terminal status from `MultichainTransactionsController` for Solana and Stellar. Tron (and Bitcoin) never get EVM `TransactionMeta.confirmed`, and Bridge API `COMPLETE` often never arrives, so the modal never flipped.

This PR uses `isNonEvmChainId` for that fallback, matching QuickBuy. Cross-chain bridges still wait for a destination tx hash.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the swap confirmation modal staying on "Swap in progress" after same-chain Tron and Bitcoin swaps completed

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/35299

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Post-trade modal for same-chain non-EVM swaps

  Background:
    Given I am logged into MetaMask Mobile
    And I have a Tron account with TRX and USDT

  Scenario: Tron same-chain swap completes the post-trade modal
    Given I open Swap
    And I select TRX as source and USDT as destination on Tron
    And I enter an amount and confirm the swap

    When the on-chain transaction confirms
    Then the post-trade modal leaves "Swap in progress"
    And the modal shows a successful swap

  Scenario: Cross-chain bridge still waits for destination settlement
    Given I start a cross-chain bridge from an EVM network to a non-EVM network

    When the source transaction confirms but the destination has not settled
    Then the post-trade modal stays in progress
```

Unit tests were run with `yarn jest app/components/UI/Bridge/components/PostTradeBottomSheet/usePostTradeTxStatus.test.ts` and passed, including new Tron and Bitcoin same-chain cases. Device/simulator verification of the Tron swap flow has not been run.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no screenshots attached. Capture the stuck "Swap in progress" post-trade modal on a confirmed Tron swap if adding this PR to review.

### **After**


https://github.com/user-attachments/assets/9de83bff-a2b9-4e39-80cb-e8894476b943



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
