### PR TITLE
perf(perps): add lifecycle measurement foundation

### DIFF
--- a/app/components/UI/Perps/adapters/mobileInfrastructure.test.ts
+++ b/app/components/UI/Perps/adapters/mobileInfrastructure.test.ts
@@ -2,6 +2,7 @@ import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEventBuilder';
 import { analytics } from '../../../../util/analytics/analytics';
 import Logger from '../../../../util/Logger';
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import {
   PerpsMeasurementName,
   PerpsTraceNames,
@@ -224,6 +225,10 @@ describe('createMobileInfrastructure', () => {
 
       expect(setTraceMeasurement).not.toHaveBeenCalled();
       expect(setSentryMeasurement).not.toHaveBeenCalled();
+      expect(DevLogger.log).toHaveBeenCalledWith(
+        'Perps tracing dropped a measurement for an unknown trace id',
+        { traceId: 'missing-trace-id', measurement: 'unknown.measurement' },
+      );
     });
 
     it.each([

--- a/app/components/UI/Perps/adapters/mobileInfrastructure.test.ts
+++ b/app/components/UI/Perps/adapters/mobileInfrastructure.test.ts
@@ -2,7 +2,21 @@ import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEventBuilder';
 import { analytics } from '../../../../util/analytics/analytics';
 import Logger from '../../../../util/Logger';
-import type { PerpsAnalyticsEvent } from '@metamask/perps-controller';
+import {
+  PerpsMeasurementName,
+  PerpsTraceNames,
+  type PerpsAnalyticsEvent,
+} from '@metamask/perps-controller';
+import { setMeasurement as setSentryMeasurement } from '@sentry/react-native';
+import {
+  setTraceMeasurement,
+  trace as startTrace,
+  TraceName,
+} from '../../../../util/trace';
+import {
+  getActivePerpsLoadingSessionTraceData,
+  recordPerpsControllerConstructedAt,
+} from '../utils/perpsLoadingSession';
 import {
   createMobileInfrastructure,
   createMobileClientConfig,
@@ -50,7 +64,11 @@ jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
 jest.mock('../../../../util/trace', () => ({
   trace: jest.fn(),
   endTrace: jest.fn(),
-  TraceName: {},
+  setTraceMeasurement: jest.fn(),
+  TraceName: {
+    PerpsMarketDataPreload: 'Perps Market Data Preload',
+    PerpsUserDataPreload: 'Perps User Data Preload',
+  },
 }));
 
 jest.mock('@sentry/react-native', () => ({
@@ -59,6 +77,11 @@ jest.mock('@sentry/react-native', () => ({
 
 jest.mock('react-native-performance', () => ({
   now: jest.fn(() => 123),
+}));
+
+jest.mock('../utils/perpsLoadingSession', () => ({
+  getActivePerpsLoadingSessionTraceData: jest.fn(),
+  recordPerpsControllerConstructedAt: jest.fn(),
 }));
 
 jest.mock('../providers/PerpsStreamManager', () => ({
@@ -121,6 +144,135 @@ jest.mock('../../../../util/intl', () => ({
 describe('createMobileInfrastructure', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('performance tracing', () => {
+    it('forwards the post-hydration controller timestamp', () => {
+      const infra = createMobileInfrastructure();
+
+      infra.performance.onControllerConstructed?.(321);
+
+      expect(recordPerpsControllerConstructedAt).toHaveBeenCalledWith(321);
+    });
+
+    it.each([
+      [
+        PerpsMeasurementName.PerpsMarketDataPreload,
+        PerpsTraceNames.MarketDataPreload,
+        TraceName.PerpsMarketDataPreload,
+      ],
+      [
+        PerpsMeasurementName.PerpsUserDataPreload,
+        PerpsTraceNames.UserDataPreload,
+        TraceName.PerpsUserDataPreload,
+      ],
+    ])(
+      'targets %s to its explicit preload trace',
+      (name, coreName, traceName) => {
+        const infra = createMobileInfrastructure();
+        infra.tracer.trace({
+          name: coreName,
+          id: 'trace-id',
+          op: 'perps.preload',
+        });
+
+        infra.tracer.setMeasurement(name, 42, 'millisecond', 'trace-id');
+
+        expect(setTraceMeasurement).toHaveBeenCalledWith(
+          { name: traceName, id: 'trace-id' },
+          name,
+          42,
+          'millisecond',
+        );
+        expect(setSentryMeasurement).not.toHaveBeenCalled();
+      },
+    );
+
+    it('targets child measurements to the trace that opened their id', () => {
+      const infra = createMobileInfrastructure();
+      infra.tracer.trace({
+        name: PerpsTraceNames.MarketDataPreload,
+        id: 'trace-id',
+        op: 'perps.preload',
+      });
+
+      infra.tracer.setMeasurement(
+        'terminal_request_duration_ms',
+        17,
+        'millisecond',
+        'trace-id',
+      );
+
+      expect(setTraceMeasurement).toHaveBeenCalledWith(
+        { name: TraceName.PerpsMarketDataPreload, id: 'trace-id' },
+        'terminal_request_duration_ms',
+        17,
+        'millisecond',
+      );
+      expect(setSentryMeasurement).not.toHaveBeenCalled();
+    });
+
+    it('does not write an explicit-id measurement without its trace', () => {
+      const infra = createMobileInfrastructure();
+
+      infra.tracer.setMeasurement(
+        'unknown.measurement',
+        1,
+        'millisecond',
+        'missing-trace-id',
+      );
+
+      expect(setTraceMeasurement).not.toHaveBeenCalled();
+      expect(setSentryMeasurement).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      [PerpsTraceNames.MarketDataPreload, TraceName.PerpsMarketDataPreload],
+      [PerpsTraceNames.UserDataPreload, TraceName.PerpsUserDataPreload],
+    ])(
+      'correlates the %s trace with the active loading session',
+      (name, traceName) => {
+        jest.mocked(getActivePerpsLoadingSessionTraceData).mockReturnValue({
+          perps_session_id: 'session-id',
+          account_generation: 1,
+          context_generation: 1,
+        });
+        const infra = createMobileInfrastructure();
+
+        infra.tracer.trace({
+          name,
+          id: 'preload-id',
+          op: 'perps.preload',
+          data: { provider: 'hyperliquid' },
+        });
+
+        expect(startTrace).toHaveBeenCalledWith({
+          name: traceName,
+          id: 'preload-id',
+          op: 'perps.preload',
+          tags: undefined,
+          data: {
+            provider: 'hyperliquid',
+            perps_session_id: 'session-id',
+            account_generation: 1,
+            context_generation: 1,
+          },
+        });
+      },
+    );
+
+    it('preserves ambient measurements without an explicit trace id', () => {
+      const infra = createMobileInfrastructure();
+
+      infra.tracer.setMeasurement('legacy.measurement', 7, 'millisecond');
+
+      expect(setSentryMeasurement).toHaveBeenCalledWith(
+        'legacy.measurement',
+        7,
+        'millisecond',
+      );
+      expect(setTraceMeasurement).not.toHaveBeenCalled();
+    });
   });
 
   describe('metrics', () => {

--- a/app/components/UI/Perps/adapters/mobileInfrastructure.ts
+++ b/app/components/UI/Perps/adapters/mobileInfrastructure.ts
@@ -340,6 +340,13 @@ export function createMobileInfrastructure(): PerpsPlatformDependencies {
         if (id) {
           const traceName = traceNamesById.get(id);
           if (!traceName) {
+            DevLogger.log(
+              'Perps tracing dropped a measurement for an unknown trace id',
+              {
+                traceId: id,
+                measurement: name,
+              },
+            );
             return;
           }
           setTraceMeasurement(

--- a/app/components/UI/Perps/adapters/mobileInfrastructure.ts
+++ b/app/components/UI/Perps/adapters/mobileInfrastructure.ts
@@ -11,7 +11,12 @@ import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEventBuilder';
 import { analytics } from '../../../../util/analytics/analytics';
-import { trace, endTrace, TraceName } from '../../../../util/trace';
+import {
+  trace,
+  endTrace,
+  setTraceMeasurement,
+  TraceName,
+} from '../../../../util/trace';
 import {
   setMeasurement,
   addBreadcrumb,
@@ -49,6 +54,10 @@ import {
   getTerminalGlobalSnapshotUrl,
   resolveTerminalApiUrl,
 } from '../constants/terminalApi';
+import {
+  getActivePerpsLoadingSessionTraceData,
+  recordPerpsControllerConstructedAt,
+} from '../utils/perpsLoadingSession';
 
 /**
  * Resolves the Terminal API base URL based on build environment.
@@ -73,6 +82,21 @@ export function getTerminalApiUrl(): string {
 function toTraceName(name: PerpsTraceName): TraceName {
   return name as unknown as TraceName;
 }
+
+function getPreloadTraceData(
+  name: PerpsTraceName,
+): { perps_session_id: string } | undefined {
+  const traceName = toTraceName(name);
+  if (
+    traceName !== TraceName.PerpsMarketDataPreload &&
+    traceName !== TraceName.PerpsUserDataPreload
+  ) {
+    return undefined;
+  }
+  return getActivePerpsLoadingSessionTraceData();
+}
+
+const MAX_TRACKED_PERPS_TRACE_IDS = 100;
 
 /**
  * Creates a mobile-specific analytics adapter that implements PerpsMetrics
@@ -228,6 +252,7 @@ export function createMobileInfrastructure(): PerpsPlatformDependencies {
   const terminalGlobalSnapshotUrl = getTerminalGlobalSnapshotUrl(
     terminalMarketDataUrl,
   );
+  const traceNamesById = new Map<string, TraceName>();
 
   return {
     // === Observability (stateless utilities) ===
@@ -259,6 +284,7 @@ export function createMobileInfrastructure(): PerpsPlatformDependencies {
       now(): number {
         return performance.now();
       },
+      onControllerConstructed: recordPerpsControllerConstructedAt,
     },
     tracer: {
       trace(params: {
@@ -268,12 +294,29 @@ export function createMobileInfrastructure(): PerpsPlatformDependencies {
         tags?: Record<string, PerpsTraceValue>;
         data?: Record<string, PerpsTraceValue>;
       }): void {
+        const traceName = toTraceName(params.name);
+        const loadingSessionData = getPreloadTraceData(params.name);
+        if (
+          !traceNamesById.has(params.id) &&
+          traceNamesById.size >= MAX_TRACKED_PERPS_TRACE_IDS
+        ) {
+          const oldestId = traceNamesById.keys().next().value;
+          if (oldestId) {
+            traceNamesById.delete(oldestId);
+            DevLogger.log('Perps tracing evicted an unfinished trace id', {
+              traceId: oldestId,
+            });
+          }
+        }
+        traceNamesById.set(params.id, traceName);
         trace({
-          name: toTraceName(params.name),
+          name: traceName,
           id: params.id,
           op: params.op,
           tags: params.tags,
-          data: params.data,
+          data: loadingSessionData
+            ? { ...params.data, ...loadingSessionData }
+            : params.data,
         });
       },
       endTrace(params: {
@@ -286,8 +329,27 @@ export function createMobileInfrastructure(): PerpsPlatformDependencies {
           id: params.id,
           data: params.data,
         });
+        traceNamesById.delete(params.id);
       },
-      setMeasurement(name: string, value: number, unit: string): void {
+      setMeasurement(
+        name: string,
+        value: number,
+        unit: string,
+        id?: string,
+      ): void {
+        if (id) {
+          const traceName = traceNamesById.get(id);
+          if (!traceName) {
+            return;
+          }
+          setTraceMeasurement(
+            { name: traceName, id },
+            name,
+            value,
+            unit as Parameters<typeof setTraceMeasurement>[3],
+          );
+          return;
+        }
         setMeasurement(name, value, unit);
       },
       addBreadcrumb(breadcrumb: {

--- a/app/components/UI/Perps/constants/terminalApi.ts
+++ b/app/components/UI/Perps/constants/terminalApi.ts
@@ -14,6 +14,9 @@ export const TERMINAL_API_URLS = {
   PRD: 'https://terminal.api.cx.metamask.io/v1/perpetuals',
 } as const;
 
+export const TERMINAL_GLOBAL_SNAPSHOT_DATA_SOURCE =
+  'terminal-global-snapshot-mark';
+
 /** Resolves the existing Terminal market-data URL for a Mobile build. */
 export function resolveTerminalApiUrl(
   environment: string | undefined,

--- a/app/components/UI/Perps/hooks/stream/usePerpsLiveFills.test.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLiveFills.test.ts
@@ -5,12 +5,13 @@ import { type OrderFill } from '@metamask/perps-controller';
 
 // Mock the stream provider
 const mockSubscribe = jest.fn();
+const mockGetSnapshot = jest.fn((): OrderFill[] | null => []);
 
 jest.mock('../../providers/PerpsStreamManager', () => ({
   usePerpsStream: jest.fn(() => ({
     fills: {
       subscribe: mockSubscribe,
-      getSnapshot: jest.fn(() => []),
+      getSnapshot: mockGetSnapshot,
     },
   })),
   PerpsStreamProvider: ({ children }: { children: React.ReactNode }) =>
@@ -33,6 +34,7 @@ describe('usePerpsLiveFills', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetSnapshot.mockReturnValue([]);
     jest.useFakeTimers();
   });
 
@@ -185,6 +187,33 @@ describe('usePerpsLiveFills', () => {
     await waitFor(() => {
       expect(result.current.fills).toEqual(validFills);
     });
+  });
+
+  it('starts loading when the account context has no fills snapshot', () => {
+    mockGetSnapshot.mockReturnValue(null);
+    mockSubscribe.mockReturnValue(jest.fn());
+
+    const { result } = renderHook(() => usePerpsLiveFills());
+
+    expect(result.current.fills).toEqual([]);
+    expect(result.current.isInitialLoading).toBe(true);
+  });
+
+  it('returns to loading when the account context clears', () => {
+    let capturedCallback: ((fills: OrderFill[]) => void) | undefined;
+    mockSubscribe.mockImplementation(({ callback }) => {
+      capturedCallback = callback;
+      return jest.fn();
+    });
+    const { result } = renderHook(() => usePerpsLiveFills());
+    act(() => capturedCallback?.([mockFill]));
+    expect(result.current.isInitialLoading).toBe(false);
+
+    mockGetSnapshot.mockReturnValue(null);
+    act(() => capturedCallback?.([]));
+
+    expect(result.current.fills).toEqual([]);
+    expect(result.current.isInitialLoading).toBe(true);
   });
 
   it('replaces fills on each update', async () => {

--- a/app/components/UI/Perps/hooks/stream/usePerpsLiveFills.test.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLiveFills.test.ts
@@ -10,6 +10,7 @@ jest.mock('../../providers/PerpsStreamManager', () => ({
   usePerpsStream: jest.fn(() => ({
     fills: {
       subscribe: mockSubscribe,
+      getSnapshot: jest.fn(() => []),
     },
   })),
   PerpsStreamProvider: ({ children }: { children: React.ReactNode }) =>

--- a/app/components/UI/Perps/hooks/stream/usePerpsLiveFills.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLiveFills.ts
@@ -31,10 +31,9 @@ export function usePerpsLiveFills(
   const { throttleMs = 0 } = options;
   const stream = usePerpsStream();
   const [fills, setFills] = useState<OrderFill[]>(EMPTY_FILLS);
-  // FillStreamChannel.getCachedData() always returns [] (never null),
-  // so subscribe() will always call the callback synchronously in useEffect.
-  // Start with false to avoid a 1-frame skeleton flash.
-  const [isInitialLoading, setIsInitialLoading] = useState(false);
+  const [isInitialLoading, setIsInitialLoading] = useState(
+    () => stream.fills.getSnapshot() === null,
+  );
   const lastFillsRef = useRef<OrderFill[]>(EMPTY_FILLS);
   const hasReceivedFirstUpdate = useRef(false);
 
@@ -46,9 +45,15 @@ export function usePerpsLiveFills(
 
     const unsubscribe = stream.fills.subscribe({
       callback: (newFills) => {
-        // null/undefined means no cached data yet, keep loading state
-        if (newFills === null || newFills === undefined) {
-          // Keep isInitialLoading as true, fills as empty array
+        if (
+          newFills === null ||
+          newFills === undefined ||
+          stream.fills.getSnapshot() === null
+        ) {
+          hasReceivedFirstUpdate.current = false;
+          setIsInitialLoading(true);
+          lastFillsRef.current = EMPTY_FILLS;
+          setFills(EMPTY_FILLS);
           return;
         }
 

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -4005,6 +4005,24 @@ describe('PerpsStreamManager', () => {
 
       expect(callback).toHaveBeenCalledWith(undefined);
     });
+
+    it('restores the mounted symbol after cache clear and reconnect', () => {
+      const callback = jest.fn();
+      testStreamManager.topOfBook.subscribeToSymbol({
+        symbol: 'BTC',
+        callback,
+      });
+
+      testStreamManager.topOfBook.clearCache();
+      testStreamManager.topOfBook.reconnect();
+
+      expect(mockSubscribeToPrices).toHaveBeenLastCalledWith({
+        symbols: ['BTC'],
+        includeOrderBook: true,
+        callback: expect.any(Function),
+      });
+      expect(mockSubscribeToPrices).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('FocusedPriceStreamChannel', () => {

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -1392,6 +1392,44 @@ describe('PerpsStreamManager', () => {
   });
 
   describe('PriceStreamChannel.prewarm non-blocking behavior', () => {
+    it('drops a late direct-price callback after prewarm takes ownership', async () => {
+      const makePrice = (price: string): PriceUpdate => ({
+        symbol: 'BTC',
+        price,
+        timestamp: Date.now(),
+        isTradable: true,
+      });
+      const callback = jest.fn();
+      testStreamManager.prices.subscribeToSymbols({
+        symbols: ['BTC'],
+        callback,
+      });
+      const directCall = mockSubscribeToPrices.mock.calls.at(-1);
+      if (!directCall) throw new Error('Direct subscription did not start');
+      const directCallback = directCall[0].callback;
+
+      await testStreamManager.prices.prewarm();
+      await waitFor(() =>
+        expect(mockSubscribeToPrices.mock.calls.length).toBeGreaterThan(1),
+      );
+      const prewarmCall = mockSubscribeToPrices.mock.calls.at(-1);
+      if (!prewarmCall) throw new Error('Prewarm subscription did not start');
+      const prewarmCallback = prewarmCall[0].callback;
+      directCallback([makePrice('1')]);
+      prewarmCallback([makePrice('2')]);
+
+      expect(callback).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          BTC: expect.objectContaining({ price: '1' }),
+        }),
+      );
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          BTC: expect.objectContaining({ price: '2' }),
+        }),
+      );
+    });
+
     it('keeps the first live price update immediate after cached prewarm data', async () => {
       let prewarmCallback: ((updates: PriceUpdate[]) => void) | undefined;
       const makePrice = (price: string): PriceUpdate => ({
@@ -3045,6 +3083,27 @@ describe('PerpsStreamManager', () => {
       unsubscribe();
     });
 
+    it('drops a late OI-cap callback after reconnect', async () => {
+      const callbacks: ((caps: string[]) => void)[] = [];
+      mockSubscribeToOICaps.mockImplementation(
+        (params: { callback: (caps: string[]) => void }) => {
+          callbacks.push(params.callback);
+          return mockUnsubscribeFromOICaps;
+        },
+      );
+      const callback = jest.fn();
+      testStreamManager.oiCaps.subscribe({ callback, throttleMs: 0 });
+      await waitFor(() => expect(callbacks).toHaveLength(1));
+
+      testStreamManager.oiCaps.reconnect();
+      await waitFor(() => expect(callbacks).toHaveLength(2));
+      act(() => callbacks[0](['STALE']));
+      act(() => callbacks[1](['BTC']));
+
+      expect(callback).not.toHaveBeenCalledWith(['STALE']);
+      expect(callback).toHaveBeenCalledWith(['BTC']);
+    });
+
     it('notifies subscribers when markets reach OI cap', async () => {
       let oiCapCallback: ((caps: string[]) => void) | null = null;
       mockSubscribeToOICaps.mockImplementation(
@@ -3897,6 +3956,27 @@ describe('PerpsStreamManager', () => {
         bestAsk: '50001',
         spread: undefined,
       });
+    });
+
+    it('drops a late top-of-book callback after reconnect', () => {
+      const callback = jest.fn();
+      testStreamManager.topOfBook.subscribeToSymbol({
+        symbol: 'BTC',
+        callback,
+      });
+      const staleCallback = mockSubscribeToPrices.mock.calls[0][0].callback;
+
+      testStreamManager.topOfBook.reconnect();
+      const currentCallback = mockSubscribeToPrices.mock.calls[1][0].callback;
+      staleCallback([{ symbol: 'BTC', bestBid: '1', bestAsk: '2' }]);
+      currentCallback([{ symbol: 'BTC', bestBid: '3', bestAsk: '4' }]);
+
+      expect(callback).not.toHaveBeenCalledWith(
+        expect.objectContaining({ bestBid: '1' }),
+      );
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({ bestBid: '3' }),
+      );
     });
 
     it('does not subscribe when symbol is empty', () => {

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -4023,6 +4023,27 @@ describe('PerpsStreamManager', () => {
       });
       expect(mockSubscribeToPrices).toHaveBeenCalledTimes(2);
     });
+
+    it('restores the active symbol when another symbol remains mounted', () => {
+      testStreamManager.topOfBook.subscribeToSymbol({
+        symbol: 'BTC',
+        callback: jest.fn(),
+      });
+      testStreamManager.topOfBook.subscribeToSymbol({
+        symbol: 'ETH',
+        callback: jest.fn(),
+      });
+
+      testStreamManager.topOfBook.clearCache();
+      testStreamManager.topOfBook.reconnect();
+
+      expect(mockSubscribeToPrices).toHaveBeenLastCalledWith({
+        symbols: ['ETH'],
+        includeOrderBook: true,
+        callback: expect.any(Function),
+      });
+      expect(mockSubscribeToPrices).toHaveBeenCalledTimes(3);
+    });
   });
 
   describe('FocusedPriceStreamChannel', () => {

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -15,6 +15,7 @@ import {
   type PerpsMarketData,
   type Position,
   type Order,
+  type OrderFill,
   type AccountState,
 } from '@metamask/perps-controller';
 import { trace, TraceName, TraceOperation } from '../../../../util/trace';
@@ -24,7 +25,15 @@ import {
   resetPerpsLifecycleContextForTests,
 } from '../utils/perpsLifecycleContext';
 import { PerpsConnectionManager } from '../services/PerpsConnectionManager';
-import { selectPerpsTerminalBackendEnabledFlag } from '../selectors/featureFlags';
+import {
+  selectHip3ConfigVersion,
+  selectPerpsTerminalBackendEnabledFlag,
+} from '../selectors/featureFlags';
+import {
+  selectPerpsNetwork,
+  selectPerpsProvider,
+} from '../selectors/perpsController';
+import { selectPerpsSelectedAccountAddress } from '../selectors/selectedAccountAddress';
 import StorageWrapper from '../../../../store/storage-wrapper';
 import {
   PERPS_DISK_CACHE_MARKETS,
@@ -44,7 +53,15 @@ jest.mock('../../../../store', () => ({
   store: { getState: jest.fn(() => ({})) },
 }));
 jest.mock('../selectors/featureFlags', () => ({
+  selectHip3ConfigVersion: jest.fn(() => 0),
   selectPerpsTerminalBackendEnabledFlag: jest.fn(() => true),
+}));
+jest.mock('../selectors/perpsController', () => ({
+  selectPerpsNetwork: jest.fn(() => 'mainnet'),
+  selectPerpsProvider: jest.fn(() => 'hyperliquid'),
+}));
+jest.mock('../selectors/selectedAccountAddress', () => ({
+  selectPerpsSelectedAccountAddress: jest.fn(() => '0x123456789'),
 }));
 jest.mock('../../../../store/storage-wrapper', () => ({
   __esModule: true,
@@ -66,6 +83,12 @@ const mockStorageWrapper = StorageWrapper as jest.Mocked<typeof StorageWrapper>;
 const mockTrace = trace as jest.Mock;
 const mockSelectPerpsTerminalBackendEnabledFlag =
   selectPerpsTerminalBackendEnabledFlag as unknown as jest.Mock;
+const mockSelectHip3ConfigVersion =
+  selectHip3ConfigVersion as unknown as jest.Mock;
+const mockSelectPerpsNetwork = selectPerpsNetwork as unknown as jest.Mock;
+const mockSelectPerpsProvider = selectPerpsProvider as unknown as jest.Mock;
+const mockSelectPerpsSelectedAccountAddress =
+  selectPerpsSelectedAccountAddress as unknown as jest.Mock;
 
 // Test component that uses the stream hook
 const TestPriceComponent = ({
@@ -109,6 +132,10 @@ describe('PerpsStreamManager', () => {
 
     // Restore the default Terminal flag state (enabled) after any per-test override.
     mockSelectPerpsTerminalBackendEnabledFlag.mockReturnValue(true);
+    mockSelectHip3ConfigVersion.mockReturnValue(0);
+    mockSelectPerpsNetwork.mockReturnValue('mainnet');
+    mockSelectPerpsProvider.mockReturnValue('hyperliquid');
+    mockSelectPerpsSelectedAccountAddress.mockReturnValue('0x123456789');
 
     // Create a fresh stream manager for each test
     testStreamManager = new PerpsStreamManager();
@@ -952,6 +979,129 @@ describe('PerpsStreamManager', () => {
       testStreamManager.positions.subscribe({ callback, throttleMs: 0 });
       testStreamManager.positions.clearCache();
       expect(callback).toHaveBeenLastCalledWith(null);
+    });
+
+    it('rejects old user callbacks after clear and accepts replacement subscriptions', () => {
+      const orderCallbacks: ((orders: Order[]) => void)[] = [];
+      const positionCallbacks: ((positions: Position[]) => void)[] = [];
+      const accountCallbacks: ((account: AccountState | null) => void)[] = [];
+      const fillCallbacks: ((
+        fills: OrderFill[],
+        isSnapshot?: boolean,
+      ) => void)[] = [];
+      mockSubscribeToOrders.mockImplementation(({ callback }) => {
+        orderCallbacks.push(callback);
+        return jest.fn();
+      });
+      mockSubscribeToPositions.mockImplementation(({ callback }) => {
+        positionCallbacks.push(callback);
+        return jest.fn();
+      });
+      mockSubscribeToAccount.mockImplementation(({ callback }) => {
+        accountCallbacks.push(callback);
+        return jest.fn();
+      });
+      const mockSubscribeToOrderFills = jest.fn(({ callback }) => {
+        fillCallbacks.push(callback);
+        return jest.fn();
+      });
+      mockEngine.context.PerpsController = {
+        ...mockEngine.context.PerpsController,
+        subscribeToOrderFills: mockSubscribeToOrderFills,
+      } as unknown as typeof mockEngine.context.PerpsController;
+      const order = { orderId: 'old-order' } as Order;
+      const position = { symbol: 'BTC', size: '1' } as Position;
+      const account = { totalBalance: '1' } as AccountState;
+      const fill = {
+        orderId: 'old-order',
+        symbol: 'BTC',
+        side: 'buy',
+        size: '1',
+        price: '1',
+        pnl: '0',
+        direction: 'Open Long',
+        fee: '0',
+        feeToken: 'USDC',
+        timestamp: 1,
+      } as OrderFill;
+
+      testStreamManager.orders.subscribe({ callback: jest.fn() });
+      testStreamManager.positions.subscribe({ callback: jest.fn() });
+      testStreamManager.account.subscribe({ callback: jest.fn() });
+      testStreamManager.fills.subscribe({ callback: jest.fn() });
+      testStreamManager.orders.clearCache();
+      testStreamManager.positions.clearCache();
+      testStreamManager.account.clearCache();
+      testStreamManager.fills.clearCache();
+
+      orderCallbacks[0]?.([order]);
+      positionCallbacks[0]?.([position]);
+      accountCallbacks[0]?.(account);
+      fillCallbacks[0]?.([fill], true);
+
+      expect(testStreamManager.orders.getSnapshot()).toBeNull();
+      expect(testStreamManager.positions.getSnapshot()).toBeNull();
+      expect(testStreamManager.account.getSnapshot()).toBeNull();
+      expect(testStreamManager.fills.getSnapshot()).toBeNull();
+
+      testStreamManager.orders.subscribe({ callback: jest.fn() });
+      testStreamManager.positions.subscribe({ callback: jest.fn() });
+      testStreamManager.account.subscribe({ callback: jest.fn() });
+      testStreamManager.fills.subscribe({ callback: jest.fn() });
+      orderCallbacks[1]?.([order]);
+      positionCallbacks[1]?.([position]);
+      accountCallbacks[1]?.(account);
+      fillCallbacks[1]?.([fill], true);
+
+      expect(testStreamManager.orders.getSnapshot()).toEqual([order]);
+      expect(testStreamManager.positions.getSnapshot()).toEqual([position]);
+      expect(testStreamManager.account.getSnapshot()).toEqual(account);
+      expect(testStreamManager.fills.getSnapshot()).toEqual([fill]);
+    });
+
+    it('rejects user callbacks when the selected address changes', () => {
+      const orderCallback = jest.fn();
+      const positionCallback = jest.fn();
+      const accountCallback = jest.fn();
+      const fillCallback = jest.fn();
+      mockSubscribeToOrders.mockImplementation(({ callback }) => {
+        orderCallback.mockImplementation(callback);
+        return jest.fn();
+      });
+      mockSubscribeToPositions.mockImplementation(({ callback }) => {
+        positionCallback.mockImplementation(callback);
+        return jest.fn();
+      });
+      mockSubscribeToAccount.mockImplementation(({ callback }) => {
+        accountCallback.mockImplementation(callback);
+        return jest.fn();
+      });
+      mockEngine.context.PerpsController = {
+        ...mockEngine.context.PerpsController,
+        subscribeToOrderFills: jest.fn(({ callback }) => {
+          fillCallback.mockImplementation(callback);
+          return jest.fn();
+        }),
+      } as unknown as typeof mockEngine.context.PerpsController;
+
+      testStreamManager.orders.subscribe({ callback: jest.fn() });
+      testStreamManager.positions.subscribe({ callback: jest.fn() });
+      testStreamManager.account.subscribe({ callback: jest.fn() });
+      testStreamManager.fills.subscribe({ callback: jest.fn() });
+      (
+        mockEngine.context.AccountTreeController
+          .getAccountsFromSelectedAccountGroup as jest.Mock
+      ).mockReturnValue([{ address: '0x987654321' }]);
+
+      orderCallback([]);
+      positionCallback([]);
+      accountCallback({ totalBalance: '1' } as AccountState);
+      fillCallback([], true);
+
+      expect(testStreamManager.orders.getSnapshot()).toBeNull();
+      expect(testStreamManager.positions.getSnapshot()).toBeNull();
+      expect(testStreamManager.account.getSnapshot()).toBeNull();
+      expect(testStreamManager.fills.getSnapshot()).toBeNull();
     });
 
     it('cleans up prewarm subscription when clearing account cache', () => {
@@ -1818,6 +1968,28 @@ describe('PerpsStreamManager', () => {
       expect(btcCb).toHaveBeenCalledTimes(1);
     });
 
+    it('drops a late callback from the previous subscription generation', () => {
+      const callback = jest.fn();
+      testStreamManager.prices.subscribeToSymbols({
+        symbols: ['BTC-PERP'],
+        callback,
+      });
+      const staleCallback = priceCallback;
+
+      testStreamManager.prices.reconnect();
+      const currentCallback = priceCallback;
+
+      staleCallback([makePrice('BTC-PERP', '50000')]);
+      expect(callback).not.toHaveBeenCalled();
+
+      currentCallback([makePrice('BTC-PERP', '50001')]);
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'BTC-PERP': expect.objectContaining({ price: '50001' }),
+        }),
+      );
+    });
+
     it('preserves first-update and throttle semantics for scoped dispatch', () => {
       const cb = jest.fn();
 
@@ -1958,6 +2130,7 @@ describe('PerpsStreamManager', () => {
       // Account switch clears caches and notifies every subscriber with cleared data
       act(() => {
         testStreamManager.prices.clearCache();
+        testStreamManager.prices.reconnect();
       });
       expect(btcCb).toHaveBeenCalledWith({});
       expect(ethCb).toHaveBeenCalledWith({});
@@ -2816,8 +2989,8 @@ describe('PerpsStreamManager', () => {
       expect(mockDevLogger.log).toHaveBeenCalledWith(
         'PerpsStreamManager: Provider/network/flag changed during fetch, discarding data',
         expect.objectContaining({
-          fetchedFor: 'providerA:mainnet:terminal',
-          current: 'providerB:mainnet:terminal',
+          fetchedFor: 'providerA:mainnet:0:terminal',
+          current: 'providerB:mainnet:0:terminal',
         }),
       );
 
@@ -3872,6 +4045,32 @@ describe('PerpsStreamManager', () => {
       expect(mockSubscribeToPrices).toHaveBeenCalledTimes(2);
       expect(mockSubscribeToPrices).toHaveBeenLastCalledWith(
         expect.objectContaining({ symbols: ['ETH'] }),
+      );
+    });
+
+    it('restores the focused symbol and rejects the prior callback on reconnect', () => {
+      const callback = jest.fn();
+      testStreamManager.focusedPrice.subscribeToSymbol({
+        symbol: 'BTC',
+        callback,
+      });
+      const staleCallback = mockSubscribeToPrices.mock.calls[0][0].callback;
+
+      testStreamManager.focusedPrice.reconnect();
+
+      expect(mockSubscribeToPrices).toHaveBeenCalledTimes(2);
+      expect(mockSubscribeToPrices).toHaveBeenLastCalledWith(
+        expect.objectContaining({ symbols: ['BTC'] }),
+      );
+      expect(callback).toHaveBeenCalledWith(undefined);
+      callback.mockClear();
+      staleCallback([{ symbol: 'BTC', price: '50000' }]);
+      expect(callback).not.toHaveBeenCalled();
+
+      const currentCallback = mockSubscribeToPrices.mock.calls[1][0].callback;
+      currentCallback([{ symbol: 'BTC', price: '50001' }]);
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({ symbol: 'BTC', price: '50001' }),
       );
     });
 

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -3988,6 +3988,20 @@ describe('PerpsStreamManager', () => {
       });
 
       expect(mockSubscribeToPrices).not.toHaveBeenCalled();
+
+      testStreamManager.topOfBook.subscribeToSymbol({
+        symbol: 'BTC',
+        callback,
+      });
+      testStreamManager.topOfBook.clearCache();
+      testStreamManager.topOfBook.reconnect();
+
+      expect(mockSubscribeToPrices).toHaveBeenCalledTimes(2);
+      expect(mockSubscribeToPrices).toHaveBeenLastCalledWith({
+        symbols: ['BTC'],
+        includeOrderBook: true,
+        callback: expect.any(Function),
+      });
     });
 
     it('clears top of book cache when clearCache called', () => {
@@ -4025,13 +4039,15 @@ describe('PerpsStreamManager', () => {
     });
 
     it('restores the active symbol when another symbol remains mounted', () => {
+      const btcCallback = jest.fn();
+      const ethCallback = jest.fn();
       testStreamManager.topOfBook.subscribeToSymbol({
         symbol: 'BTC',
-        callback: jest.fn(),
+        callback: btcCallback,
       });
       testStreamManager.topOfBook.subscribeToSymbol({
         symbol: 'ETH',
-        callback: jest.fn(),
+        callback: ethCallback,
       });
 
       testStreamManager.topOfBook.clearCache();
@@ -4043,6 +4059,38 @@ describe('PerpsStreamManager', () => {
         callback: expect.any(Function),
       });
       expect(mockSubscribeToPrices).toHaveBeenCalledTimes(3);
+
+      const currentCallback = mockSubscribeToPrices.mock.lastCall?.[0].callback;
+      currentCallback([{ symbol: 'ETH', bestBid: '3', bestAsk: '4' }]);
+      expect(ethCallback).toHaveBeenCalledWith(
+        expect.objectContaining({ bestBid: '3' }),
+      );
+      expect(btcCallback).not.toHaveBeenCalledWith(
+        expect.objectContaining({ bestBid: '3' }),
+      );
+    });
+
+    it('refocuses to a surviving symbol after the active subscriber leaves', () => {
+      const btcCallback = jest.fn();
+      const unsubscribeBtc = testStreamManager.topOfBook.subscribeToSymbol({
+        symbol: 'BTC',
+        callback: btcCallback,
+      });
+      const unsubscribeEth = testStreamManager.topOfBook.subscribeToSymbol({
+        symbol: 'ETH',
+        callback: jest.fn(),
+      });
+
+      unsubscribeEth();
+
+      expect(mockSubscribeToPrices).toHaveBeenLastCalledWith({
+        symbols: ['BTC'],
+        includeOrderBook: true,
+        callback: expect.any(Function),
+      });
+      expect(mockSubscribeToPrices).toHaveBeenCalledTimes(3);
+
+      unsubscribeBtc();
     });
   });
 

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -62,7 +62,6 @@ import {
 } from '../constants/terminalApi';
 import {
   createPerpsLoadingSessionIdentity,
-  getActivePerpsLoadingSessionIdentity,
   getActivePerpsLoadingSessionTraceData,
   recordPerpsLoadingSessionValuesReady,
   type PerpsLoadingSessionIdentity,
@@ -195,12 +194,18 @@ abstract class StreamChannel<T> {
     generation: number;
     address: string | null;
   }): boolean {
+    if (!this.isSubscriptionGenerationCurrent(context)) {
+      return false;
+    }
     const currentAddress =
       getEvmAccountFromSelectedAccountGroup()?.address?.toLowerCase() ?? null;
-    return (
-      context.generation === this.subscriptionGeneration &&
-      context.address === currentAddress
-    );
+    return context.address === currentAddress;
+  }
+
+  protected isSubscriptionGenerationCurrent(context: {
+    generation: number;
+  }): boolean {
+    return context.generation === this.subscriptionGeneration;
   }
 
   protected invalidateSubscriptionContext(): void {
@@ -762,6 +767,7 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
   private prewarmUnsubscribe?: () => void;
   private actualPriceUnsubscribe?: () => void;
   private firstDataTraceId?: string;
+  private deliveryToken = 0;
 
   protected endOpenFirstDataTrace(): void {
     if (this.firstDataTraceId) {
@@ -850,11 +856,15 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
     this.wsConnectionStartTime = performance.now();
     const loadingIdentity = getCurrentPerpsLoadingSessionIdentity();
     const subscriptionContext = this.getSubscriptionContext();
+    const deliveryToken = ++this.deliveryToken;
 
     this.wsSubscription = Engine.context.PerpsController.subscribeToPrices({
       symbols: allSymbols,
       callback: (updates: PriceUpdate[]) => {
-        if (!this.isSubscriptionContextCurrent(subscriptionContext)) {
+        if (
+          deliveryToken !== this.deliveryToken ||
+          !this.isSubscriptionGenerationCurrent(subscriptionContext)
+        ) {
           return;
         }
         recordPerpsLoadingSessionValuesReady(
@@ -1032,6 +1042,10 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
           },
         );
 
+        if (this.wsSubscription) {
+          this.disconnect();
+        }
+
         // End any first-price span still open from a prior connect()/prewarm
         // before overwriting the trace id, or that span is orphaned and ships
         // bogus first-data telemetry.
@@ -1049,6 +1063,7 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
         this.wsConnectionStartTime = performance.now();
         const loadingIdentity = getCurrentPerpsLoadingSessionIdentity();
         const subscriptionContext = this.getSubscriptionContext();
+        const deliveryToken = ++this.deliveryToken;
 
         // WARNING: Do NOT set includeMarketData: true here. It triggers
         // per-symbol activeAssetCtx subscriptions (N symbols × N DEXs = N²
@@ -1058,7 +1073,10 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
           symbols: this.allMarketSymbols,
           includeMarketData: false,
           callback: (updates: PriceUpdate[]) => {
-            if (!this.isSubscriptionContextCurrent(subscriptionContext)) {
+            if (
+              deliveryToken !== this.deliveryToken ||
+              !this.isSubscriptionGenerationCurrent(subscriptionContext)
+            ) {
               return;
             }
             recordPerpsLoadingSessionValuesReady(
@@ -1142,6 +1160,7 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
    * Cleanup pre-warm subscription
    */
   public cleanupPrewarm(): void {
+    this.deliveryToken += 1;
     this.invalidateSubscriptionContext();
     // Prewarm starts the first-price trace; end it here too so a soft reconnect
     // (preserveCaches: true skips clearCache) doesn't leave it open to be
@@ -1894,8 +1913,12 @@ class OICapStreamChannel extends StreamChannel<string[]> {
     if (!this.ensureReady()) return;
 
     // Subscribe to OI cap updates (zero overhead - extracted from existing webData3)
+    const subscriptionContext = this.getSubscriptionContext();
     this.wsSubscription = Engine.context.PerpsController.subscribeToOICaps({
       callback: (caps: string[]) => {
+        if (!this.isSubscriptionGenerationCurrent(subscriptionContext)) {
+          return;
+        }
         this.cache.set('oiCaps', caps);
         this.notifySubscribers(caps);
       },
@@ -1994,22 +2017,31 @@ class TopOfBookStreamChannel extends StreamChannel<
 
     // Start trace for first top-of-book measurement (before subscription)
     this.firstDataTraceId = uuidv4();
+    const traceId = this.firstDataTraceId;
     trace({
       name: TraceName.PerpsWebSocketFirstOrderBook,
-      id: this.firstDataTraceId,
+      id: traceId,
       op: TraceOperation.PerpsOperation,
       tags: buildPerpsCufStartTags(),
     });
     this.wsConnectionStartTime = performance.now();
+    const subscribedSymbol = this.currentSymbol;
+    const subscriptionContext = this.getSubscriptionContext();
 
     this.wsSubscription = Engine.context.PerpsController.subscribeToPrices({
-      symbols: [this.currentSymbol],
+      symbols: [subscribedSymbol],
       includeOrderBook: true,
       callback: (updates: PriceUpdate[]) => {
-        const update = updates.find((u) => u.symbol === this.currentSymbol);
+        if (!this.isSubscriptionGenerationCurrent(subscriptionContext)) {
+          return;
+        }
+        const update = updates.find((u) => u.symbol === subscribedSymbol);
         if (update) {
           // Track first top-of-book data (only once per connection)
-          if (this.wsConnectionStartTime !== null && this.firstDataTraceId) {
+          if (
+            this.wsConnectionStartTime !== null &&
+            this.firstDataTraceId === traceId
+          ) {
             const firstDataDuration =
               performance.now() - this.wsConnectionStartTime;
             DevLogger.log(
@@ -2018,7 +2050,7 @@ class TopOfBookStreamChannel extends StreamChannel<
             );
             endTrace({
               name: TraceName.PerpsWebSocketFirstOrderBook,
-              id: this.firstDataTraceId,
+              id: traceId,
               data: { success: true, duration: firstDataDuration },
             });
             this.wsConnectionStartTime = null;
@@ -2142,7 +2174,7 @@ class FocusedPriceStreamChannel extends StreamChannel<PriceUpdate | undefined> {
       symbols: [subscribedSymbol],
       includeMarketData: true,
       callback: (updates: PriceUpdate[]) => {
-        if (!this.isSubscriptionContextCurrent(subscriptionContext)) {
+        if (!this.isSubscriptionGenerationCurrent(subscriptionContext)) {
           return;
         }
         const update = updates.find((u) => u.symbol === subscribedSymbol);
@@ -2240,6 +2272,12 @@ class FocusedPriceStreamChannel extends StreamChannel<PriceUpdate | undefined> {
     this.connect();
   }
 
+  public disconnect() {
+    this.currentSymbol = null;
+    this.cachedPriceUpdate = undefined;
+    super.disconnect();
+  }
+
   public reconnect(): void {
     const symbol =
       this.currentSymbol ?? this.symbolSubscribers.keys().next().value;
@@ -2250,12 +2288,6 @@ class FocusedPriceStreamChannel extends StreamChannel<PriceUpdate | undefined> {
       this.currentSymbol = symbol;
       this.connect();
     }
-  }
-
-  public disconnect() {
-    this.currentSymbol = null;
-    this.cachedPriceUpdate = undefined;
-    super.disconnect();
   }
 }
 
@@ -2475,8 +2507,7 @@ class MarketDataChannel extends StreamChannel<PerpsMarketData[]> {
             : 'provider',
           data.length,
           {},
-          getActivePerpsLoadingSessionIdentity() ??
-            getCurrentPerpsLoadingSessionIdentity(),
+          getCurrentPerpsLoadingSessionIdentity(),
         );
         // Notify all subscribers
         this.notifySubscribers(data);

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -2089,8 +2089,10 @@ class TopOfBookStreamChannel extends StreamChannel<
   }
 
   public clearCache(): void {
+    const symbol = this.currentSymbol;
     this.cachedTopOfBook = undefined;
     super.clearCache();
+    this.currentSymbol = symbol;
   }
 
   subscribeToSymbol(params: {
@@ -2120,7 +2122,6 @@ class TopOfBookStreamChannel extends StreamChannel<
     }
 
     return this.subscribe({
-      symbols: [params.symbol],
       callback: params.callback,
     });
   }
@@ -2132,8 +2133,7 @@ class TopOfBookStreamChannel extends StreamChannel<
   }
 
   public reconnect(): void {
-    const symbol =
-      this.currentSymbol ?? this.symbolSubscribers.keys().next().value;
+    const symbol = this.currentSymbol;
     this.disconnect();
     super.clearCache();
     if (symbol && this.subscribers.size > 0) {

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -2120,6 +2120,7 @@ class TopOfBookStreamChannel extends StreamChannel<
     }
 
     return this.subscribe({
+      symbols: [params.symbol],
       callback: params.callback,
     });
   }
@@ -2131,7 +2132,8 @@ class TopOfBookStreamChannel extends StreamChannel<
   }
 
   public reconnect(): void {
-    const symbol = this.currentSymbol;
+    const symbol =
+      this.currentSymbol ?? this.symbolSubscribers.keys().next().value;
     this.disconnect();
     super.clearCache();
     if (symbol && this.subscribers.size > 0) {

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -785,6 +785,31 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
     }
   }
 
+  private finishFirstDataTrace(): void {
+    const traceId = this.firstDataTraceId;
+    if (this.wsConnectionStartTime === null || !traceId) {
+      return;
+    }
+
+    const firstDataDuration = performance.now() - this.wsConnectionStartTime;
+    DevLogger.log(
+      `${PERFORMANCE_CONFIG.LoggingMarkers.WebsocketPerformance} PerpsWS: First price data received`,
+      { duration: `${firstDataDuration.toFixed(0)}ms` },
+    );
+    endTrace({
+      name: TraceName.PerpsWebSocketFirstPrice,
+      id: traceId,
+      data: {
+        ...getCapturedLoadingSessionTraceData(traceId),
+        success: true,
+        duration: firstDataDuration,
+      },
+    });
+    this.wsConnectionStartTime = null;
+    clearCapturedLoadingSessionTraceData(traceId);
+    this.firstDataTraceId = undefined;
+  }
+
   private allMarketSymbols: string[] = [];
   // Unique ID per prewarm cycle to detect stale promises and prevent subscription leaks
   private prewarmCycleId: number = 0;
@@ -876,26 +901,7 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
           PerpsConnectionManager.getConnectionGeneration(),
         );
         // Track first price data from WebSocket (only once per connection)
-        if (this.wsConnectionStartTime !== null && this.firstDataTraceId) {
-          const firstDataDuration =
-            performance.now() - this.wsConnectionStartTime;
-          DevLogger.log(
-            `${PERFORMANCE_CONFIG.LoggingMarkers.WebsocketPerformance} PerpsWS: First price data received`,
-            { duration: `${firstDataDuration.toFixed(0)}ms` },
-          );
-          endTrace({
-            name: TraceName.PerpsWebSocketFirstPrice,
-            id: this.firstDataTraceId,
-            data: {
-              ...getCapturedLoadingSessionTraceData(this.firstDataTraceId),
-              success: true,
-              duration: firstDataDuration,
-            },
-          });
-          this.wsConnectionStartTime = null;
-          clearCapturedLoadingSessionTraceData(this.firstDataTraceId);
-          this.firstDataTraceId = undefined;
-        }
+        this.finishFirstDataTrace();
 
         // Update cache and build price map
         const priceMap: Record<string, PriceUpdate> = {};
@@ -1088,26 +1094,7 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
               PerpsConnectionManager.getConnectionGeneration(),
             );
             // Track first price data from WebSocket (only once per prewarm)
-            if (this.wsConnectionStartTime !== null && this.firstDataTraceId) {
-              const firstDataDuration =
-                performance.now() - this.wsConnectionStartTime;
-              DevLogger.log(
-                `${PERFORMANCE_CONFIG.LoggingMarkers.WebsocketPerformance} PerpsWS: First price data received`,
-                { duration: `${firstDataDuration.toFixed(0)}ms` },
-              );
-              endTrace({
-                name: TraceName.PerpsWebSocketFirstPrice,
-                id: this.firstDataTraceId,
-                data: {
-                  ...getCapturedLoadingSessionTraceData(this.firstDataTraceId),
-                  success: true,
-                  duration: firstDataDuration,
-                },
-              });
-              this.wsConnectionStartTime = null;
-              clearCapturedLoadingSessionTraceData(this.firstDataTraceId);
-              this.firstDataTraceId = undefined;
-            }
+            this.finishFirstDataTrace();
 
             const priceMap: Record<string, PriceUpdate> = {};
             updates.forEach((update) => {

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -26,7 +26,15 @@ import {
   findEvmAccount,
 } from '@metamask/perps-controller';
 import { store } from '../../../../store';
-import { selectPerpsTerminalBackendEnabledFlag } from '../selectors/featureFlags';
+import {
+  selectHip3ConfigVersion,
+  selectPerpsTerminalBackendEnabledFlag,
+} from '../selectors/featureFlags';
+import {
+  selectPerpsNetwork,
+  selectPerpsProvider,
+} from '../selectors/perpsController';
+import { selectPerpsSelectedAccountAddress } from '../selectors/selectedAccountAddress';
 import {
   PROVIDER_CONFIG,
   PERPS_DISK_CACHE_MARKETS,
@@ -48,7 +56,17 @@ import {
 import { CandleStreamChannel } from './channels/CandleStreamChannel';
 import { getPreloadedData } from '../hooks/stream/hasCachedPerpsData';
 import { InternalAccount } from '@metamask/keyring-internal-api';
-import { getTerminalGlobalSnapshotUrl } from '../constants/terminalApi';
+import {
+  getTerminalGlobalSnapshotUrl,
+  TERMINAL_GLOBAL_SNAPSHOT_DATA_SOURCE,
+} from '../constants/terminalApi';
+import {
+  createPerpsLoadingSessionIdentity,
+  getActivePerpsLoadingSessionIdentity,
+  getActivePerpsLoadingSessionTraceData,
+  recordPerpsLoadingSessionValuesReady,
+  type PerpsLoadingSessionIdentity,
+} from '../utils/perpsLoadingSession';
 
 /**
  * Gets the EVM account from the selected account group.
@@ -59,6 +77,55 @@ function getEvmAccountFromSelectedAccountGroup() {
   const { AccountTreeController } = Engine.context;
   const accounts = AccountTreeController.getAccountsFromSelectedAccountGroup();
   return findEvmAccount(accounts as InternalAccount[]);
+}
+
+function getCurrentPerpsLoadingSessionIdentity(): PerpsLoadingSessionIdentity {
+  const state = store.getState();
+  return createPerpsLoadingSessionIdentity({
+    address: selectPerpsSelectedAccountAddress(state),
+    hip3ConfigVersion: selectHip3ConfigVersion(state),
+    network: selectPerpsNetwork(state),
+    provider: selectPerpsProvider(state),
+  });
+}
+
+type LoadingSessionTraceData = ReturnType<
+  typeof getActivePerpsLoadingSessionTraceData
+>;
+const loadingSessionDataByTraceId = new Map<string, LoadingSessionTraceData>();
+const MAX_CAPTURED_LOADING_SESSION_TRACE_IDS = 100;
+
+function captureLoadingSessionTraceData(
+  traceId: string,
+): LoadingSessionTraceData {
+  const sessionData = getActivePerpsLoadingSessionTraceData();
+  const data = sessionData
+    ? {
+        ...sessionData,
+        connection_generation: PerpsConnectionManager.getConnectionGeneration(),
+      }
+    : undefined;
+  loadingSessionDataByTraceId.set(traceId, data);
+  while (
+    loadingSessionDataByTraceId.size > MAX_CAPTURED_LOADING_SESSION_TRACE_IDS
+  ) {
+    const oldestTraceId = loadingSessionDataByTraceId.keys().next().value;
+    if (oldestTraceId === undefined) {
+      break;
+    }
+    loadingSessionDataByTraceId.delete(oldestTraceId);
+  }
+  return data;
+}
+
+function getCapturedLoadingSessionTraceData(
+  traceId: string,
+): LoadingSessionTraceData {
+  return loadingSessionDataByTraceId.get(traceId);
+}
+
+function clearCapturedLoadingSessionTraceData(traceId: string): void {
+  loadingSessionDataByTraceId.delete(traceId);
 }
 
 // Generic subscription parameters
@@ -100,6 +167,7 @@ abstract class StreamChannel<T> {
   // subscribers. Channels without symbol subscriptions never touch this map.
   protected readonly symbolSubscribers = new Map<string, Set<string>>();
   protected wsSubscription: (() => void) | null = null;
+  private subscriptionGeneration = 0;
   readonly #onDataPersist?: () => void;
   readonly #lifecycle?: StreamChannelLifecycle;
 
@@ -110,6 +178,33 @@ abstract class StreamChannel<T> {
 
   protected triggerPersist(): void {
     this.#onDataPersist?.();
+  }
+
+  protected getSubscriptionContext(): {
+    generation: number;
+    address: string | null;
+  } {
+    return {
+      generation: this.subscriptionGeneration,
+      address:
+        getEvmAccountFromSelectedAccountGroup()?.address?.toLowerCase() ?? null,
+    };
+  }
+
+  protected isSubscriptionContextCurrent(context: {
+    generation: number;
+    address: string | null;
+  }): boolean {
+    const currentAddress =
+      getEvmAccountFromSelectedAccountGroup()?.address?.toLowerCase() ?? null;
+    return (
+      context.generation === this.subscriptionGeneration &&
+      context.address === currentAddress
+    );
+  }
+
+  protected invalidateSubscriptionContext(): void {
+    this.subscriptionGeneration += 1;
   }
 
   // Track account context to prevent stale data across account switches
@@ -499,6 +594,7 @@ abstract class StreamChannel<T> {
   }
 
   public disconnect() {
+    this.invalidateSubscriptionContext();
     this.#lifecycle?.onDisconnect?.();
     this.connectRetryCount = 0;
     if (this.deferConnectTimer) {
@@ -614,6 +710,7 @@ abstract class StreamChannel<T> {
   }
 
   public clearCache(): void {
+    this.invalidateSubscriptionContext();
     // End any first-data trace still open, so clearing the cache before first
     // data doesn't leave a span running until the 5-minute auto-clean.
     this.endOpenFirstDataTrace();
@@ -671,8 +768,13 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
       endTrace({
         name: TraceName.PerpsWebSocketFirstPrice,
         id: this.firstDataTraceId,
-        data: { success: false, reason: 'disconnected' },
+        data: {
+          ...getCapturedLoadingSessionTraceData(this.firstDataTraceId),
+          success: false,
+          reason: 'disconnected',
+        },
       });
+      clearCapturedLoadingSessionTraceData(this.firstDataTraceId);
       this.firstDataTraceId = undefined;
     }
   }
@@ -743,12 +845,26 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
       id: this.firstDataTraceId,
       op: TraceOperation.PerpsOperation,
       tags: buildPerpsCufStartTags(),
+      data: captureLoadingSessionTraceData(this.firstDataTraceId),
     });
     this.wsConnectionStartTime = performance.now();
+    const loadingIdentity = getCurrentPerpsLoadingSessionIdentity();
+    const subscriptionContext = this.getSubscriptionContext();
 
     this.wsSubscription = Engine.context.PerpsController.subscribeToPrices({
       symbols: allSymbols,
       callback: (updates: PriceUpdate[]) => {
+        if (!this.isSubscriptionContextCurrent(subscriptionContext)) {
+          return;
+        }
+        recordPerpsLoadingSessionValuesReady(
+          'prices',
+          'fresh_socket',
+          updates.length,
+          {},
+          loadingIdentity,
+          PerpsConnectionManager.getConnectionGeneration(),
+        );
         // Track first price data from WebSocket (only once per connection)
         if (this.wsConnectionStartTime !== null && this.firstDataTraceId) {
           const firstDataDuration =
@@ -760,9 +876,14 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
           endTrace({
             name: TraceName.PerpsWebSocketFirstPrice,
             id: this.firstDataTraceId,
-            data: { success: true, duration: firstDataDuration },
+            data: {
+              ...getCapturedLoadingSessionTraceData(this.firstDataTraceId),
+              success: true,
+              duration: firstDataDuration,
+            },
           });
           this.wsConnectionStartTime = null;
+          clearCapturedLoadingSessionTraceData(this.firstDataTraceId);
           this.firstDataTraceId = undefined;
         }
 
@@ -923,8 +1044,11 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
           id: this.firstDataTraceId,
           op: TraceOperation.PerpsOperation,
           tags: buildPerpsCufStartTags(),
+          data: captureLoadingSessionTraceData(this.firstDataTraceId),
         });
         this.wsConnectionStartTime = performance.now();
+        const loadingIdentity = getCurrentPerpsLoadingSessionIdentity();
+        const subscriptionContext = this.getSubscriptionContext();
 
         // WARNING: Do NOT set includeMarketData: true here. It triggers
         // per-symbol activeAssetCtx subscriptions (N symbols × N DEXs = N²
@@ -934,6 +1058,17 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
           symbols: this.allMarketSymbols,
           includeMarketData: false,
           callback: (updates: PriceUpdate[]) => {
+            if (!this.isSubscriptionContextCurrent(subscriptionContext)) {
+              return;
+            }
+            recordPerpsLoadingSessionValuesReady(
+              'prices',
+              'fresh_socket',
+              updates.length,
+              {},
+              loadingIdentity,
+              PerpsConnectionManager.getConnectionGeneration(),
+            );
             // Track first price data from WebSocket (only once per prewarm)
             if (this.wsConnectionStartTime !== null && this.firstDataTraceId) {
               const firstDataDuration =
@@ -945,9 +1080,14 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
               endTrace({
                 name: TraceName.PerpsWebSocketFirstPrice,
                 id: this.firstDataTraceId,
-                data: { success: true, duration: firstDataDuration },
+                data: {
+                  ...getCapturedLoadingSessionTraceData(this.firstDataTraceId),
+                  success: true,
+                  duration: firstDataDuration,
+                },
               });
               this.wsConnectionStartTime = null;
+              clearCapturedLoadingSessionTraceData(this.firstDataTraceId);
               this.firstDataTraceId = undefined;
             }
 
@@ -1002,6 +1142,7 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
    * Cleanup pre-warm subscription
    */
   public cleanupPrewarm(): void {
+    this.invalidateSubscriptionContext();
     // Prewarm starts the first-price trace; end it here too so a soft reconnect
     // (preserveCaches: true skips clearCache) doesn't leave it open to be
     // overwritten by the next prewarm.
@@ -1025,8 +1166,13 @@ class OrderStreamChannel extends StreamChannel<Order[] | null> {
       endTrace({
         name: TraceName.PerpsWebSocketFirstOrders,
         id: this.firstDataTraceId,
-        data: { success: false, reason: 'disconnected' },
+        data: {
+          ...getCapturedLoadingSessionTraceData(this.firstDataTraceId),
+          success: false,
+          reason: 'disconnected',
+        },
       });
+      clearCapturedLoadingSessionTraceData(this.firstDataTraceId);
       this.firstDataTraceId = undefined;
     }
   }
@@ -1042,25 +1188,21 @@ class OrderStreamChannel extends StreamChannel<Order[] | null> {
       name: TraceName.PerpsWebSocketFirstOrders,
       id: this.firstDataTraceId,
       op: TraceOperation.PerpsOperation,
+      data: captureLoadingSessionTraceData(this.firstDataTraceId),
     });
 
     // Track WebSocket connection start time for duration calculation
     this.wsConnectionStartTime = performance.now();
+    const loadingIdentity = getCurrentPerpsLoadingSessionIdentity();
+    const subscriptionContext = this.getSubscriptionContext();
 
     this.wsSubscription = Engine.context.PerpsController.subscribeToOrders({
       callback: (orders: Order[]) => {
-        // Validate account context
-        const currentAccount =
-          getEvmAccountFromSelectedAccountGroup()?.address || null;
-        if (this.accountAddress && this.accountAddress !== currentAccount) {
-          Logger.error(new Error('OrderStreamChannel: Wrong account context'), {
-            expected: currentAccount,
-            received: this.accountAddress,
-          });
+        if (!this.isSubscriptionContextCurrent(subscriptionContext)) {
           return;
         }
-        this.accountAddress = currentAccount;
-        this.cacheAccountAddress = currentAccount;
+        this.accountAddress = subscriptionContext.address;
+        this.cacheAccountAddress = subscriptionContext.address;
 
         // Track first order data from WebSocket (only once per connection)
         if (this.wsConnectionStartTime !== null && this.firstDataTraceId) {
@@ -1080,15 +1222,25 @@ class OrderStreamChannel extends StreamChannel<Order[] | null> {
             name: TraceName.PerpsWebSocketFirstOrders,
             id: this.firstDataTraceId,
             data: {
+              ...getCapturedLoadingSessionTraceData(this.firstDataTraceId),
               success: true,
               duration: firstDataDuration,
             },
           });
 
           this.wsConnectionStartTime = null;
+          clearCapturedLoadingSessionTraceData(this.firstDataTraceId);
           this.firstDataTraceId = undefined;
         }
 
+        recordPerpsLoadingSessionValuesReady(
+          'orders',
+          'fresh_socket',
+          orders.length,
+          {},
+          loadingIdentity,
+          PerpsConnectionManager.getConnectionGeneration(),
+        );
         this.cache.set('orders', orders);
         this.notifySubscribers(orders);
         // Orders confirmed in the live stream — close pending cancel / limit
@@ -1251,8 +1403,13 @@ class PositionStreamChannel extends StreamChannel<Position[] | null> {
       endTrace({
         name: TraceName.PerpsWebSocketFirstPositions,
         id: this.firstDataTraceId,
-        data: { success: false, reason: 'disconnected' },
+        data: {
+          ...getCapturedLoadingSessionTraceData(this.firstDataTraceId),
+          success: false,
+          reason: 'disconnected',
+        },
       });
+      clearCapturedLoadingSessionTraceData(this.firstDataTraceId);
       this.firstDataTraceId = undefined;
     }
   }
@@ -1268,28 +1425,21 @@ class PositionStreamChannel extends StreamChannel<Position[] | null> {
       name: TraceName.PerpsWebSocketFirstPositions,
       id: this.firstDataTraceId,
       op: TraceOperation.PerpsOperation,
+      data: captureLoadingSessionTraceData(this.firstDataTraceId),
     });
 
     // Track WebSocket connection start time for duration calculation
     this.wsConnectionStartTime = performance.now();
+    const loadingIdentity = getCurrentPerpsLoadingSessionIdentity();
+    const subscriptionContext = this.getSubscriptionContext();
 
     this.wsSubscription = Engine.context.PerpsController.subscribeToPositions({
       callback: (positions: Position[]) => {
-        // Validate account context
-        const currentAccount =
-          getEvmAccountFromSelectedAccountGroup()?.address || null;
-        if (this.accountAddress && this.accountAddress !== currentAccount) {
-          Logger.error(
-            new Error('PositionStreamChannel: Wrong account context'),
-            {
-              expected: currentAccount,
-              received: this.accountAddress,
-            },
-          );
+        if (!this.isSubscriptionContextCurrent(subscriptionContext)) {
           return;
         }
-        this.accountAddress = currentAccount;
-        this.cacheAccountAddress = currentAccount;
+        this.accountAddress = subscriptionContext.address;
+        this.cacheAccountAddress = subscriptionContext.address;
 
         // Track first position data from WebSocket (only once per connection)
         if (this.wsConnectionStartTime !== null && this.firstDataTraceId) {
@@ -1310,15 +1460,25 @@ class PositionStreamChannel extends StreamChannel<Position[] | null> {
             name: TraceName.PerpsWebSocketFirstPositions,
             id: this.firstDataTraceId,
             data: {
+              ...getCapturedLoadingSessionTraceData(this.firstDataTraceId),
               success: true,
               duration: firstDataDuration,
             },
           });
 
           this.wsConnectionStartTime = null;
+          clearCapturedLoadingSessionTraceData(this.firstDataTraceId);
           this.firstDataTraceId = undefined;
         }
 
+        recordPerpsLoadingSessionValuesReady(
+          'positions',
+          'fresh_socket',
+          positions.length,
+          {},
+          loadingIdentity,
+          PerpsConnectionManager.getConnectionGeneration(),
+        );
         this.cache.set('positions', positions);
         this.notifySubscribers(positions);
         // Positions just rendered to subscribers — close any pending CUF span
@@ -1469,8 +1629,16 @@ class FillStreamChannel extends StreamChannel<OrderFill[]> {
 
     if (!this.ensureReady()) return;
 
+    const subscriptionContext = this.getSubscriptionContext();
+
     this.wsSubscription = Engine.context.PerpsController.subscribeToOrderFills({
       callback: (fills: OrderFill[], isSnapshot?: boolean) => {
+        if (!this.isSubscriptionContextCurrent(subscriptionContext)) {
+          return;
+        }
+        this.accountAddress = subscriptionContext.address;
+        this.cacheAccountAddress = subscriptionContext.address;
+
         let updated: OrderFill[];
         if (isSnapshot) {
           // Snapshot: replace cache with initial historical data
@@ -1491,7 +1659,11 @@ class FillStreamChannel extends StreamChannel<OrderFill[]> {
   }
 
   protected getCachedData() {
-    return this.cache.get('fills') || [];
+    const cached = this.cache.get('fills');
+    if (cached === undefined) {
+      return [];
+    }
+    return this.isAccountContextCurrent() ? cached : null;
   }
 
   protected getClearedData(): OrderFill[] {
@@ -1499,7 +1671,9 @@ class FillStreamChannel extends StreamChannel<OrderFill[]> {
   }
 
   public getSnapshot(): OrderFill[] | null {
-    return this.cache.get('fills') ?? null;
+    return this.isAccountContextCurrent()
+      ? (this.cache.get('fills') ?? null)
+      : null;
   }
 
   /**
@@ -1556,8 +1730,13 @@ class AccountStreamChannel extends StreamChannel<AccountState | null> {
       endTrace({
         name: TraceName.PerpsWebSocketFirstAccount,
         id: this.firstDataTraceId,
-        data: { success: false, reason: 'disconnected' },
+        data: {
+          ...getCapturedLoadingSessionTraceData(this.firstDataTraceId),
+          success: false,
+          reason: 'disconnected',
+        },
       });
+      clearCapturedLoadingSessionTraceData(this.firstDataTraceId);
       this.firstDataTraceId = undefined;
     }
   }
@@ -1573,28 +1752,21 @@ class AccountStreamChannel extends StreamChannel<AccountState | null> {
       name: TraceName.PerpsWebSocketFirstAccount,
       id: this.firstDataTraceId,
       op: TraceOperation.PerpsOperation,
+      data: captureLoadingSessionTraceData(this.firstDataTraceId),
     });
 
     // Track WebSocket connection start time for duration calculation
     this.wsConnectionStartTime = performance.now();
+    const loadingIdentity = getCurrentPerpsLoadingSessionIdentity();
+    const subscriptionContext = this.getSubscriptionContext();
 
     this.wsSubscription = Engine.context.PerpsController.subscribeToAccount({
       callback: (account: AccountState | null) => {
-        // Validate account context
-        const currentAccount =
-          getEvmAccountFromSelectedAccountGroup()?.address || null;
-        if (this.accountAddress && this.accountAddress !== currentAccount) {
-          Logger.error(
-            new Error('AccountStreamChannel: Wrong account context'),
-            {
-              expected: currentAccount,
-              received: this.accountAddress,
-            },
-          );
+        if (!this.isSubscriptionContextCurrent(subscriptionContext)) {
           return;
         }
-        this.accountAddress = currentAccount;
-        this.cacheAccountAddress = currentAccount;
+        this.accountAddress = subscriptionContext.address;
+        this.cacheAccountAddress = subscriptionContext.address;
 
         // Track first account data from WebSocket (only once per connection)
         if (this.wsConnectionStartTime !== null && this.firstDataTraceId) {
@@ -1614,15 +1786,25 @@ class AccountStreamChannel extends StreamChannel<AccountState | null> {
             name: TraceName.PerpsWebSocketFirstAccount,
             id: this.firstDataTraceId,
             data: {
+              ...getCapturedLoadingSessionTraceData(this.firstDataTraceId),
               success: true,
               duration: firstDataDuration,
             },
           });
 
           this.wsConnectionStartTime = null;
+          clearCapturedLoadingSessionTraceData(this.firstDataTraceId);
           this.firstDataTraceId = undefined;
         }
 
+        recordPerpsLoadingSessionValuesReady(
+          'account',
+          'fresh_socket',
+          account ? 1 : 0,
+          {},
+          loadingIdentity,
+          PerpsConnectionManager.getConnectionGeneration(),
+        );
         // Use base cache Map with consistent key
         this.cache.set('account', account);
         this.notifySubscribers(account as AccountState | null);
@@ -1714,18 +1896,6 @@ class OICapStreamChannel extends StreamChannel<string[]> {
     // Subscribe to OI cap updates (zero overhead - extracted from existing webData3)
     this.wsSubscription = Engine.context.PerpsController.subscribeToOICaps({
       callback: (caps: string[]) => {
-        // Validate account context
-        const currentAccount =
-          getEvmAccountFromSelectedAccountGroup()?.address || null;
-        if (this.accountAddress && this.accountAddress !== currentAccount) {
-          Logger.error(new Error('OICapStreamChannel: Wrong account context'), {
-            expected: currentAccount,
-            received: this.accountAddress,
-          });
-          return;
-        }
-        this.accountAddress = currentAccount;
-
         this.cache.set('oiCaps', caps);
         this.notifySubscribers(caps);
       },
@@ -1927,6 +2097,16 @@ class TopOfBookStreamChannel extends StreamChannel<
     this.cachedTopOfBook = undefined;
     super.disconnect();
   }
+
+  public reconnect(): void {
+    const symbol = this.currentSymbol;
+    this.disconnect();
+    super.clearCache();
+    if (symbol && this.subscribers.size > 0) {
+      this.currentSymbol = symbol;
+      this.connect();
+    }
+  }
 }
 
 /**
@@ -1955,11 +2135,17 @@ class FocusedPriceStreamChannel extends StreamChannel<PriceUpdate | undefined> {
       symbol: this.currentSymbol,
     });
 
+    const subscribedSymbol = this.currentSymbol;
+    const subscriptionContext = this.getSubscriptionContext();
+
     this.wsSubscription = Engine.context.PerpsController.subscribeToPrices({
-      symbols: [this.currentSymbol],
+      symbols: [subscribedSymbol],
       includeMarketData: true,
       callback: (updates: PriceUpdate[]) => {
-        const update = updates.find((u) => u.symbol === this.currentSymbol);
+        if (!this.isSubscriptionContextCurrent(subscriptionContext)) {
+          return;
+        }
+        const update = updates.find((u) => u.symbol === subscribedSymbol);
         if (update) {
           this.cachedPriceUpdate = update;
           // Scope dispatch to subscribers registered for this update's symbol.
@@ -2054,6 +2240,18 @@ class FocusedPriceStreamChannel extends StreamChannel<PriceUpdate | undefined> {
     this.connect();
   }
 
+  public reconnect(): void {
+    const symbol =
+      this.currentSymbol ?? this.symbolSubscribers.keys().next().value;
+    this.cachedPriceUpdate = undefined;
+    this.disconnect();
+    super.clearCache();
+    if (symbol && this.subscribers.size > 0) {
+      this.currentSymbol = symbol;
+      this.connect();
+    }
+  }
+
   public disconnect() {
     this.currentSymbol = null;
     this.cachedPriceUpdate = undefined;
@@ -2080,7 +2278,7 @@ class MarketDataChannel extends StreamChannel<PerpsMarketData[]> {
     return (
       data.length > 0 &&
       data.every(
-        (market) => market.dataSource === 'terminal-global-snapshot-mark',
+        (market) => market.dataSource === TERMINAL_GLOBAL_SNAPSHOT_DATA_SOURCE,
       )
     );
   }
@@ -2096,9 +2294,9 @@ class MarketDataChannel extends StreamChannel<PerpsMarketData[]> {
 
   private getCurrentSourceKey(): string {
     const controller = Engine.context.PerpsController;
-    const terminalEnabled = selectPerpsTerminalBackendEnabledFlag(
-      store.getState(),
-    );
+    const state = store.getState();
+    const terminalEnabled = selectPerpsTerminalBackendEnabledFlag(state);
+    const hip3ConfigVersion = selectHip3ConfigVersion(state);
     const activeProvider =
       controller.state.activeProvider ?? PROVIDER_CONFIG.DefaultProvider;
     const providerNetworkKey = buildProviderCacheKey(
@@ -2111,7 +2309,7 @@ class MarketDataChannel extends StreamChannel<PerpsMarketData[]> {
     } else if (terminalEnabled) {
       source = 'terminal';
     }
-    return `${providerNetworkKey}:${source}`;
+    return `${providerNetworkKey}:${hip3ConfigVersion}:${source}`;
   }
 
   protected connect() {
@@ -2164,6 +2362,13 @@ class MarketDataChannel extends StreamChannel<PerpsMarketData[]> {
         cacheValidForMs: this.CACHE_DURATION - cacheAge,
         providerId: currentProviderId,
       });
+      recordPerpsLoadingSessionValuesReady(
+        'markets',
+        'memory_cache',
+        cached.length,
+        {},
+        getCurrentPerpsLoadingSessionIdentity(),
+      );
       // subscribe() already delivered this cache. Existing subscribers already
       // render it, so wait for the next fresh fetch before notifying again.
     }
@@ -2217,6 +2422,13 @@ class MarketDataChannel extends StreamChannel<PerpsMarketData[]> {
           this.cache.set('markets', cachedForProvider);
           this.lastFetchTime = Date.now();
           this.cachedSourceKey = controllerNetworkKey;
+          recordPerpsLoadingSessionValuesReady(
+            'markets',
+            'memory_cache',
+            cachedForProvider.length,
+            {},
+            getCurrentPerpsLoadingSessionIdentity(),
+          );
           this.notifySubscribers(cachedForProvider, 'cache');
           return;
         }
@@ -2256,6 +2468,16 @@ class MarketDataChannel extends StreamChannel<PerpsMarketData[]> {
         this.cache.set('markets', data);
         this.lastFetchTime = Date.now();
         this.cachedSourceKey = preFetchNetworkKey;
+        recordPerpsLoadingSessionValuesReady(
+          'markets',
+          this.isCompleteGlobalSnapshot(data)
+            ? 'terminal_global_snapshot_v2'
+            : 'provider',
+          data.length,
+          {},
+          getActivePerpsLoadingSessionIdentity() ??
+            getCurrentPerpsLoadingSessionIdentity(),
+        );
         // Notify all subscribers
         this.notifySubscribers(data);
         this.triggerPersist();
@@ -2385,6 +2607,7 @@ class MarketDataChannel extends StreamChannel<PerpsMarketData[]> {
       this.cache.clear();
       this.lastFetchTime = 0;
       this.cachedSourceKey = null;
+      this.lastDeliveredAt = null;
     }
 
     this.subscribers.forEach((subscriber) => {
@@ -2484,6 +2707,31 @@ export class PerpsStreamManager {
     this.positions.seedCache('positions', snapshot.positions);
     this.orders.seedCache('orders', snapshot.orders);
     this.account.seedCache('account', snapshot.accountState);
+
+    const proofSource =
+      source === 'cache' ? 'memory_cache' : 'provider_snapshot';
+    const loadingIdentity = getCurrentPerpsLoadingSessionIdentity();
+    recordPerpsLoadingSessionValuesReady(
+      'positions',
+      proofSource,
+      snapshot.positions.length,
+      {},
+      loadingIdentity,
+    );
+    recordPerpsLoadingSessionValuesReady(
+      'orders',
+      proofSource,
+      snapshot.orders.length,
+      {},
+      loadingIdentity,
+    );
+    recordPerpsLoadingSessionValuesReady(
+      'account',
+      proofSource,
+      1,
+      {},
+      loadingIdentity,
+    );
 
     this.positions.publish(snapshot.positions, source);
     this.orders.publish(snapshot.orders, source);

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -2063,7 +2063,7 @@ class TopOfBookStreamChannel extends StreamChannel<
             spread: update.spread,
           };
           this.cachedTopOfBook = topOfBook;
-          this.notifySubscribers(topOfBook);
+          this.notifySubscribersForSymbols(topOfBook, [subscribedSymbol]);
         }
       },
     });
@@ -2103,6 +2103,9 @@ class TopOfBookStreamChannel extends StreamChannel<
         | undefined,
     ) => void;
   }): () => void {
+    if (!params.symbol) {
+      return () => undefined;
+    }
     if (this.currentSymbol && this.currentSymbol !== params.symbol) {
       DevLogger.log(
         'TopOfBookStreamChannel: Warning - different symbol requested, staying on current',
@@ -2121,9 +2124,31 @@ class TopOfBookStreamChannel extends StreamChannel<
       this.currentSymbol = params.symbol;
     }
 
-    return this.subscribe({
+    const unsubscribe = this.subscribe({
+      symbols: [params.symbol],
       callback: params.callback,
     });
+
+    return () => {
+      unsubscribe();
+      this.refocusToRemainingSymbol();
+    };
+  }
+
+  private refocusToRemainingSymbol(): void {
+    if (this.subscribers.size === 0) {
+      return;
+    }
+    if (this.currentSymbol && this.symbolSubscribers.has(this.currentSymbol)) {
+      return;
+    }
+    const nextSymbol = this.symbolSubscribers.keys().next().value;
+    if (!nextSymbol) {
+      return;
+    }
+    this.disconnect();
+    this.currentSymbol = nextSymbol;
+    this.connect();
   }
 
   public disconnect() {
@@ -2133,7 +2158,10 @@ class TopOfBookStreamChannel extends StreamChannel<
   }
 
   public reconnect(): void {
-    const symbol = this.currentSymbol;
+    const symbol =
+      this.currentSymbol && this.symbolSubscribers.has(this.currentSymbol)
+        ? this.currentSymbol
+        : this.symbolSubscribers.keys().next().value;
     this.disconnect();
     super.clearCache();
     if (symbol && this.subscribers.size > 0) {

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -90,9 +90,17 @@ const mockStreamManagerInstance = {
   account: { clearCache: jest.fn(), prewarm: jest.fn(() => jest.fn()) },
   marketData: { clearCache: jest.fn(), prewarm: jest.fn(() => jest.fn()) },
   prices: { clearCache: jest.fn(), prewarm: jest.fn(async () => jest.fn()) },
-  oiCaps: { clearCache: jest.fn(), prewarm: jest.fn(() => jest.fn()) },
+  oiCaps: {
+    clearCache: jest.fn(),
+    prewarm: jest.fn(() => jest.fn()),
+    reconnect: jest.fn(),
+  },
   fills: { clearCache: jest.fn(), prewarm: jest.fn(() => jest.fn()) },
-  topOfBook: { clearCache: jest.fn(), prewarm: jest.fn(() => jest.fn()) },
+  topOfBook: {
+    clearCache: jest.fn(),
+    prewarm: jest.fn(() => jest.fn()),
+    reconnect: jest.fn(),
+  },
   focusedPrice: { clearCache: jest.fn(), reconnect: jest.fn() },
   candles: {
     clearCache: jest.fn(),
@@ -1012,6 +1020,33 @@ describe('PerpsConnectionManager', () => {
       mockPerpsController.reconnectWithNewContext.mockResolvedValue();
     });
 
+    it('runs a queued force request after the current reconnect fails', async () => {
+      const manager = PerpsConnectionManager as unknown as {
+        performReconnection: () => Promise<void>;
+        reconnectWithNewContext: (options?: {
+          force?: boolean;
+        }) => Promise<void>;
+      };
+      let rejectFirst: ((error: Error) => void) | undefined;
+      const firstAttempt = new Promise<void>((_resolve, reject) => {
+        rejectFirst = reject;
+      });
+      const reconnect = jest
+        .spyOn(manager, 'performReconnection')
+        .mockImplementationOnce(() => firstAttempt)
+        .mockResolvedValueOnce();
+
+      const first = manager.reconnectWithNewContext();
+      await Promise.resolve();
+      const queued = manager.reconnectWithNewContext({ force: true });
+      rejectFirst?.(new Error('first reconnect failed'));
+
+      await expect(first).resolves.toBeUndefined();
+      await expect(queued).resolves.toBeUndefined();
+      expect(reconnect).toHaveBeenCalledTimes(2);
+      reconnect.mockRestore();
+    });
+
     it('reconnects again when account changes during reconnection preload', async () => {
       jest.useFakeTimers();
       const addressA = '0x1111111111111111111111111111111111111111';
@@ -1145,6 +1180,8 @@ describe('PerpsConnectionManager', () => {
         reconnectWithNewContext: () => Promise<void>;
       };
       const selectedMarketContextKey = manager.getSelectedMarketContextKey();
+      const initialConnectionGeneration =
+        PerpsConnectionManager.getConnectionGeneration();
       manager.initializedMarketContextKey = selectedMarketContextKey;
       manager.initializedConnectionGeneration = 0;
       manager.pendingSkipMarketNotify = true;
@@ -1154,9 +1191,12 @@ describe('PerpsConnectionManager', () => {
 
       await manager.reconnectWithNewContext();
 
-      expect(listener).not.toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledTimes(1);
       expect(PerpsConnectionManager.getInitializedMarketContextKey()).toBe(
         selectedMarketContextKey,
+      );
+      expect(PerpsConnectionManager.getConnectionGeneration()).toBe(
+        initialConnectionGeneration + 1,
       );
       unsubscribe();
     });

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -1180,6 +1180,7 @@ describe('PerpsConnectionManager', () => {
       await Promise.resolve();
       await Promise.resolve();
 
+      expect(mockPerpsController.getActiveProvider).not.toHaveBeenCalled();
       expect(manager.isConnected).toBe(true);
       expect(manager.isInitialized).toBe(true);
       expect(manager.initializedUserContextKey).toBe('replacement');

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -55,6 +55,17 @@ jest.mock('../utils/perpsCufTrace', () => ({
   endPerpsCufTrace: jest.fn(),
 }));
 
+jest.mock('../utils/perpsLoadingSession', () => ({
+  getActivePerpsLoadingSessionTraceData: jest.fn(),
+  markPerpsLoadingSessionConnectionValidated: jest.fn(),
+  setPerpsLoadingSessionLifecycle: jest.fn(),
+  startPerpsLoadingSession: jest.fn(),
+}));
+
+jest.mock('../utils/perpsLifecycleContext', () => ({
+  getPerpsLifecycleContext: jest.fn(() => 'warm'),
+}));
+
 // Mock selectors
 jest.mock('../../../../selectors/accountsController', () => ({
   selectSelectedInternalAccountAddress: jest.fn(),
@@ -82,6 +93,7 @@ const mockStreamManagerInstance = {
   oiCaps: { clearCache: jest.fn(), prewarm: jest.fn(() => jest.fn()) },
   fills: { clearCache: jest.fn(), prewarm: jest.fn(() => jest.fn()) },
   topOfBook: { clearCache: jest.fn(), prewarm: jest.fn(() => jest.fn()) },
+  focusedPrice: { clearCache: jest.fn(), reconnect: jest.fn() },
   candles: {
     clearCache: jest.fn(),
     prewarm: jest.fn(() => jest.fn()),
@@ -120,12 +132,19 @@ import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import Engine from '../../../../core/Engine';
 import { store } from '../../../../store';
 import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
-import { selectPerpsNetwork } from '../selectors/perpsController';
+import {
+  selectPerpsNetwork,
+  selectPerpsProvider,
+} from '../selectors/perpsController';
 import {
   clearPendingPerpsCufTraces,
   endPerpsCufTrace,
 } from '../utils/perpsCufTrace';
 import { TraceName } from '../../../../util/trace';
+import {
+  setPerpsLoadingSessionLifecycle,
+  startPerpsLoadingSession,
+} from '../utils/perpsLoadingSession';
 
 const mockClearPendingPerpsCufTraces =
   clearPendingPerpsCufTraces as jest.MockedFunction<
@@ -157,12 +176,21 @@ const resetManager = (manager: unknown) => {
     isConnected: boolean;
     isConnecting: boolean;
     isInitialized: boolean;
+    initializedMarketContextKey: string | null;
+    initializedConnectionGeneration: number | null;
+    initializedUserContextKey: string | null;
+    connectionGeneration: number;
     isDisconnecting: boolean;
     connectionRefCount: number;
     initPromise: Promise<void> | null;
     disconnectPromise: Promise<void> | null;
     pendingReconnectPromise: Promise<void> | null;
+    pendingReconnectRequest: {
+      userContextKey: string;
+      force: boolean;
+    } | null;
     ensureConnectedPromise: Promise<void> | null;
+    pendingConnectionGenerationAdvanced: boolean;
     unsubscribeFromStore: (() => void) | null;
     previousAddress: string | undefined;
     previousPerpsNetwork: 'mainnet' | 'testnet' | undefined;
@@ -199,12 +227,18 @@ const resetManager = (manager: unknown) => {
   m.isConnected = false;
   m.isConnecting = false;
   m.isInitialized = false;
+  m.initializedMarketContextKey = null;
+  m.initializedConnectionGeneration = null;
+  m.initializedUserContextKey = null;
+  m.connectionGeneration = 0;
   m.isDisconnecting = false;
   m.connectionRefCount = 0;
   m.initPromise = null;
   m.disconnectPromise = null;
   m.pendingReconnectPromise = null;
+  m.pendingReconnectRequest = null;
   m.ensureConnectedPromise = null;
+  m.pendingConnectionGenerationAdvanced = false;
   m.unsubscribeFromStore = null;
   m.previousAddress = undefined;
   m.previousPerpsNetwork = undefined;
@@ -244,6 +278,10 @@ describe('PerpsConnectionManager', () => {
         },
       },
     });
+    (selectPerpsNetwork as unknown as jest.Mock).mockReturnValue('testnet');
+    (selectPerpsProvider as unknown as jest.Mock).mockReturnValue(
+      'hyperliquid',
+    );
 
     // Clear StreamManager mock calls
     mockStreamManagerInstance.positions.clearCache.mockClear();
@@ -329,6 +367,65 @@ describe('PerpsConnectionManager', () => {
       expect(mockDevLogger.log).toHaveBeenCalledWith(
         expect.stringContaining('refCount: 2'),
       );
+    });
+
+    it('reconnects when the selected account changes during initial preload', async () => {
+      const initialAddress = '0x1111111111111111111111111111111111111111';
+      const nextAddress = '0x2222222222222222222222222222222222222222';
+      let notifyPrewarmStarted: () => void = () => undefined;
+      const prewarmStarted = new Promise<void>((resolve) => {
+        notifyPrewarmStarted = resolve;
+      });
+      let resolveInitialPrewarm: (() => void) | undefined;
+
+      (
+        selectSelectedInternalAccountByScope as unknown as jest.Mock
+      ).mockReturnValue(() => ({ address: initialAddress }));
+      mockPerpsController.init.mockResolvedValue();
+      mockStreamManagerInstance.prices.prewarm.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveInitialPrewarm = () => resolve(jest.fn());
+            notifyPrewarmStarted();
+          }),
+      );
+
+      const connectPromise = PerpsConnectionManager.connect();
+      await prewarmStarted;
+      if (!resolveInitialPrewarm) {
+        throw new Error('Initial preload did not start.');
+      }
+
+      (
+        selectSelectedInternalAccountByScope as unknown as jest.Mock
+      ).mockReturnValue(() => ({ address: nextAddress }));
+      storeCallbacks[storeCallbacks.length - 1]();
+
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      resolveInitialPrewarm();
+      await connectPromise;
+
+      for (let attempt = 0; attempt < 10; attempt++) {
+        if (mockPerpsController.init.mock.calls.length >= 2) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      const pendingReconnect = (
+        PerpsConnectionManager as unknown as {
+          pendingReconnectPromise: Promise<void> | null;
+        }
+      ).pendingReconnectPromise;
+      await pendingReconnect;
+
+      expect(mockPerpsController.init).toHaveBeenCalledTimes(2);
+      expect(PerpsConnectionManager.isSelectedUserContextReady()).toBe(true);
+
+      (
+        selectSelectedInternalAccountByScope as unknown as jest.Mock
+      ).mockReturnValue(() => ({
+        address: '0x1234567890123456789012345678901234567890',
+      }));
     });
 
     it('sets error state and resets flags when connection fails', async () => {
@@ -515,6 +612,11 @@ describe('PerpsConnectionManager', () => {
     });
 
     it('returns connecting state while connection is in progress', async () => {
+      const marketContextListener = jest.fn();
+      const unsubscribe =
+        PerpsConnectionManager.subscribeToInitializedMarketContext(
+          marketContextListener,
+        );
       mockPerpsController.init.mockImplementation(
         () => new Promise((resolve) => setTimeout(resolve, 100)),
       );
@@ -532,6 +634,11 @@ describe('PerpsConnectionManager', () => {
       expect(finalState.isConnecting).toBe(false);
       expect(finalState.isConnected).toBe(true);
       expect(finalState.isInitialized).toBe(true);
+      expect(PerpsConnectionManager.getInitializedMarketContextKey()).toBe(
+        'testnet|hyperliquid|0',
+      );
+      expect(marketContextListener).toHaveBeenCalledTimes(1);
+      unsubscribe();
     });
   });
 
@@ -688,6 +795,13 @@ describe('PerpsConnectionManager', () => {
       // Trigger the store callback with the changed value
       storeCallback();
 
+      // Cleared user channels must not subscribe to the old provider while the
+      // account reconnect is still inside its debounce window.
+      expect(PerpsConnectionManager.getConnectionState().isInitialized).toBe(
+        false,
+      );
+      expect(PerpsConnectionManager.getInitializedUserContextKey()).toBeNull();
+
       // Wait for async operations
       await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -705,6 +819,7 @@ describe('PerpsConnectionManager', () => {
       expect(
         mockStreamManagerInstance.marketData.clearCache,
       ).not.toHaveBeenCalled();
+      expect(startPerpsLoadingSession).not.toHaveBeenCalled();
     });
 
     it('detects network changes and triggers reconnection', async () => {
@@ -744,6 +859,27 @@ describe('PerpsConnectionManager', () => {
       expect(
         mockStreamManagerInstance.marketData.clearCache,
       ).toHaveBeenCalledWith();
+      expect(startPerpsLoadingSession).not.toHaveBeenCalled();
+    });
+
+    it('does not start a homepage session while disconnected', async () => {
+      mockPerpsController.init.mockResolvedValue();
+      await PerpsConnectionManager.connect();
+      const callback = storeCallbacks[storeCallbacks.length - 1];
+      (
+        PerpsConnectionManager as unknown as { isConnected: boolean }
+      ).isConnected = false;
+      jest.mocked(startPerpsLoadingSession).mockClear();
+
+      (
+        selectSelectedInternalAccountByScope as unknown as jest.Mock
+      ).mockReturnValue(() => ({ address: '0xdisconnected' }));
+      callback();
+
+      expect(startPerpsLoadingSession).not.toHaveBeenCalled();
+      expect(
+        mockStreamManagerInstance.positions.clearCache,
+      ).not.toHaveBeenCalled();
     });
 
     it('debounces rapid state changes into a single reconnection', async () => {
@@ -876,6 +1012,61 @@ describe('PerpsConnectionManager', () => {
       mockPerpsController.reconnectWithNewContext.mockResolvedValue();
     });
 
+    it('reconnects again when account changes during reconnection preload', async () => {
+      jest.useFakeTimers();
+      const addressA = '0x1111111111111111111111111111111111111111';
+      const addressB = '0x2222222222222222222222222222222222222222';
+      const addressC = '0x3333333333333333333333333333333333333333';
+      let notifyBPreloadStarted: () => void = () => undefined;
+      const bPreloadStarted = new Promise<void>((resolve) => {
+        notifyBPreloadStarted = resolve;
+      });
+      let resolveBPreload: (() => void) | undefined;
+      (
+        selectSelectedInternalAccountByScope as unknown as jest.Mock
+      ).mockReturnValue(() => ({ address: addressA }));
+      mockPerpsController.init.mockResolvedValue();
+      mockStreamManagerInstance.prices.prewarm
+        .mockResolvedValueOnce(jest.fn())
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveBPreload = () => resolve(jest.fn());
+              notifyBPreloadStarted();
+            }),
+        )
+        .mockResolvedValueOnce(jest.fn());
+      await PerpsConnectionManager.connect();
+      const storeCallback = storeCallbacks[storeCallbacks.length - 1];
+      const manager = PerpsConnectionManager as unknown as {
+        pendingReconnectPromise: Promise<void> | null;
+      };
+
+      (
+        selectSelectedInternalAccountByScope as unknown as jest.Mock
+      ).mockReturnValue(() => ({ address: addressB }));
+      storeCallback();
+      jest.advanceTimersByTime(50);
+      await bPreloadStarted;
+      const reconnectPromise = manager.pendingReconnectPromise;
+      if (!reconnectPromise || !resolveBPreload) {
+        throw new Error('Account B reconnection preload did not start.');
+      }
+      (
+        selectSelectedInternalAccountByScope as unknown as jest.Mock
+      ).mockReturnValue(() => ({ address: addressC }));
+      storeCallback();
+      jest.advanceTimersByTime(50);
+      await Promise.resolve();
+      resolveBPreload();
+      await reconnectPromise;
+
+      expect(mockPerpsController.init).toHaveBeenCalledTimes(3);
+      expect(mockStreamManagerInstance.prices.prewarm).toHaveBeenCalledTimes(3);
+      expect(PerpsConnectionManager.isSelectedUserContextReady()).toBe(true);
+      jest.useRealTimers();
+    });
+
     it('clears all StreamManager caches on reconnection', async () => {
       // Setup connected state first
       mockPerpsController.init.mockResolvedValue();
@@ -912,9 +1103,62 @@ describe('PerpsConnectionManager', () => {
       expect(mockStreamManagerInstance.candles.reconnect).toHaveBeenCalledTimes(
         1,
       );
+      expect(
+        mockStreamManagerInstance.focusedPrice.reconnect,
+      ).toHaveBeenCalledTimes(1);
       expect(mockPerpsController.init.mock.invocationCallOrder[0]).toBeLessThan(
         mockStreamManagerInstance.candles.reconnect.mock.invocationCallOrder[0],
       );
+    });
+
+    it('invalidates market readiness during a non-account reconnect', async () => {
+      const manager = PerpsConnectionManager as unknown as {
+        initializedMarketContextKey: string | null;
+        initializedConnectionGeneration: number | null;
+        pendingSkipMarketNotify: boolean;
+        getSelectedMarketContextKey: () => string;
+        reconnectWithNewContext: () => Promise<void>;
+      };
+      const selectedMarketContextKey = manager.getSelectedMarketContextKey();
+      manager.initializedMarketContextKey = selectedMarketContextKey;
+      manager.initializedConnectionGeneration = 0;
+      manager.pendingSkipMarketNotify = false;
+      const listener = jest.fn();
+      const unsubscribe =
+        PerpsConnectionManager.subscribeToInitializedMarketContext(listener);
+
+      await manager.reconnectWithNewContext();
+
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(PerpsConnectionManager.getInitializedMarketContextKey()).toBe(
+        selectedMarketContextKey,
+      );
+      unsubscribe();
+    });
+
+    it('preserves market readiness during an account-only reconnect', async () => {
+      const manager = PerpsConnectionManager as unknown as {
+        initializedMarketContextKey: string | null;
+        initializedConnectionGeneration: number | null;
+        pendingSkipMarketNotify: boolean;
+        getSelectedMarketContextKey: () => string;
+        reconnectWithNewContext: () => Promise<void>;
+      };
+      const selectedMarketContextKey = manager.getSelectedMarketContextKey();
+      manager.initializedMarketContextKey = selectedMarketContextKey;
+      manager.initializedConnectionGeneration = 0;
+      manager.pendingSkipMarketNotify = true;
+      const listener = jest.fn();
+      const unsubscribe =
+        PerpsConnectionManager.subscribeToInitializedMarketContext(listener);
+
+      await manager.reconnectWithNewContext();
+
+      expect(listener).not.toHaveBeenCalled();
+      expect(PerpsConnectionManager.getInitializedMarketContextKey()).toBe(
+        selectedMarketContextKey,
+      );
+      unsubscribe();
     });
 
     it('waits for concurrent controller reinit before health-check ping', async () => {
@@ -946,6 +1190,11 @@ describe('PerpsConnectionManager', () => {
 
     it('logs error and resets connecting flag when reconnection fails', async () => {
       const error = new Error('Reconnection failed');
+      (
+        PerpsConnectionManager as unknown as {
+          initializedMarketContextKey: string | null;
+        }
+      ).initializedMarketContextKey = 'mainnet|hyperliquid|0';
       mockPerpsController.init.mockRejectedValueOnce(error);
 
       // Reconnection errors are caught, logged, and re-thrown (so caller can handle)
@@ -964,6 +1213,9 @@ describe('PerpsConnectionManager', () => {
       expect(
         mockStreamManagerInstance.candles.reconnect,
       ).not.toHaveBeenCalled();
+      expect(
+        PerpsConnectionManager.getInitializedMarketContextKey(),
+      ).toBeNull();
     });
   });
 
@@ -1265,6 +1517,9 @@ describe('PerpsConnectionManager', () => {
       expect(mockStreamManagerInstance.oiCaps.clearCache).toHaveBeenCalled();
       expect(mockStreamManagerInstance.fills.clearCache).toHaveBeenCalled();
       expect(mockStreamManagerInstance.topOfBook.clearCache).toHaveBeenCalled();
+      expect(
+        mockStreamManagerInstance.focusedPrice.clearCache,
+      ).toHaveBeenCalled();
       expect(mockStreamManagerInstance.candles.clearCache).toHaveBeenCalled();
       // Hard teardown must also abandon pending confirmation CUFs.
       expect(mockClearPendingPerpsCufTraces).toHaveBeenCalled();
@@ -1716,6 +1971,32 @@ describe('PerpsConnectionManager', () => {
       );
     });
 
+    it('advances the connection generation before re-registering streams', async () => {
+      await PerpsConnectionManager.connect();
+      const initialGeneration =
+        PerpsConnectionManager.getConnectionGeneration();
+      const listener = jest.fn();
+      const unsubscribe =
+        PerpsConnectionManager.subscribeToConnectionGeneration(listener);
+
+      await PerpsConnectionManager.resumeFromForeground({
+        source: PERPS_CONNECTION_SOURCE.WALLET_ROOT_FOREGROUND,
+        suppressError: true,
+      });
+
+      expect(PerpsConnectionManager.getConnectionGeneration()).toBe(
+        initialGeneration + 1,
+      );
+      expect(PerpsConnectionManager.getInitializedConnectionGeneration()).toBe(
+        initialGeneration + 1,
+      );
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener.mock.invocationCallOrder[0]).toBeLessThan(
+        mockStreamManagerInstance.clearAllChannels.mock.invocationCallOrder[0],
+      );
+      unsubscribe();
+    });
+
     it('retries ping after delay and skips reconnect when retry succeeds', async () => {
       // Establish an initial connection
       await PerpsConnectionManager.connect();
@@ -1831,6 +2112,7 @@ describe('PerpsConnectionManager', () => {
     it('calls ensureConnected when not currently connected', async () => {
       // Manager starts disconnected (from resetManager in beforeEach)
       (Engine.context.PerpsController.init as jest.Mock).mockClear();
+      jest.mocked(setPerpsLoadingSessionLifecycle).mockClear();
 
       await PerpsConnectionManager.resumeFromForeground({
         source: PERPS_CONNECTION_SOURCE.WALLET_ROOT_MOUNT,
@@ -1839,6 +2121,17 @@ describe('PerpsConnectionManager', () => {
       expect(Engine.context.PerpsController.init).toHaveBeenCalled();
       expect(PerpsConnectionManager.getConnectionState().isConnected).toBe(
         true,
+      );
+      expect(setPerpsLoadingSessionLifecycle).not.toHaveBeenCalled();
+    });
+
+    it('upgrades a disconnected foreground resume to reconnect', async () => {
+      await PerpsConnectionManager.resumeFromForeground({
+        source: PERPS_CONNECTION_SOURCE.WALLET_ROOT_FOREGROUND,
+      });
+
+      expect(setPerpsLoadingSessionLifecycle).toHaveBeenCalledWith(
+        'background_reconnect',
       );
     });
 
@@ -1865,8 +2158,10 @@ describe('PerpsConnectionManager', () => {
         startConnectionTimeout: (suppressError?: boolean) => void;
         error: string | null;
         isConnecting: boolean;
+        initializedMarketContextKey: string | null;
       };
       m.isConnecting = true;
+      m.initializedMarketContextKey = 'testnet|hyperliquid|1';
 
       m.startConnectionTimeout(true);
 
@@ -1875,6 +2170,7 @@ describe('PerpsConnectionManager', () => {
 
       // Error should NOT be set because suppressError=true
       expect(m.error).toBeNull();
+      expect(m.initializedMarketContextKey).toBeNull();
 
       jest.useRealTimers();
     });

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -191,6 +191,7 @@ const resetManager = (manager: unknown) => {
     isDisconnecting: boolean;
     connectionRefCount: number;
     initPromise: Promise<void> | null;
+    initializationGeneration: number;
     disconnectPromise: Promise<void> | null;
     pendingReconnectPromise: Promise<void> | null;
     pendingReconnectRequest: {
@@ -242,6 +243,7 @@ const resetManager = (manager: unknown) => {
   m.isDisconnecting = false;
   m.connectionRefCount = 0;
   m.initPromise = null;
+  m.initializationGeneration = 0;
   m.disconnectPromise = null;
   m.pendingReconnectPromise = null;
   m.pendingReconnectRequest = null;
@@ -1047,6 +1049,74 @@ describe('PerpsConnectionManager', () => {
       reconnect.mockRestore();
     });
 
+    it('does not reject a healthy connection at the retry cap', async () => {
+      const manager = PerpsConnectionManager as unknown as {
+        isConnected: boolean;
+        pendingReconnectRequest: {
+          userContextKey: string;
+          force: boolean;
+        } | null;
+        performReconnection: () => Promise<void>;
+        reconnectWithNewContext: () => Promise<void>;
+      };
+      manager.isConnected = true;
+      const reconnect = jest
+        .spyOn(manager, 'performReconnection')
+        .mockImplementation(async () => {
+          manager.pendingReconnectRequest = {
+            userContextKey: 'queued',
+            force: true,
+          };
+        });
+
+      await expect(manager.reconnectWithNewContext()).resolves.toBeUndefined();
+      expect(reconnect).toHaveBeenCalledTimes(3);
+      reconnect.mockRestore();
+    });
+
+    it('rejects a falsy reconnect failure', async () => {
+      const manager = PerpsConnectionManager as unknown as {
+        performReconnection: () => Promise<void>;
+        reconnectWithNewContext: () => Promise<void>;
+      };
+      const reconnect = jest
+        .spyOn(manager, 'performReconnection')
+        .mockRejectedValueOnce(undefined);
+
+      await expect(manager.reconnectWithNewContext()).rejects.toBeInstanceOf(
+        Error,
+      );
+      reconnect.mockRestore();
+    });
+
+    it('bounds a force reconnect waiting on hung initialization', async () => {
+      jest.useFakeTimers();
+      mockPerpsController.init.mockImplementation(
+        () => new Promise(() => undefined),
+      );
+      void PerpsConnectionManager.connect();
+      await Promise.resolve();
+      const manager = PerpsConnectionManager as unknown as {
+        performSerializedReconnection: () => Promise<void>;
+        reconnectWithNewContext: (options?: {
+          force?: boolean;
+        }) => Promise<void>;
+      };
+      const reconnect = jest
+        .spyOn(manager, 'performSerializedReconnection')
+        .mockResolvedValue();
+
+      const forced = manager.reconnectWithNewContext({ force: true });
+      await jest.advanceTimersByTimeAsync(
+        PERPS_CONSTANTS.ConnectionAttemptTimeoutMs,
+      );
+      await forced;
+
+      expect(reconnect).toHaveBeenCalledTimes(1);
+      reconnect.mockRestore();
+      jest.useRealTimers();
+    });
+
     it('reconnects again when account changes during reconnection preload', async () => {
       jest.useFakeTimers();
       const addressA = '0x1111111111111111111111111111111111111111';
@@ -1123,7 +1193,7 @@ describe('PerpsConnectionManager', () => {
       expect(mockStreamManagerInstance.prices.clearCache).toHaveBeenCalled();
     });
 
-    it('reinitializes the controller and mounted candle subscriptions', async () => {
+    it('reinitializes the controller and mounted screen subscriptions', async () => {
       mockPerpsController.init.mockResolvedValue();
 
       await (
@@ -1140,6 +1210,12 @@ describe('PerpsConnectionManager', () => {
       );
       expect(
         mockStreamManagerInstance.focusedPrice.reconnect,
+      ).toHaveBeenCalledTimes(1);
+      expect(mockStreamManagerInstance.oiCaps.reconnect).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(
+        mockStreamManagerInstance.topOfBook.reconnect,
       ).toHaveBeenCalledTimes(1);
       expect(mockPerpsController.init.mock.invocationCallOrder[0]).toBeLessThan(
         mockStreamManagerInstance.candles.reconnect.mock.invocationCallOrder[0],
@@ -1198,6 +1274,12 @@ describe('PerpsConnectionManager', () => {
       expect(PerpsConnectionManager.getConnectionGeneration()).toBe(
         initialConnectionGeneration + 1,
       );
+      expect(mockStreamManagerInstance.oiCaps.reconnect).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(
+        mockStreamManagerInstance.topOfBook.reconnect,
+      ).toHaveBeenCalledTimes(1);
       unsubscribe();
     });
 

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -192,6 +192,7 @@ const resetManager = (manager: unknown) => {
     connectionRefCount: number;
     initPromise: Promise<void> | null;
     initializationGeneration: number;
+    initializationTraceId: string | null;
     disconnectPromise: Promise<void> | null;
     pendingReconnectPromise: Promise<void> | null;
     pendingReconnectRequest: {
@@ -244,6 +245,7 @@ const resetManager = (manager: unknown) => {
   m.connectionRefCount = 0;
   m.initPromise = null;
   m.initializationGeneration = 0;
+  m.initializationTraceId = null;
   m.disconnectPromise = null;
   m.pendingReconnectPromise = null;
   m.pendingReconnectRequest = null;
@@ -1057,9 +1059,13 @@ describe('PerpsConnectionManager', () => {
           force: boolean;
         } | null;
         performReconnection: () => Promise<void>;
+        isSelectedUserContextReady: () => boolean;
         reconnectWithNewContext: () => Promise<void>;
       };
       manager.isConnected = true;
+      const readiness = jest
+        .spyOn(manager, 'isSelectedUserContextReady')
+        .mockReturnValue(true);
       const reconnect = jest
         .spyOn(manager, 'performReconnection')
         .mockImplementation(async () => {
@@ -1072,6 +1078,39 @@ describe('PerpsConnectionManager', () => {
       await expect(manager.reconnectWithNewContext()).resolves.toBeUndefined();
       expect(reconnect).toHaveBeenCalledTimes(3);
       reconnect.mockRestore();
+      readiness.mockRestore();
+    });
+
+    it('rejects the retry cap when the selected user is not ready', async () => {
+      const manager = PerpsConnectionManager as unknown as {
+        isConnected: boolean;
+        pendingReconnectRequest: {
+          userContextKey: string;
+          force: boolean;
+        } | null;
+        performReconnection: () => Promise<void>;
+        isSelectedUserContextReady: () => boolean;
+        reconnectWithNewContext: () => Promise<void>;
+      };
+      manager.isConnected = true;
+      const readiness = jest
+        .spyOn(manager, 'isSelectedUserContextReady')
+        .mockReturnValue(false);
+      const reconnect = jest
+        .spyOn(manager, 'performReconnection')
+        .mockImplementation(async () => {
+          manager.pendingReconnectRequest = {
+            userContextKey: 'queued',
+            force: true,
+          };
+        });
+
+      await expect(manager.reconnectWithNewContext()).rejects.toThrow(
+        'Perps reconnect did not settle',
+      );
+      expect(reconnect).toHaveBeenCalledTimes(3);
+      reconnect.mockRestore();
+      readiness.mockRestore();
     });
 
     it('rejects a falsy reconnect failure', async () => {
@@ -1097,6 +1136,7 @@ describe('PerpsConnectionManager', () => {
       void PerpsConnectionManager.connect();
       await Promise.resolve();
       const manager = PerpsConnectionManager as unknown as {
+        initializationTraceId: string | null;
         performSerializedReconnection: () => Promise<void>;
         reconnectWithNewContext: (options?: {
           force?: boolean;
@@ -1113,6 +1153,7 @@ describe('PerpsConnectionManager', () => {
       await forced;
 
       expect(reconnect).toHaveBeenCalledTimes(1);
+      expect(manager.initializationTraceId).toBeNull();
       reconnect.mockRestore();
       jest.useRealTimers();
     });

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -270,6 +270,7 @@ describe('PerpsConnectionManager', () => {
     >;
     disconnect: jest.MockedFunction<() => Promise<void>>;
     reconnectWithNewContext: jest.MockedFunction<() => Promise<void>>;
+    getActiveProvider: jest.Mock;
   };
 
   // No need for beforeAll - singleton is created on first access
@@ -1141,7 +1142,7 @@ describe('PerpsConnectionManager', () => {
         jest.requireActual('../../../../util/trace'),
         'endTrace',
       );
-      void PerpsConnectionManager.connect();
+      const obsoleteInitialization = PerpsConnectionManager.connect();
       await Promise.resolve();
       const manager = PerpsConnectionManager as unknown as {
         isConnected: boolean;
@@ -1179,6 +1180,7 @@ describe('PerpsConnectionManager', () => {
       resolveInitialization?.();
       await Promise.resolve();
       await Promise.resolve();
+      await Promise.resolve();
 
       expect(mockPerpsController.getActiveProvider).not.toHaveBeenCalled();
       expect(manager.isConnected).toBe(true);
@@ -1189,6 +1191,7 @@ describe('PerpsConnectionManager', () => {
           ([request]) => (request as { id?: string }).id === retiredTraceId,
         ),
       ).toHaveLength(1);
+      await obsoleteInitialization;
       reconnect.mockRestore();
       endTrace.mockRestore();
       jest.useRealTimers();

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -1128,14 +1128,25 @@ describe('PerpsConnectionManager', () => {
       reconnect.mockRestore();
     });
 
-    it('bounds a force reconnect waiting on hung initialization', async () => {
+    it('bounds force handoff and blocks the obsolete initialization commit', async () => {
       jest.useFakeTimers();
+      let resolveInitialization: (() => void) | undefined;
       mockPerpsController.init.mockImplementation(
-        () => new Promise(() => undefined),
+        () =>
+          new Promise<void>((resolve) => {
+            resolveInitialization = resolve;
+          }),
+      );
+      const endTrace = jest.spyOn(
+        jest.requireActual('../../../../util/trace'),
+        'endTrace',
       );
       void PerpsConnectionManager.connect();
       await Promise.resolve();
       const manager = PerpsConnectionManager as unknown as {
+        isConnected: boolean;
+        isInitialized: boolean;
+        initializedUserContextKey: string | null;
         initializationTraceId: string | null;
         performSerializedReconnection: () => Promise<void>;
         reconnectWithNewContext: (options?: {
@@ -1144,7 +1155,12 @@ describe('PerpsConnectionManager', () => {
       };
       const reconnect = jest
         .spyOn(manager, 'performSerializedReconnection')
-        .mockResolvedValue();
+        .mockImplementation(async () => {
+          manager.isConnected = true;
+          manager.isInitialized = true;
+          manager.initializedUserContextKey = 'replacement';
+        });
+      const retiredTraceId = manager.initializationTraceId;
 
       const forced = manager.reconnectWithNewContext({ force: true });
       await jest.advanceTimersByTimeAsync(
@@ -1154,7 +1170,26 @@ describe('PerpsConnectionManager', () => {
 
       expect(reconnect).toHaveBeenCalledTimes(1);
       expect(manager.initializationTraceId).toBeNull();
+      expect(endTrace).toHaveBeenCalledWith({
+        name: TraceName.PerpsConnectionEstablishment,
+        id: retiredTraceId,
+        data: { success: false, reason: 'superseded' },
+      });
+
+      resolveInitialization?.();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(manager.isConnected).toBe(true);
+      expect(manager.isInitialized).toBe(true);
+      expect(manager.initializedUserContextKey).toBe('replacement');
+      expect(
+        endTrace.mock.calls.filter(
+          ([request]) => (request as { id?: string }).id === retiredTraceId,
+        ),
+      ).toHaveLength(1);
       reconnect.mockRestore();
+      endTrace.mockRestore();
       jest.useRealTimers();
     });
 

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -110,6 +110,7 @@ class PerpsConnectionManagerClass {
   private connectionRefCount = 0;
   private initPromise: Promise<void> | null = null;
   private initializationGeneration = 0;
+  private initializationTraceId: string | null = null;
   private disconnectPromise: Promise<void> | null = null;
   private ensureConnectedPromise: Promise<void> | null = null;
   private hasPreloaded = false;
@@ -995,6 +996,7 @@ class PerpsConnectionManagerClass {
     let initPromise: Promise<void> = Promise.resolve();
     initPromise = (async () => {
       const traceId = uuidv4();
+      this.initializationTraceId = traceId;
       const loadingSessionTraceData = getActivePerpsLoadingSessionTraceData();
       const connectionStartTime = performance.now();
       let traceData: Record<string, string | number | boolean> | undefined;
@@ -1154,14 +1156,17 @@ class PerpsConnectionManagerClass {
         DevLogger.log('PerpsConnectionManager: Connection failed', error);
         throw error;
       } finally {
-        endTrace({
-          name: TraceName.PerpsConnectionEstablishment,
-          id: traceId,
-          data: {
-            ...loadingSessionTraceData,
-            ...traceData,
-          },
-        });
+        if (this.initializationTraceId === traceId) {
+          endTrace({
+            name: TraceName.PerpsConnectionEstablishment,
+            id: traceId,
+            data: {
+              ...loadingSessionTraceData,
+              ...traceData,
+            },
+          });
+          this.initializationTraceId = null;
+        }
         if (this.initPromise === initPromise) {
           this.initPromise = null;
         }
@@ -1197,6 +1202,14 @@ class PerpsConnectionManagerClass {
       if (this.initPromise) {
         const pendingInitialization = this.initPromise;
         this.initializationGeneration += 1;
+        if (this.initializationTraceId) {
+          endTrace({
+            name: TraceName.PerpsConnectionEstablishment,
+            id: this.initializationTraceId,
+            data: { success: false, reason: 'superseded' },
+          });
+          this.initializationTraceId = null;
+        }
         await Promise.race([
           pendingInitialization.catch(() => undefined),
           wait(PERPS_CONSTANTS.ConnectionAttemptTimeoutMs),
@@ -1289,7 +1302,11 @@ class PerpsConnectionManagerClass {
     logPerpsConnectionProof('reconnect_attempt_limit_reached', {
       max_attempts: MAX_SERIALIZED_RECONNECT_ATTEMPTS,
     });
-    if (!lastAttemptFailed && this.isConnected) {
+    if (
+      !lastAttemptFailed &&
+      this.isConnected &&
+      this.isSelectedUserContextReady()
+    ) {
       return;
     }
     throw (

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -54,11 +54,36 @@ import {
 } from '../selectors/perpsController';
 import { selectHip3ConfigVersion } from '../selectors/featureFlags';
 import { ensureError } from '../../../../util/errorUtils';
+import {
+  getActivePerpsLoadingSessionTraceData,
+  markPerpsLoadingSessionConnectionValidated,
+  setPerpsLoadingSessionLifecycle,
+} from '../utils/perpsLoadingSession';
+import { getPerpsLifecycleContext } from '../utils/perpsLifecycleContext';
+import { buildPerpsMarketContextKey } from '../utils/perpsMarketContext';
 
 interface ConnectOptions {
   source?: string;
   suppressError?: boolean;
   preserveCaches?: boolean;
+}
+
+interface PendingReconnectRequest {
+  userContextKey: string;
+  force: boolean;
+}
+
+function logPerpsConnectionProof(
+  stage: string,
+  data: Record<string, string | number | boolean> = {},
+): void {
+  DevLogger.log(
+    `[PerpsConnectionProof] ${JSON.stringify({
+      stage,
+      monotonic_ms: Number(performance.now().toFixed(3)),
+      ...data,
+    })}`,
+  );
 }
 
 /**
@@ -71,6 +96,13 @@ class PerpsConnectionManagerClass {
   private isConnected = false;
   private isConnecting = false;
   private isInitialized = false;
+  private initializedMarketContextKey: string | null = null;
+  private initializedConnectionGeneration: number | null = null;
+  private readonly initializedMarketContextListeners = new Set<() => void>();
+  private connectionGeneration = 0;
+  private readonly connectionGenerationListeners = new Set<() => void>();
+  private initializedUserContextKey: string | null = null;
+  private readonly initializedUserContextListeners = new Set<() => void>();
   private isDisconnecting = false;
   private error: string | null = null;
   private connectionRefCount = 0;
@@ -88,9 +120,11 @@ class PerpsConnectionManagerClass {
   private gracePeriodTimer: number | null = null;
   private isInGracePeriod = false;
   private pendingReconnectPromise: Promise<void> | null = null;
+  private pendingReconnectRequest: PendingReconnectRequest | null = null;
   private connectionTimeoutRef: ReturnType<typeof setTimeout> | null = null;
   private stateChangeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   private pendingSkipMarketNotify = false;
+  private pendingConnectionGenerationAdvanced = false;
   private netInfoUnsubscribe: (() => void) | null = null;
   private wasOffline = false;
   private networkRestoreRetryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -99,6 +133,54 @@ class PerpsConnectionManagerClass {
   private constructor() {
     // Private constructor to enforce singleton pattern
     // Monitoring will be set up on first connect
+  }
+
+  private getSelectedMarketContextKey(): string {
+    const state = store.getState();
+    return buildPerpsMarketContextKey(
+      selectPerpsNetwork(state),
+      selectPerpsProvider(state),
+      selectHip3ConfigVersion(state),
+    );
+  }
+
+  private getSelectedUserContextKey(): string {
+    const state = store.getState();
+    const address =
+      selectSelectedInternalAccountByScope(state)(
+        'eip155:1',
+      )?.address.toLowerCase() ?? '';
+    return `${this.getSelectedMarketContextKey()}|${address}`;
+  }
+
+  private setInitializedUserContextKey(key: string | null): void {
+    if (this.initializedUserContextKey === key) {
+      return;
+    }
+    this.initializedUserContextKey = key;
+    this.initializedUserContextListeners.forEach((listener) => listener());
+  }
+
+  private setInitializedMarketContextKey(key: string | null): void {
+    if (key === null) {
+      this.setInitializedUserContextKey(null);
+    }
+    const initializedGeneration =
+      key === null ? null : this.connectionGeneration;
+    if (
+      this.initializedMarketContextKey === key &&
+      this.initializedConnectionGeneration === initializedGeneration
+    ) {
+      return;
+    }
+    this.initializedMarketContextKey = key;
+    this.initializedConnectionGeneration = initializedGeneration;
+    this.initializedMarketContextListeners.forEach((listener) => listener());
+  }
+
+  private advanceConnectionGeneration(): void {
+    this.connectionGeneration += 1;
+    this.connectionGenerationListeners.forEach((listener) => listener());
   }
 
   /**
@@ -139,15 +221,30 @@ class PerpsConnectionManagerClass {
         this.previousProvider !== undefined &&
         this.previousProvider !== currentProvider;
       const hasHip3Changed = this.previousHip3Version !== currentHip3Version;
+      const accountOnly =
+        hasAccountChanged &&
+        !hasProviderChanged &&
+        !hasPerpsNetworkChanged &&
+        !hasHip3Changed;
+      const hasContextChanged =
+        hasAccountChanged ||
+        hasPerpsNetworkChanged ||
+        hasProviderChanged ||
+        hasHip3Changed;
+
+      if (
+        hasContextChanged &&
+        this.pendingReconnectPromise &&
+        !this.isConnected
+      ) {
+        this.pendingReconnectRequest = {
+          userContextKey: this.getSelectedUserContextKey(),
+          force: true,
+        };
+      }
 
       // If account, network, provider, or HIP-3 config changed and we're connected, trigger reconnection
-      if (
-        (hasAccountChanged ||
-          hasPerpsNetworkChanged ||
-          hasProviderChanged ||
-          hasHip3Changed) &&
-        this.isConnected
-      ) {
+      if (hasContextChanged && this.isConnected) {
         DevLogger.log(
           hasHip3Changed
             ? '[DEX:WHITELIST] PerpsConnectionManager: HIP-3 config version CHANGED - triggering reconnection'
@@ -169,6 +266,13 @@ class PerpsConnectionManagerClass {
             currentHip3Version,
           },
         );
+        logPerpsConnectionProof('context_change_detected', {
+          account_changed: hasAccountChanged,
+          network_changed: hasPerpsNetworkChanged,
+          provider_changed: hasProviderChanged,
+          hip3_changed: hasHip3Changed,
+          connection_generation: this.connectionGeneration,
+        });
 
         // Immediately clear ALL cached data to prevent old account data from showing
         const streamManager = getStreamManagerInstance();
@@ -179,14 +283,15 @@ class PerpsConnectionManagerClass {
           );
         }
 
+        // Block cleared channels from subscribing to the old provider during
+        // the reconnect debounce. Otherwise the provider can synchronously
+        // replay its prior-account cache under the newly selected identity.
+        // Existing global subscriptions stay mounted on account-only changes.
+        this.isInitialized = false;
+        this.setInitializedUserContextKey(null);
+
         // Account-only switches keep market data visible (it's global, not account-specific).
         // Provider/network/HIP-3 switches must flush stale market data immediately.
-        const accountOnly =
-          hasAccountChanged &&
-          !hasProviderChanged &&
-          !hasPerpsNetworkChanged &&
-          !hasHip3Changed;
-
         // User-scoped data must reset on every account switch.
         streamManager.positions.clearCache();
         streamManager.orders.clearCache();
@@ -196,10 +301,14 @@ class PerpsConnectionManagerClass {
         // Global market state is account-independent. Preserve it for an
         // account-only switch; provider/network/DEX changes invalidate it.
         if (!accountOnly) {
+          this.advanceConnectionGeneration();
+          this.pendingConnectionGenerationAdvanced = true;
+          this.setInitializedMarketContextKey(null);
           streamManager.prices.clearCache();
           streamManager.marketData.clearCache();
           streamManager.oiCaps.clearCache();
           streamManager.topOfBook.clearCache();
+          streamManager.focusedPrice.clearCache();
           streamManager.candles.clearCache();
         }
 
@@ -473,6 +582,7 @@ class PerpsConnectionManagerClass {
       this.isConnecting = false;
       this.isConnected = false;
       this.isInitialized = false;
+      this.setInitializedMarketContextKey(null);
       if (!suppressError) {
         this.setError(PERPS_ERROR_CODES.CONNECTION_TIMEOUT);
       }
@@ -506,8 +616,12 @@ class PerpsConnectionManagerClass {
    * header appear frozen after foregrounding until the user navigates away
    * and back (which happens to trigger a fresh subscription elsewhere).
    */
-  private resubscribeActiveStreamChannels(): void {
+  private resubscribeActiveStreamChannels(advanceGeneration = true): void {
+    if (advanceGeneration) {
+      this.advanceConnectionGeneration();
+    }
     getStreamManagerInstance().clearAllChannels();
+    this.setInitializedMarketContextKey(this.getSelectedMarketContextKey());
   }
 
   async resumeFromForeground(options?: ConnectOptions): Promise<void> {
@@ -522,14 +636,11 @@ class PerpsConnectionManagerClass {
 
     // If the existing connection is healthy, keep it instead of forcing a reconnect.
     if (this.isConnected && this.isInitialized) {
+      let connectionHealthy = false;
       try {
         const provider = Engine.context.PerpsController.getActiveProvider();
         await provider.ping();
-        if (!suppressError) {
-          this.clearError();
-        }
-        this.resubscribeActiveStreamChannels();
-        return;
+        connectionHealthy = true;
       } catch {
         // First ping failed — JS thread may be sluggish right after foregrounding.
         // Wait briefly and retry before triggering a full reconnection.
@@ -538,24 +649,31 @@ class PerpsConnectionManagerClass {
           const retryProvider =
             Engine.context.PerpsController.getActiveProvider();
           await retryProvider.ping();
+          connectionHealthy = true;
           DevLogger.log(
             'PerpsConnectionManager: resumeFromForeground - retry ping succeeded, connection healthy',
           );
-          if (!suppressError) {
-            this.clearError();
-          }
-          this.resubscribeActiveStreamChannels();
-          return;
         } catch {
           DevLogger.log(
             'PerpsConnectionManager: resumeFromForeground - retry ping also failed, falling through to soft reconnect',
           );
         }
       }
+      if (connectionHealthy) {
+        if (!suppressError) {
+          this.clearError();
+        }
+        this.resubscribeActiveStreamChannels();
+        markPerpsLoadingSessionConnectionValidated();
+        return;
+      }
     }
 
     // Soft reconnect: preserve cached data so no loading skeletons appear.
     // The WebSocket was likely still alive — avoid a jarring skeleton flash.
+    if (source === PERPS_CONNECTION_SOURCE.WALLET_ROOT_FOREGROUND) {
+      setPerpsLoadingSessionLifecycle('background_reconnect');
+    }
     await this.ensureConnected({ source, suppressError, preserveCaches: true });
   }
 
@@ -695,6 +813,7 @@ class PerpsConnectionManagerClass {
             // Skip when preserveCaches=true (soft foreground resume): cached data
             // is still valid and clearing it would cause unnecessary loading skeletons.
             if (!options.preserveCaches) {
+              this.advanceConnectionGeneration();
               const streamManager = getStreamManagerInstance();
               streamManager.positions.clearCache();
               streamManager.orders.clearCache();
@@ -704,7 +823,9 @@ class PerpsConnectionManagerClass {
               streamManager.oiCaps.clearCache();
               streamManager.fills.clearCache();
               streamManager.topOfBook.clearCache();
+              streamManager.focusedPrice.clearCache();
               streamManager.candles.clearCache();
+              this.setInitializedMarketContextKey(null);
               // Hard teardown (streams torn down, caches cleared): abandon any
               // pending confirmation CUF as `disconnected`, or a later reconnect
               // delivery would end the stale op as a success with a duration
@@ -869,6 +990,7 @@ class PerpsConnectionManagerClass {
 
     this.initPromise = (async () => {
       const traceId = uuidv4();
+      const loadingSessionTraceData = getActivePerpsLoadingSessionTraceData();
       const connectionStartTime = performance.now();
       let traceData: Record<string, string | number | boolean> | undefined;
 
@@ -877,6 +999,7 @@ class PerpsConnectionManagerClass {
           name: TraceName.PerpsConnectionEstablishment,
           id: traceId,
           op: TraceOperation.PerpsOperation,
+          data: loadingSessionTraceData,
         });
 
         DevLogger.log('PerpsConnectionManager: Initializing connection');
@@ -933,6 +1056,7 @@ class PerpsConnectionManagerClass {
         // Mark as connected - WebSocket connection validated and ready
         this.isConnected = true;
         this.isConnecting = false;
+        this.setInitializedMarketContextKey(this.getSelectedMarketContextKey());
         // Clear errors on successful connection
         this.clearError();
 
@@ -959,7 +1083,14 @@ class PerpsConnectionManagerClass {
 
         // Stage 3: Pre-load positions and orders subscriptions to populate cache
         const preloadStart = performance.now();
+        const preloadedUserContextKey = this.getSelectedUserContextKey();
         await this.preloadSubscriptions();
+        if (
+          this.isInitialized &&
+          preloadedUserContextKey === this.getSelectedUserContextKey()
+        ) {
+          this.setInitializedUserContextKey(preloadedUserContextKey);
+        }
         setMeasurement(
           PerpsMeasurementName.PerpsSubscriptionsPreload,
           performance.now() - preloadStart,
@@ -993,6 +1124,7 @@ class PerpsConnectionManagerClass {
         this.isConnecting = false;
         this.isConnected = false;
         this.isInitialized = false;
+        this.setInitializedMarketContextKey(null);
 
         // Clear connection timeout on error
         this.clearConnectionTimeout();
@@ -1016,7 +1148,10 @@ class PerpsConnectionManagerClass {
         endTrace({
           name: TraceName.PerpsConnectionEstablishment,
           id: traceId,
-          data: traceData,
+          data: {
+            ...loadingSessionTraceData,
+            ...traceData,
+          },
         });
         this.initPromise = null;
       }
@@ -1045,11 +1180,10 @@ class PerpsConnectionManagerClass {
       // Clear connection timeout if active
       this.clearConnectionTimeout();
 
-      // Clear all pending promises to cancel in-flight operations
-      // Note: Actual disconnect happens in performReconnection → Controller.init → performInitialization
+      // Cancel pending initialization. An in-flight reconnect cannot be
+      // cancelled, so force requests join it and queue another pass below.
       this.isConnecting = false;
       this.initPromise = null;
-      this.pendingReconnectPromise = null;
     } else {
       // Wait for pending initialization if exists
       if (this.initPromise) {
@@ -1057,26 +1191,62 @@ class PerpsConnectionManagerClass {
           'PerpsConnectionManager: Waiting for pending initialization before reconnecting',
         );
         await this.initPromise;
-        // After init completes, check if we're already connected
-        if (this.isConnected) {
+        // A context change can land while the initial preload is in flight.
+        // Keep reconnecting when that connection belongs to the prior user.
+        if (this.isConnected && this.isSelectedUserContextReady()) {
           return;
         }
       }
 
       // If already reconnecting, return existing promise
       if (this.pendingReconnectPromise) {
+        this.pendingReconnectRequest = {
+          userContextKey: this.getSelectedUserContextKey(),
+          force: this.pendingReconnectRequest?.force ?? false,
+        };
         return this.pendingReconnectPromise;
       }
     }
 
+    if (this.pendingReconnectPromise) {
+      this.pendingReconnectRequest = {
+        userContextKey: this.getSelectedUserContextKey(),
+        force: true,
+      };
+      return this.pendingReconnectPromise;
+    }
+
     // Create a new reconnection promise
-    this.pendingReconnectPromise = this.performReconnection();
+    const reconnectPromise = this.performSerializedReconnection();
+    this.pendingReconnectPromise = reconnectPromise;
 
     try {
-      await this.pendingReconnectPromise;
+      await reconnectPromise;
     } finally {
-      this.pendingReconnectPromise = null;
+      if (this.pendingReconnectPromise === reconnectPromise) {
+        this.pendingReconnectPromise = null;
+      }
     }
+  }
+
+  private async performSerializedReconnection(): Promise<void> {
+    let pendingRequest: PendingReconnectRequest | null;
+
+    do {
+      this.pendingReconnectRequest = null;
+      await this.performReconnection();
+      pendingRequest = this.getPendingReconnectRequest();
+    } while (
+      pendingRequest?.force ||
+      (this.isConnected &&
+        (!this.isSelectedUserContextReady() ||
+          (pendingRequest !== null &&
+            pendingRequest.userContextKey !== this.initializedUserContextKey)))
+    );
+  }
+
+  private getPendingReconnectRequest(): PendingReconnectRequest | null {
+    return this.pendingReconnectRequest;
   }
 
   /**
@@ -1087,9 +1257,17 @@ class PerpsConnectionManagerClass {
     const reconnectionStartTime = performance.now();
     let traceData: Record<string, string | number | boolean> | undefined;
 
+    if (getPerpsLifecycleContext() === 'background_resume') {
+      setPerpsLoadingSessionLifecycle('background_reconnect');
+    }
+
     DevLogger.log(
       'PerpsConnectionManager: Reconnecting with new account/network context',
     );
+    logPerpsConnectionProof('reconnect_started', {
+      reconnect_id: traceId,
+      connection_generation: this.connectionGeneration,
+    });
 
     // Abandon any pending confirmation CUF (and any stale reconnect span) from
     // the previous session BEFORE arming this reconnection's own span. The
@@ -1130,14 +1308,26 @@ class PerpsConnectionManagerClass {
         op: TraceOperation.PerpsOperation,
       });
 
+      const skipMarketNotify = this.pendingSkipMarketNotify;
+      this.pendingSkipMarketNotify = false;
+      const connectionGenerationAlreadyAdvanced =
+        this.pendingConnectionGenerationAdvanced;
+      this.pendingConnectionGenerationAdvanced = false;
+      if (!skipMarketNotify) {
+        if (!connectionGenerationAlreadyAdvanced) {
+          this.advanceConnectionGeneration();
+        }
+      }
+
       // Stage 1: Clean up existing connections and clear caches
       const cleanupStart = performance.now();
       this.cleanupPreloadedSubscriptions();
 
       // Clear all cached data from StreamManager to reset UI immediately
       const streamManager = getStreamManagerInstance();
-      const skipMarketNotify = this.pendingSkipMarketNotify;
-      this.pendingSkipMarketNotify = false;
+      if (!skipMarketNotify) {
+        this.setInitializedMarketContextKey(null);
+      }
 
       streamManager.positions.clearCache();
       streamManager.orders.clearCache();
@@ -1148,6 +1338,7 @@ class PerpsConnectionManagerClass {
         streamManager.marketData.clearCache();
         streamManager.oiCaps.clearCache();
         streamManager.topOfBook.clearCache();
+        streamManager.focusedPrice.clearCache();
         streamManager.candles.clearCache();
       }
       setMeasurement(
@@ -1222,6 +1413,10 @@ class PerpsConnectionManagerClass {
       const healthCheckStart = performance.now();
       const provider = Engine.context.PerpsController.getActiveProvider();
       await provider.ping();
+      logPerpsConnectionProof('reconnect_health_validated', {
+        reconnect_id: traceId,
+        connection_generation: this.connectionGeneration,
+      });
       setMeasurement(
         PerpsMeasurementName.PerpsReconnectionHealthCheck,
         performance.now() - healthCheckStart,
@@ -1247,6 +1442,7 @@ class PerpsConnectionManagerClass {
       this.isConnected = true;
       this.isInitialized = true;
       this.isDisconnecting = false;
+      this.setInitializedMarketContextKey(this.getSelectedMarketContextKey());
       // Clear errors on successful reconnection
       this.clearError();
 
@@ -1254,13 +1450,33 @@ class PerpsConnectionManagerClass {
         'PerpsConnectionManager: Successfully reconnected with new context',
       );
 
-      // Candle subscriptions are screen-driven and are not part of the global
-      // preload. Restore mounted consumers only after the new context is ready.
+      // Focused price and candle subscriptions are screen-driven and are not
+      // part of the global preload. Restore mounted consumers only after the
+      // new context is ready.
       streamManager.candles.reconnect();
+      streamManager.focusedPrice.reconnect();
 
       // Stage 4: Pre-load subscriptions again with new account
       const preloadStart = performance.now();
+      const preloadedUserContextKey = this.getSelectedUserContextKey();
       await this.preloadSubscriptions();
+      if (
+        this.isInitialized &&
+        preloadedUserContextKey === this.getSelectedUserContextKey()
+      ) {
+        this.setInitializedUserContextKey(preloadedUserContextKey);
+        logPerpsConnectionProof('reconnect_preload_committed', {
+          reconnect_id: traceId,
+          connection_generation: this.connectionGeneration,
+          selected_user_context_ready: this.isSelectedUserContextReady(),
+        });
+      } else {
+        logPerpsConnectionProof('reconnect_preload_rejected', {
+          reconnect_id: traceId,
+          connection_generation: this.connectionGeneration,
+          selected_user_context_ready: false,
+        });
+      }
       setMeasurement(
         PerpsMeasurementName.PerpsReconnectionPreload,
         performance.now() - preloadStart,
@@ -1293,6 +1509,7 @@ class PerpsConnectionManagerClass {
     } catch (error) {
       this.isConnected = false;
       this.isInitialized = false;
+      this.setInitializedMarketContextKey(null);
 
       // Clear connection timeout on error
       this.clearConnectionTimeout();
@@ -1321,6 +1538,14 @@ class PerpsConnectionManagerClass {
       );
       throw error;
     } finally {
+      logPerpsConnectionProof('reconnect_finished', {
+        reconnect_id: traceId,
+        connection_generation: this.connectionGeneration,
+        success: traceData?.success === true,
+        elapsed_ms: Number(
+          Math.max(0, performance.now() - reconnectionStartTime).toFixed(3),
+        ),
+      });
       endTrace({
         name: TraceName.PerpsAccountSwitchReconnection,
         id: traceId,
@@ -1369,6 +1594,10 @@ class PerpsConnectionManagerClass {
     // Uses force: true to bypass the refCount guard — ensureConnected must
     // always tear down, regardless of how many components hold references.
     if (this.isConnected || this.isInitialized) {
+      if (preserveCaches) {
+        this.advanceConnectionGeneration();
+        this.setInitializedMarketContextKey(null);
+      }
       await this.performActualDisconnection({ force: true, preserveCaches });
     }
 
@@ -1389,7 +1618,7 @@ class PerpsConnectionManagerClass {
     // controller comes back so subscribers do not keep stale WebSocket
     // unsubscribe references from the pre-reconnect provider.
     if (preserveCaches) {
-      this.resubscribeActiveStreamChannels();
+      this.resubscribeActiveStreamChannels(false);
     }
   }
 
@@ -1539,6 +1768,44 @@ class PerpsConnectionManagerClass {
       isInGracePeriod: this.isInGracePeriod,
       error: this.error,
     };
+  }
+
+  getInitializedMarketContextKey(): string | null {
+    return this.initializedMarketContextKey;
+  }
+
+  getConnectionGeneration(): number {
+    return this.connectionGeneration;
+  }
+
+  getInitializedConnectionGeneration(): number | null {
+    return this.initializedConnectionGeneration;
+  }
+
+  getInitializedUserContextKey(): string | null {
+    return this.initializedUserContextKey;
+  }
+
+  isSelectedUserContextReady(): boolean {
+    return (
+      this.initializedUserContextKey !== null &&
+      this.initializedUserContextKey === this.getSelectedUserContextKey()
+    );
+  }
+
+  subscribeToInitializedUserContext(listener: () => void): () => void {
+    this.initializedUserContextListeners.add(listener);
+    return () => this.initializedUserContextListeners.delete(listener);
+  }
+
+  subscribeToInitializedMarketContext(listener: () => void): () => void {
+    this.initializedMarketContextListeners.add(listener);
+    return () => this.initializedMarketContextListeners.delete(listener);
+  }
+
+  subscribeToConnectionGeneration(listener: () => void): () => void {
+    this.connectionGenerationListeners.add(listener);
+    return () => this.connectionGenerationListeners.delete(listener);
   }
 
   /**

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -73,6 +73,8 @@ interface PendingReconnectRequest {
   force: boolean;
 }
 
+const MAX_SERIALIZED_RECONNECT_ATTEMPTS = 3;
+
 function logPerpsConnectionProof(
   stage: string,
   data: Record<string, string | number | boolean> = {},
@@ -1180,10 +1182,15 @@ class PerpsConnectionManagerClass {
       // Clear connection timeout if active
       this.clearConnectionTimeout();
 
-      // Cancel pending initialization. An in-flight reconnect cannot be
-      // cancelled, so force requests join it and queue another pass below.
-      this.isConnecting = false;
-      this.initPromise = null;
+      // Initialization cannot be cancelled safely. Let it settle before the
+      // forced reconnect replaces its controller and stream ownership.
+      if (this.initPromise) {
+        try {
+          await this.initPromise;
+        } catch {
+          // The forced reconnect below owns recovery from the failed init.
+        }
+      }
     } else {
       // Wait for pending initialization if exists
       if (this.initPromise) {
@@ -1230,18 +1237,43 @@ class PerpsConnectionManagerClass {
   }
 
   private async performSerializedReconnection(): Promise<void> {
-    let pendingRequest: PendingReconnectRequest | null;
+    let lastError: unknown;
 
-    do {
+    for (
+      let attempt = 1;
+      attempt <= MAX_SERIALIZED_RECONNECT_ATTEMPTS;
+      attempt += 1
+    ) {
       this.pendingReconnectRequest = null;
-      await this.performReconnection();
-      pendingRequest = this.getPendingReconnectRequest();
-    } while (
-      pendingRequest?.force ||
-      (this.isConnected &&
-        (!this.isSelectedUserContextReady() ||
-          (pendingRequest !== null &&
-            pendingRequest.userContextKey !== this.initializedUserContextKey)))
+      try {
+        await this.performReconnection();
+        lastError = undefined;
+      } catch (error) {
+        lastError = error;
+      }
+
+      const pendingRequest = this.getPendingReconnectRequest();
+      const shouldRetry =
+        pendingRequest?.force === true ||
+        (pendingRequest !== null &&
+          pendingRequest.userContextKey !== this.initializedUserContextKey) ||
+        (this.isConnected && !this.isSelectedUserContextReady());
+      if (!shouldRetry) {
+        if (lastError) {
+          throw lastError;
+        }
+        return;
+      }
+    }
+
+    logPerpsConnectionProof('reconnect_attempt_limit_reached', {
+      max_attempts: MAX_SERIALIZED_RECONNECT_ATTEMPTS,
+    });
+    throw (
+      lastError ??
+      new Error(
+        `Perps reconnect did not settle after ${MAX_SERIALIZED_RECONNECT_ATTEMPTS} attempts`,
+      )
     );
   }
 
@@ -1313,10 +1345,8 @@ class PerpsConnectionManagerClass {
       const connectionGenerationAlreadyAdvanced =
         this.pendingConnectionGenerationAdvanced;
       this.pendingConnectionGenerationAdvanced = false;
-      if (!skipMarketNotify) {
-        if (!connectionGenerationAlreadyAdvanced) {
-          this.advanceConnectionGeneration();
-        }
+      if (!connectionGenerationAlreadyAdvanced) {
+        this.advanceConnectionGeneration();
       }
 
       // Stage 1: Clean up existing connections and clear caches
@@ -1450,11 +1480,12 @@ class PerpsConnectionManagerClass {
         'PerpsConnectionManager: Successfully reconnected with new context',
       );
 
-      // Focused price and candle subscriptions are screen-driven and are not
-      // part of the global preload. Restore mounted consumers only after the
-      // new context is ready.
-      streamManager.candles.reconnect();
+      // Screen-driven subscriptions are not part of the global preload.
+      // Restore mounted consumers only after the new context is ready.
+      streamManager.oiCaps.reconnect();
+      streamManager.topOfBook.reconnect();
       streamManager.focusedPrice.reconnect();
+      streamManager.candles.reconnect();
 
       // Stage 4: Pre-load subscriptions again with new account
       const preloadStart = performance.now();

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -109,6 +109,7 @@ class PerpsConnectionManagerClass {
   private error: string | null = null;
   private connectionRefCount = 0;
   private initPromise: Promise<void> | null = null;
+  private initializationGeneration = 0;
   private disconnectPromise: Promise<void> | null = null;
   private ensureConnectedPromise: Promise<void> | null = null;
   private hasPreloaded = false;
@@ -990,7 +991,9 @@ class PerpsConnectionManagerClass {
     // Start connection timeout to prevent hanging indefinitely
     this.startConnectionTimeout(suppressError);
 
-    this.initPromise = (async () => {
+    const initializationGeneration = ++this.initializationGeneration;
+    let initPromise: Promise<void> = Promise.resolve();
+    initPromise = (async () => {
       const traceId = uuidv4();
       const loadingSessionTraceData = getActivePerpsLoadingSessionTraceData();
       const connectionStartTime = performance.now();
@@ -1012,9 +1015,10 @@ class PerpsConnectionManagerClass {
           { source, suppressError },
           async () => {
             await Engine.context.PerpsController.init();
-            this.isInitialized = true;
           },
         );
+        if (initializationGeneration !== this.initializationGeneration) return;
+        this.isInitialized = true;
         setMeasurement(
           PerpsMeasurementName.PerpsProviderInit,
           performance.now() - initStart,
@@ -1030,6 +1034,7 @@ class PerpsConnectionManagerClass {
         const healthCheckStart = performance.now();
         const provider = Engine.context.PerpsController.getActiveProvider();
         await provider.ping();
+        if (initializationGeneration !== this.initializationGeneration) return;
         setMeasurement(
           PerpsMeasurementName.PerpsConnectionHealthCheck,
           performance.now() - healthCheckStart,
@@ -1087,6 +1092,7 @@ class PerpsConnectionManagerClass {
         const preloadStart = performance.now();
         const preloadedUserContextKey = this.getSelectedUserContextKey();
         await this.preloadSubscriptions();
+        if (initializationGeneration !== this.initializationGeneration) return;
         if (
           this.isInitialized &&
           preloadedUserContextKey === this.getSelectedUserContextKey()
@@ -1123,6 +1129,7 @@ class PerpsConnectionManagerClass {
           success: true,
         };
       } catch (error) {
+        if (initializationGeneration !== this.initializationGeneration) return;
         this.isConnecting = false;
         this.isConnected = false;
         this.isInitialized = false;
@@ -1155,11 +1162,14 @@ class PerpsConnectionManagerClass {
             ...traceData,
           },
         });
-        this.initPromise = null;
+        if (this.initPromise === initPromise) {
+          this.initPromise = null;
+        }
       }
     })();
 
-    return this.initPromise;
+    this.initPromise = initPromise;
+    return initPromise;
   }
 
   /**
@@ -1185,10 +1195,14 @@ class PerpsConnectionManagerClass {
       // Initialization cannot be cancelled safely. Let it settle before the
       // forced reconnect replaces its controller and stream ownership.
       if (this.initPromise) {
-        try {
-          await this.initPromise;
-        } catch {
-          // The forced reconnect below owns recovery from the failed init.
+        const pendingInitialization = this.initPromise;
+        this.initializationGeneration += 1;
+        await Promise.race([
+          pendingInitialization.catch(() => undefined),
+          wait(PERPS_CONSTANTS.ConnectionAttemptTimeoutMs),
+        ]);
+        if (this.initPromise === pendingInitialization) {
+          this.initPromise = null;
         }
       }
     } else {
@@ -1237,7 +1251,8 @@ class PerpsConnectionManagerClass {
   }
 
   private async performSerializedReconnection(): Promise<void> {
-    let lastError: unknown;
+    let lastError: Error | undefined;
+    let lastAttemptFailed = false;
 
     for (
       let attempt = 1;
@@ -1248,8 +1263,13 @@ class PerpsConnectionManagerClass {
       try {
         await this.performReconnection();
         lastError = undefined;
+        lastAttemptFailed = false;
       } catch (error) {
-        lastError = error;
+        lastError = ensureError(
+          error,
+          'PerpsConnectionManager.performSerializedReconnection',
+        );
+        lastAttemptFailed = true;
       }
 
       const pendingRequest = this.getPendingReconnectRequest();
@@ -1259,7 +1279,7 @@ class PerpsConnectionManagerClass {
           pendingRequest.userContextKey !== this.initializedUserContextKey) ||
         (this.isConnected && !this.isSelectedUserContextReady());
       if (!shouldRetry) {
-        if (lastError) {
+        if (lastAttemptFailed && lastError) {
           throw lastError;
         }
         return;
@@ -1269,6 +1289,9 @@ class PerpsConnectionManagerClass {
     logPerpsConnectionProof('reconnect_attempt_limit_reached', {
       max_attempts: MAX_SERIALIZED_RECONNECT_ATTEMPTS,
     });
+    if (!lastAttemptFailed && this.isConnected) {
+      return;
+    }
     throw (
       lastError ??
       new Error(

--- a/app/components/UI/Perps/utils/perpsLoadingSession.test.ts
+++ b/app/components/UI/Perps/utils/perpsLoadingSession.test.ts
@@ -593,6 +593,13 @@ describe('perpsLoadingSession', () => {
 
       expect(setMeasurement).toHaveBeenCalledTimes(3);
       expect(valuesReadyRecords()).toHaveLength(2);
+      expect(valuesReadyRecords()).toEqual(
+        expect.arrayContaining([expect.objectContaining({ pre_session: true })]),
+      );
+      expect(annotateTrace).toHaveBeenCalledWith(
+        { name: TraceName.PerpsLoadingSession, id: 'session-id-1' },
+        { has_pre_session_milestone: true },
+      );
     });
 
     it('preserves initial values when the Homepage prepares the pending session', () => {
@@ -877,6 +884,28 @@ describe('perpsLoadingSession', () => {
       );
       unsubscribe();
       jest.useRealTimers();
+    });
+
+    it('continues notifying after a listener throws', () => {
+      const throwingListener = jest.fn(() => {
+        throw new Error('listener failed');
+      });
+      const receivingListener = jest.fn();
+      const unsubscribeThrowing =
+        subscribeToPerpsLoadingSession(throwingListener);
+      const unsubscribeReceiving =
+        subscribeToPerpsLoadingSession(receivingListener);
+
+      expect(() => startPerpsLoadingSession()).not.toThrow();
+      expect(receivingListener).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'started' }),
+      );
+      expect(DevLogger.log).toHaveBeenCalledWith(
+        'Perps loading session listener failed',
+        expect.objectContaining({ error: expect.any(Error) }),
+      );
+      unsubscribeThrowing();
+      unsubscribeReceiving();
     });
 
     it('keeps recorded cache provenance ahead of Terminal row provenance', () => {

--- a/app/components/UI/Perps/utils/perpsLoadingSession.test.ts
+++ b/app/components/UI/Perps/utils/perpsLoadingSession.test.ts
@@ -594,7 +594,9 @@ describe('perpsLoadingSession', () => {
       expect(setMeasurement).toHaveBeenCalledTimes(3);
       expect(valuesReadyRecords()).toHaveLength(2);
       expect(valuesReadyRecords()).toEqual(
-        expect.arrayContaining([expect.objectContaining({ pre_session: true })]),
+        expect.arrayContaining([
+          expect.objectContaining({ pre_session: true }),
+        ]),
       );
       expect(annotateTrace).toHaveBeenCalledWith(
         { name: TraceName.PerpsLoadingSession, id: 'session-id-1' },

--- a/app/components/UI/Perps/utils/perpsLoadingSession.test.ts
+++ b/app/components/UI/Perps/utils/perpsLoadingSession.test.ts
@@ -1,0 +1,1072 @@
+import performance from 'react-native-performance';
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import {
+  annotateTraceByRequest as annotateTrace,
+  endTrace,
+  setTraceMeasurement as setMeasurement,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../util/trace';
+import {
+  cancelPerpsLoadingSession,
+  finishPerpsLoadingSession,
+  createPerpsLoadingSessionIdentity,
+  getActivePerpsLoadingSessionContext,
+  markPerpsLoadingSessionConnectionValidated,
+  preparePerpsLoadingSession,
+  recordPerpsControllerConstructedAt,
+  resolvePerpsMarketSource,
+  recordPerpsLoadingSessionValuesReady,
+  resetPerpsLoadingSessionForTesting,
+  setPerpsLoadingSessionLifecycle,
+  startPerpsLoadingSession,
+  subscribeToPerpsLoadingSession,
+} from './perpsLoadingSession';
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'session-id-1'),
+}));
+
+jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
+  DevLogger: { log: jest.fn() },
+}));
+
+jest.mock('../../../../util/trace', () => ({
+  annotateTraceByRequest: jest.fn(),
+  endTrace: jest.fn(),
+  setTraceMeasurement: jest.fn(),
+  trace: jest.fn(),
+  TraceName: { PerpsLoadingSession: 'Perps Loading Session' },
+  TraceOperation: { PerpsLoading: 'perps.loading' },
+}));
+
+jest.mock('react-native-performance', () => ({
+  __esModule: true,
+  default: {
+    now: jest.fn(() => 400),
+    getEntriesByName: jest.fn(() => []),
+  },
+}));
+
+describe('perpsLoadingSession', () => {
+  const recordFresh = (
+    stream: 'positions' | 'orders' | 'account' | 'prices',
+    itemCount: number,
+    detail: Record<string, number> = {},
+  ) =>
+    recordPerpsLoadingSessionValuesReady(
+      stream,
+      'fresh_socket',
+      itemCount,
+      detail,
+      undefined,
+      7,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetPerpsLoadingSessionForTesting();
+    jest.mocked(performance.now).mockReturnValue(400);
+    jest.mocked(performance.getEntriesByName).mockReturnValue([]);
+  });
+
+  it('starts one session and logs the canonical marker', () => {
+    const sessionId = startPerpsLoadingSession();
+
+    expect(sessionId).toBe('session-id-1');
+    expect(DevLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '"stage":"perps_bootstrap_start","perps_session_id":"session-id-1"',
+      ),
+    );
+    expect(trace).toHaveBeenCalledWith({
+      name: TraceName.PerpsLoadingSession,
+      id: 'session-id-1',
+      op: TraceOperation.PerpsLoading,
+      tags: {
+        provider: 'unknown',
+        network: 'unknown',
+      },
+      data: {
+        lifecycle: 'cold_no_cache',
+        surface: 'homepage',
+        account_generation: 1,
+        context_generation: 1,
+      },
+    });
+    expect(setMeasurement).toHaveBeenCalledWith(
+      { name: TraceName.PerpsLoadingSession, id: 'session-id-1' },
+      'process_to_perps_bootstrap_start_ms',
+      400,
+      'millisecond',
+    );
+  });
+
+  it('writes a buffered controller construction timestamp after session start', () => {
+    recordPerpsControllerConstructedAt(125);
+
+    startPerpsLoadingSession();
+
+    expect(setMeasurement).toHaveBeenCalledWith(
+      { name: TraceName.PerpsLoadingSession, id: 'session-id-1' },
+      'process_to_perps_controller_constructed_ms',
+      125,
+      'millisecond',
+    );
+  });
+
+  it('starts the loading trace with provider and network cohorts', () => {
+    startPerpsLoadingSession({
+      provider: 'hyperliquid',
+      network: 'testnet',
+    });
+
+    expect(trace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: {
+          provider: 'hyperliquid',
+          network: 'testnet',
+        },
+      }),
+    );
+  });
+
+  it('targets the active session when construction is reported after start', () => {
+    startPerpsLoadingSession();
+    jest.mocked(setMeasurement).mockClear();
+
+    recordPerpsControllerConstructedAt(425);
+
+    expect(setMeasurement).toHaveBeenCalledWith(
+      { name: TraceName.PerpsLoadingSession, id: 'session-id-1' },
+      'process_to_perps_controller_constructed_ms',
+      425,
+      'millisecond',
+    );
+  });
+
+  it('ignores invalid construction timestamps', () => {
+    recordPerpsControllerConstructedAt(Number.NaN);
+    recordPerpsControllerConstructedAt(-1);
+
+    startPerpsLoadingSession();
+
+    expect(setMeasurement).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'process_to_perps_controller_constructed_ms',
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('updates the bounded lifecycle on the active session', () => {
+    startPerpsLoadingSession();
+
+    setPerpsLoadingSessionLifecycle('background_reconnect');
+
+    expect(getActivePerpsLoadingSessionContext()?.lifecycle).toBe(
+      'background_reconnect',
+    );
+    expect(annotateTrace).toHaveBeenCalledWith(
+      { name: TraceName.PerpsLoadingSession, id: 'session-id-1' },
+      { lifecycle: 'background_reconnect' },
+    );
+  });
+
+  it('waits for the foreground connection decision before finishing a short resume', () => {
+    startPerpsLoadingSession({ lifecycle: 'background_short' });
+
+    finishPerpsLoadingSession({
+      success: true,
+      content_state: 'filled',
+      content_variant: 'trending',
+    });
+    expect(endTrace).not.toHaveBeenCalled();
+
+    markPerpsLoadingSessionConnectionValidated();
+    expect(endTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          required_live_streams_complete: true,
+        }),
+      }),
+    );
+  });
+
+  it('returns the same id and does not emit a second trace or marker on repeated start', () => {
+    const first = startPerpsLoadingSession();
+    const second = startPerpsLoadingSession();
+
+    expect(first).toBe('session-id-1');
+    expect(second).toBe(first);
+    expect(trace).toHaveBeenCalledTimes(1);
+    expect(DevLogger.log).toHaveBeenCalledTimes(1);
+  });
+
+  it('increments account and context generations independently', () => {
+    const firstIdentity = createPerpsLoadingSessionIdentity({
+      address: '0xabc',
+      hip3ConfigVersion: 1,
+      network: 'mainnet',
+      provider: 'hyperliquid',
+    });
+    startPerpsLoadingSession({ identity: firstIdentity });
+    expect(getActivePerpsLoadingSessionContext()).toEqual(
+      expect.objectContaining({ accountGeneration: 1, contextGeneration: 1 }),
+    );
+
+    cancelPerpsLoadingSession('context_changed');
+    const networkIdentity = createPerpsLoadingSessionIdentity({
+      address: '0xabc',
+      hip3ConfigVersion: 1,
+      network: 'testnet',
+      provider: 'hyperliquid',
+    });
+    startPerpsLoadingSession({ identity: networkIdentity });
+    expect(getActivePerpsLoadingSessionContext()).toEqual(
+      expect.objectContaining({ accountGeneration: 1, contextGeneration: 2 }),
+    );
+
+    cancelPerpsLoadingSession('context_changed');
+    const accountIdentity = createPerpsLoadingSessionIdentity({
+      address: '0xdef',
+      hip3ConfigVersion: 1,
+      network: 'testnet',
+      provider: 'hyperliquid',
+    });
+    startPerpsLoadingSession({ identity: accountIdentity });
+
+    expect(getActivePerpsLoadingSessionContext()).toEqual(
+      expect.objectContaining({ accountGeneration: 2, contextGeneration: 3 }),
+    );
+  });
+
+  it('ends a cancelled session without reporting a success or failure', () => {
+    startPerpsLoadingSession();
+
+    cancelPerpsLoadingSession('app_backgrounded');
+
+    expect(endTrace).toHaveBeenCalledWith({
+      name: TraceName.PerpsLoadingSession,
+      id: 'session-id-1',
+      data: {
+        cancellation_reason: 'app_backgrounded',
+        required_live_streams_complete: false,
+      },
+    });
+    expect(getActivePerpsLoadingSessionContext()).toBeNull();
+  });
+
+  it('disarms a prepared buffer when cancelled before the session starts', () => {
+    preparePerpsLoadingSession();
+    recordPerpsLoadingSessionValuesReady('markets', 'provider', 4);
+    finishPerpsLoadingSession({
+      success: true,
+      content_state: 'empty',
+      content_variant: 'trending',
+    });
+
+    cancelPerpsLoadingSession('surface_unmounted');
+    startPerpsLoadingSession();
+
+    expect(setMeasurement).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'markets_ready_ms',
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(endTrace).not.toHaveBeenCalled();
+  });
+
+  it('cancels rather than failing the old session on restart', () => {
+    startPerpsLoadingSession();
+
+    startPerpsLoadingSession({ restart: true });
+
+    expect(endTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          cancellation_reason: 'session_restarted',
+        }),
+      }),
+    );
+    expect(endTrace).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ success: false }),
+      }),
+    );
+  });
+
+  it('ignores completion from a stale render generation', () => {
+    startPerpsLoadingSession();
+
+    finishPerpsLoadingSession(
+      { success: true, content_state: 'filled' },
+      'stale-session-id',
+    );
+
+    expect(endTrace).not.toHaveBeenCalled();
+    expect(getActivePerpsLoadingSessionContext()?.id).toBe('session-id-1');
+  });
+
+  describe('recordPerpsLoadingSessionValuesReady', () => {
+    const valuesReadyRecords = () =>
+      jest
+        .mocked(DevLogger.log)
+        .mock.calls.map(([message]) => String(message))
+        .filter((message) => message.includes('"stage":"values_ready"'))
+        .map(
+          (message) =>
+            JSON.parse(message.replace('[PerpsLoadProof] ', '')) as {
+              stage: string;
+              perps_session_id: string;
+              lifecycle: string;
+              stream: string;
+              source: string;
+              item_count: number;
+              elapsed_ms: number;
+              account_generation: number;
+              context_generation: number;
+              connection_generation?: number;
+              main_market_count?: number;
+            },
+        );
+
+    const startSessionAt = (monotonicMs: number) => {
+      jest.mocked(performance.now).mockReturnValue(monotonicMs);
+      startPerpsLoadingSession();
+      jest.mocked(DevLogger.log).mockClear();
+      jest.mocked(setMeasurement).mockClear();
+    };
+
+    it('records markets_ready once with source, coverage, and bootstrap-relative elapsed', () => {
+      startSessionAt(400);
+      jest.mocked(performance.now).mockReturnValue(550);
+
+      recordPerpsLoadingSessionValuesReady('markets', 'provider', 12, {
+        main_market_count: 10,
+        hip3_market_count: 2,
+        priced_market_count: 11,
+        trend_market_count: 8,
+      });
+      recordPerpsLoadingSessionValuesReady('markets', 'memory_cache', 20, {
+        main_market_count: 18,
+      });
+
+      expect(setMeasurement).toHaveBeenCalledTimes(1);
+      expect(setMeasurement).toHaveBeenCalledWith(
+        { name: TraceName.PerpsLoadingSession, id: 'session-id-1' },
+        'markets_ready_ms',
+        150,
+        'millisecond',
+      );
+      expect(valuesReadyRecords()).toEqual([
+        expect.objectContaining({
+          stage: 'values_ready',
+          perps_session_id: 'session-id-1',
+          lifecycle: 'cold_no_cache',
+          stream: 'markets',
+          source: 'provider',
+          item_count: 12,
+          elapsed_ms: 150,
+          account_generation: 1,
+          context_generation: 1,
+          main_market_count: 10,
+          hip3_market_count: 2,
+          priced_market_count: 11,
+          trend_market_count: 8,
+        }),
+      ]);
+    });
+
+    it('updates market readiness when fresh data replaces cache', () => {
+      startSessionAt(400);
+      jest
+        .mocked(performance.now)
+        .mockReturnValueOnce(450)
+        .mockReturnValue(520);
+
+      recordPerpsLoadingSessionValuesReady('markets', 'memory_cache', 5);
+      recordPerpsLoadingSessionValuesReady(
+        'markets',
+        'terminal_global_snapshot_v2',
+        5,
+      );
+
+      expect(setMeasurement).toHaveBeenNthCalledWith(
+        1,
+        { name: TraceName.PerpsLoadingSession, id: 'session-id-1' },
+        'markets_ready_ms',
+        50,
+        'millisecond',
+      );
+      expect(setMeasurement).toHaveBeenNthCalledWith(
+        2,
+        { name: TraceName.PerpsLoadingSession, id: 'session-id-1' },
+        'markets_ready_ms',
+        120,
+        'millisecond',
+      );
+      expect(getActivePerpsLoadingSessionContext()?.marketSource).toBe(
+        'terminal_v2',
+      );
+    });
+
+    it('does not record account_cache_ready from mixed cache sources', () => {
+      startSessionAt(400);
+      jest.mocked(performance.now).mockReturnValue(480);
+
+      recordPerpsLoadingSessionValuesReady('positions', 'memory_cache', 2);
+      recordPerpsLoadingSessionValuesReady('orders', 'provider_snapshot', 0);
+      recordPerpsLoadingSessionValuesReady('account', 'memory_cache', 1);
+
+      expect(setMeasurement).not.toHaveBeenCalled();
+      expect(valuesReadyRecords()).toHaveLength(0);
+    });
+
+    it('records account_cache_ready when one source has positions, orders, and account', () => {
+      startSessionAt(400);
+      jest.mocked(performance.now).mockReturnValue(480);
+
+      recordPerpsLoadingSessionValuesReady('positions', 'provider_snapshot', 2);
+      recordPerpsLoadingSessionValuesReady('orders', 'provider_snapshot', 0);
+
+      expect(setMeasurement).not.toHaveBeenCalled();
+
+      jest.mocked(performance.now).mockReturnValue(510);
+      recordPerpsLoadingSessionValuesReady('account', 'provider_snapshot', 1);
+
+      expect(setMeasurement).toHaveBeenCalledTimes(1);
+      expect(setMeasurement).toHaveBeenCalledWith(
+        { name: TraceName.PerpsLoadingSession, id: 'session-id-1' },
+        'account_cache_ready_ms',
+        110,
+        'millisecond',
+      );
+      expect(valuesReadyRecords()).toEqual([
+        expect.objectContaining({
+          stream: 'account',
+          source: 'provider_snapshot',
+          item_count: 1,
+          elapsed_ms: 110,
+        }),
+      ]);
+    });
+
+    it('records empty positions and orders as live but not empty prices or null account', () => {
+      startSessionAt(400);
+      jest.mocked(performance.now).mockReturnValue(430);
+
+      recordFresh('positions', 0);
+      recordFresh('orders', 0);
+      recordFresh('account', 0);
+      recordFresh('prices', 0, {
+        subscribed_symbol_count: 7,
+      });
+
+      expect(setMeasurement).toHaveBeenCalledTimes(2);
+      expect(setMeasurement).toHaveBeenCalledWith(
+        { name: TraceName.PerpsLoadingSession, id: 'session-id-1' },
+        'positions_live_ms',
+        30,
+        'millisecond',
+      );
+      expect(setMeasurement).toHaveBeenCalledWith(
+        { name: TraceName.PerpsLoadingSession, id: 'session-id-1' },
+        'orders_live_ms',
+        30,
+        'millisecond',
+      );
+      expect(setMeasurement).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'account_live_ms',
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(setMeasurement).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'prices_live_ms',
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(valuesReadyRecords()).toEqual([
+        expect.objectContaining({
+          stream: 'positions',
+          item_count: 0,
+          connection_generation: 7,
+        }),
+        expect.objectContaining({
+          stream: 'orders',
+          item_count: 0,
+          connection_generation: 7,
+        }),
+      ]);
+    });
+
+    it('does not treat fresh_socket as cache-ready or rewrite a recorded milestone', () => {
+      startSessionAt(400);
+      jest.mocked(performance.now).mockReturnValue(440);
+      recordFresh('positions', 3);
+      jest.mocked(performance.now).mockReturnValue(460);
+      recordFresh('positions', 4);
+      recordPerpsLoadingSessionValuesReady('orders', 'memory_cache', 1);
+      recordPerpsLoadingSessionValuesReady('account', 'memory_cache', 1);
+
+      expect(setMeasurement).toHaveBeenCalledTimes(1);
+      expect(setMeasurement).toHaveBeenCalledWith(
+        { name: TraceName.PerpsLoadingSession, id: 'session-id-1' },
+        'positions_live_ms',
+        40,
+        'millisecond',
+      );
+      expect(valuesReadyRecords()).toHaveLength(1);
+    });
+
+    it('restarts live milestones on a newer connection generation', () => {
+      startSessionAt(400);
+
+      recordFresh('positions', 1);
+      recordPerpsLoadingSessionValuesReady(
+        'orders',
+        'fresh_socket',
+        1,
+        {},
+        undefined,
+        8,
+      );
+
+      expect(valuesReadyRecords()).toEqual([
+        expect.objectContaining({
+          stream: 'positions',
+          connection_generation: 7,
+        }),
+        expect.objectContaining({
+          stream: 'orders',
+          connection_generation: 8,
+        }),
+      ]);
+      expect(getActivePerpsLoadingSessionContext()?.connectionGeneration).toBe(
+        8,
+      );
+    });
+
+    it('does not advance generation for an ineligible empty account tick', () => {
+      startSessionAt(400);
+      recordFresh('positions', 1);
+
+      recordPerpsLoadingSessionValuesReady(
+        'account',
+        'fresh_socket',
+        0,
+        {},
+        undefined,
+        8,
+      );
+
+      expect(getActivePerpsLoadingSessionContext()?.connectionGeneration).toBe(
+        7,
+      );
+      expect(valuesReadyRecords()).toHaveLength(1);
+    });
+
+    it('does not let a global price tick select the user-stream generation', () => {
+      startSessionAt(400);
+
+      recordFresh('prices', 4);
+
+      expect(valuesReadyRecords()).toHaveLength(0);
+      expect(
+        getActivePerpsLoadingSessionContext()?.connectionGeneration,
+      ).toBeUndefined();
+    });
+
+    it('buffers values observed before the parent session effect starts', () => {
+      preparePerpsLoadingSession();
+      recordPerpsLoadingSessionValuesReady('markets', 'provider', 4);
+      recordFresh('positions', 0);
+
+      expect(setMeasurement).not.toHaveBeenCalled();
+      expect(DevLogger.log).not.toHaveBeenCalled();
+
+      startPerpsLoadingSession();
+
+      expect(setMeasurement).toHaveBeenCalledTimes(3);
+      expect(valuesReadyRecords()).toHaveLength(2);
+    });
+
+    it('preserves initial values when the Homepage prepares the pending session', () => {
+      preparePerpsLoadingSession();
+      recordPerpsLoadingSessionValuesReady('markets', 'provider', 4);
+      startPerpsLoadingSession();
+
+      expect(setMeasurement).toHaveBeenCalledWith(
+        { name: TraceName.PerpsLoadingSession, id: 'session-id-1' },
+        'markets_ready_ms',
+        0,
+        'millisecond',
+      );
+    });
+
+    it('does not carry post-completion live ticks into the next generation', () => {
+      startPerpsLoadingSession({ lifecycle: 'navigate_return' });
+      finishPerpsLoadingSession({
+        success: true,
+        content_state: 'empty',
+        content_variant: 'trending',
+      });
+      jest.clearAllMocks();
+
+      recordFresh('positions', 1);
+      preparePerpsLoadingSession();
+      startPerpsLoadingSession();
+
+      expect(setMeasurement).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'positions_live_ms',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('accepts price ticks only after a current user stream fixes the connection generation', () => {
+      const oldIdentity = createPerpsLoadingSessionIdentity({
+        address: '0xold',
+        hip3ConfigVersion: 1,
+        network: 'mainnet',
+        provider: 'hyperliquid',
+      });
+      const currentIdentity = createPerpsLoadingSessionIdentity({
+        address: '0xcurrent',
+        hip3ConfigVersion: 1,
+        network: 'mainnet',
+        provider: 'hyperliquid',
+      });
+      startPerpsLoadingSession({ identity: currentIdentity });
+
+      recordPerpsLoadingSessionValuesReady(
+        'positions',
+        'fresh_socket',
+        1,
+        {},
+        oldIdentity,
+        7,
+      );
+      recordPerpsLoadingSessionValuesReady(
+        'orders',
+        'fresh_socket',
+        0,
+        {},
+        currentIdentity,
+        7,
+      );
+      recordPerpsLoadingSessionValuesReady(
+        'prices',
+        'fresh_socket',
+        4,
+        {},
+        oldIdentity,
+        7,
+      );
+
+      expect(setMeasurement).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'positions_live_ms',
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(setMeasurement).toHaveBeenCalledWith(
+        expect.anything(),
+        'prices_live_ms',
+        expect.anything(),
+        'millisecond',
+      );
+    });
+
+    it('does not buffer live ticks before the Homepage prepares a session', () => {
+      recordFresh('positions', 1);
+
+      preparePerpsLoadingSession();
+      startPerpsLoadingSession();
+
+      expect(setMeasurement).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'positions_live_ms',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('finishPerpsLoadingSession', () => {
+    const finishData = {
+      success: true,
+      content_state: 'empty',
+      content_variant: 'trending',
+      market_source: 'provider',
+      account_source: 'memory_cache',
+      lifecycle: 'cold_no_cache',
+      surface: 'homepage',
+    };
+
+    it('ends the active session once', () => {
+      startPerpsLoadingSession({ lifecycle: 'navigate_return' });
+
+      finishPerpsLoadingSession(finishData);
+      finishPerpsLoadingSession({
+        ...finishData,
+        content_variant: 'positions',
+      });
+
+      expect(endTrace).toHaveBeenCalledTimes(1);
+      expect(endTrace).toHaveBeenCalledWith({
+        name: TraceName.PerpsLoadingSession,
+        id: 'session-id-1',
+        timestamp: undefined,
+        data: {
+          ...finishData,
+          required_live_streams_complete: true,
+        },
+      });
+      expect(getActivePerpsLoadingSessionContext()).toBeNull();
+    });
+
+    it('does not end a trace when no session is active', () => {
+      finishPerpsLoadingSession(finishData);
+
+      expect(endTrace).not.toHaveBeenCalled();
+    });
+
+    it('clears active session state so a new lifecycle can start', () => {
+      startPerpsLoadingSession({ lifecycle: 'navigate_return' });
+      finishPerpsLoadingSession(finishData);
+
+      const nextId = startPerpsLoadingSession();
+
+      expect(nextId).toBe('session-id-1');
+      expect(trace).toHaveBeenCalledTimes(2);
+      expect(getActivePerpsLoadingSessionContext()).toEqual({
+        id: 'session-id-1',
+        marketSource: 'unknown',
+        accountSource: 'unknown',
+        lifecycle: 'cold_no_cache',
+        accountGeneration: 1,
+        contextGeneration: 2,
+      });
+    });
+
+    it('waits for fresh markets and the complete live account on a network switch', () => {
+      startPerpsLoadingSession({ lifecycle: 'network_switch' });
+      finishPerpsLoadingSession({ ...finishData, content_state: 'filled' });
+
+      expect(endTrace).not.toHaveBeenCalled();
+
+      recordPerpsLoadingSessionValuesReady('markets', 'memory_cache', 4);
+      recordFresh('positions', 0);
+      recordFresh('orders', 0);
+      recordFresh('account', 1);
+
+      expect(endTrace).not.toHaveBeenCalled();
+
+      recordPerpsLoadingSessionValuesReady(
+        'markets',
+        'terminal_global_snapshot_v2',
+        4,
+      );
+
+      expect(endTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            content_variant: 'trending',
+            required_live_streams_complete: true,
+          }),
+        }),
+      );
+      expect(setMeasurement).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'prices_live_ms',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('updates empty account content when fresh markets arrive', () => {
+      startPerpsLoadingSession({ lifecycle: 'cold_no_cache' });
+      recordFresh('positions', 0);
+      recordFresh('orders', 0);
+      recordFresh('account', 1);
+
+      finishPerpsLoadingSession({ ...finishData, market_count: 5 });
+      expect(endTrace).not.toHaveBeenCalled();
+
+      recordPerpsLoadingSessionValuesReady('markets', 'provider', 5);
+      expect(endTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            content_state: 'filled',
+            market_count: 5,
+            market_source: 'provider',
+            required_live_streams_complete: true,
+          }),
+        }),
+      );
+    });
+
+    it('waits for the complete live account on positions content', () => {
+      startPerpsLoadingSession();
+      finishPerpsLoadingSession({
+        ...finishData,
+        content_variant: 'positions',
+      });
+
+      expect(endTrace).not.toHaveBeenCalled();
+
+      recordFresh('positions', 1);
+      recordFresh('orders', 0);
+      recordFresh('account', 1);
+
+      expect(endTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            content_variant: 'positions',
+            required_live_streams_complete: true,
+          }),
+        }),
+      );
+    });
+
+    it('ends and releases a session at the bounded timeout', () => {
+      jest.useFakeTimers();
+      const startedAtWallMs = Date.now();
+      startPerpsLoadingSession();
+      const expectedDeadline = startedAtWallMs + 90_000;
+      jest.mocked(performance.now).mockReturnValue(120_400);
+      const dateNow = jest
+        .spyOn(Date, 'now')
+        .mockReturnValue(startedAtWallMs + 120_000);
+
+      jest.advanceTimersByTime(120_000);
+
+      expect(endTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timestamp: expectedDeadline,
+          data: expect.objectContaining({
+            success: false,
+            failure_stage: 'loading_session_timeout',
+          }),
+        }),
+      );
+      expect(getActivePerpsLoadingSessionContext()).toBeNull();
+      dateNow.mockRestore();
+      jest.useRealTimers();
+    });
+
+    it('notifies subscribers when a session times out', () => {
+      jest.useFakeTimers();
+      const listener = jest.fn();
+      const unsubscribe = subscribeToPerpsLoadingSession(listener);
+      startPerpsLoadingSession();
+
+      jest.advanceTimersByTime(90_000);
+
+      expect(listener).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          type: 'timed_out',
+          context: expect.objectContaining({ id: 'session-id-1' }),
+        }),
+      );
+      unsubscribe();
+      jest.useRealTimers();
+    });
+
+    it('keeps recorded cache provenance ahead of Terminal row provenance', () => {
+      startPerpsLoadingSession();
+      recordPerpsLoadingSessionValuesReady('markets', 'memory_cache', 3);
+      const sessionMarketSource =
+        getActivePerpsLoadingSessionContext()?.marketSource;
+
+      expect(resolvePerpsMarketSource('memory_cache')).toBe('memory_cache');
+      expect(resolvePerpsMarketSource('unknown')).toBe('unknown');
+      expect(resolvePerpsMarketSource(sessionMarketSource)).toBe(
+        'memory_cache',
+      );
+      expect(resolvePerpsMarketSource(null)).toBe('unknown');
+    });
+
+    it('waits for a fresh empty market response before finishing an empty cold surface', () => {
+      startPerpsLoadingSession({ lifecycle: 'cold_no_cache' });
+      recordFresh('positions', 0);
+      recordFresh('orders', 0);
+      recordFresh('account', 1);
+
+      finishPerpsLoadingSession({ ...finishData, market_count: 0 });
+      expect(endTrace).not.toHaveBeenCalled();
+
+      recordPerpsLoadingSessionValuesReady('markets', 'provider', 0);
+
+      expect(endTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            content_state: 'empty',
+            market_count: 0,
+            market_source: 'provider',
+            required_live_streams_complete: true,
+          }),
+        }),
+      );
+    });
+
+    it('replaces an intermediate empty result with the fresh market response', () => {
+      startPerpsLoadingSession({ lifecycle: 'network_switch' });
+      recordFresh('positions', 0);
+      recordFresh('orders', 0);
+      recordFresh('account', 1);
+
+      finishPerpsLoadingSession({ ...finishData, market_count: 0 });
+      recordPerpsLoadingSessionValuesReady('markets', 'provider', 280);
+
+      expect(endTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            content_state: 'filled',
+            market_count: 280,
+            market_source: 'provider',
+            required_live_streams_complete: true,
+          }),
+        }),
+      );
+    });
+
+    it('does not rewrite account-owned content from market cardinality', () => {
+      startPerpsLoadingSession({ lifecycle: 'cold_no_cache' });
+      finishPerpsLoadingSession({
+        ...finishData,
+        content_state: 'empty',
+        content_variant: 'positions',
+        market_count: 0,
+      });
+
+      recordPerpsLoadingSessionValuesReady('markets', 'provider', 280);
+      recordFresh('positions', 0);
+      recordFresh('orders', 0);
+      recordFresh('account', 1);
+
+      expect(endTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            content_state: 'empty',
+            content_variant: 'positions',
+            market_count: 0,
+          }),
+        }),
+      );
+    });
+
+    it('exposes the coherent account cache source and recorded market source', () => {
+      startPerpsLoadingSession();
+      recordPerpsLoadingSessionValuesReady(
+        'markets',
+        'terminal_global_snapshot_v2',
+        8,
+      );
+      recordPerpsLoadingSessionValuesReady('positions', 'memory_cache', 1);
+      recordPerpsLoadingSessionValuesReady('orders', 'memory_cache', 0);
+      recordPerpsLoadingSessionValuesReady('account', 'memory_cache', 1);
+
+      expect(getActivePerpsLoadingSessionContext()).toEqual({
+        id: 'session-id-1',
+        marketSource: 'terminal_v2',
+        accountSource: 'memory_cache',
+        lifecycle: 'cold_no_cache',
+        accountGeneration: 1,
+        contextGeneration: 1,
+      });
+    });
+
+    it('uses fresh_socket for account_source when account_live is recorded and no cache source won', () => {
+      startPerpsLoadingSession();
+      recordFresh('account', 1);
+
+      expect(getActivePerpsLoadingSessionContext()?.accountSource).toBe(
+        'fresh_socket',
+      );
+    });
+
+    it('keeps the coherent cache account_source when account_live arrives later', () => {
+      startPerpsLoadingSession();
+      recordPerpsLoadingSessionValuesReady('positions', 'memory_cache', 1);
+      recordPerpsLoadingSessionValuesReady('orders', 'memory_cache', 0);
+      recordPerpsLoadingSessionValuesReady('account', 'memory_cache', 1);
+      recordFresh('account', 1);
+
+      expect(getActivePerpsLoadingSessionContext()?.accountSource).toBe(
+        'memory_cache',
+      );
+    });
+
+    it('ends a visible-error session with success false and content_state error', () => {
+      startPerpsLoadingSession();
+
+      finishPerpsLoadingSession({
+        success: false,
+        content_state: 'error',
+        content_variant: 'error',
+      });
+
+      expect(endTrace).toHaveBeenCalledWith({
+        name: TraceName.PerpsLoadingSession,
+        id: 'session-id-1',
+        timestamp: undefined,
+        data: {
+          success: false,
+          content_state: 'error',
+          content_variant: 'error',
+          required_live_streams_complete: false,
+        },
+      });
+    });
+
+    it('uses the latest pending content requirement before live streams complete', () => {
+      startPerpsLoadingSession();
+      finishPerpsLoadingSession({
+        ...finishData,
+        content_variant: 'positions',
+      });
+      finishPerpsLoadingSession({
+        ...finishData,
+        content_variant: 'positions_and_orders',
+      });
+
+      expect(endTrace).not.toHaveBeenCalled();
+
+      recordFresh('positions', 1);
+      recordFresh('orders', 0);
+      recordFresh('account', 1);
+
+      expect(endTrace).toHaveBeenCalledTimes(1);
+      expect(endTrace).toHaveBeenCalledWith({
+        name: TraceName.PerpsLoadingSession,
+        id: 'session-id-1',
+        data: {
+          ...finishData,
+          content_variant: 'positions_and_orders',
+          required_live_streams_complete: true,
+        },
+      });
+    });
+
+    it('finishes without waiting for Homepage Ready', () => {
+      startPerpsLoadingSession({ lifecycle: 'navigate_return' });
+      finishPerpsLoadingSession(finishData);
+
+      expect(endTrace).toHaveBeenCalledTimes(1);
+      expect(endTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            required_live_streams_complete: true,
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/app/components/UI/Perps/utils/perpsLoadingSession.ts
+++ b/app/components/UI/Perps/utils/perpsLoadingSession.ts
@@ -1,0 +1,775 @@
+import { v4 as uuidv4 } from 'uuid';
+import performance from 'react-native-performance';
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import {
+  annotateTraceByRequest,
+  endTrace,
+  setTraceMeasurement,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../util/trace';
+import {
+  PERPS_BOOTSTRAP_STAGE,
+  PERPS_LOADING_CACHE_SOURCES,
+  PERPS_LOADING_SESSION_TIMEOUT_MS,
+  PERPS_VALUES_READY_STAGE,
+  type PerpsLoadingLifecycle,
+  type PerpsLoadingSessionCancellationReason,
+  type PerpsLoadingSessionContext,
+  type PerpsLoadingSessionIdentity,
+  type PerpsLoadingSessionUpdate,
+  type PerpsLoadingSource,
+  type PerpsLoadingStream,
+  type PerpsSessionAccountSource,
+  type PerpsSessionMarketSource,
+  type StartPerpsLoadingSessionOptions,
+} from './perpsLoadingSessionModel';
+
+export {
+  createPerpsLoadingSessionIdentity,
+  PERPS_BOOTSTRAP_STAGE,
+  PERPS_LOADING_SESSION_TIMEOUT_MS,
+  PERPS_VALUES_READY_STAGE,
+  resolvePerpsLoadingLifecycle,
+} from './perpsLoadingSessionModel';
+export type {
+  PerpsLoadingLifecycle,
+  PerpsLoadingSessionCancellationReason,
+  PerpsLoadingSessionContext,
+  PerpsLoadingSessionIdentity,
+  PerpsLoadingSessionUpdate,
+  PerpsLoadingSource,
+  PerpsLoadingStream,
+  PerpsLoadingSurface,
+  PerpsSessionAccountSource,
+  PerpsSessionMarketSource,
+} from './perpsLoadingSessionModel';
+
+const PRE_SESSION_EVENT_BUFFER_LIMIT = 20;
+
+const MILESTONE_MEASUREMENTS = {
+  markets_ready: 'markets_ready_ms',
+  account_cache_ready: 'account_cache_ready_ms',
+  positions_live: 'positions_live_ms',
+  orders_live: 'orders_live_ms',
+  account_live: 'account_live_ms',
+  prices_live: 'prices_live_ms',
+} as const;
+const PROCESS_TO_BOOTSTRAP_START_MEASUREMENT =
+  'process_to_perps_bootstrap_start_ms';
+const PROCESS_TO_CONTROLLER_CONSTRUCTED_MEASUREMENT =
+  'process_to_perps_controller_constructed_ms';
+
+type Milestone = keyof typeof MILESTONE_MEASUREMENTS;
+type CacheStream = 'positions' | 'orders' | 'account';
+
+let activeSessionId: string | null = null;
+let activeSessionIdentity: PerpsLoadingSessionIdentity | null = null;
+let activeLifecycle: PerpsLoadingLifecycle = 'cold_no_cache';
+let activeAccountGeneration = 0;
+let activeContextGeneration = 0;
+let activeConnectionGeneration: number | undefined;
+let accountGenerationCounter = 0;
+let contextGenerationCounter = 0;
+let lastStartedSessionIdentity: PerpsLoadingSessionIdentity | null = null;
+let latestSessionContext: PerpsLoadingSessionContext | null = null;
+let sessionStartedAtMs: number | null = null;
+let controllerConstructedAtMs: number | null = null;
+const recordedMilestones = new Set<Milestone>();
+const cacheObservedBySource = new Map<PerpsLoadingSource, Set<CacheStream>>();
+const sessionListeners = new Set<(update: PerpsLoadingSessionUpdate) => void>();
+let marketsReadySource: PerpsLoadingSource | null = null;
+let accountCacheSource: PerpsLoadingSource | null = null;
+let pendingFinishData: Record<string, string | number | boolean> | null = null;
+let backgroundConnectionValidationPending = false;
+let sessionTimeout: ReturnType<typeof setTimeout> | null = null;
+let preSessionEvents: {
+  stream: PerpsLoadingStream;
+  source: PerpsLoadingSource;
+  itemCount: number;
+  detail: Record<string, number>;
+  identity?: PerpsLoadingSessionIdentity;
+  connectionGeneration?: number;
+  recordedAtMs: number;
+}[] = [];
+let preSessionBufferArmed = false;
+
+function notifySessionListeners(update: PerpsLoadingSessionUpdate): void {
+  sessionListeners.forEach((listener) => listener(update));
+}
+
+export function subscribeToPerpsLoadingSession(
+  listener: (update: PerpsLoadingSessionUpdate) => void,
+): () => void {
+  sessionListeners.add(listener);
+  return () => sessionListeners.delete(listener);
+}
+
+export function preparePerpsLoadingSession(): void {
+  if (activeSessionId) {
+    return;
+  }
+  if (!preSessionBufferArmed) {
+    preSessionEvents = [];
+  }
+  preSessionBufferArmed = true;
+}
+
+export function startPerpsLoadingSession(
+  options: StartPerpsLoadingSessionOptions = {},
+): string {
+  if (activeSessionId && !options.restart) {
+    return activeSessionId;
+  }
+
+  if (activeSessionId) {
+    cancelPerpsLoadingSession('session_restarted');
+  }
+
+  const sessionId = uuidv4();
+  activeSessionId = sessionId;
+  activeSessionIdentity = options.identity ?? null;
+  activeLifecycle = options.lifecycle ?? 'cold_no_cache';
+  backgroundConnectionValidationPending =
+    activeLifecycle === 'background_short';
+  contextGenerationCounter += 1;
+  activeContextGeneration = contextGenerationCounter;
+  activeConnectionGeneration = undefined;
+  if (
+    accountGenerationCounter === 0 ||
+    (options.identity !== undefined &&
+      lastStartedSessionIdentity?.accountKey !== options.identity.accountKey)
+  ) {
+    accountGenerationCounter += 1;
+  }
+  activeAccountGeneration = accountGenerationCounter;
+  lastStartedSessionIdentity = options.identity ?? null;
+  const now = performance.now();
+  sessionStartedAtMs = now;
+  recordedMilestones.clear();
+  cacheObservedBySource.clear();
+  marketsReadySource = null;
+  accountCacheSource = null;
+  pendingFinishData = null;
+  DevLogger.log(
+    `[PerpsLoadProof] ${JSON.stringify({
+      stage: PERPS_BOOTSTRAP_STAGE,
+      perps_session_id: sessionId,
+      lifecycle: activeLifecycle,
+      account_generation: activeAccountGeneration,
+      context_generation: activeContextGeneration,
+      monotonic_ms: Number(now.toFixed(3)),
+    })}`,
+  );
+  trace({
+    name: TraceName.PerpsLoadingSession,
+    id: sessionId,
+    op: TraceOperation.PerpsLoading,
+    tags: {
+      provider: options.provider ?? 'unknown',
+      network: options.network ?? 'unknown',
+    },
+    data: {
+      lifecycle: activeLifecycle,
+      surface: options.surface ?? 'homepage',
+      account_generation: activeAccountGeneration,
+      context_generation: activeContextGeneration,
+    },
+  });
+  setTraceMeasurement(
+    { name: TraceName.PerpsLoadingSession, id: sessionId },
+    PROCESS_TO_BOOTSTRAP_START_MEASUREMENT,
+    now,
+    'millisecond',
+  );
+  if (controllerConstructedAtMs !== null) {
+    setTraceMeasurement(
+      { name: TraceName.PerpsLoadingSession, id: sessionId },
+      PROCESS_TO_CONTROLLER_CONSTRUCTED_MEASUREMENT,
+      controllerConstructedAtMs,
+      'millisecond',
+    );
+  }
+
+  const startedContext = getActivePerpsLoadingSessionContext();
+  if (startedContext) {
+    notifySessionListeners({ type: 'started', context: startedContext });
+  }
+
+  sessionTimeout = setTimeout(() => {
+    const deadlineMs =
+      (sessionStartedAtMs ?? performance.now()) +
+      PERPS_LOADING_SESSION_TIMEOUT_MS;
+    const lateByMs = Math.max(0, performance.now() - deadlineMs);
+    endActiveLoadingSession(
+      {
+        success: false,
+        content_state: 'error',
+        failure_stage: 'loading_session_timeout',
+        required_live_streams_complete: false,
+      },
+      Date.now() - lateByMs,
+    );
+  }, PERPS_LOADING_SESSION_TIMEOUT_MS);
+
+  const bufferedEvents = preSessionEvents;
+  preSessionEvents = [];
+  preSessionBufferArmed = false;
+  bufferedEvents.forEach((event) => {
+    recordValuesReady(event);
+  });
+  return sessionId;
+}
+
+export function recordPerpsControllerConstructedAt(monotonicMs: number): void {
+  if (!Number.isFinite(monotonicMs) || monotonicMs < 0) {
+    return;
+  }
+  controllerConstructedAtMs = monotonicMs;
+  if (!activeSessionId) {
+    return;
+  }
+  setTraceMeasurement(
+    { name: TraceName.PerpsLoadingSession, id: activeSessionId },
+    PROCESS_TO_CONTROLLER_CONSTRUCTED_MEASUREMENT,
+    monotonicMs,
+    'millisecond',
+  );
+}
+
+export function recordPerpsLoadingSessionValuesReady(
+  stream: PerpsLoadingStream,
+  source: PerpsLoadingSource,
+  itemCount: number,
+  detail: Record<string, number> = {},
+  identity?: PerpsLoadingSessionIdentity,
+  connectionGeneration?: number,
+): void {
+  if (!activeSessionId || sessionStartedAtMs === null) {
+    if (!preSessionBufferArmed) {
+      return;
+    }
+    const recordedAtMs = performance.now();
+    preSessionEvents.push({
+      stream,
+      source,
+      itemCount,
+      detail,
+      identity,
+      connectionGeneration,
+      recordedAtMs,
+    });
+    preSessionEvents = preSessionEvents.slice(-PRE_SESSION_EVENT_BUFFER_LIMIT);
+    return;
+  }
+
+  if (!matchesActiveSessionIdentity(stream, identity)) {
+    return;
+  }
+
+  recordValuesReady({
+    stream,
+    source,
+    itemCount,
+    detail,
+    identity,
+    connectionGeneration,
+    recordedAtMs: performance.now(),
+  });
+}
+
+function prepareFreshSocketGeneration(
+  source: PerpsLoadingSource,
+  connectionGeneration?: number,
+): boolean {
+  if (source !== 'fresh_socket') {
+    return true;
+  }
+  if (
+    typeof connectionGeneration !== 'number' ||
+    !Number.isInteger(connectionGeneration)
+  ) {
+    return false;
+  }
+  if (activeConnectionGeneration === undefined) {
+    return true;
+  }
+  if (connectionGeneration < activeConnectionGeneration) {
+    return false;
+  }
+  if (connectionGeneration === activeConnectionGeneration) {
+    return true;
+  }
+
+  const previousConnectionGeneration = activeConnectionGeneration;
+  activeConnectionGeneration = connectionGeneration;
+  for (const milestone of [
+    'positions_live',
+    'orders_live',
+    'account_live',
+    'prices_live',
+  ] as const) {
+    recordedMilestones.delete(milestone);
+  }
+  annotateTraceByRequest(
+    { name: TraceName.PerpsLoadingSession, id: activeSessionId ?? undefined },
+    { connection_generation: connectionGeneration },
+  );
+  DevLogger.log(
+    `[PerpsLoadProof] ${JSON.stringify({
+      stage: 'connection_generation_advanced',
+      perps_session_id: activeSessionId,
+      lifecycle: activeLifecycle,
+      account_generation: activeAccountGeneration,
+      context_generation: activeContextGeneration,
+      previous_connection_generation: previousConnectionGeneration,
+      connection_generation: connectionGeneration,
+      monotonic_ms: Number(performance.now().toFixed(3)),
+    })}`,
+  );
+  return true;
+}
+
+function isFreshMarketSource(source: PerpsLoadingSource): boolean {
+  return source === 'terminal_global_snapshot_v2' || source === 'provider';
+}
+
+function matchesActiveSessionIdentity(
+  stream: PerpsLoadingStream,
+  identity?: PerpsLoadingSessionIdentity,
+): boolean {
+  if (!activeSessionIdentity) {
+    return true;
+  }
+  if (!identity) {
+    return false;
+  }
+  return stream === 'markets' || stream === 'prices'
+    ? identity.marketKey === activeSessionIdentity.marketKey
+    : identity.userKey === activeSessionIdentity.userKey;
+}
+
+function recordValuesReady({
+  stream,
+  source,
+  itemCount,
+  detail,
+  identity,
+  connectionGeneration,
+  recordedAtMs,
+}: {
+  stream: PerpsLoadingStream;
+  source: PerpsLoadingSource;
+  itemCount: number;
+  detail: Record<string, number>;
+  identity?: PerpsLoadingSessionIdentity;
+  connectionGeneration?: number;
+  recordedAtMs: number;
+}): void {
+  if (
+    !activeSessionId ||
+    sessionStartedAtMs === null ||
+    !matchesActiveSessionIdentity(stream, identity) ||
+    (source === 'fresh_socket' &&
+      (stream === 'account' || stream === 'prices') &&
+      itemCount <= 0) ||
+    !prepareFreshSocketGeneration(source, connectionGeneration)
+  ) {
+    return;
+  }
+
+  if (
+    source === 'fresh_socket' &&
+    stream === 'prices' &&
+    activeConnectionGeneration === undefined
+  ) {
+    return;
+  }
+
+  let milestone: Milestone | null = null;
+  if (stream === 'markets') {
+    milestone =
+      itemCount > 0 || (itemCount === 0 && isFreshMarketSource(source))
+        ? 'markets_ready'
+        : null;
+  } else if (source === 'fresh_socket') {
+    if (stream === 'positions' || stream === 'orders') {
+      milestone = `${stream}_live`;
+    } else if ((stream === 'account' || stream === 'prices') && itemCount > 0) {
+      milestone = `${stream}_live`;
+    }
+  } else if (
+    PERPS_LOADING_CACHE_SOURCES.has(source) &&
+    (stream === 'positions' || stream === 'orders' || stream === 'account') &&
+    (stream !== 'account' || itemCount > 0)
+  ) {
+    const observed =
+      cacheObservedBySource.get(source) ?? new Set<CacheStream>();
+    observed.add(stream);
+    cacheObservedBySource.set(source, observed);
+    milestone = observed.size === 3 ? 'account_cache_ready' : null;
+  }
+  const upgradesMarketSource =
+    milestone === 'markets_ready' &&
+    recordedMilestones.has(milestone) &&
+    marketsReadySource !== null &&
+    !isFreshMarketSource(marketsReadySource) &&
+    isFreshMarketSource(source);
+  if (
+    !milestone ||
+    (recordedMilestones.has(milestone) && !upgradesMarketSource)
+  ) {
+    return;
+  }
+  recordedMilestones.add(milestone);
+  if (
+    source === 'fresh_socket' &&
+    stream !== 'prices' &&
+    activeConnectionGeneration === undefined &&
+    typeof connectionGeneration === 'number'
+  ) {
+    activeConnectionGeneration = connectionGeneration;
+    annotateTraceByRequest(
+      { name: TraceName.PerpsLoadingSession, id: activeSessionId },
+      { connection_generation: connectionGeneration },
+    );
+  }
+  if (milestone === 'markets_ready') {
+    marketsReadySource = source;
+    if (
+      pendingFinishData &&
+      isFreshMarketSource(source) &&
+      pendingFinishData.content_variant === 'trending'
+    ) {
+      pendingFinishData = {
+        ...pendingFinishData,
+        content_state: itemCount > 0 ? 'filled' : 'empty',
+        market_count: itemCount,
+        market_source:
+          source === 'terminal_global_snapshot_v2' ? 'terminal_v2' : 'provider',
+      };
+    }
+  }
+  if (milestone === 'account_cache_ready') {
+    accountCacheSource = source;
+  }
+
+  const elapsedMs = Math.max(0, recordedAtMs - sessionStartedAtMs);
+  setTraceMeasurement(
+    { name: TraceName.PerpsLoadingSession, id: activeSessionId },
+    MILESTONE_MEASUREMENTS[milestone],
+    elapsedMs,
+    'millisecond',
+  );
+  DevLogger.log(
+    `[PerpsLoadProof] ${JSON.stringify({
+      stage: PERPS_VALUES_READY_STAGE,
+      perps_session_id: activeSessionId,
+      lifecycle: activeLifecycle,
+      account_generation: activeAccountGeneration,
+      context_generation: activeContextGeneration,
+      ...(source === 'fresh_socket'
+        ? { connection_generation: activeConnectionGeneration }
+        : {}),
+      stream,
+      source,
+      item_count: itemCount,
+      elapsed_ms: Number(elapsedMs.toFixed(3)),
+      monotonic_ms: Number(recordedAtMs.toFixed(3)),
+      ...detail,
+    })}`,
+  );
+
+  const milestoneContext = getActivePerpsLoadingSessionContext();
+  if (milestoneContext) {
+    notifySessionListeners({ type: 'milestone', context: milestoneContext });
+  }
+
+  tryFinishPendingSession();
+}
+
+export function resolvePerpsMarketSource(
+  sessionMarketSource?: PerpsSessionMarketSource | null,
+): PerpsSessionMarketSource {
+  if (sessionMarketSource && sessionMarketSource !== 'unknown') {
+    return sessionMarketSource;
+  }
+  return 'unknown';
+}
+
+function recordedMarketSource(): PerpsSessionMarketSource {
+  if (marketsReadySource === 'terminal_global_snapshot_v2') {
+    return 'terminal_v2';
+  }
+  if (
+    marketsReadySource === 'provider' ||
+    marketsReadySource === 'memory_cache'
+  ) {
+    return marketsReadySource;
+  }
+  return 'unknown';
+}
+
+function recordedAccountSource(): PerpsSessionAccountSource {
+  if (
+    accountCacheSource === 'memory_cache' ||
+    accountCacheSource === 'provider_snapshot'
+  ) {
+    return accountCacheSource;
+  }
+  if (recordedMilestones.has('account_live')) {
+    return 'fresh_socket';
+  }
+  return 'unknown';
+}
+
+export function getActivePerpsLoadingSessionContext(): PerpsLoadingSessionContext | null {
+  if (!activeSessionId) {
+    return null;
+  }
+  const context = {
+    id: activeSessionId,
+    marketSource: recordedMarketSource(),
+    accountSource: recordedAccountSource(),
+    lifecycle: activeLifecycle,
+    accountGeneration: activeAccountGeneration,
+    contextGeneration: activeContextGeneration,
+    ...(activeConnectionGeneration === undefined
+      ? {}
+      : { connectionGeneration: activeConnectionGeneration }),
+  };
+  latestSessionContext = context;
+  return context;
+}
+
+export function getActivePerpsLoadingSessionIdentity(): PerpsLoadingSessionIdentity | null {
+  return activeSessionIdentity ? { ...activeSessionIdentity } : null;
+}
+
+export function getPerpsLoadingSessionContext(
+  sessionId: string,
+): PerpsLoadingSessionContext | null {
+  const activeContext = getActivePerpsLoadingSessionContext();
+  if (activeContext?.id === sessionId) {
+    return activeContext;
+  }
+  return latestSessionContext?.id === sessionId ? latestSessionContext : null;
+}
+
+export function setPerpsLoadingSessionLifecycle(
+  lifecycle: PerpsLoadingLifecycle,
+): void {
+  if (!activeSessionId || activeLifecycle === lifecycle) {
+    return;
+  }
+  activeLifecycle = lifecycle;
+  if (lifecycle !== 'background_short') {
+    backgroundConnectionValidationPending = false;
+  }
+  annotateTraceByRequest(
+    { name: TraceName.PerpsLoadingSession, id: activeSessionId },
+    { lifecycle },
+  );
+  const lifecycleContext = getActivePerpsLoadingSessionContext();
+  if (lifecycleContext) {
+    notifySessionListeners({ type: 'lifecycle', context: lifecycleContext });
+  }
+  tryFinishPendingSession();
+}
+
+export function markPerpsLoadingSessionConnectionValidated(): void {
+  if (!activeSessionId || !backgroundConnectionValidationPending) return;
+  backgroundConnectionValidationPending = false;
+  tryFinishPendingSession();
+}
+
+export function getActivePerpsLoadingSessionTraceData():
+  | {
+      perps_session_id: string;
+      account_generation: number;
+      context_generation: number;
+      connection_generation?: number;
+    }
+  | undefined {
+  return activeSessionId
+    ? {
+        perps_session_id: activeSessionId,
+        account_generation: activeAccountGeneration,
+        context_generation: activeContextGeneration,
+        ...(activeConnectionGeneration === undefined
+          ? {}
+          : { connection_generation: activeConnectionGeneration }),
+      }
+    : undefined;
+}
+
+function endActiveLoadingSession(
+  data: Record<string, string | number | boolean>,
+  timestamp?: number,
+): void {
+  if (!activeSessionId) {
+    return;
+  }
+  const endedContext = getActivePerpsLoadingSessionContext();
+  const updateType =
+    data.failure_stage === 'loading_session_timeout' ? 'timed_out' : 'finished';
+  endTrace({
+    name: TraceName.PerpsLoadingSession,
+    id: activeSessionId,
+    timestamp,
+    data: {
+      success: data.success ?? true,
+      content_state: data.content_state ?? 'filled',
+      ...data,
+    },
+  });
+  resetActiveLoadingSession();
+  if (endedContext) {
+    notifySessionListeners({ type: updateType, context: endedContext });
+  }
+}
+
+function resetActiveLoadingSession(): void {
+  if (sessionTimeout) {
+    clearTimeout(sessionTimeout);
+    sessionTimeout = null;
+  }
+  activeSessionId = null;
+  activeSessionIdentity = null;
+  activeLifecycle = 'cold_no_cache';
+  activeAccountGeneration = 0;
+  activeContextGeneration = 0;
+  activeConnectionGeneration = undefined;
+  sessionStartedAtMs = null;
+  recordedMilestones.clear();
+  cacheObservedBySource.clear();
+  marketsReadySource = null;
+  accountCacheSource = null;
+  pendingFinishData = null;
+  backgroundConnectionValidationPending = false;
+  preSessionEvents = [];
+  preSessionBufferArmed = false;
+}
+
+export function cancelPerpsLoadingSession(
+  reason: PerpsLoadingSessionCancellationReason,
+): void {
+  if (!activeSessionId) {
+    preSessionEvents = [];
+    preSessionBufferArmed = false;
+    return;
+  }
+  const cancelledContext = getActivePerpsLoadingSessionContext();
+  endTrace({
+    name: TraceName.PerpsLoadingSession,
+    id: activeSessionId,
+    data: {
+      cancellation_reason: reason,
+      required_live_streams_complete: false,
+    },
+  });
+  resetActiveLoadingSession();
+  if (cancelledContext) {
+    notifySessionListeners({ type: 'cancelled', context: cancelledContext });
+  }
+}
+
+function requiresLiveAccount(
+  data: Record<string, string | number | boolean>,
+): boolean {
+  return (
+    data.success !== false &&
+    (activeLifecycle === 'cold_no_cache' ||
+      activeLifecycle === 'background_reconnect' ||
+      activeLifecycle === 'account_switch' ||
+      activeLifecycle === 'network_switch' ||
+      data.content_variant === 'positions' ||
+      data.content_variant === 'orders' ||
+      data.content_variant === 'positions_and_orders')
+  );
+}
+
+function requiresFreshMarkets(
+  data: Record<string, string | number | boolean>,
+): boolean {
+  return (
+    data.success !== false &&
+    (data.content_variant === 'trending' || data.content_variant === 'pills') &&
+    (activeLifecycle === 'cold_no_cache' ||
+      activeLifecycle === 'background_reconnect' ||
+      activeLifecycle === 'network_switch')
+  );
+}
+
+function hasRequiredLiveStreams(
+  data: Record<string, string | number | boolean>,
+): boolean {
+  if (data.success === false) {
+    return true;
+  }
+  return (
+    !backgroundConnectionValidationPending &&
+    (!requiresLiveAccount(data) ||
+      (recordedMilestones.has('positions_live') &&
+        recordedMilestones.has('orders_live') &&
+        recordedMilestones.has('account_live'))) &&
+    (!requiresFreshMarkets(data) ||
+      marketsReadySource === 'terminal_global_snapshot_v2' ||
+      marketsReadySource === 'provider')
+  );
+}
+
+function tryFinishPendingSession(): void {
+  if (!pendingFinishData || !hasRequiredLiveStreams(pendingFinishData)) {
+    return;
+  }
+  endActiveLoadingSession({
+    ...pendingFinishData,
+    required_live_streams_complete: pendingFinishData.success !== false,
+  });
+}
+
+export function finishPerpsLoadingSession(
+  data: Record<string, string | number | boolean> = {},
+  expectedSessionId?: string,
+): void {
+  if (expectedSessionId && activeSessionId !== expectedSessionId) {
+    return;
+  }
+  if (!activeSessionId) {
+    return;
+  }
+  if (pendingFinishData?.success === false && data.success !== false) {
+    return;
+  }
+  pendingFinishData = data;
+  tryFinishPendingSession();
+}
+
+export function resetPerpsLoadingSessionForTesting(): void {
+  activeSessionId = null;
+  activeSessionIdentity = null;
+  activeLifecycle = 'cold_no_cache';
+  activeAccountGeneration = 0;
+  activeContextGeneration = 0;
+  activeConnectionGeneration = undefined;
+  accountGenerationCounter = 0;
+  contextGenerationCounter = 0;
+  lastStartedSessionIdentity = null;
+  latestSessionContext = null;
+  sessionStartedAtMs = null;
+  controllerConstructedAtMs = null;
+  recordedMilestones.clear();
+  cacheObservedBySource.clear();
+  marketsReadySource = null;
+  accountCacheSource = null;
+  pendingFinishData = null;
+  backgroundConnectionValidationPending = false;
+  if (sessionTimeout) {
+    clearTimeout(sessionTimeout);
+    sessionTimeout = null;
+  }
+  preSessionEvents = [];
+  preSessionBufferArmed = false;
+}

--- a/app/components/UI/Perps/utils/perpsLoadingSession.ts
+++ b/app/components/UI/Perps/utils/perpsLoadingSession.ts
@@ -63,6 +63,7 @@ const PROCESS_TO_CONTROLLER_CONSTRUCTED_MEASUREMENT =
 
 type Milestone = keyof typeof MILESTONE_MEASUREMENTS;
 type CacheStream = 'positions' | 'orders' | 'account';
+const REQUIRED_ACCOUNT_CACHE_STREAM_COUNT: number = 3;
 
 let activeSessionId: string | null = null;
 let activeSessionIdentity: PerpsLoadingSessionIdentity | null = null;
@@ -96,7 +97,13 @@ let preSessionEvents: {
 let preSessionBufferArmed = false;
 
 function notifySessionListeners(update: PerpsLoadingSessionUpdate): void {
-  sessionListeners.forEach((listener) => listener(update));
+  sessionListeners.forEach((listener) => {
+    try {
+      listener(update);
+    } catch (error) {
+      DevLogger.log('Perps loading session listener failed', { error });
+    }
+  });
 }
 
 export function subscribeToPerpsLoadingSession(
@@ -217,7 +224,7 @@ export function startPerpsLoadingSession(
   preSessionEvents = [];
   preSessionBufferArmed = false;
   bufferedEvents.forEach((event) => {
-    recordValuesReady(event);
+    recordValuesReady({ ...event, preSession: true });
   });
   return sessionId;
 }
@@ -358,6 +365,7 @@ function recordValuesReady({
   identity,
   connectionGeneration,
   recordedAtMs,
+  preSession = false,
 }: {
   stream: PerpsLoadingStream;
   source: PerpsLoadingSource;
@@ -366,6 +374,7 @@ function recordValuesReady({
   identity?: PerpsLoadingSessionIdentity;
   connectionGeneration?: number;
   recordedAtMs: number;
+  preSession?: boolean;
 }): void {
   if (
     !activeSessionId ||
@@ -373,9 +382,12 @@ function recordValuesReady({
     !matchesActiveSessionIdentity(stream, identity) ||
     (source === 'fresh_socket' &&
       (stream === 'account' || stream === 'prices') &&
-      itemCount <= 0) ||
-    !prepareFreshSocketGeneration(source, connectionGeneration)
+      itemCount <= 0)
   ) {
+    return;
+  }
+
+  if (!prepareFreshSocketGeneration(source, connectionGeneration)) {
     return;
   }
 
@@ -408,7 +420,10 @@ function recordValuesReady({
       cacheObservedBySource.get(source) ?? new Set<CacheStream>();
     observed.add(stream);
     cacheObservedBySource.set(source, observed);
-    milestone = observed.size === 3 ? 'account_cache_ready' : null;
+    milestone =
+      observed.size === REQUIRED_ACCOUNT_CACHE_STREAM_COUNT
+        ? 'account_cache_ready'
+        : null;
   }
   const upgradesMarketSource =
     milestone === 'markets_ready' &&
@@ -456,6 +471,12 @@ function recordValuesReady({
   }
 
   const elapsedMs = Math.max(0, recordedAtMs - sessionStartedAtMs);
+  if (preSession) {
+    annotateTraceByRequest(
+      { name: TraceName.PerpsLoadingSession, id: activeSessionId },
+      { has_pre_session_milestone: true },
+    );
+  }
   setTraceMeasurement(
     { name: TraceName.PerpsLoadingSession, id: activeSessionId },
     MILESTONE_MEASUREMENTS[milestone],
@@ -477,6 +498,7 @@ function recordValuesReady({
       item_count: itemCount,
       elapsed_ms: Number(elapsedMs.toFixed(3)),
       monotonic_ms: Number(recordedAtMs.toFixed(3)),
+      ...(preSession ? { pre_session: true } : {}),
       ...detail,
     })}`,
   );
@@ -539,7 +561,6 @@ export function getActivePerpsLoadingSessionContext(): PerpsLoadingSessionContex
       ? {}
       : { connectionGeneration: activeConnectionGeneration }),
   };
-  latestSessionContext = context;
   return context;
 }
 
@@ -612,6 +633,7 @@ function endActiveLoadingSession(
     return;
   }
   const endedContext = getActivePerpsLoadingSessionContext();
+  latestSessionContext = endedContext;
   const updateType =
     data.failure_stage === 'loading_session_timeout' ? 'timed_out' : 'finished';
   endTrace({
@@ -661,6 +683,7 @@ export function cancelPerpsLoadingSession(
     return;
   }
   const cancelledContext = getActivePerpsLoadingSessionContext();
+  latestSessionContext = cancelledContext;
   endTrace({
     name: TraceName.PerpsLoadingSession,
     id: activeSessionId,
@@ -748,28 +771,10 @@ export function finishPerpsLoadingSession(
 }
 
 export function resetPerpsLoadingSessionForTesting(): void {
-  activeSessionId = null;
-  activeSessionIdentity = null;
-  activeLifecycle = 'cold_no_cache';
-  activeAccountGeneration = 0;
-  activeContextGeneration = 0;
-  activeConnectionGeneration = undefined;
+  resetActiveLoadingSession();
   accountGenerationCounter = 0;
   contextGenerationCounter = 0;
   lastStartedSessionIdentity = null;
   latestSessionContext = null;
-  sessionStartedAtMs = null;
   controllerConstructedAtMs = null;
-  recordedMilestones.clear();
-  cacheObservedBySource.clear();
-  marketsReadySource = null;
-  accountCacheSource = null;
-  pendingFinishData = null;
-  backgroundConnectionValidationPending = false;
-  if (sessionTimeout) {
-    clearTimeout(sessionTimeout);
-    sessionTimeout = null;
-  }
-  preSessionEvents = [];
-  preSessionBufferArmed = false;
 }

--- a/app/components/UI/Perps/utils/perpsLoadingSessionModel.ts
+++ b/app/components/UI/Perps/utils/perpsLoadingSessionModel.ts
@@ -1,0 +1,121 @@
+export const PERPS_BOOTSTRAP_STAGE = 'perps_bootstrap_start';
+export const PERPS_VALUES_READY_STAGE = 'values_ready';
+export const PERPS_LOADING_SESSION_TIMEOUT_MS = 90_000;
+
+export type PerpsLoadingStream =
+  | 'markets'
+  | 'positions'
+  | 'orders'
+  | 'account'
+  | 'prices';
+
+export type PerpsLoadingSource =
+  | 'memory_cache'
+  | 'provider_snapshot'
+  | 'terminal_global_snapshot_v2'
+  | 'provider'
+  | 'fresh_socket';
+
+export const PERPS_LOADING_CACHE_SOURCES: ReadonlySet<PerpsLoadingSource> =
+  new Set(['memory_cache', 'provider_snapshot']);
+
+export type PerpsSessionMarketSource =
+  | 'terminal_v2'
+  | 'provider'
+  | 'memory_cache'
+  | 'unknown';
+
+export type PerpsSessionAccountSource =
+  | 'provider_snapshot'
+  | 'memory_cache'
+  | 'fresh_socket'
+  | 'unknown';
+
+export type PerpsLoadingLifecycle =
+  | 'cold_no_cache'
+  | 'navigate_return'
+  | 'background_short'
+  | 'background_reconnect'
+  | 'account_switch'
+  | 'network_switch';
+
+export type PerpsLoadingSurface = 'homepage';
+
+export interface StartPerpsLoadingSessionOptions {
+  lifecycle?: PerpsLoadingLifecycle;
+  surface?: PerpsLoadingSurface;
+  restart?: boolean;
+  identity?: PerpsLoadingSessionIdentity;
+  provider?: string;
+  network?: 'mainnet' | 'testnet';
+}
+
+export interface PerpsLoadingSessionIdentity {
+  marketKey: string;
+  userKey: string;
+  accountKey: string;
+}
+
+export interface PerpsLoadingSessionContext {
+  id: string;
+  marketSource: PerpsSessionMarketSource;
+  accountSource: PerpsSessionAccountSource;
+  lifecycle: PerpsLoadingLifecycle;
+  accountGeneration: number;
+  contextGeneration: number;
+  connectionGeneration?: number;
+}
+
+export type PerpsLoadingSessionCancellationReason =
+  | 'app_backgrounded'
+  | 'context_changed'
+  | 'session_restarted'
+  | 'surface_unfocused'
+  | 'surface_unmounted';
+
+export type PerpsLoadingSessionUpdate =
+  | {
+      type: 'started' | 'milestone' | 'lifecycle';
+      context: PerpsLoadingSessionContext;
+    }
+  | { type: 'finished'; context: PerpsLoadingSessionContext }
+  | {
+      type: 'cancelled' | 'timed_out';
+      context: PerpsLoadingSessionContext;
+    };
+
+export function createPerpsLoadingSessionIdentity({
+  address,
+  hip3ConfigVersion,
+  network,
+  provider,
+}: {
+  address?: string;
+  hip3ConfigVersion: number;
+  network: 'mainnet' | 'testnet';
+  provider?: string;
+}): PerpsLoadingSessionIdentity {
+  const marketKey = JSON.stringify([
+    provider ?? '',
+    network,
+    hip3ConfigVersion,
+  ]);
+  const accountKey = address?.toLowerCase() ?? '';
+  return {
+    marketKey,
+    userKey: JSON.stringify([marketKey, accountKey]),
+    accountKey,
+  };
+}
+
+export function resolvePerpsLoadingLifecycle(
+  context: 'cold_process' | 'warm' | 'background_resume',
+): PerpsLoadingLifecycle {
+  if (context === 'warm') {
+    return 'navigate_return';
+  }
+  if (context === 'background_resume') {
+    return 'background_short';
+  }
+  return 'cold_no_cache';
+}

--- a/app/components/UI/Perps/utils/perpsMarketContext.ts
+++ b/app/components/UI/Perps/utils/perpsMarketContext.ts
@@ -1,0 +1,7 @@
+export function buildPerpsMarketContextKey(
+  network: string,
+  provider: string | undefined,
+  hip3ConfigVersion: number,
+): string {
+  return `${network}|${provider ?? 'unknown'}|${hip3ConfigVersion}`;
+}

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -191,6 +191,7 @@ export enum TraceName {
   PerpsAccountSwitchReconnection = 'Perps Account Switch Reconnection',
   PerpsMarketDataPreload = 'Perps Market Data Preload',
   PerpsUserDataPreload = 'Perps User Data Preload',
+  PerpsLoadingSession = 'Perps Loading Session',
   // Perps chart: first visible candle after the market detail chart mounts.
   PerpsChartFirstCandle = 'perps.chart.first_candle',
   // Perps chart: fullscreen chart visible after open.
@@ -334,6 +335,7 @@ export enum TraceOperation {
   AccountUi = 'account.ui',
   // Perps
   PerpsOperation = 'perps.operation',
+  PerpsLoading = 'perps.loading',
   PerpsMarketData = 'perps.market_data',
   PerpsOrderSubmission = 'perps.order_submission',
   PerpsPositionManagement = 'perps.position_management',

--- a/docs/perps/performance/LOADING_SESSION.md
+++ b/docs/perps/performance/LOADING_SESSION.md
@@ -12,6 +12,9 @@ empty, or error and all required fresh data has arrived.
 
 The foundation does not mount a screen or start a session by itself. Homepage
 and other screen integrations are separate changes.
+It does own shared connection replacement and stream subscription isolation,
+including restoring mounted market-detail channels after the controller
+connection changes. Screen readiness and presentation remain outside this PR.
 
 ## Identity
 
@@ -28,13 +31,15 @@ cannot complete the current session.
 
 ## Generations
 
-- `account_generation` advances when the selected account changes.
+- `account_generation` advances when a session starts for a different account.
 - `context_generation` advances for every new loading session.
 - `connection_generation` advances when the connection is replaced.
 
 Fresh socket milestones must use the active connection generation. When a
 newer connection takes ownership, previously recorded live milestones are
 cleared and must arrive again from that connection.
+Account-owned streams establish the connection generation. A global price tick
+cannot establish it before positions, orders, or account data arrives.
 
 Generation values are trace data for individual-run correlation. Dashboards
 must not group by them.

--- a/docs/perps/performance/LOADING_SESSION.md
+++ b/docs/perps/performance/LOADING_SESSION.md
@@ -1,0 +1,93 @@
+# Perps loading session
+
+The loading session measures one visible Perps loading generation. It does not
+replace app startup, controller preload, connection, or Homepage section traces.
+Those traces keep their existing owners.
+
+## Boundary
+
+A screen integration starts the session when a visible Perps surface begins
+loading. It finishes the same session when the surface resolves to content,
+empty, or error and all required fresh data has arrived.
+
+The foundation does not mount a screen or start a session by itself. Homepage
+and other screen integrations are separate changes.
+
+## Identity
+
+Each session stores three keys:
+
+- `marketKey`: provider, Perps network, and HIP-3 configuration
+- `accountKey`: selected account address
+- `userKey`: market key plus account key
+
+Market and price deliveries must match `marketKey`. Positions, orders, and
+account deliveries must match `userKey`. Socket callbacks capture this
+identity when they subscribe, so a late callback from an old account or network
+cannot complete the current session.
+
+## Generations
+
+- `account_generation` advances when the selected account changes.
+- `context_generation` advances for every new loading session.
+- `connection_generation` advances when the connection is replaced.
+
+Fresh socket milestones must use the active connection generation. When a
+newer connection takes ownership, previously recorded live milestones are
+cleared and must arrive again from that connection.
+
+Generation values are trace data for individual-run correlation. Dashboards
+must not group by them.
+
+## Sources and milestones
+
+Bounded sources:
+
+- markets: `memory_cache`, `terminal_global_snapshot_v2`, or `provider`
+- account snapshot: `memory_cache` or `provider_snapshot`
+- live data: `fresh_socket`
+
+Bootstrap-relative measurements:
+
+- `markets_ready_ms`
+- `account_cache_ready_ms`
+- `positions_live_ms`
+- `orders_live_ms`
+- `account_live_ms`
+- `prices_live_ms`
+
+The account cache milestone requires positions, orders, and account data from
+the same cache source. Cold start, account switch, network switch, and reconnect
+cannot finish from cached account data. They wait for fresh positions, orders,
+and account deliveries.
+
+## Lifecycle
+
+The bounded lifecycle values are:
+
+- `cold_no_cache`
+- `navigate_return`
+- `background_short`
+- `background_reconnect`
+- `account_switch`
+- `network_switch`
+
+A short background sample waits for foreground connection validation. If the
+connection must reconnect, the session changes to `background_reconnect` and
+waits for fresh live milestones.
+
+The wallet-root initial mount and its retry keep the current cold or warm
+lifecycle. Only an actual wallet-root foreground resume may upgrade a session
+to `background_reconnect`.
+
+Cancelled and timed-out sessions retain their real outcome. A screen
+integration must cancel on context change, background, focus loss, or unmount
+instead of allowing an old generation to finish.
+
+## Correlation
+
+`perps_session_id` is attached to controller preload and first-data traces for
+drill-down. `Perps Loading Session` owns only bootstrap-relative offsets and
+bounded outcome data. Sentry dashboards compare the independent traces by
+release, platform, lifecycle, content variant, and source. They do not join
+unrelated traces by timestamp.

--- a/tests/controller-mocking/mock-config/perps-controller-mixin.test.ts
+++ b/tests/controller-mocking/mock-config/perps-controller-mixin.test.ts
@@ -32,6 +32,7 @@ const CHANNELS_REQUIRING_GET_SNAPSHOT = [
   'prices',
   'marketData',
   'account',
+  'fills',
   'orders',
   'positions',
 ] as const;

--- a/tests/controller-mocking/mock-config/perps-controller-mixin.ts
+++ b/tests/controller-mocking/mock-config/perps-controller-mixin.ts
@@ -726,6 +726,7 @@ export function buildE2EMockStreamManagerPlain(): Record<
       },
     },
     fills: {
+      getSnapshot: () => mockService.getMockOrderFills(),
       subscribe: (params: { callback: (data: OrderFill[]) => void }) => {
         setTimeout(() => params.callback(mockService.getMockOrderFills()), 0);
         return () => undefined;


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This extracts the shared Perps measurement and connection layer from the larger reference PR, [#34948](https://github.com/MetaMask/metamask-mobile/pull/34948).

Account, network, provider, and background changes can overlap while Perps streams reconnect. Without explicit ownership, an old delivery can complete a newer measurement or leave a mounted screen subscribed to a retired controller. This PR adds:

- a loading-session contract with context identity, connection generation, and trace correlation;
- serialized, bounded controller replacement that retires stale initializations;
- delivery checks that keep account-owned streams isolated while avoiding account lookups on every market or price tick;
- restoration of mounted open-interest, top-of-book, focused-price, and candle subscriptions after controller replacement.

No screen starts a loading session in this PR. It establishes the shared contract and protects the existing connection layer. The Homepage child PR will activate the session model and provide screen-level runtime measurements.

On-device validation covered cold entry, short and long background transitions, account changes, and a bidirectional testnet/mainnet reconnect on a Pixel 6. The final flows completed without recovery or financial mutation, and no stale market, network, or account data appeared.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved Perps data recovery after account, network, and background changes

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/TAT-3608

Reference implementation: https://github.com/MetaMask/metamask-mobile/pull/34948

Controller v13 integration: https://github.com/MetaMask/metamask-mobile/pull/35312

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps connection context isolation

  Background:
    Given I am logged into MetaMask Mobile on Android
    And Perps is enabled
    And I am on a Perps market detail screen

  Scenario: market data recovers after a network round trip
    Given BTC Pro is connected to Hyperliquid testnet
    When I switch Perps to mainnet
    And I wait for the BTC market data to settle
    And I switch Perps back to testnet
    Then BTC Pro should remain on the same market
    And the visible market, account, positions, orders, and prices should belong to testnet

  Scenario: account data recovers after a context change
    When I switch to another fixture account
    Then the visible positions and orders should belong to the selected account
    And data from the previous account should not appear

  Scenario: mounted streams recover after backgrounding
    When I background the app past the Perps connection grace period
    And I return the app to the foreground
    Then the mounted market data should reconnect
    And the current market should receive fresh prices without reopening the screen
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A. No UI changes.

### **After**

N/A. No UI changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md` for the full
checklist semantics.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Perps WebSocket delivery, account-switch isolation, and connection/reconnect orchestration—bugs could show stale positions/orders or block recovery after backgrounding or context changes.
> 
> **Overview**
> Adds a **shared loading-session and tracing contract** on the mobile Perps platform layer: preload traces and connection spans carry session identity, controller construction is recorded, and trace-scoped measurements route through `setTraceMeasurement` instead of orphan Sentry metrics when a trace id is known.
> 
> **`PerpsConnectionManager`** gains market/user context keys, a monotonic **connection generation**, and listeners so UI can tell when the active provider context is ready. Reconnects are **serialized with a retry cap**; force reconnect can **supersede in-flight initialization** without committing stale preload. On account/network/provider/HIP-3 changes, user streams clear immediately and **`isInitialized` drops** during the debounce so cleared channels cannot resubscribe under the old identity; non-account changes also bump generation and invalidate market readiness. Foreground resume advances generation before resubscribing; **OI caps, top-of-book, focused price, and candles** are explicitly reconnected after context replacement.
> 
> **`PerpsStreamManager`** invalidates **subscription generations** (and price **delivery tokens**) so late WebSocket callbacks after `clearCache`, `disconnect`, prewarm handoff, or reconnect are ignored; user channels bind deliveries to the captured account address. First-data traces attach captured loading-session metadata; market/user readiness is reported via **`recordPerpsLoadingSessionValuesReady`**. Market cache keys now include **HIP-3 config version**; terminal global snapshot uses a named data-source constant.
> 
> **`usePerpsLiveFills`** treats a null fills snapshot as loading again when the account context clears. Tests cover tracing adapters, stream stale-callback behavior, and connection edge cases (mid-preload account change, queued force reconnect, initialization supersession).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1e3a78d079021be51943911a92738a3ba447de4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->