### PR TITLE
fix(perps): show market for trigger-market orders

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.test.tsx
@@ -86,10 +86,8 @@ describe('PerpsProOrderCard', () => {
     expect(screen.getByText('Close long')).toBeOnTheScreen();
     expect(screen.getByText('Stop market')).toBeOnTheScreen();
     expect(screen.getByText('13 SOL')).toBeOnTheScreen();
-    // Trigger orders resolve display price from triggerPrice via
-    // resolveOrderDisplayPriceAndLabel ($101), not the leftover order price.
-    expect(screen.getByText('$1,313')).toBeOnTheScreen();
-    expect(screen.getByText('$101')).toBeOnTheScreen();
+    expect(screen.getByText('$---')).toBeOnTheScreen();
+    expect(screen.getByText('Market')).toBeOnTheScreen();
     expect(screen.getByText('Yes')).toBeOnTheScreen();
     expect(screen.getByText('$220 / $130')).toBeOnTheScreen();
     expect(screen.getByText('Price below $101.00')).toBeOnTheScreen();

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.test.tsx
@@ -72,6 +72,7 @@ describe('PerpsProOrderCard', () => {
       <PerpsProOrderCard
         order={{
           ...baseOrder,
+          price: '100',
           triggerPrice: '101',
           takeProfitPrice: '220',
           stopLossPrice: '130',
@@ -86,7 +87,7 @@ describe('PerpsProOrderCard', () => {
     expect(screen.getByText('Close long')).toBeOnTheScreen();
     expect(screen.getByText('Stop market')).toBeOnTheScreen();
     expect(screen.getByText('13 SOL')).toBeOnTheScreen();
-    expect(screen.getByText('$---')).toBeOnTheScreen();
+    expect(screen.getByText('$1,300')).toBeOnTheScreen();
     expect(screen.getByText('Market')).toBeOnTheScreen();
     expect(screen.getByText('Yes')).toBeOnTheScreen();
     expect(screen.getByText('$220 / $130')).toBeOnTheScreen();

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.tsx
@@ -40,6 +40,7 @@ import { isClosingOrder } from '../../../utils/orderDirection';
 import {
   formatOrderTypeLabel,
   getOrderPositionDirection,
+  getValidOrderPrice,
   getValidTriggerPrice,
   inferTriggerConditionKey,
   isTriggerOrder,
@@ -163,19 +164,26 @@ const PerpsProOrderCard = ({
     ? TagSeverity.Success
     : TagSeverity.Danger;
   const size = formatPositionSize(order.originalSize);
-  const { priceValue } = resolveOrderDisplayPriceAndLabel(order);
+  const { priceValue, labelKey } = resolveOrderDisplayPriceAndLabel(order);
+  const estimatedOrderPrice =
+    getValidOrderPrice(order) ?? getValidTriggerPrice(order);
   const validTriggerPrice = getValidTriggerPrice(order);
   const canEditPrice = Boolean(onEditPrice) && !isEditPriceDisabled;
   const canEditSize = Boolean(onEditSize) && !isEditSizeDisabled;
   const orderValue =
-    priceValue === null
+    estimatedOrderPrice === null
       ? PERPS_CONSTANTS.FallbackPriceDisplay
-      : formatPerpsFiat(Number.parseFloat(order.originalSize) * priceValue, {
-          ranges: PRICE_RANGES_UNIVERSAL,
-        });
+      : formatPerpsFiat(
+          Number.parseFloat(order.originalSize) * estimatedOrderPrice,
+          {
+            ranges: PRICE_RANGES_UNIVERSAL,
+          },
+        );
   const price =
     priceValue === null
-      ? strings('perps.order.market')
+      ? labelKey === 'perps.order.market_price'
+        ? strings('perps.order.market')
+        : PERPS_CONSTANTS.FallbackPriceDisplay
       : formatPerpsFiat(priceValue, {
           ranges: PRICE_RANGES_UNIVERSAL,
         });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/utils/proOrderSort.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/utils/proOrderSort.test.ts
@@ -91,7 +91,7 @@ describe('sortProOrders', () => {
   });
 
   it.each(['price', 'orderValue'] as const)(
-    'sorts unavailable trigger-market %s as zero',
+    'sorts trigger-market %s using its estimated price',
     (field) => {
       const orders = [
         makeOrder({
@@ -115,8 +115,8 @@ describe('sortProOrders', () => {
       });
 
       expect(result.map((order) => order.orderId)).toEqual([
-        'trigger-market',
         'limit',
+        'trigger-market',
       ]);
     },
   );

--- a/app/components/UI/Perps/Views/PerpsProMarketView/utils/proOrderSort.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/utils/proOrderSort.test.ts
@@ -64,17 +64,19 @@ describe('sortProOrders', () => {
     expect(result.map((order) => order.orderId)).toEqual(['small', 'large']);
   });
 
-  it('sorts trigger orders using their displayed trigger price', () => {
+  it('sorts trigger-limit orders using their displayed limit price', () => {
     const orders = [
       makeOrder({
         orderId: 'high',
         isTrigger: true,
+        triggerOrderType: 'take_profit_limit',
         triggerPrice: '200',
         price: '100',
       }),
       makeOrder({
         orderId: 'low',
         isTrigger: true,
+        triggerOrderType: 'take_profit_limit',
         triggerPrice: '150',
         price: '300',
       }),
@@ -85,6 +87,37 @@ describe('sortProOrders', () => {
       direction: 'asc',
     });
 
-    expect(result.map((order) => order.orderId)).toEqual(['low', 'high']);
+    expect(result.map((order) => order.orderId)).toEqual(['high', 'low']);
   });
+
+  it.each(['price', 'orderValue'] as const)(
+    'sorts unavailable trigger-market %s as zero',
+    (field) => {
+      const orders = [
+        makeOrder({
+          orderId: 'limit',
+          price: '100',
+        }),
+        makeOrder({
+          orderId: 'trigger-market',
+          orderType: 'market',
+          isTrigger: true,
+          triggerOrderType: 'stop_market',
+          detailedOrderType: 'Stop Market',
+          triggerPrice: '200',
+          price: '198',
+        }),
+      ];
+
+      const result = sortProOrders(orders, {
+        field,
+        direction: 'asc',
+      });
+
+      expect(result.map((order) => order.orderId)).toEqual([
+        'trigger-market',
+        'limit',
+      ]);
+    },
+  );
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/utils/proOrderSort.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/utils/proOrderSort.ts
@@ -4,7 +4,10 @@ import {
   type ProOrdersSortDirection,
   type ProOrdersSortField,
 } from '@metamask/perps-controller';
-import { resolveOrderDisplayPriceAndLabel } from '../../../utils/orderUtils';
+import {
+  getValidOrderPrice,
+  getValidTriggerPrice,
+} from '../../../utils/orderUtils';
 import { compareProSortValues } from './proSortCompare';
 
 export type ProOrderSortField = ProOrdersSortField;
@@ -47,7 +50,7 @@ const getOrderSize = (order: Order): number =>
   Math.abs(Number.parseFloat(order.originalSize || order.size)) || 0;
 
 const getOrderPrice = (order: Order): number =>
-  resolveOrderDisplayPriceAndLabel(order).priceValue ?? 0;
+  getValidOrderPrice(order) ?? getValidTriggerPrice(order) ?? 0;
 
 const getSortValue = (order: Order, field: ProOrderSortField): number => {
   switch (field) {

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
@@ -398,6 +398,26 @@ describe('PerpsCard', () => {
       expect(queryByText('perps.order.trigger_price')).toBeNull();
     });
 
+    it('shows unavailable price for trigger-limit order without a limit price', () => {
+      const triggerLimitOrderWithoutPrice = {
+        ...mockOrder,
+        isTrigger: true,
+        orderType: 'limit' as const,
+        triggerOrderType: 'take_profit_limit' as const,
+        detailedOrderType: 'Take Profit Limit',
+        triggerPrice: '2800',
+        price: '0',
+      };
+
+      const { getByText, queryByText } = render(
+        <PerpsCard order={triggerLimitOrderWithoutPrice} testID="test-card" />,
+      );
+
+      expect(getByText('$---')).toBeOnTheScreen();
+      expect(getByText('perps.order.limit_price')).toBeOnTheScreen();
+      expect(queryByText('perps.order.market')).toBeNull();
+    });
+
     it('keeps limit price label for non-trigger limit orders when triggerPrice is "0"', () => {
       const limitOrderWithZeroTriggerPrice = {
         ...mockOrder,

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
@@ -337,11 +337,14 @@ describe('PerpsCard', () => {
       expect(queryByText('<$0.01')).toBeNull();
     });
 
-    it('uses trigger price label for trigger orders', () => {
+    it('uses limit price label for trigger-limit orders', () => {
       const triggerOrder = {
         ...mockOrder,
         isTrigger: true,
+        orderType: 'limit' as const,
+        triggerOrderType: 'take_profit_limit' as const,
         triggerPrice: '3100',
+        price: '2800',
         detailedOrderType: 'Take Profit Limit',
       };
 
@@ -349,25 +352,27 @@ describe('PerpsCard', () => {
         <PerpsCard order={triggerOrder} testID="test-card" />,
       );
 
-      expect(getByText('$3,100')).toBeDefined();
-      expect(getByText('perps.order.trigger_price')).toBeDefined();
+      expect(getByText('$2,800')).toBeOnTheScreen();
+      expect(getByText('perps.order.limit_price')).toBeOnTheScreen();
     });
 
-    it('falls back to market price label when trigger order has no valid trigger price', () => {
-      const triggerMarketOrderWithoutPrice = {
+    it('uses market price label for trigger-market with trigger and cap prices', () => {
+      const triggerMarketOrder = {
         ...mockOrder,
         isTrigger: true,
-        triggerPrice: '0',
-        price: '0',
+        orderType: 'market' as const,
+        triggerOrderType: 'stop_market' as const,
+        triggerPrice: '3000',
+        price: '2970',
         detailedOrderType: 'Stop Market',
       };
 
       const { getByText, queryByText } = render(
-        <PerpsCard order={triggerMarketOrderWithoutPrice} testID="test-card" />,
+        <PerpsCard order={triggerMarketOrder} testID="test-card" />,
       );
 
-      expect(getByText('perps.order.market')).toBeDefined();
-      expect(getByText('perps.order.market_price')).toBeDefined();
+      expect(getByText('perps.order.market')).toBeOnTheScreen();
+      expect(getByText('perps.order.market_price')).toBeOnTheScreen();
       expect(queryByText('perps.order.trigger_price')).toBeNull();
     });
 

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -18,6 +18,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import {
   getPerpsDisplaySymbol,
+  PERPS_CONSTANTS,
   PERPS_EVENT_VALUE,
   PERPS_EVENT_PROPERTY,
   type Order,
@@ -95,7 +96,9 @@ const getOrderListDisplay = (order: Order): OrderListDisplay => {
         ? formatPerpsFiat(priceValue, {
             ranges: PRICE_RANGES_UNIVERSAL,
           })
-        : strings('perps.order.market'),
+        : labelKey === 'perps.order.market_price'
+          ? strings('perps.order.market')
+          : PERPS_CONSTANTS.FallbackPriceDisplay,
     subvalueText: strings(labelKey),
     subvalueColor: TextColor.TextAlternative,
   };

--- a/app/components/UI/Perps/components/PerpsCompactOrderRow/PerpsCompactOrderRow.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCompactOrderRow/PerpsCompactOrderRow.test.tsx
@@ -27,6 +27,9 @@ jest.mock('../../utils/formatUtils', () => ({
 
 jest.mock('@metamask/perps-controller', () => ({
   getPerpsDisplaySymbol: jest.fn((symbol) => symbol),
+  isLimitExecutionOrderType: jest.fn((orderType) =>
+    String(orderType).includes('limit'),
+  ),
   isTPSLOrder: jest.fn(
     (detailedOrderType?: string) =>
       (detailedOrderType ?? '').toLowerCase().includes('take profit') ||
@@ -107,15 +110,14 @@ describe('PerpsCompactOrderRow', () => {
     expect(screen.getByText('Stop market close short')).toBeOnTheScreen();
   });
 
-  it('uses trigger price for trigger orders when available', () => {
-    const { formatPerpsFiat } = jest.requireMock('../../utils/formatUtils');
+  it('renders market price for trigger-market with a valid trigger', () => {
     render(<PerpsCompactOrderRow order={mockTriggerOrder} />);
 
-    expect(formatPerpsFiat).toHaveBeenCalledWith(47000, expect.any(Object));
+    expect(screen.getByText('Market')).toBeOnTheScreen();
+    expect(screen.getByText('Market price')).toBeOnTheScreen();
   });
 
-  it('falls back to order price for trigger-market orders when trigger price is invalid', () => {
-    const { formatPerpsFiat } = jest.requireMock('../../utils/formatUtils');
+  it('ignores cap price for trigger-market without a valid trigger', () => {
     const triggerOrderWithInvalidTriggerPrice: Order = {
       ...mockTriggerOrder,
       orderType: 'market',
@@ -128,7 +130,7 @@ describe('PerpsCompactOrderRow', () => {
       <PerpsCompactOrderRow order={triggerOrderWithInvalidTriggerPrice} />,
     );
 
-    expect(formatPerpsFiat).toHaveBeenCalledWith(48000, expect.any(Object));
+    expect(screen.getByText('Market')).toBeOnTheScreen();
     expect(screen.getByText('Market price')).toBeOnTheScreen();
     expect(screen.queryByText('Trigger price')).toBeNull();
   });

--- a/app/components/UI/Perps/components/PerpsCompactOrderRow/PerpsCompactOrderRow.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCompactOrderRow/PerpsCompactOrderRow.test.tsx
@@ -27,6 +27,9 @@ jest.mock('../../utils/formatUtils', () => ({
 
 jest.mock('@metamask/perps-controller', () => ({
   getPerpsDisplaySymbol: jest.fn((symbol) => symbol),
+  PERPS_CONSTANTS: {
+    FallbackPriceDisplay: '$---',
+  },
   isLimitExecutionOrderType: jest.fn((orderType) =>
     String(orderType).includes('limit'),
   ),
@@ -149,6 +152,22 @@ describe('PerpsCompactOrderRow', () => {
 
     expect(screen.getByText('Limit price')).toBeOnTheScreen();
     expect(screen.queryByText('Trigger price')).toBeNull();
+  });
+
+  it('renders unavailable price for trigger-limit order without a limit price', () => {
+    const triggerLimitOrderWithoutPrice: Order = {
+      ...mockTriggerOrder,
+      triggerOrderType: 'take_profit_limit',
+      detailedOrderType: 'Take Profit Limit',
+      triggerPrice: '47000',
+      price: '0',
+    };
+
+    render(<PerpsCompactOrderRow order={triggerLimitOrderWithoutPrice} />);
+
+    expect(screen.getByText('$---')).toBeOnTheScreen();
+    expect(screen.getByText('Limit price')).toBeOnTheScreen();
+    expect(screen.queryByText('Market')).toBeNull();
   });
 
   it('uses order price for limit orders', () => {

--- a/app/components/UI/Perps/components/PerpsCompactOrderRow/PerpsCompactOrderRow.tsx
+++ b/app/components/UI/Perps/components/PerpsCompactOrderRow/PerpsCompactOrderRow.tsx
@@ -6,7 +6,11 @@ import {
   formatPerpsFiat,
   PRICE_RANGES_UNIVERSAL,
 } from '../../utils/formatUtils';
-import { getPerpsDisplaySymbol, type Order } from '@metamask/perps-controller';
+import {
+  getPerpsDisplaySymbol,
+  PERPS_CONSTANTS,
+  type Order,
+} from '@metamask/perps-controller';
 import { strings } from '../../../../../../locales/i18n';
 import {
   formatOrderLabel,
@@ -52,7 +56,9 @@ const PerpsCompactOrderRow: React.FC<PerpsCompactOrderRowProps> = ({
       ? formatPerpsFiat(priceValue, {
           ranges: PRICE_RANGES_UNIVERSAL,
         })
-      : strings('perps.order.market');
+      : labelKey === 'perps.order.market_price'
+        ? strings('perps.order.market')
+        : PERPS_CONSTANTS.FallbackPriceDisplay;
 
   const orderTypeLabel = strings(labelKey);
 

--- a/app/components/UI/Perps/utils/orderUtils.test.ts
+++ b/app/components/UI/Perps/utils/orderUtils.test.ts
@@ -511,15 +511,15 @@ describe('orderUtils', () => {
       detailedOrderType: 'Take Profit Limit',
     };
 
-    it('returns trigger price label when trigger price is valid', () => {
+    it('returns limit price for trigger-limit with a distinct trigger price', () => {
       const result = resolveOrderDisplayPriceAndLabel({
         ...baseOrder,
         triggerPrice: '51000',
       });
 
       expect(result).toEqual({
-        priceValue: 51000,
-        labelKey: 'perps.order.trigger_price',
+        priceValue: 50000,
+        labelKey: 'perps.order.limit_price',
       });
     });
 
@@ -536,13 +536,14 @@ describe('orderUtils', () => {
       });
     });
 
-    it('returns market label when trigger market has no valid prices', () => {
+    it('returns market label for trigger-market with trigger and cap prices', () => {
       const result = resolveOrderDisplayPriceAndLabel({
         ...baseOrder,
         orderType: 'market',
         detailedOrderType: 'Stop Market',
-        triggerPrice: '0',
-        price: '0',
+        triggerOrderType: 'stop_market',
+        triggerPrice: '49000',
+        price: '48510',
       });
 
       expect(result).toEqual({

--- a/app/components/UI/Perps/utils/orderUtils.test.ts
+++ b/app/components/UI/Perps/utils/orderUtils.test.ts
@@ -511,9 +511,23 @@ describe('orderUtils', () => {
       detailedOrderType: 'Take Profit Limit',
     };
 
-    it('returns limit price for trigger-limit with a distinct trigger price', () => {
+    it('returns limit price from the detailed type compatibility fallback', () => {
       const result = resolveOrderDisplayPriceAndLabel({
         ...baseOrder,
+        triggerPrice: '51000',
+      });
+
+      expect(result).toEqual({
+        priceValue: 50000,
+        labelKey: 'perps.order.limit_price',
+      });
+    });
+
+    it('returns limit price for a normalized trigger-limit order', () => {
+      const result = resolveOrderDisplayPriceAndLabel({
+        ...baseOrder,
+        detailedOrderType: undefined,
+        triggerOrderType: 'take_profit_limit',
         triggerPrice: '51000',
       });
 
@@ -532,6 +546,20 @@ describe('orderUtils', () => {
 
       expect(result).toEqual({
         priceValue: 49500,
+        labelKey: 'perps.order.limit_price',
+      });
+    });
+
+    it('returns an unavailable limit price without labelling it as market', () => {
+      const result = resolveOrderDisplayPriceAndLabel({
+        ...baseOrder,
+        triggerOrderType: 'take_profit_limit',
+        triggerPrice: '51000',
+        price: '0',
+      });
+
+      expect(result).toEqual({
+        priceValue: null,
         labelKey: 'perps.order.limit_price',
       });
     });

--- a/app/components/UI/Perps/utils/orderUtils.ts
+++ b/app/components/UI/Perps/utils/orderUtils.ts
@@ -96,6 +96,8 @@ export const isTriggerOrder = (order: Order): boolean =>
  *
  * Hyperliquid trigger-market orders carry a limit price as a slippage cap, but
  * that cap is not a guaranteed execution price and must display as Market.
+ * Orders without a normalized `triggerOrderType` fall back to their detailed
+ * provider order type for backwards compatibility.
  *
  * @param order - Open order normalized by the Perps controller.
  * @returns The display price and its localized label key.
@@ -111,7 +113,7 @@ export const resolveOrderDisplayPriceAndLabel = (
   const hasDetailedMarketExecution =
     normalizedDetailedOrderType.includes('market');
   const isLimitOrder =
-    isTrigger && order.triggerOrderType !== undefined
+    order.triggerOrderType !== undefined
       ? isLimitExecutionOrderType(order.triggerOrderType)
       : hasDetailedLimitExecution ||
         (!hasDetailedMarketExecution && order.orderType === 'limit');
@@ -124,7 +126,7 @@ export const resolveOrderDisplayPriceAndLabel = (
     };
   }
 
-  if (isLimitOrder && validOrderPrice !== null) {
+  if (isLimitOrder) {
     return {
       priceValue: validOrderPrice,
       labelKey: 'perps.order.limit_price',

--- a/app/components/UI/Perps/utils/orderUtils.ts
+++ b/app/components/UI/Perps/utils/orderUtils.ts
@@ -81,7 +81,6 @@ export const isPriceOutsideDeviationBand = (
 };
 
 type OrderPriceLabelKey =
-  | 'perps.order.trigger_price'
   | 'perps.order.limit_price'
   | 'perps.order.market_price';
 
@@ -92,22 +91,36 @@ type OrderPriceLabelKey =
 export const isTriggerOrder = (order: Order): boolean =>
   Boolean(order.isTrigger || isTPSLOrder(order.detailedOrderType));
 
+/**
+ * Resolves the execution price shown for an open order.
+ *
+ * Hyperliquid trigger-market orders carry a limit price as a slippage cap, but
+ * that cap is not a guaranteed execution price and must display as Market.
+ *
+ * @param order - Open order normalized by the Perps controller.
+ * @returns The display price and its localized label key.
+ */
 export const resolveOrderDisplayPriceAndLabel = (
   order: Order,
 ): { priceValue: number | null; labelKey: OrderPriceLabelKey } => {
   const detailedOrderType = order.detailedOrderType ?? '';
   const normalizedDetailedOrderType = detailedOrderType.toLowerCase();
-  const isLimitOrder = Boolean(
-    order.orderType === 'limit' ||
-      normalizedDetailedOrderType.includes('limit'),
-  );
-  const validTriggerPrice = getValidTriggerPrice(order);
+  const isTrigger = isTriggerOrder(order);
+  const hasDetailedLimitExecution =
+    normalizedDetailedOrderType.includes('limit');
+  const hasDetailedMarketExecution =
+    normalizedDetailedOrderType.includes('market');
+  const isLimitOrder =
+    isTrigger && order.triggerOrderType !== undefined
+      ? isLimitExecutionOrderType(order.triggerOrderType)
+      : hasDetailedLimitExecution ||
+        (!hasDetailedMarketExecution && order.orderType === 'limit');
   const validOrderPrice = getValidOrderPrice(order);
 
-  if (isTriggerOrder(order) && validTriggerPrice !== null) {
+  if (isTrigger && !isLimitOrder) {
     return {
-      priceValue: validTriggerPrice,
-      labelKey: 'perps.order.trigger_price',
+      priceValue: null,
+      labelKey: 'perps.order.market_price',
     };
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Trigger-market open orders were displaying their trigger price as the order price. Hyperliquid supplies these orders with both a trigger price and a venue-generated limit price used as a slippage cap, but neither value is a guaranteed execution price. Showing a numeric value therefore implied that the market order would fill at that price.

This change resolves open-order prices by execution type. Stop Market and Take Profit Market orders now display **Market** with an unavailable order value, while Stop Limit and Take Profit Limit orders display their actual limit price. The shared resolver keeps Pro, compact, and home order surfaces—and their sorting behavior—consistent while preserving the trigger condition separately.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed trigger-market orders displaying a misleading numeric price

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3735

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps trigger-order price display

  Background:
    Given I have a funded Perps account
    And Perps Pro mode is active
    And triggered order types are enabled

  Scenario: user views an open trigger-market order
    Given I have placed a Stop Market or Take Profit Market order

    When user opens the Orders panel
    Then the Price field displays "Market"
    And the Order value field displays the unavailable fallback
    And the Trigger condition displays the numeric trigger price

  Scenario: user views an open trigger-limit order
    Given I have placed a Stop Limit or Take Profit Limit order with distinct trigger and limit prices

    When user opens the Orders panel
    Then the Price field displays the limit price
    And the Trigger condition displays the trigger price

  Scenario: user views a trigger-market order outside Perps Pro
    Given I have an open Stop Market or Take Profit Market order

    When user views the order in a compact or home order list
    Then the order price displays "Market"
    And no trigger or slippage-cap value is presented as the execution price
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-26 at 22 20 57" src="https://github.com/user-attachments/assets/4f8419b2-8776-417b-a5f8-1b91d52ffe46" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)