### PR TITLE
fix(perps): address trigger order review feedback

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.test.tsx
@@ -72,6 +72,7 @@ describe('PerpsProOrderCard', () => {
       <PerpsProOrderCard
         order={{
           ...baseOrder,
+          price: '100',
           triggerPrice: '101',
           takeProfitPrice: '220',
           stopLossPrice: '130',
@@ -86,7 +87,7 @@ describe('PerpsProOrderCard', () => {
     expect(screen.getByText('Close long')).toBeOnTheScreen();
     expect(screen.getByText('Stop market')).toBeOnTheScreen();
     expect(screen.getByText('13 SOL')).toBeOnTheScreen();
-    expect(screen.getByText('$---')).toBeOnTheScreen();
+    expect(screen.getByText('$1,300')).toBeOnTheScreen();
     expect(screen.getByText('Market')).toBeOnTheScreen();
     expect(screen.getByText('Yes')).toBeOnTheScreen();
     expect(screen.getByText('$220 / $130')).toBeOnTheScreen();

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.tsx
@@ -40,6 +40,7 @@ import { isClosingOrder } from '../../../utils/orderDirection';
 import {
   formatOrderTypeLabel,
   getOrderPositionDirection,
+  getValidOrderPrice,
   getValidTriggerPrice,
   inferTriggerConditionKey,
   isTriggerOrder,
@@ -163,19 +164,26 @@ const PerpsProOrderCard = ({
     ? TagSeverity.Success
     : TagSeverity.Danger;
   const size = formatPositionSize(order.originalSize);
-  const { priceValue } = resolveOrderDisplayPriceAndLabel(order);
+  const { priceValue, labelKey } = resolveOrderDisplayPriceAndLabel(order);
+  const estimatedOrderPrice =
+    getValidOrderPrice(order) ?? getValidTriggerPrice(order);
   const validTriggerPrice = getValidTriggerPrice(order);
   const canEditPrice = Boolean(onEditPrice) && !isEditPriceDisabled;
   const canEditSize = Boolean(onEditSize) && !isEditSizeDisabled;
   const orderValue =
-    priceValue === null
+    estimatedOrderPrice === null
       ? PERPS_CONSTANTS.FallbackPriceDisplay
-      : formatPerpsFiat(Number.parseFloat(order.originalSize) * priceValue, {
-          ranges: PRICE_RANGES_UNIVERSAL,
-        });
+      : formatPerpsFiat(
+          Number.parseFloat(order.originalSize) * estimatedOrderPrice,
+          {
+            ranges: PRICE_RANGES_UNIVERSAL,
+          },
+        );
   const price =
     priceValue === null
-      ? strings('perps.order.market')
+      ? labelKey === 'perps.order.market_price'
+        ? strings('perps.order.market')
+        : PERPS_CONSTANTS.FallbackPriceDisplay
       : formatPerpsFiat(priceValue, {
           ranges: PRICE_RANGES_UNIVERSAL,
         });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/utils/proOrderSort.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/utils/proOrderSort.test.ts
@@ -91,7 +91,7 @@ describe('sortProOrders', () => {
   });
 
   it.each(['price', 'orderValue'] as const)(
-    'sorts unavailable trigger-market %s as zero',
+    'sorts trigger-market %s using its estimated price',
     (field) => {
       const orders = [
         makeOrder({
@@ -115,8 +115,8 @@ describe('sortProOrders', () => {
       });
 
       expect(result.map((order) => order.orderId)).toEqual([
-        'trigger-market',
         'limit',
+        'trigger-market',
       ]);
     },
   );

--- a/app/components/UI/Perps/Views/PerpsProMarketView/utils/proOrderSort.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/utils/proOrderSort.ts
@@ -4,7 +4,10 @@ import {
   type ProOrdersSortDirection,
   type ProOrdersSortField,
 } from '@metamask/perps-controller';
-import { resolveOrderDisplayPriceAndLabel } from '../../../utils/orderUtils';
+import {
+  getValidOrderPrice,
+  getValidTriggerPrice,
+} from '../../../utils/orderUtils';
 import { compareProSortValues } from './proSortCompare';
 
 export type ProOrderSortField = ProOrdersSortField;
@@ -47,7 +50,7 @@ const getOrderSize = (order: Order): number =>
   Math.abs(Number.parseFloat(order.originalSize || order.size)) || 0;
 
 const getOrderPrice = (order: Order): number =>
-  resolveOrderDisplayPriceAndLabel(order).priceValue ?? 0;
+  getValidOrderPrice(order) ?? getValidTriggerPrice(order) ?? 0;
 
 const getSortValue = (order: Order, field: ProOrderSortField): number => {
   switch (field) {

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
@@ -398,6 +398,26 @@ describe('PerpsCard', () => {
       expect(queryByText('perps.order.trigger_price')).toBeNull();
     });
 
+    it('shows unavailable price for trigger-limit order without a limit price', () => {
+      const triggerLimitOrderWithoutPrice = {
+        ...mockOrder,
+        isTrigger: true,
+        orderType: 'limit' as const,
+        triggerOrderType: 'take_profit_limit' as const,
+        detailedOrderType: 'Take Profit Limit',
+        triggerPrice: '2800',
+        price: '0',
+      };
+
+      const { getByText, queryByText } = render(
+        <PerpsCard order={triggerLimitOrderWithoutPrice} testID="test-card" />,
+      );
+
+      expect(getByText('$---')).toBeOnTheScreen();
+      expect(getByText('perps.order.limit_price')).toBeOnTheScreen();
+      expect(queryByText('perps.order.market')).toBeNull();
+    });
+
     it('keeps limit price label for non-trigger limit orders when triggerPrice is "0"', () => {
       const limitOrderWithZeroTriggerPrice = {
         ...mockOrder,

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -18,6 +18,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import {
   getPerpsDisplaySymbol,
+  PERPS_CONSTANTS,
   PERPS_EVENT_VALUE,
   PERPS_EVENT_PROPERTY,
   type Order,
@@ -95,7 +96,9 @@ const getOrderListDisplay = (order: Order): OrderListDisplay => {
         ? formatPerpsFiat(priceValue, {
             ranges: PRICE_RANGES_UNIVERSAL,
           })
-        : strings('perps.order.market'),
+        : labelKey === 'perps.order.market_price'
+          ? strings('perps.order.market')
+          : PERPS_CONSTANTS.FallbackPriceDisplay,
     subvalueText: strings(labelKey),
     subvalueColor: TextColor.TextAlternative,
   };

--- a/app/components/UI/Perps/components/PerpsCompactOrderRow/PerpsCompactOrderRow.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCompactOrderRow/PerpsCompactOrderRow.test.tsx
@@ -27,6 +27,9 @@ jest.mock('../../utils/formatUtils', () => ({
 
 jest.mock('@metamask/perps-controller', () => ({
   getPerpsDisplaySymbol: jest.fn((symbol) => symbol),
+  PERPS_CONSTANTS: {
+    FallbackPriceDisplay: '$---',
+  },
   isLimitExecutionOrderType: jest.fn((orderType) =>
     String(orderType).includes('limit'),
   ),
@@ -149,6 +152,22 @@ describe('PerpsCompactOrderRow', () => {
 
     expect(screen.getByText('Limit price')).toBeOnTheScreen();
     expect(screen.queryByText('Trigger price')).toBeNull();
+  });
+
+  it('renders unavailable price for trigger-limit order without a limit price', () => {
+    const triggerLimitOrderWithoutPrice: Order = {
+      ...mockTriggerOrder,
+      triggerOrderType: 'take_profit_limit',
+      detailedOrderType: 'Take Profit Limit',
+      triggerPrice: '47000',
+      price: '0',
+    };
+
+    render(<PerpsCompactOrderRow order={triggerLimitOrderWithoutPrice} />);
+
+    expect(screen.getByText('$---')).toBeOnTheScreen();
+    expect(screen.getByText('Limit price')).toBeOnTheScreen();
+    expect(screen.queryByText('Market')).toBeNull();
   });
 
   it('uses order price for limit orders', () => {

--- a/app/components/UI/Perps/components/PerpsCompactOrderRow/PerpsCompactOrderRow.tsx
+++ b/app/components/UI/Perps/components/PerpsCompactOrderRow/PerpsCompactOrderRow.tsx
@@ -6,7 +6,11 @@ import {
   formatPerpsFiat,
   PRICE_RANGES_UNIVERSAL,
 } from '../../utils/formatUtils';
-import { getPerpsDisplaySymbol, type Order } from '@metamask/perps-controller';
+import {
+  getPerpsDisplaySymbol,
+  PERPS_CONSTANTS,
+  type Order,
+} from '@metamask/perps-controller';
 import { strings } from '../../../../../../locales/i18n';
 import {
   formatOrderLabel,
@@ -52,7 +56,9 @@ const PerpsCompactOrderRow: React.FC<PerpsCompactOrderRowProps> = ({
       ? formatPerpsFiat(priceValue, {
           ranges: PRICE_RANGES_UNIVERSAL,
         })
-      : strings('perps.order.market');
+      : labelKey === 'perps.order.market_price'
+        ? strings('perps.order.market')
+        : PERPS_CONSTANTS.FallbackPriceDisplay;
 
   const orderTypeLabel = strings(labelKey);
 

--- a/app/components/UI/Perps/utils/orderUtils.test.ts
+++ b/app/components/UI/Perps/utils/orderUtils.test.ts
@@ -531,9 +531,23 @@ describe('orderUtils', () => {
       detailedOrderType: 'Take Profit Limit',
     };
 
-    it('returns limit price for trigger-limit with a distinct trigger price', () => {
+    it('returns limit price from the detailed type compatibility fallback', () => {
       const result = resolveOrderDisplayPriceAndLabel({
         ...baseOrder,
+        triggerPrice: '51000',
+      });
+
+      expect(result).toEqual({
+        priceValue: 50000,
+        labelKey: 'perps.order.limit_price',
+      });
+    });
+
+    it('returns limit price for a normalized trigger-limit order', () => {
+      const result = resolveOrderDisplayPriceAndLabel({
+        ...baseOrder,
+        detailedOrderType: undefined,
+        triggerOrderType: 'take_profit_limit',
         triggerPrice: '51000',
       });
 
@@ -552,6 +566,20 @@ describe('orderUtils', () => {
 
       expect(result).toEqual({
         priceValue: 49500,
+        labelKey: 'perps.order.limit_price',
+      });
+    });
+
+    it('returns an unavailable limit price without labelling it as market', () => {
+      const result = resolveOrderDisplayPriceAndLabel({
+        ...baseOrder,
+        triggerOrderType: 'take_profit_limit',
+        triggerPrice: '51000',
+        price: '0',
+      });
+
+      expect(result).toEqual({
+        priceValue: null,
         labelKey: 'perps.order.limit_price',
       });
     });

--- a/app/components/UI/Perps/utils/orderUtils.ts
+++ b/app/components/UI/Perps/utils/orderUtils.ts
@@ -126,6 +126,8 @@ export const isTriggerOrder = (order: Order): boolean =>
  *
  * Hyperliquid trigger-market orders carry a limit price as a slippage cap, but
  * that cap is not a guaranteed execution price and must display as Market.
+ * Orders without a normalized `triggerOrderType` fall back to their detailed
+ * provider order type for backwards compatibility.
  *
  * @param order - Open order normalized by the Perps controller.
  * @returns The display price and its localized label key.
@@ -141,7 +143,7 @@ export const resolveOrderDisplayPriceAndLabel = (
   const hasDetailedMarketExecution =
     normalizedDetailedOrderType.includes('market');
   const isLimitOrder =
-    isTrigger && order.triggerOrderType !== undefined
+    order.triggerOrderType !== undefined
       ? isLimitExecutionOrderType(order.triggerOrderType)
       : hasDetailedLimitExecution ||
         (!hasDetailedMarketExecution && order.orderType === 'limit');
@@ -154,7 +156,7 @@ export const resolveOrderDisplayPriceAndLabel = (
     };
   }
 
-  if (isLimitOrder && validOrderPrice !== null) {
+  if (isLimitOrder) {
     return {
       priceValue: validOrderPrice,
       labelKey: 'perps.order.limit_price',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Addresses the validated review findings on #35355. Trigger-market execution prices still display as Market, while order-value and sorting calculations use the best available numeric estimate. Missing trigger-limit prices now display as unavailable with a Limit price label rather than being mislabeled Market.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #35355

## **Manual testing steps**

```gherkin
Feature: Perps trigger-order review fixes

  Scenario: user views a trigger-market order in Perps Pro
    Given an open trigger-market order has trigger and slippage-cap prices
    When user views and sorts the Orders panel
    Then the Price field displays "Market"
    And Order value and sorting use the best available estimate

  Scenario: a trigger-limit order has no usable limit price
    Given an open trigger-limit order has an unusable limit price
    When user views the order
    Then the price displays the unavailable fallback
    And the label remains "Limit price"
```

## **Screenshots/Recordings**

### **Before**

N/A — follow-up corrections to the existing PR.

### **After**

N/A — focused automated coverage is included.

## **Pre-merge author checklist**

- [x] I've followed MetaMask coding standards.
- [x] I've completed the PR template to the best of my ability.
- [x] I've included tests if applicable.
- [x] I've documented the compatibility fallback using JSDoc.
- [x] I've considered labeling requirements.

#### Performance checks (if applicable)

- [x] Android testing considered; no runtime performance path changed.
- [x] Power-user performance considered; sorting remains pure in-memory computation.
- [x] Instrumentation considered; no new operation requires tracing.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR.
- [ ] I confirm that this PR addresses all acceptance criteria and includes necessary evidence.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d5fda5-fe1c-4907-94cd-aeb900634bac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d5fda5-fe1c-4907-94cd-aeb900634bac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

