### PR TITLE
feat(social): prefetch trader feed after leaderboard loads

### DIFF
--- a/app/components/Views/SocialLeaderboard/FeedView/FeedView.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/FeedView.tsx
@@ -89,9 +89,10 @@ type AnimatedScrollHandler = React.ComponentProps<
 
 export interface FeedViewProps {
   /**
-   * Whether the Feed tab is the active page. The feed fetch only fires when
-   * active so simply opening the Follow Trading surface (which mounts both tab
-   * pages) doesn't request the feed until the user actually views it. Defaults
+   * Whether the Feed tab is the active page. The visible feed query only
+   * subscribes when active so the off-screen page doesn't keep a live
+   * observer. First-page data for both audiences is still prefetched when
+   * Follow Trading opens, so tapping Feed can render from cache. Defaults
    * to `true` for standalone use.
    */
   isActive?: boolean;

--- a/app/components/Views/SocialLeaderboard/FeedView/hooks/traderFeedQueries.test.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/hooks/traderFeedQueries.test.ts
@@ -1,0 +1,136 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { FEED_CAIP2_CHAINS } from '../feed-constants';
+import { mockFeedResponse, mockSpotFeedItem } from '../mocks/coreFeed.mock';
+import {
+  FEED_PAGE_LIMIT,
+  PREFETCH_FEED_AUDIENCES,
+  buildTraderFeedQueryKey,
+  fetchTraderFeedPage,
+  getTraderFeedNextPageParam,
+  prefetchTraderFeeds,
+  toFeedScope,
+} from './traderFeedQueries';
+
+const expectedFeedFetchOptions = {
+  limit: FEED_PAGE_LIMIT,
+  chains: [...FEED_CAIP2_CHAINS],
+};
+
+const mockCall = jest.fn();
+
+jest.mock('../../../../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    controllerMessenger: {
+      _brand: 'rootMessenger',
+      call(this: unknown, ...args: unknown[]) {
+        if (!this || (this as { _brand?: string })._brand !== 'rootMessenger') {
+          throw new TypeError("Cannot read property 'getAction' of undefined");
+        }
+        return mockCall(...args);
+      },
+    },
+  },
+}));
+
+describe('traderFeedQueries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('toFeedScope', () => {
+    it('maps the following audience to the following scope', () => {
+      expect(toFeedScope('following')).toBe('following');
+    });
+
+    it('maps the all audience to the leaderboard scope', () => {
+      expect(toFeedScope('all')).toBe('leaderboard');
+    });
+  });
+
+  describe('buildTraderFeedQueryKey', () => {
+    it('returns the SocialService fetchFeed key for the given scope', () => {
+      expect(buildTraderFeedQueryKey('following')).toEqual([
+        'SocialService:fetchFeed',
+        { scope: 'following', chains: FEED_CAIP2_CHAINS },
+      ]);
+    });
+  });
+
+  describe('getTraderFeedNextPageParam', () => {
+    it('returns the older cursor when present', () => {
+      expect(getTraderFeedNextPageParam(mockFeedResponse([], 'cursor-1'))).toBe(
+        'cursor-1',
+      );
+    });
+
+    it('returns undefined when the older cursor is missing', () => {
+      expect(getTraderFeedNextPageParam(mockFeedResponse([]))).toBeUndefined();
+    });
+  });
+
+  describe('fetchTraderFeedPage', () => {
+    it('requests the first page without an olderThan cursor', async () => {
+      mockCall.mockResolvedValue(mockFeedResponse([mockSpotFeedItem()]));
+
+      await fetchTraderFeedPage('following');
+
+      expect(mockCall).toHaveBeenCalledWith('SocialService:fetchFeed', {
+        scope: 'following',
+        ...expectedFeedFetchOptions,
+      });
+    });
+
+    it('passes the olderThan cursor for a follow-up page', async () => {
+      mockCall.mockResolvedValue(mockFeedResponse([]));
+
+      await fetchTraderFeedPage('leaderboard', 'cursor-1');
+
+      expect(mockCall).toHaveBeenCalledWith('SocialService:fetchFeed', {
+        scope: 'leaderboard',
+        ...expectedFeedFetchOptions,
+        olderThan: 'cursor-1',
+      });
+    });
+  });
+
+  describe('prefetchTraderFeeds', () => {
+    it('prefetches the first page of every feed audience', async () => {
+      mockCall.mockResolvedValue(mockFeedResponse([]));
+      const prefetchInfiniteQuery = jest.fn().mockResolvedValue(undefined);
+      const queryClient = {
+        prefetchInfiniteQuery,
+      } as unknown as QueryClient;
+
+      await prefetchTraderFeeds(queryClient);
+
+      expect(prefetchInfiniteQuery).toHaveBeenCalledTimes(
+        PREFETCH_FEED_AUDIENCES.length,
+      );
+      expect(prefetchInfiniteQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: buildTraderFeedQueryKey('following'),
+          retry: false,
+        }),
+      );
+      expect(prefetchInfiniteQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: buildTraderFeedQueryKey('leaderboard'),
+          retry: false,
+        }),
+      );
+    });
+
+    it('still resolves when one audience fetch rejects', async () => {
+      const prefetchInfiniteQuery = jest
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('boom'));
+      const queryClient = {
+        prefetchInfiniteQuery,
+      } as unknown as QueryClient;
+
+      await expect(prefetchTraderFeeds(queryClient)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/app/components/Views/SocialLeaderboard/FeedView/hooks/traderFeedQueries.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/hooks/traderFeedQueries.ts
@@ -1,0 +1,83 @@
+import type { QueryClient } from '@tanstack/react-query';
+import type {
+  FeedResponse,
+  FetchFeedOptions,
+} from '@metamask/social-controllers';
+import Engine from '../../../../../core/Engine';
+import { FEED_CAIP2_CHAINS } from '../feed-constants';
+import type { FeedAudience } from '../types';
+
+/** Feed scope the social API expects, derived from the audience toggle. */
+export type FeedScope = NonNullable<FetchFeedOptions['scope']>;
+
+/** Page size requested per feed page. */
+export const FEED_PAGE_LIMIT = 30;
+
+/** Audiences whose first page is warmed when Follow Trading opens. */
+export const PREFETCH_FEED_AUDIENCES: readonly FeedAudience[] = [
+  'following',
+  'all',
+];
+
+export const toFeedScope = (audience: FeedAudience): FeedScope =>
+  audience === 'following' ? 'following' : 'leaderboard';
+
+export const buildTraderFeedQueryKey = (
+  scope: FeedScope,
+): [string, { scope: FeedScope; chains: typeof FEED_CAIP2_CHAINS }] => [
+  'SocialService:fetchFeed',
+  { scope, chains: FEED_CAIP2_CHAINS },
+];
+
+/**
+ * Fetches one feed page via `SocialService:fetchFeed`.
+ *
+ * Call as a member expression so the messenger keeps its `this` binding;
+ * aliasing `.call` into a local detaches it and breaks action lookup.
+ */
+export const fetchTraderFeedPage = (
+  scope: FeedScope,
+  pageParam?: string,
+): Promise<FeedResponse> => {
+  const messenger = Engine.controllerMessenger as unknown as {
+    call: (
+      action: 'SocialService:fetchFeed',
+      fetchOptions: FetchFeedOptions,
+    ) => Promise<FeedResponse>;
+  };
+  return messenger.call('SocialService:fetchFeed', {
+    scope,
+    limit: FEED_PAGE_LIMIT,
+    chains: [...FEED_CAIP2_CHAINS],
+    ...(pageParam ? { olderThan: pageParam } : {}),
+  });
+};
+
+/**
+ * react-query only stops paginating on `undefined`; guard the empty cursor
+ * so an exhausted feed doesn't loop back to the first page.
+ */
+export const getTraderFeedNextPageParam = (
+  lastPage: FeedResponse,
+): string | undefined => lastPage.pagination?.olderCursor ?? undefined;
+
+/**
+ * Warms the first page of each feed audience into the shared React Query
+ * cache so the Feed tab and audience toggle can render without waiting on
+ * a network round trip.
+ */
+export const prefetchTraderFeeds = async (
+  queryClient: QueryClient,
+): Promise<void> => {
+  await Promise.allSettled(
+    PREFETCH_FEED_AUDIENCES.map((audience) => {
+      const scope = toFeedScope(audience);
+      return queryClient.prefetchInfiniteQuery({
+        queryKey: buildTraderFeedQueryKey(scope),
+        queryFn: ({ pageParam }: { pageParam?: string }) =>
+          fetchTraderFeedPage(scope, pageParam),
+        retry: false,
+      });
+    }),
+  );
+};

--- a/app/components/Views/SocialLeaderboard/FeedView/hooks/usePrefetchTraderFeeds.test.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/hooks/usePrefetchTraderFeeds.test.ts
@@ -1,0 +1,130 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import ReactQueryService from '../../../../../core/ReactQueryService';
+import { selectIsUnlocked } from '../../../../../selectors/keyringController';
+import { prefetchTraderFeeds } from './traderFeedQueries';
+import { usePrefetchTraderFeeds } from './usePrefetchTraderFeeds';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../../core/ReactQueryService', () => ({
+  __esModule: true,
+  default: {
+    queryClient: {},
+  },
+}));
+
+jest.mock('./traderFeedQueries', () => ({
+  prefetchTraderFeeds: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockPrefetchTraderFeeds = prefetchTraderFeeds as jest.MockedFunction<
+  typeof prefetchTraderFeeds
+>;
+
+const flushIdlePrefetch = () => {
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+};
+
+describe('usePrefetchTraderFeeds', () => {
+  const originalRequestIdleCallback = (
+    globalThis as { requestIdleCallback?: unknown }
+  ).requestIdleCallback;
+  const originalCancelIdleCallback = (
+    globalThis as { cancelIdleCallback?: unknown }
+  ).cancelIdleCallback;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    delete (globalThis as { requestIdleCallback?: unknown })
+      .requestIdleCallback;
+    delete (globalThis as { cancelIdleCallback?: unknown }).cancelIdleCallback;
+
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectIsUnlocked) {
+        return true;
+      }
+      return undefined;
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    if (originalRequestIdleCallback) {
+      (globalThis as { requestIdleCallback?: unknown }).requestIdleCallback =
+        originalRequestIdleCallback;
+    }
+    if (originalCancelIdleCallback) {
+      (globalThis as { cancelIdleCallback?: unknown }).cancelIdleCallback =
+        originalCancelIdleCallback;
+    }
+  });
+
+  it('prefetches both feed audiences on idle when enabled', () => {
+    renderHook(() => usePrefetchTraderFeeds(true));
+
+    expect(mockPrefetchTraderFeeds).not.toHaveBeenCalled();
+
+    flushIdlePrefetch();
+
+    expect(mockPrefetchTraderFeeds).toHaveBeenCalledWith(
+      ReactQueryService.queryClient,
+    );
+  });
+
+  it('does not prefetch when disabled', () => {
+    renderHook(() => usePrefetchTraderFeeds(false));
+
+    flushIdlePrefetch();
+
+    expect(mockPrefetchTraderFeeds).not.toHaveBeenCalled();
+  });
+
+  it('does not prefetch when the wallet is locked', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectIsUnlocked) {
+        return false;
+      }
+      return undefined;
+    });
+
+    renderHook(() => usePrefetchTraderFeeds(true));
+
+    flushIdlePrefetch();
+
+    expect(mockPrefetchTraderFeeds).not.toHaveBeenCalled();
+  });
+
+  it('prefetches once enabled flips from false to true', () => {
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => usePrefetchTraderFeeds(enabled),
+      { initialProps: { enabled: false } },
+    );
+
+    flushIdlePrefetch();
+    expect(mockPrefetchTraderFeeds).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+    flushIdlePrefetch();
+
+    expect(mockPrefetchTraderFeeds).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels a pending idle prefetch when enabled becomes false', () => {
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => usePrefetchTraderFeeds(enabled),
+      { initialProps: { enabled: true } },
+    );
+
+    rerender({ enabled: false });
+    flushIdlePrefetch();
+
+    expect(mockPrefetchTraderFeeds).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/Views/SocialLeaderboard/FeedView/hooks/usePrefetchTraderFeeds.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/hooks/usePrefetchTraderFeeds.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import ReactQueryService from '../../../../../core/ReactQueryService';
+import { selectIsUnlocked } from '../../../../../selectors/keyringController';
+import { prefetchTraderFeeds } from './traderFeedQueries';
+
+/** Fallback timeout when `requestIdleCallback` never fires. */
+const FEED_PREFETCH_IDLE_TIMEOUT_MS = 1000;
+
+interface IdleCallbackGlobals {
+  requestIdleCallback?: (
+    callback: () => void,
+    options?: { timeout?: number },
+  ) => number;
+  cancelIdleCallback?: (handle: number) => void;
+}
+
+/**
+ * Defers a low-priority task until the JS thread is idle so it doesn't contend
+ * with scrolling/taps right after the leaderboard paints. Falls back to a
+ * macrotask where `requestIdleCallback` is unavailable.
+ */
+const scheduleIdleTask = (task: () => void): (() => void) => {
+  const idleGlobals = globalThis as typeof globalThis & IdleCallbackGlobals;
+
+  if (idleGlobals.requestIdleCallback) {
+    const idleCallbackId = idleGlobals.requestIdleCallback(task, {
+      timeout: FEED_PREFETCH_IDLE_TIMEOUT_MS,
+    });
+    return () => idleGlobals.cancelIdleCallback?.(idleCallbackId);
+  }
+
+  const timeoutId = setTimeout(task, 0);
+  return () => clearTimeout(timeoutId);
+};
+
+/**
+ * Prefetches Following and All feed first pages after the visible
+ * leaderboard query has settled, so tapping Feed (or switching audience)
+ * is cache-backed without delaying the landing list.
+ */
+export const usePrefetchTraderFeeds = (enabled = true): void => {
+  const isUnlocked = useSelector(selectIsUnlocked);
+  const shouldPrefetch = enabled && isUnlocked;
+  const shouldPrefetchRef = useRef(shouldPrefetch);
+  shouldPrefetchRef.current = shouldPrefetch;
+
+  useEffect(() => {
+    if (!shouldPrefetch) {
+      return undefined;
+    }
+
+    return scheduleIdleTask(() => {
+      if (!shouldPrefetchRef.current) {
+        return;
+      }
+
+      prefetchTraderFeeds(ReactQueryService.queryClient).catch(() => undefined);
+    });
+  }, [shouldPrefetch]);
+};

--- a/app/components/Views/SocialLeaderboard/FeedView/hooks/useTraderFeed.test.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/hooks/useTraderFeed.test.ts
@@ -9,6 +9,7 @@ import {
   mockPerpFeedItem,
   mockSpotFeedItem,
 } from '../mocks/coreFeed.mock';
+import { prefetchTraderFeeds } from './traderFeedQueries';
 
 const expectedFeedFetchOptions = {
   limit: 30,
@@ -47,12 +48,14 @@ jest.mock('../../../../../util/social/socialServiceTelemetry', () => ({
     error ? (error instanceof Error ? error.message : String(error)) : null,
 }));
 
-const createWrapper = () => {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, cacheTime: 0 } },
-  });
+const createWrapper = (queryClient?: QueryClient) => {
+  const client =
+    queryClient ??
+    new QueryClient({
+      defaultOptions: { queries: { retry: false, cacheTime: 0 } },
+    });
   return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
+    React.createElement(QueryClientProvider, { client }, children);
 };
 
 describe('useTraderFeed', () => {
@@ -244,5 +247,27 @@ describe('useTraderFeed', () => {
     expect(result.current.items).toHaveLength(1);
     expect(result.current.items[0]?.type).toBe('perps');
     expect(result.current.hasLoadedItems).toBe(true);
+  });
+
+  it('does not refetch when first-page data is already in the cache', async () => {
+    mockCall.mockResolvedValue(mockFeedResponse([mockSpotFeedItem()]));
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, staleTime: 5 * 60 * 1000 },
+      },
+    });
+
+    await prefetchTraderFeeds(queryClient);
+    expect(mockCall).toHaveBeenCalledTimes(2);
+    mockCall.mockClear();
+
+    const { result } = renderHook(
+      () => useTraderFeed({ audience: 'following' }),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+    expect(mockCall).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
   });
 });

--- a/app/components/Views/SocialLeaderboard/FeedView/hooks/useTraderFeed.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/hooks/useTraderFeed.ts
@@ -6,11 +6,7 @@ import {
   type InfiniteData,
   type UseInfiniteQueryOptions,
 } from '@tanstack/react-query';
-import type {
-  FeedResponse,
-  FetchFeedOptions,
-} from '@metamask/social-controllers';
-import Engine from '../../../../../core/Engine';
+import type { FeedResponse } from '@metamask/social-controllers';
 import { selectIsUnlocked } from '../../../../../selectors/keyringController';
 import {
   formatSocialQueryErrorMessage,
@@ -25,12 +21,12 @@ import type {
   FeedSection,
   FeedTypeFilter,
 } from '../types';
-
-/** Feed scope the social API expects, derived from the audience toggle. */
-type FeedScope = NonNullable<FetchFeedOptions['scope']>;
-
-/** Page size requested per feed page. */
-const FEED_PAGE_LIMIT = 30;
+import {
+  buildTraderFeedQueryKey,
+  fetchTraderFeedPage,
+  getTraderFeedNextPageParam,
+  toFeedScope,
+} from './traderFeedQueries';
 
 export interface UseTraderFeedOptions {
   /**
@@ -117,37 +113,16 @@ export const useTraderFeed = (
   const { audience = 'all', typeFilter = 'all', enabled = true } = options;
   const isUnlocked = useSelector(selectIsUnlocked);
 
-  const scope: FeedScope =
-    audience === 'following' ? 'following' : 'leaderboard';
+  const scope = toFeedScope(audience);
 
   const queryClient = useQueryClient();
-  const queryKey = useMemo(
-    () => ['SocialService:fetchFeed', { scope, chains: FEED_CAIP2_CHAINS }],
-    [scope],
-  );
+  const queryKey = useMemo(() => buildTraderFeedQueryKey(scope), [scope]);
 
   const query = useInfiniteQuery({
     queryKey,
-    queryFn: ({ pageParam }: { pageParam?: string }) => {
-      // Call as a member expression so the messenger keeps its `this` binding;
-      // aliasing `.call` into a local detaches it and breaks action lookup.
-      const messenger = Engine.controllerMessenger as unknown as {
-        call: (
-          action: 'SocialService:fetchFeed',
-          fetchOptions: FetchFeedOptions,
-        ) => Promise<FeedResponse>;
-      };
-      return messenger.call('SocialService:fetchFeed', {
-        scope,
-        limit: FEED_PAGE_LIMIT,
-        chains: [...FEED_CAIP2_CHAINS],
-        ...(pageParam ? { olderThan: pageParam } : {}),
-      });
-    },
-    // react-query only stops paginating on `undefined`; guard the empty cursor
-    // so an exhausted feed doesn't loop back to the first page.
-    getNextPageParam: (lastPage: FeedResponse) =>
-      lastPage.pagination?.olderCursor ?? undefined,
+    queryFn: ({ pageParam }: { pageParam?: string }) =>
+      fetchTraderFeedPage(scope, pageParam),
+    getNextPageParam: getTraderFeedNextPageParam,
     enabled: enabled && isUnlocked,
     retry: false,
   } as unknown as UseInfiniteQueryOptions<FeedResponse, Error>);

--- a/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.test.tsx
@@ -86,11 +86,31 @@ jest.mock(
   }),
 );
 
+const mockUsePrefetchTraderFeeds = jest.fn();
+jest.mock('../FeedView/hooks/usePrefetchTraderFeeds', () => ({
+  usePrefetchTraderFeeds: (enabled?: boolean) =>
+    mockUsePrefetchTraderFeeds(enabled),
+}));
+
+let mockSettleLeaderboardOnMount = false;
+
 jest.mock('../TopTradersView', () => {
+  const ReactActual = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
   return {
     __esModule: true,
-    default: () => <View testID="mock-top-traders" />,
+    default: ({
+      onVisibleLeaderboardSettled,
+    }: {
+      onVisibleLeaderboardSettled?: () => void;
+    }) => {
+      ReactActual.useEffect(() => {
+        if (mockSettleLeaderboardOnMount) {
+          onVisibleLeaderboardSettled?.();
+        }
+      }, [onVisibleLeaderboardSettled]);
+      return <View testID="mock-top-traders" />;
+    },
   };
 });
 
@@ -177,6 +197,7 @@ describe('SocialTradersTabsView', () => {
     mockOnSpotAvailabilityChange = undefined;
     mockHasNotificationPreferences.mockReturnValue(false);
     mockRouteParams = {};
+    mockSettleLeaderboardOnMount = false;
   });
 
   it('renders the header, tabs, and both pages', () => {
@@ -383,6 +404,21 @@ describe('SocialTradersTabsView', () => {
     expect(
       screen.getByTestId('mock-feed').props.accessibilityState?.selected,
     ).toBe(true);
+  });
+
+  it('holds feed prefetch back until the visible leaderboard query settles', () => {
+    renderWithProvider(<SocialTradersTabsView />);
+
+    expect(mockUsePrefetchTraderFeeds).toHaveBeenCalledWith(false);
+    expect(mockUsePrefetchTraderFeeds).not.toHaveBeenCalledWith(true);
+  });
+
+  it('enables feed prefetch after the visible leaderboard query settles', () => {
+    mockSettleLeaderboardOnMount = true;
+
+    renderWithProvider(<SocialTradersTabsView />);
+
+    expect(mockUsePrefetchTraderFeeds).toHaveBeenCalledWith(true);
   });
 
   it('mounts the spot Buy orchestrator (outside the pager) when the feed offers a spot Buy', () => {

--- a/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx
+++ b/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx
@@ -49,6 +49,7 @@ import FeedView from '../FeedView';
 import FeedSpotBuyAction, {
   type FeedSpotBuyActionHandle,
 } from '../FeedView/components/FeedSpotBuyAction';
+import { usePrefetchTraderFeeds } from '../FeedView/hooks/usePrefetchTraderFeeds';
 import TopTradersView from '../TopTradersView';
 import type { SocialTabPageHandle } from '../shared/tabPageScroll';
 import { SCROLLABLE_SCREEN_SAFE_AREA_EDGES } from '../shared/scrollableScreenSafeArea';
@@ -82,6 +83,13 @@ const SocialTradersTabsView: React.FC = () => {
   const navigation = useNavigation<AppNavigationProp>();
   const route = useRoute<RouteProp<RootStackParamList, 'TopTradersView'>>();
   const { track } = useSocialLeaderboardAnalytics();
+  // Wait until the visible leaderboard query settles before warming feed
+  // pages, so those requests never contend with the landing list fetch.
+  const [isLeaderboardSettled, setIsLeaderboardSettled] = useState(false);
+  const handleVisibleLeaderboardSettled = useCallback(() => {
+    setIsLeaderboardSettled(true);
+  }, []);
+  usePrefetchTraderFeeds(isLeaderboardSettled);
   const pagerRef = useRef<PagerView>(null);
   const programmaticTabChangeRef = useRef(false);
   const [activeIndex, setActiveIndex] = useState(LEADERBOARD_INDEX);
@@ -457,6 +465,7 @@ const SocialTradersTabsView: React.FC = () => {
               <TopTradersView
                 onScroll={leaderboardScrollHandler}
                 pageRef={leaderboardPageRef}
+                onVisibleLeaderboardSettled={handleVisibleLeaderboardSettled}
               />
             </View>
             <View

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -591,6 +591,53 @@ describe('TopTradersView', () => {
     });
   });
 
+  it('does not notify feed prefetch while the visible leaderboard query is in flight', () => {
+    const onVisibleLeaderboardSettled = jest.fn();
+
+    renderWithProvider(
+      <TopTradersView
+        onVisibleLeaderboardSettled={onVisibleLeaderboardSettled}
+      />,
+    );
+
+    expect(onVisibleLeaderboardSettled).not.toHaveBeenCalled();
+  });
+
+  it('notifies feed prefetch once the visible leaderboard query has fetched', () => {
+    const onVisibleLeaderboardSettled = jest.fn();
+    const { rerender } = renderWithProvider(
+      <TopTradersView
+        onVisibleLeaderboardSettled={onVisibleLeaderboardSettled}
+      />,
+    );
+
+    setTabResult(LANDING_TAB, { isFetching: false, hasFetched: true });
+    rerender(
+      <TopTradersView
+        onVisibleLeaderboardSettled={onVisibleLeaderboardSettled}
+      />,
+    );
+
+    expect(onVisibleLeaderboardSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it('holds feed prefetch back while a warm Tokens cache revalidates', () => {
+    const onVisibleLeaderboardSettled = jest.fn();
+    setTabResult(LANDING_TAB, {
+      isLoading: false,
+      isFetching: true,
+      hasFetched: true,
+    });
+
+    renderWithProvider(
+      <TopTradersView
+        onVisibleLeaderboardSettled={onVisibleLeaderboardSettled}
+      />,
+    );
+
+    expect(onVisibleLeaderboardSettled).not.toHaveBeenCalled();
+  });
+
   it('narrows the enabled queries back to the visible tab when the sort changes', () => {
     jest.useFakeTimers();
     try {

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
@@ -156,6 +156,12 @@ export interface TopTradersViewProps {
    * title stays put when the user switches tabs.
    */
   pageRef?: React.Ref<SocialTabPageHandle>;
+  /**
+   * Fires once the visible leaderboard query is no longer in flight (success
+   * or error). The parent uses this to start feed prefetch only after the
+   * landing list has loaded, so those requests never contend with it.
+   */
+  onVisibleLeaderboardSettled?: () => void;
 }
 
 /**
@@ -166,6 +172,7 @@ export interface TopTradersViewProps {
 const TopTradersView: React.FC<TopTradersViewProps> = ({
   onScroll,
   pageRef,
+  onVisibleLeaderboardSettled,
 }) => {
   const navigation = useNavigation<AppNavigationProp>();
   const route = useRoute<RouteProp<RootStackParamList, 'TopTradersView'>>();
@@ -281,6 +288,11 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
     isPerpsEnabled &&
     !activeResult.isFetching &&
     TYPE_FILTER_OPTIONS.some((tab) => !queryEnabledTabs[tab]);
+  // Gate on `isFetching` (not `isLoading`) for the same warm-cache reason as
+  // secondary-tab prefetch: a homepage-warmed Tokens query paints immediately
+  // but still revalidates, and feed fetches must wait until that finishes.
+  const isVisibleLeaderboardSettled =
+    !activeResult.isFetching && activeResult.hasFetched;
   const shouldRefreshAll = queryEnabledTabs.all;
   const shouldRefreshTokens = isPerpsEnabled && queryEnabledTabs.tokens;
   const shouldRefreshPerps = isPerpsEnabled && queryEnabledTabs.perps;
@@ -337,6 +349,13 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
       setQueryEnabledTabs({ all: true, tokens: true, perps: true });
     });
   }, [shouldPrefetchSecondaryTabs]);
+
+  useEffect(() => {
+    if (!isVisibleLeaderboardSettled) {
+      return;
+    }
+    onVisibleLeaderboardSettled?.();
+  }, [isVisibleLeaderboardSettled, onVisibleLeaderboardSettled]);
 
   const handleTabPress = useCallback(
     (next: TabFilter) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Opening Follow Trading currently fetches the leaderboard first, then waits on a network call the first time the user taps Feed (and again when switching Following / All). That makes the Feed tab feel blocked even though the user has already been looking at the leaderboard.

This warms the first page of both feed audiences (`following` and `leaderboard`) into the same React Query cache the Feed tab reads, but only **after** the visible leaderboard query has settled (`!isFetching && hasFetched`). Prefetch is then deferred to idle so it does not contend with the landing list paint or its in-flight request. Tapping Feed or switching audience can then render from cache instead of waiting on the network.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Improved Follow Trading so the activity feed is ready as soon as the user opens it from the leaderboard

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: Slack request to prefetch Follow Trading feed when the leaderboard opens

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Prefetch trader feed after leaderboard loads

  Background:
    Given I am logged into MetaMask Mobile
    And Follow Trading is enabled

  Scenario: user opens Feed after the leaderboard has loaded
    Given I open Follow Trading from Home
    And the Leaderboard tab is selected
    And the ranked trader list has finished loading

    When I tap the Feed tab
    Then the Following feed appears without a blocking network wait
    And I can switch to All without a blocking network wait

  Scenario: leaderboard still loads first
    Given I open Follow Trading from Home with a cold cache

    Then the Leaderboard list starts loading immediately
    And feed requests do not start until that list has settled
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A - performance change with no visual UI difference

### **After**

N/A - performance change with no visual UI difference

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C092MDPA0LU/p1787816495394259?thread_ts=1787816495.394259&cid=C092MDPA0LU)

<div><a href="https://cursor.com/agents/bc-93e36732-ebb3-536e-8ffc-bf2ae598e264?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93e36732-ebb3-536e-8ffc-bf2ae598e264&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

