### PR TITLE
chore(onboarding): report android google ACM errors to Sentry

### DIFF
--- a/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.test.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.test.ts
@@ -3,6 +3,7 @@ import { OAuthError, OAuthErrorType } from '../../error';
 import { AndroidGoogleLoginHandler } from './google';
 import { Web3AuthNetwork } from '@metamask/seedless-onboarding-controller';
 import { signInWithGoogle } from '@metamask/react-native-acm';
+import Logger from '../../../../util/Logger';
 
 jest.mock('@metamask/react-native-acm', () => ({
   signInWithGoogle: jest.fn(),
@@ -10,6 +11,7 @@ jest.mock('@metamask/react-native-acm', () => ({
 
 jest.mock('../../../../util/Logger', () => ({
   log: jest.fn(),
+  error: jest.fn(),
 }));
 
 const mockSignInWithGoogle = signInWithGoogle as jest.Mock;
@@ -34,18 +36,29 @@ describe('AndroidGoogleLoginHandler', () => {
       await expect(handler.login()).rejects.toMatchObject({
         code: OAuthErrorType.UserCancelled,
       });
+
       expect(mockSignInWithGoogle).toHaveBeenCalledTimes(1);
+      expect(Logger.error).not.toHaveBeenCalled();
     });
 
-    it('treats "no credential" as UserCancelled', async () => {
-      mockSignInWithGoogle.mockRejectedValue(
-        new Error('Legacy sign-in returned no credential'),
-      );
+    it('throws UserCancelled when ACM returns no credential', async () => {
+      const nativeError = new Error('Legacy sign-in returned no credential');
+      mockSignInWithGoogle.mockRejectedValue(nativeError);
 
       await expect(handler.login()).rejects.toMatchObject({
         code: OAuthErrorType.UserCancelled,
       });
+
       expect(mockSignInWithGoogle).toHaveBeenCalledTimes(1);
+      expect(Logger.error).toHaveBeenCalledWith(
+        nativeError,
+        expect.objectContaining({
+          tags: expect.objectContaining({
+            acm_error: 'no_credential',
+            view: 'AndroidGoogleLogin',
+          }),
+        }),
+      );
     });
 
     it('treats American spelling "canceled" as UserCancelled', async () => {
@@ -68,16 +81,28 @@ describe('AndroidGoogleLoginHandler', () => {
       await expect(handler.login()).rejects.toMatchObject({
         code: OAuthErrorType.UserCancelled,
       });
+
+      expect(Logger.error).not.toHaveBeenCalled();
     });
 
     it('throws GoogleLoginOneTapFailure for One Tap failure without cancel wording', async () => {
-      mockSignInWithGoogle.mockRejectedValue(
-        new Error('During begin signin, failure response from one tap'),
+      const nativeError = new Error(
+        'During begin signin, failure response from one tap',
       );
+      mockSignInWithGoogle.mockRejectedValue(nativeError);
 
       await expect(handler.login()).rejects.toMatchObject({
         code: OAuthErrorType.GoogleLoginOneTapFailure,
       });
+
+      expect(Logger.error).toHaveBeenCalledWith(
+        nativeError,
+        expect.objectContaining({
+          tags: expect.objectContaining({
+            acm_error: 'one_tap_failure',
+          }),
+        }),
+      );
     });
 
     it('throws GoogleLoginNoMatchingCredential when One Tap failure includes matching credential', async () => {

--- a/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.test.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.test.ts
@@ -130,10 +130,11 @@ describe('AndroidGoogleLoginHandler', () => {
         new Error('user disabled the feature'),
       );
 
-      await expect(handler.login()).rejects.toThrow(OAuthError);
       await expect(handler.login()).rejects.toMatchObject({
         code: OAuthErrorType.GoogleLoginUserDisabledOneTapFeature,
       });
+
+      expect(Logger.error).not.toHaveBeenCalled();
     });
 
     it('throws GoogleLoginNoProviderDependencies when provider dependencies not found', async () => {

--- a/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.ts
@@ -89,6 +89,51 @@ const reportAndroidGoogleAcmError = (
 };
 
 /**
+ * Map a native ACM / legacy Google Error to OAuthError and report classified
+ * strings to Sentry. UserCancelled is swallowed in Onboarding.
+ */
+const throwMappedNativeAcmError = (error: Error): never => {
+  const acmKind = classifyAndroidGoogleAcmError(error.message);
+  const mapsToUserCancelled =
+    isOAuthUserCancellationMessage(error.message) ||
+    ACM_ERRORS_REGEX.NO_CREDENTIAL.test(error.message);
+  if (acmKind && (!mapsToUserCancelled || acmKind === 'no_credential')) {
+    reportAndroidGoogleAcmError(error, acmKind);
+  }
+  if (mapsToUserCancelled) {
+    throw new OAuthError(
+      'handleGoogleLogin: User cancelled the login process',
+      OAuthErrorType.UserCancelled,
+    );
+  }
+  if (ACM_ERRORS_REGEX.USER_DISABLED_FEATURE.test(error.message)) {
+    throw new OAuthError(
+      'handleGoogleLogin: User disabled One Tap sign-in feature',
+      OAuthErrorType.GoogleLoginUserDisabledOneTapFeature,
+    );
+  }
+  if (ACM_ERRORS_REGEX.NO_PROVIDER_DEPENDENCIES.test(error.message)) {
+    throw new OAuthError(
+      'handleGoogleLogin: Credential provider not available',
+      OAuthErrorType.GoogleLoginNoProviderDependencies,
+    );
+  }
+  if (ACM_ERRORS_REGEX.NO_MATCHING_CREDENTIAL.test(error.message)) {
+    throw new OAuthError(
+      'handleGoogleLogin: Google login has no matching credential',
+      OAuthErrorType.GoogleLoginNoMatchingCredential,
+    );
+  }
+  if (ACM_ERRORS_REGEX.ONE_TAP_FAILURE.test(error.message)) {
+    throw new OAuthError(
+      `handleGoogleLogin: One tap failure - ${error.message}`,
+      OAuthErrorType.GoogleLoginOneTapFailure,
+    );
+  }
+  throw new OAuthError(error, OAuthErrorType.UnknownError);
+};
+
+/**
  * AndroidGoogleLoginHandler is the login handler for the Google login on android.
  */
 export class AndroidGoogleLoginHandler extends BaseLoginHandler {
@@ -160,58 +205,14 @@ export class AndroidGoogleLoginHandler extends BaseLoginHandler {
       Logger.log(error, 'handleGoogleLogin: error');
       if (error instanceof OAuthError) {
         throw error;
-      } else if (error instanceof Error) {
-        const acmKind = classifyAndroidGoogleAcmError(error.message);
-        const mapsToUserCancelled =
-          isOAuthUserCancellationMessage(error.message) ||
-          ACM_ERRORS_REGEX.NO_CREDENTIAL.test(error.message);
-        // UserCancelled is swallowed in Onboarding and skipped in OAuthService traces.
-        // Report ACM strings that still throw UserCancelled (no-credential) plus
-        // the specific GoogleLogin* buckets. Skip explicit cancel wording.
-        if (
-          acmKind &&
-          (!mapsToUserCancelled || acmKind === 'no_credential')
-        ) {
-          reportAndroidGoogleAcmError(error, acmKind);
-        }
-        if (mapsToUserCancelled) {
-          throw new OAuthError(
-            'handleGoogleLogin: User cancelled the login process',
-            OAuthErrorType.UserCancelled,
-          );
-        } else if (ACM_ERRORS_REGEX.USER_DISABLED_FEATURE.test(error.message)) {
-          throw new OAuthError(
-            'handleGoogleLogin: User disabled One Tap sign-in feature',
-            OAuthErrorType.GoogleLoginUserDisabledOneTapFeature,
-          );
-        } else if (
-          ACM_ERRORS_REGEX.NO_PROVIDER_DEPENDENCIES.test(error.message)
-        ) {
-          throw new OAuthError(
-            'handleGoogleLogin: Credential provider not available',
-            OAuthErrorType.GoogleLoginNoProviderDependencies,
-          );
-        } else if (
-          ACM_ERRORS_REGEX.NO_MATCHING_CREDENTIAL.test(error.message)
-        ) {
-          throw new OAuthError(
-            'handleGoogleLogin: Google login has no matching credential',
-            OAuthErrorType.GoogleLoginNoMatchingCredential,
-          );
-        } else if (ACM_ERRORS_REGEX.ONE_TAP_FAILURE.test(error.message)) {
-          throw new OAuthError(
-            `handleGoogleLogin: One tap failure - ${error.message}`,
-            OAuthErrorType.GoogleLoginOneTapFailure,
-          );
-        } else {
-          throw new OAuthError(error, OAuthErrorType.UnknownError);
-        }
-      } else {
-        throw new OAuthError(
-          'handleGoogleLogin: Unknown error',
-          OAuthErrorType.UnknownError,
-        );
       }
+      if (error instanceof Error) {
+        throwMappedNativeAcmError(error);
+      }
+      throw new OAuthError(
+        'handleGoogleLogin: Unknown error',
+        OAuthErrorType.UnknownError,
+      );
     }
   }
 

--- a/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.ts
@@ -44,6 +44,9 @@ type AndroidGoogleAcmErrorKind =
   | 'no_matching_credential'
   | 'one_tap_failure';
 
+/** Bound Sentry context so a runaway native message cannot blow extras. */
+const NATIVE_MESSAGE_SENTRY_MAX_CHARS = 500;
+
 /**
  * Classify the native ACM / legacy Google error string for Sentry.
  * Login outcome mapping is unchanged: no-credential still throws UserCancelled.
@@ -82,7 +85,10 @@ const reportAndroidGoogleAcmError = (
     context: {
       name: 'android_google_acm',
       data: {
-        native_message: nativeError.message.slice(0, 500),
+        native_message: nativeError.message.slice(
+          0,
+          NATIVE_MESSAGE_SENTRY_MAX_CHARS,
+        ),
       },
     },
   });
@@ -97,7 +103,11 @@ const throwMappedNativeAcmError = (error: Error): never => {
   const mapsToUserCancelled =
     isOAuthUserCancellationMessage(error.message) ||
     ACM_ERRORS_REGEX.NO_CREDENTIAL.test(error.message);
-  if (acmKind && (!mapsToUserCancelled || acmKind === 'no_credential')) {
+  if (
+    acmKind &&
+    acmKind !== 'user_disabled_feature' &&
+    (!mapsToUserCancelled || acmKind === 'no_credential')
+  ) {
     reportAndroidGoogleAcmError(error, acmKind);
   }
   if (mapsToUserCancelled) {

--- a/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.ts
@@ -37,6 +37,57 @@ const ACM_ERRORS_REGEX = {
     /no provider dependencies|provider.{0,20}not available|provider.{0,20}configuration/i,
 };
 
+type AndroidGoogleAcmErrorKind =
+  | 'no_credential'
+  | 'user_disabled_feature'
+  | 'no_provider_dependencies'
+  | 'no_matching_credential'
+  | 'one_tap_failure';
+
+/**
+ * Classify the native ACM / legacy Google error string for Sentry.
+ * Login outcome mapping is unchanged: no-credential still throws UserCancelled.
+ */
+const classifyAndroidGoogleAcmError = (
+  message: string,
+): AndroidGoogleAcmErrorKind | undefined => {
+  if (ACM_ERRORS_REGEX.NO_CREDENTIAL.test(message)) {
+    return 'no_credential';
+  }
+  if (ACM_ERRORS_REGEX.USER_DISABLED_FEATURE.test(message)) {
+    return 'user_disabled_feature';
+  }
+  if (ACM_ERRORS_REGEX.NO_PROVIDER_DEPENDENCIES.test(message)) {
+    return 'no_provider_dependencies';
+  }
+  if (ACM_ERRORS_REGEX.NO_MATCHING_CREDENTIAL.test(message)) {
+    return 'no_matching_credential';
+  }
+  if (ACM_ERRORS_REGEX.ONE_TAP_FAILURE.test(message)) {
+    return 'one_tap_failure';
+  }
+  return undefined;
+};
+
+const reportAndroidGoogleAcmError = (
+  nativeError: Error,
+  kind: AndroidGoogleAcmErrorKind,
+): void => {
+  Logger.error(nativeError, {
+    tags: {
+      feature: 'onboarding',
+      view: 'AndroidGoogleLogin',
+      acm_error: kind,
+    },
+    context: {
+      name: 'android_google_acm',
+      data: {
+        native_message: nativeError.message.slice(0, 500),
+      },
+    },
+  });
+};
+
 /**
  * AndroidGoogleLoginHandler is the login handler for the Google login on android.
  */
@@ -110,10 +161,20 @@ export class AndroidGoogleLoginHandler extends BaseLoginHandler {
       if (error instanceof OAuthError) {
         throw error;
       } else if (error instanceof Error) {
-        if (
+        const acmKind = classifyAndroidGoogleAcmError(error.message);
+        const mapsToUserCancelled =
           isOAuthUserCancellationMessage(error.message) ||
-          ACM_ERRORS_REGEX.NO_CREDENTIAL.test(error.message)
+          ACM_ERRORS_REGEX.NO_CREDENTIAL.test(error.message);
+        // UserCancelled is swallowed in Onboarding and skipped in OAuthService traces.
+        // Report ACM strings that still throw UserCancelled (no-credential) plus
+        // the specific GoogleLogin* buckets. Skip explicit cancel wording.
+        if (
+          acmKind &&
+          (!mapsToUserCancelled || acmKind === 'no_credential')
         ) {
+          reportAndroidGoogleAcmError(error, acmKind);
+        }
+        if (mapsToUserCancelled) {
           throw new OAuthError(
             'handleGoogleLogin: User cancelled the login process',
             OAuthErrorType.UserCancelled,


### PR DESCRIPTION
## **Description**

**Before:** Android Google native ACM / legacy sign-in errors that map to `UserCancelled` (including `Legacy sign-in returned no credential`) only went to `Logger.log`. Onboarding swallows `UserCancelled`, so those native strings never reached Sentry.

**After:** Classified ACM strings call `Logger.error` with tags `view=AndroidGoogleLogin` and `acm_error` (`no_credential`, and the existing GoogleLogin* buckets). Login mapping is unchanged. Explicit cancel wording is left as `UserCancelled` without this report.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

https://consensyssoftware.atlassian.net/browse/TO-972

Fixes:

## **Manual testing steps**

```gherkin
Feature: Android Google social login

  Scenario: User dismisses Google add-account
    Given the device has no Google account
    And the user is on Create a new wallet
    When the user taps Continue with Google
    And dismisses the Google add-account UI
    Then the app stays on Create a new wallet
    And login mapping is still UserCancelled

  Scenario: Successful Google login
    Given the device can complete Google sign-in
    When the user taps Continue with Google and completes sign-in
    Then social login continues as before
```

Sentry `Logger.error` only records on non-dev builds with metrics opt-in. Search `view:AndroidGoogleLogin` / `acm_error:no_credential` after a build ships.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)