### PR TITLE
feat(confirmations): anchor confirmation_time_to_open_ms at first paint

### DIFF
--- a/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { cloneDeep } from 'lodash';
+import { fireEvent } from '@testing-library/react-native';
 import { BackHandler, ScrollView } from 'react-native';
 import {
   generateContractInteractionState,
+  mockTxId,
   personalSignatureConfirmationState,
   stakingClaimConfirmationState,
   stakingDepositConfirmationState,
@@ -10,6 +12,8 @@ import {
   typedSignV1ConfirmationState,
 } from '../../../../../util/test/confirm-data-helpers';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { ConfirmationUIType } from '../../ConfirmationView.testIds';
+import { TraceName, endTrace, trace } from '../../../../../util/trace';
 import { Confirm, ConfirmationLoader } from './confirm-component';
 import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
 import { useConfirmActions } from '../../hooks/useConfirmActions';
@@ -18,6 +22,12 @@ import useConfirmationAlerts from '../../hooks/alerts/useConfirmationAlerts';
 import { useFullScreenConfirmation } from '../../hooks/ui/useFullScreenConfirmation';
 
 jest.mock('../../hooks/useConfirmActions');
+
+jest.mock('../../../../../util/trace', () => ({
+  ...jest.requireActual('../../../../../util/trace'),
+  trace: jest.fn(),
+  endTrace: jest.fn(),
+}));
 
 jest.mock('../../../../../util/navigation/navUtils', () => ({
   ...jest.requireActual('../../../../../util/navigation/navUtils'),
@@ -614,5 +624,68 @@ describe('Confirm', () => {
 
     const bottomSheet = getByTestId('modal-confirmation-container');
     expect(bottomSheet).toBeDefined();
+  });
+
+  describe('confirmation load trace', () => {
+    const traceMock = jest.mocked(trace);
+    const endTraceMock = jest.mocked(endTrace);
+
+    it('records the load trace when a full screen confirmation paints', () => {
+      jest.mocked(useFullScreenConfirmation).mockReturnValue({
+        isFullScreenConfirmation: true,
+      });
+
+      const { getByTestId } = renderWithProvider(<Confirm />, {
+        state: generateContractInteractionState,
+      });
+
+      expect(traceMock).not.toHaveBeenCalled();
+
+      fireEvent(getByTestId(ConfirmationUIType.FLAT), 'layout');
+
+      expect(traceMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.TransactionConfirmationLoad,
+          id: mockTxId,
+          forceTransaction: true,
+        }),
+      );
+      expect(endTraceMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.TransactionConfirmationLoad,
+          id: mockTxId,
+        }),
+      );
+    });
+
+    it('records the load trace when a modal confirmation paints', () => {
+      jest.mocked(useFullScreenConfirmation).mockReturnValue({
+        isFullScreenConfirmation: false,
+      });
+
+      const { getByTestId } = renderWithProvider(<Confirm />, {
+        state: generateContractInteractionState,
+      });
+
+      fireEvent(getByTestId('transaction'), 'layout');
+
+      expect(traceMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.TransactionConfirmationLoad,
+          id: mockTxId,
+        }),
+      );
+    });
+
+    it('does not record the load trace for signature confirmations', () => {
+      const { getByTestId } = renderWithProvider(<Confirm />, {
+        state: personalSignatureConfirmationState,
+      });
+
+      fireEvent(getByTestId('personal_sign'), 'layout');
+
+      expect(traceMock).not.toHaveBeenCalled();
+      expect(endTraceMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -21,6 +21,7 @@ import { AlertsContextProvider } from '../../context/alert-system-context';
 import { ConfirmationContextProvider } from '../../context/confirmation-context';
 import { QRHardwareContextProvider } from '../../context/qr-hardware-context';
 import { useConfirmActions } from '../../hooks/useConfirmActions';
+import { useConfirmationLoadMetrics } from '../../hooks/metrics/useConfirmationLoadMetrics';
 import { useFullScreenConfirmation } from '../../hooks/ui/useFullScreenConfirmation';
 import { ConfirmationAssetPollingProvider } from '../confirmation-asset-polling-provider/confirmation-asset-polling-provider';
 import AlertBanner from '../alert-banner';
@@ -154,6 +155,7 @@ export const Confirm = ({
   const { isFullScreenConfirmation } = useFullScreenConfirmation();
   const navigation = useNavigation<AppNavigationProp>();
   const { onReject } = useConfirmActions();
+  const { onFirstPaint } = useConfirmationLoadMetrics();
   const { styles } = useStyles(styleSheet, {
     isFullScreenConfirmation,
     disableSafeArea,
@@ -198,6 +200,7 @@ export const Confirm = ({
         edges={disableSafeArea ? [] : ['right', 'bottom', 'left']}
         style={[styles.flatContainer, fullscreenStyle]}
         testID={ConfirmationUIType.FLAT}
+        onLayout={onFirstPaint}
       >
         <ConfirmWrapped styles={styles} route={route} />
       </SafeAreaView>
@@ -206,7 +209,11 @@ export const Confirm = ({
 
   return (
     <BottomSheet onClose={() => onReject()} testID={ConfirmationUIType.MODAL}>
-      <View testID={approvalRequest?.type} style={styles.confirmContainer}>
+      <View
+        testID={approvalRequest?.type}
+        style={styles.confirmContainer}
+        onLayout={onFirstPaint}
+      >
         <ConfirmWrapped styles={styles} route={route} />
       </View>
     </BottomSheet>

--- a/app/components/Views/confirmations/hooks/metrics/useConfirmationLoadMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/metrics/useConfirmationLoadMetrics.test.ts
@@ -1,0 +1,175 @@
+import { renderHook } from '@testing-library/react-hooks';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+
+import { updateConfirmationMetric } from '../../../../../core/redux/slices/confirmationMetrics';
+import { TraceName, endTrace, trace } from '../../../../../util/trace';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { useConfirmationLoadMetrics } from './useConfirmationLoadMetrics';
+
+jest.mock('../transactions/useTransactionMetadataRequest');
+
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
+
+jest.mock('../../../../../core/redux/slices/confirmationMetrics', () => ({
+  ...jest.requireActual('../../../../../core/redux/slices/confirmationMetrics'),
+  updateConfirmationMetric: jest.fn(),
+}));
+
+jest.mock('../../../../../util/trace', () => ({
+  ...jest.requireActual('../../../../../util/trace'),
+  trace: jest.fn(),
+  endTrace: jest.fn(),
+}));
+
+const TRANSACTION_ID_MOCK = '123-456';
+const CREATED_AT_MS_MOCK = 1746696740463;
+const PAINTED_AT_MS_MOCK = 1746696741463;
+
+describe('useConfirmationLoadMetrics', () => {
+  const useTransactionMetadataRequestMock = jest.mocked(
+    useTransactionMetadataRequest,
+  );
+  const updateConfirmationMetricMock = jest.mocked(updateConfirmationMetric);
+  const traceMock = jest.mocked(trace);
+  const endTraceMock = jest.mocked(endTrace);
+
+  function mockTransaction(overrides?: Partial<TransactionMeta>) {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: TRANSACTION_ID_MOCK,
+      time: CREATED_AT_MS_MOCK,
+      type: TransactionType.simpleSend,
+      ...overrides,
+    } as TransactionMeta);
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Date, 'now').mockReturnValue(PAINTED_AT_MS_MOCK);
+    useTransactionMetadataRequestMock.mockReturnValue(undefined);
+  });
+
+  it('does not report anything before first paint', () => {
+    mockTransaction();
+
+    renderHook(() => useConfirmationLoadMetrics());
+
+    expect(updateConfirmationMetricMock).not.toHaveBeenCalled();
+    expect(traceMock).not.toHaveBeenCalled();
+    expect(endTraceMock).not.toHaveBeenCalled();
+  });
+
+  it('dispatches confirmation_time_to_open_ms anchored at first paint', () => {
+    mockTransaction();
+
+    const { result } = renderHook(() => useConfirmationLoadMetrics());
+    result.current.onFirstPaint();
+
+    expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
+      id: TRANSACTION_ID_MOCK,
+      params: {
+        properties: {
+          confirmation_time_to_open_ms: 1000,
+        },
+      },
+    });
+  });
+
+  it('records a backdated trace spanning transaction creation to first paint', () => {
+    mockTransaction();
+
+    const { result } = renderHook(() => useConfirmationLoadMetrics());
+    result.current.onFirstPaint();
+
+    expect(traceMock).toHaveBeenCalledWith({
+      name: TraceName.TransactionConfirmationLoad,
+      id: TRANSACTION_ID_MOCK,
+      startTime: CREATED_AT_MS_MOCK,
+      forceTransaction: true,
+      tags: { transaction_type: 'simple_send' },
+    });
+    expect(endTraceMock).toHaveBeenCalledWith({
+      name: TraceName.TransactionConfirmationLoad,
+      id: TRANSACTION_ID_MOCK,
+      timestamp: PAINTED_AT_MS_MOCK,
+    });
+  });
+
+  it('reports once across repeated layout events', () => {
+    mockTransaction();
+
+    const { result } = renderHook(() => useConfirmationLoadMetrics());
+    result.current.onFirstPaint();
+    result.current.onFirstPaint();
+    result.current.onFirstPaint();
+
+    expect(updateConfirmationMetricMock).toHaveBeenCalledTimes(1);
+    expect(traceMock).toHaveBeenCalledTimes(1);
+    expect(endTraceMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      scenario: 'a plain transaction type',
+      expected: 'simple_send',
+      overrides: { type: TransactionType.simpleSend },
+    },
+    {
+      scenario: 'a batch resolved from its nested transactions',
+      expected: 'perps_deposit_batch',
+      overrides: {
+        type: TransactionType.batch,
+        nestedTransactions: [{ type: TransactionType.perpsRelayDeposit }],
+      },
+    },
+    {
+      scenario: 'a missing transaction type',
+      expected: 'unknown',
+      overrides: { type: undefined },
+    },
+  ])(
+    'tags the trace with $expected given $scenario',
+    ({ expected, overrides }) => {
+      mockTransaction(overrides as Partial<TransactionMeta>);
+
+      const { result } = renderHook(() => useConfirmationLoadMetrics());
+      result.current.onFirstPaint();
+
+      expect(traceMock).toHaveBeenCalledWith(
+        expect.objectContaining({ tags: { transaction_type: expected } }),
+      );
+    },
+  );
+
+  it('skips confirmations with no transaction metadata', () => {
+    useTransactionMetadataRequestMock.mockReturnValue(
+      undefined as unknown as TransactionMeta,
+    );
+
+    const { result } = renderHook(() => useConfirmationLoadMetrics());
+    result.current.onFirstPaint();
+
+    expect(updateConfirmationMetricMock).not.toHaveBeenCalled();
+    expect(traceMock).not.toHaveBeenCalled();
+  });
+
+  it.each([0, undefined])(
+    'skips transactions with an unusable creation time of %s',
+    (time) => {
+      mockTransaction({ time: time as number });
+
+      const { result } = renderHook(() => useConfirmationLoadMetrics());
+      result.current.onFirstPaint();
+
+      expect(updateConfirmationMetricMock).not.toHaveBeenCalled();
+      expect(traceMock).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/app/components/Views/confirmations/hooks/metrics/useConfirmationLoadMetrics.ts
+++ b/app/components/Views/confirmations/hooks/metrics/useConfirmationLoadMetrics.ts
@@ -1,0 +1,95 @@
+import { useCallback, useMemo, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { updateConfirmationMetric } from '../../../../../core/redux/slices/confirmationMetrics';
+import { TraceName, endTrace, trace } from '../../../../../util/trace';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { getTransactionTypeValue } from '../../../../../core/Engine/controllers/transaction-controller/metrics_properties/base';
+import { createProjectLogger } from '@metamask/utils';
+
+const log = createProjectLogger('confirmation-load-metrics');
+
+/**
+ * Records how long a transaction confirmation took to become visible, spanning
+ * transaction creation to the confirmation body's first paint.
+ *
+ * Reports the duration twice: as the `confirmation_time_to_open_ms` metric
+ * property, and as a standalone `Transaction Confirmation Load` Sentry
+ * transaction.
+ *
+ * This is generic to every redesigned confirmation. It lives on the shared
+ * `Confirm` component rather than on any feature-specific surface, so sends,
+ * swaps, approvals, dapp transactions, stake, earn, predict and MetaMask Pay
+ * all report the same span.
+ *
+ * Non-transaction confirmations (for example signature requests) have no
+ * creation timestamp to anchor against and are skipped.
+ *
+ * @returns An object with an `onFirstPaint` callback, to be passed to the root
+ * confirmation container's `onLayout`.
+ */
+export function useConfirmationLoadMetrics() {
+  const dispatch = useDispatch();
+  const transactionMeta = useTransactionMetadataRequest();
+  const didRecord = useRef(false);
+
+  const transactionId = transactionMeta?.id;
+  const createdAtMs = transactionMeta?.time;
+  const singleTransactionType = transactionMeta?.type;
+
+  const canMeasure =
+    Boolean(transactionId) &&
+    typeof createdAtMs === 'number' &&
+    createdAtMs > 0;
+
+  const transactionType = useMemo(
+    () => getTransactionTypeValue(singleTransactionType, transactionMeta),
+    [singleTransactionType, transactionMeta],
+  );
+
+  const onFirstPaint = useCallback(() => {
+    if (didRecord.current || !canMeasure) {
+      return;
+    }
+
+    didRecord.current = true;
+
+    const paintedAtMs = Date.now();
+    const durationMs = Math.round(paintedAtMs - createdAtMs);
+
+    dispatch(
+      updateConfirmationMetric({
+        id: transactionId as string,
+        params: {
+          properties: {
+            confirmation_time_to_open_ms: durationMs,
+          },
+        },
+      }),
+    );
+
+    // Started with a backdated start time and ended immediately at the paint
+    // timestamp, so no trace is left pending for confirmations that are
+    // dismissed before they ever paint.
+    trace({
+      name: TraceName.TransactionConfirmationLoad,
+      id: transactionId as string,
+      startTime: createdAtMs,
+      forceTransaction: true,
+      tags: { transaction_type: transactionType },
+    });
+
+    endTrace({
+      name: TraceName.TransactionConfirmationLoad,
+      id: transactionId as string,
+      timestamp: paintedAtMs,
+    });
+
+    log('First paint', durationMs, {
+      transactionId,
+      transactionType,
+    });
+  }, [canMeasure, createdAtMs, dispatch, transactionId, transactionType]);
+
+  return { onFirstPaint };
+}

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
@@ -1391,20 +1391,13 @@ describe('useTransactionPayMetrics', () => {
       );
     }
 
-    it('dispatches confirmation_time_to_open_ms immediately on mount', async () => {
+    it('does not dispatch confirmation_time_to_open_ms, which useConfirmationLoadMetrics owns', async () => {
       jest.spyOn(Date, 'now').mockReturnValue(1746696741463);
 
       runHook({ type: TransactionType.perpsDeposit });
       await act(async () => noop());
 
-      const calls = timingDispatches('confirmation_time_to_open_ms');
-      expect(calls).toHaveLength(1);
-      expect(calls[0][0]).toEqual({
-        id: transactionIdMock,
-        params: {
-          properties: { confirmation_time_to_open_ms: 1000 },
-        },
-      });
+      expect(timingDispatches('confirmation_time_to_open_ms')).toHaveLength(0);
     });
 
     it('dispatches confirmation_time_to_load_info_ms when pay token loads', async () => {
@@ -1474,7 +1467,6 @@ describe('useTransactionPayMetrics', () => {
       rerender({});
       await act(async () => noop());
 
-      expect(timingDispatches('confirmation_time_to_open_ms')).toHaveLength(1);
       expect(
         timingDispatches('confirmation_time_to_load_info_ms'),
       ).toHaveLength(1);

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -174,31 +174,19 @@ export function useTransactionPayMetrics() {
   const isInfoLoaded =
     hasPayToken && (!needsAccountSelect || Boolean(accountOverride));
 
+  // Anchors the *start* of "time to load info". `confirmation_time_to_open_ms`
+  // is owned by `useConfirmationLoadMetrics`, which anchors it at the
+  // confirmation body's first paint rather than at this hook's mount.
   const confirmationOpenedAtMs = useRef<number | undefined>(undefined);
-
-  const didDispatchTimeToOpen = useRef(false);
   useEffect(() => {
     if (
-      didDispatchTimeToOpen.current ||
+      confirmationOpenedAtMs.current !== undefined ||
       typeof transactionMeta?.time !== 'number' ||
       transactionMeta.time <= 0
     )
       return;
     confirmationOpenedAtMs.current = Date.now();
-    didDispatchTimeToOpen.current = true;
-    dispatch(
-      updateConfirmationMetric({
-        id: transactionId,
-        params: {
-          properties: {
-            confirmation_time_to_open_ms: Math.round(
-              confirmationOpenedAtMs.current - transactionMeta.time,
-            ),
-          },
-        },
-      }),
-    );
-  }, [transactionMeta?.time, dispatch, transactionId]);
+  }, [transactionMeta?.time]);
 
   const didDispatchTimeToLoadInfo = useRef(false);
   useEffect(() => {

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -75,6 +75,8 @@ export enum TraceName {
   TokenOverviewAdvancedChartInitialVisible = 'Token Overview Advanced Chart Initial Visible',
   /** Token overview advanced chart: skeleton cleared after time range selector change only. */
   TokenOverviewAdvancedChartTimeRangeVisible = 'Token Overview Advanced Chart Time Range Visible',
+  /** Transaction creation to the confirmation body's first paint. */
+  TransactionConfirmationLoad = 'Transaction Confirmation Load',
   TransactionConfirmed = 'Transaction Confirmed',
   LoadCollectibles = 'Load Collectibles',
   DetectNfts = 'Detect Nfts',


### PR DESCRIPTION
## **Description**

The `confirmation_time_to_open_ms` metric was owned by `useTransactionPayMetrics`, so it was only reported for MetaMask Pay confirmations, and it was recorded when that hook mounted rather than when the confirmation was actually on screen.

- A new `useConfirmationLoadMetrics` hook owns the metric and is mounted on the shared `Confirm` component, so every redesigned confirmation reports it — sends, swaps, approvals, dapp transactions, stake, earn, predict and Pay alike.
- The duration is now measured to the confirmation body's first layout pass rather than to a hook mount, so it reflects when the confirmation became visible.
- The same span is additionally emitted as a `Transaction Confirmation Load` Sentry transaction, giving production visibility into confirmation load times alongside the existing metric property.

`useTransactionPayMetrics` keeps its mount timestamp purely as the start anchor for `confirmation_time_to_load_info_ms`, which is unchanged.

Note that the span starts at `transactionMeta.time`, which `TransactionController` assigns partway through `addTransaction`. This measures transaction creation through to first paint, not the full tap-to-paint latency.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Confirmation load metric and trace

  Scenario: user opens a transaction confirmation
    Given the user is on the wallet home screen

    When user initiates a transaction and the confirmation appears
    Then a "Transaction Confirmation Load" transaction is recorded in Sentry
    And its duration spans transaction creation to the confirmation becoming visible
    And it is tagged with the normalized transaction type

  Scenario: user completes a transaction confirmation
    Given the user has a transaction confirmation open

    When user confirms the transaction
    Then the submitted transaction event includes confirmation_time_to_open_ms
    And the value matches the duration of the Sentry trace

  Scenario: user opens a signature confirmation
    Given the user is connected to a dapp

    When user triggers a signature request
    Then no confirmation load metric or trace is recorded
```

## **Screenshots/Recordings**

N/A

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes (metrics/traces and test updates) with no transaction or auth logic modified; metric semantics shift from Pay mount to first paint across all redesigned confirmations.
> 
> **Overview**
> Moves **`confirmation_time_to_open_ms`** from Pay-only hook mount timing to a shared **`useConfirmationLoadMetrics`** hook on the redesigned **`Confirm`** screen. The metric and a new Sentry **`Transaction Confirmation Load`** trace fire once on the root container’s first **`onLayout`**, measuring from **`transactionMeta.time`** to visible paint for transaction confirmations (modal and full-screen). Signature flows and missing/invalid transaction metadata are skipped.
> 
> **`useTransactionPayMetrics`** no longer emits **`confirmation_time_to_open_ms`** but still records **`confirmation_time_to_load_info_ms`** using a mount-time anchor. Tests cover the hook, **`Confirm`** integration, and updated Pay timing expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efca8d35c6fc333f9cf1a96bc5c605f526c57f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->