### PR TITLE
perf(perps): measure Homepage loading lifecycle

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsMarketContext.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketContext.test.ts
@@ -1,0 +1,87 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { usePerpsMarketContext } from './usePerpsMarketContext';
+
+let mockNetwork = 'testnet';
+let mockProvider = 'hyperliquid';
+let mockHip3ConfigVersion = 1;
+let mockInitializedContextKey: string | null = 'testnet|hyperliquid|1';
+let mockConnectionGeneration = 0;
+let mockInitializedConnectionGeneration: number | null = 0;
+let mockContextListeners: (() => void)[] = [];
+let mockGenerationListener: (() => void) | undefined;
+
+jest.mock('react-redux', () => ({
+  useSelector: (selector: (state: object) => unknown) => selector({}),
+}));
+jest.mock('../selectors/featureFlags', () => ({
+  selectHip3ConfigVersion: () => mockHip3ConfigVersion,
+}));
+jest.mock('../selectors/perpsController', () => ({
+  selectPerpsNetwork: () => mockNetwork,
+  selectPerpsProvider: () => mockProvider,
+}));
+jest.mock('../services/PerpsConnectionManager', () => ({
+  PerpsConnectionManager: {
+    getInitializedMarketContextKey: () => mockInitializedContextKey,
+    subscribeToInitializedMarketContext: (listener: () => void) => {
+      mockContextListeners.push(listener);
+      return jest.fn();
+    },
+    getConnectionGeneration: () => mockConnectionGeneration,
+    getInitializedConnectionGeneration: () =>
+      mockInitializedConnectionGeneration,
+    subscribeToConnectionGeneration: (listener: () => void) => {
+      mockGenerationListener = listener;
+      return jest.fn();
+    },
+  },
+}));
+
+describe('usePerpsMarketContext', () => {
+  beforeEach(() => {
+    mockNetwork = 'testnet';
+    mockProvider = 'hyperliquid';
+    mockHip3ConfigVersion = 1;
+    mockInitializedContextKey = 'testnet|hyperliquid|1';
+    mockConnectionGeneration = 0;
+    mockInitializedConnectionGeneration = 0;
+    mockContextListeners = [];
+    mockGenerationListener = undefined;
+  });
+
+  it('is ready when the selected and initialized contexts match', () => {
+    const { result } = renderHook(() => usePerpsMarketContext());
+
+    expect(result.current).toEqual({
+      key: 'testnet|hyperliquid|1|0',
+      identityKey: 'testnet|hyperliquid|1',
+      isReady: true,
+    });
+  });
+
+  it('starts a new market identity before a resubscribe is initialized', () => {
+    const { result } = renderHook(() => usePerpsMarketContext());
+
+    mockConnectionGeneration = 1;
+    act(() => mockGenerationListener?.());
+
+    expect(result.current.key).toBe('testnet|hyperliquid|1|1');
+    expect(result.current.isReady).toBe(false);
+
+    mockInitializedConnectionGeneration = 1;
+    act(() => mockContextListeners.forEach((listener) => listener()));
+
+    expect(result.current.isReady).toBe(true);
+  });
+
+  it('rejects a newly mounted selected context until it initializes', () => {
+    mockNetwork = 'mainnet';
+    const { result } = renderHook(() => usePerpsMarketContext());
+
+    expect(result.current.isReady).toBe(false);
+
+    mockInitializedContextKey = 'mainnet|hyperliquid|1';
+    act(() => mockContextListeners.forEach((listener) => listener()));
+    expect(result.current.isReady).toBe(true);
+  });
+});

--- a/app/components/UI/Perps/hooks/usePerpsMarketContext.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketContext.test.ts
@@ -53,7 +53,6 @@ describe('usePerpsMarketContext', () => {
     const { result } = renderHook(() => usePerpsMarketContext());
 
     expect(result.current).toEqual({
-      key: 'testnet|hyperliquid|1|0',
       identityKey: 'testnet|hyperliquid|1',
       isReady: true,
     });
@@ -65,7 +64,6 @@ describe('usePerpsMarketContext', () => {
     mockConnectionGeneration = 1;
     act(() => mockGenerationListener?.());
 
-    expect(result.current.key).toBe('testnet|hyperliquid|1|1');
     expect(result.current.isReady).toBe(false);
 
     mockInitializedConnectionGeneration = 1;

--- a/app/components/UI/Perps/hooks/usePerpsMarketContext.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketContext.ts
@@ -9,7 +9,6 @@ import {
 import { buildPerpsMarketContextKey } from '../utils/perpsMarketContext';
 
 export interface PerpsMarketContext {
-  key: string;
   identityKey: string;
   isReady: boolean;
 }
@@ -50,7 +49,6 @@ export function usePerpsMarketContext(): PerpsMarketContext {
     getInitializedConnectionGenerationSnapshot,
     getInitializedConnectionGenerationSnapshot,
   );
-  const key = `${selectedContextKey}|${connectionGeneration}`;
   const initializedKey = useSyncExternalStore(
     subscribeToInitializedMarketContext,
     getInitializedMarketContextSnapshot,
@@ -60,7 +58,6 @@ export function usePerpsMarketContext(): PerpsMarketContext {
     initializedKey === selectedContextKey &&
     initializedConnectionGeneration === connectionGeneration;
   return {
-    key,
     identityKey: selectedContextKey,
     isReady,
   };

--- a/app/components/UI/Perps/hooks/usePerpsMarketContext.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketContext.ts
@@ -1,0 +1,67 @@
+import { useSyncExternalStore } from 'react';
+import { useSelector } from 'react-redux';
+import { PerpsConnectionManager } from '../services/PerpsConnectionManager';
+import { selectHip3ConfigVersion } from '../selectors/featureFlags';
+import {
+  selectPerpsNetwork,
+  selectPerpsProvider,
+} from '../selectors/perpsController';
+import { buildPerpsMarketContextKey } from '../utils/perpsMarketContext';
+
+export interface PerpsMarketContext {
+  key: string;
+  identityKey: string;
+  isReady: boolean;
+}
+
+const subscribeToInitializedMarketContext = (listener: () => void) =>
+  PerpsConnectionManager.subscribeToInitializedMarketContext(listener);
+
+const getInitializedMarketContextSnapshot = () =>
+  PerpsConnectionManager.getInitializedMarketContextKey();
+const subscribeToConnectionGeneration = (listener: () => void) =>
+  PerpsConnectionManager.subscribeToConnectionGeneration(listener);
+const getConnectionGenerationSnapshot = () =>
+  PerpsConnectionManager.getConnectionGeneration();
+const getInitializedConnectionGenerationSnapshot = () =>
+  PerpsConnectionManager.getInitializedConnectionGeneration();
+
+/**
+ * Compares the selected market context with the connection that last completed
+ * initialization. Account reconnects keep the same market identity, so their
+ * resident global data stays usable while user data reconnects.
+ */
+export function usePerpsMarketContext(): PerpsMarketContext {
+  const network = useSelector(selectPerpsNetwork);
+  const provider = useSelector(selectPerpsProvider);
+  const hip3ConfigVersion = useSelector(selectHip3ConfigVersion);
+  const selectedContextKey = buildPerpsMarketContextKey(
+    network,
+    provider,
+    hip3ConfigVersion,
+  );
+  const connectionGeneration = useSyncExternalStore(
+    subscribeToConnectionGeneration,
+    getConnectionGenerationSnapshot,
+    getConnectionGenerationSnapshot,
+  );
+  const initializedConnectionGeneration = useSyncExternalStore(
+    subscribeToInitializedMarketContext,
+    getInitializedConnectionGenerationSnapshot,
+    getInitializedConnectionGenerationSnapshot,
+  );
+  const key = `${selectedContextKey}|${connectionGeneration}`;
+  const initializedKey = useSyncExternalStore(
+    subscribeToInitializedMarketContext,
+    getInitializedMarketContextSnapshot,
+    getInitializedMarketContextSnapshot,
+  );
+  const isReady =
+    initializedKey === selectedContextKey &&
+    initializedConnectionGeneration === connectionGeneration;
+  return {
+    key,
+    identityKey: selectedContextKey,
+    isReady,
+  };
+}

--- a/app/components/UI/Perps/hooks/usePerpsMarkets.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarkets.test.ts
@@ -18,7 +18,6 @@ jest.mock('../../../../core/Engine', () => ({
 }));
 jest.mock('./usePerpsMarketContext', () => ({
   usePerpsMarketContext: jest.fn(() => ({
-    key: `${mockMarketIdentityKey}|0`,
     identityKey: mockMarketIdentityKey,
     isReady: mockMarketContextReady,
   })),

--- a/app/components/UI/Perps/hooks/usePerpsMarkets.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarkets.test.ts
@@ -3,6 +3,9 @@ import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import { usePerpsMarkets, parseVolume } from './usePerpsMarkets';
 import { type PerpsMarketData } from '@metamask/perps-controller';
 
+let mockMarketContextReady = true;
+let mockMarketIdentityKey = 'testnet|hyperliquid|0';
+
 jest.mock('../../../../core/SDKConnect/utils/DevLogger');
 jest.mock('../../../../core/Engine', () => ({
   context: {
@@ -13,15 +16,24 @@ jest.mock('../../../../core/Engine', () => ({
     },
   },
 }));
+jest.mock('./usePerpsMarketContext', () => ({
+  usePerpsMarketContext: jest.fn(() => ({
+    key: `${mockMarketIdentityKey}|0`,
+    identityKey: mockMarketIdentityKey,
+    isReady: mockMarketContextReady,
+  })),
+}));
 
 // Mock PerpsStreamManager
 const mockSubscribe = jest.fn();
 const mockRefresh = jest.fn();
+const mockUnsubscribe = jest.fn();
 let mockChannelMarketsSnapshot: PerpsMarketData[] | null | undefined;
 const mockMarketData = {
   subscribe: mockSubscribe,
   refresh: mockRefresh,
   getSnapshot: () => mockChannelMarketsSnapshot,
+  getLastDeliveredAt: jest.fn((): number | null => Date.now()),
 };
 
 jest.mock('../providers/PerpsStreamManager', () => ({
@@ -60,13 +72,15 @@ describe('usePerpsMarkets', () => {
     jest.clearAllMocks();
     jest.useFakeTimers();
     mockChannelMarketsSnapshot = undefined;
+    mockMarketContextReady = true;
+    mockMarketIdentityKey = 'testnet|hyperliquid|0';
 
     // Set up default mock behavior
     mockSubscribe.mockImplementation(({ callback }) => {
       // Simulate immediate callback with data
       setTimeout(() => callback(mockMarketDataArray), 0);
       // Return unsubscribe function
-      return jest.fn();
+      return mockUnsubscribe;
     });
     mockRefresh.mockResolvedValue(undefined);
   });
@@ -114,6 +128,42 @@ describe('usePerpsMarkets', () => {
       expect(result.current.isLoading).toBe(false);
       expect(result.current.isRefreshing).toBe(false);
       expect(result.current.error).toBeNull();
+    });
+
+    it('waits to subscribe when the selected market context is not ready', () => {
+      mockMarketContextReady = false;
+      mockSubscribe.mockImplementation(() => mockUnsubscribe);
+
+      const { result } = renderHook(() => usePerpsMarkets());
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.hasResolvedInitialData).toBe(false);
+      expect(mockSubscribe).not.toHaveBeenCalled();
+    });
+
+    it('keeps resident markets visible while the connection generation changes', () => {
+      mockChannelMarketsSnapshot = mockMarketDataArray;
+      mockSubscribe.mockImplementation(() => mockUnsubscribe);
+      const { result, rerender } = renderHook(() => usePerpsMarkets());
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.markets).toHaveLength(2);
+      expect(mockSubscribe).toHaveBeenCalledTimes(1);
+
+      mockMarketContextReady = false;
+      rerender(undefined);
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.hasResolvedInitialData).toBe(true);
+      expect(result.current.markets).toHaveLength(2);
+      expect(mockSubscribe).toHaveBeenCalledTimes(1);
+      expect(mockUnsubscribe).not.toHaveBeenCalled();
+
+      mockMarketContextReady = true;
+      rerender(undefined);
+
+      expect(mockSubscribe).toHaveBeenCalledTimes(1);
+      expect(mockUnsubscribe).not.toHaveBeenCalled();
     });
   });
 
@@ -217,6 +267,21 @@ describe('usePerpsMarkets', () => {
       // Assert
       expect(result.current.markets).toEqual([]);
       expect(result.current.error).toBeNull();
+      expect(result.current.hasResolvedInitialData).toBe(true);
+    });
+
+    it('returns to unresolved when the current market channel is cleared', async () => {
+      const { result } = renderHook(() => usePerpsMarkets());
+
+      await waitFor(() => {
+        expect(result.current.hasResolvedInitialData).toBe(true);
+      });
+
+      const subscriberCallback = mockSubscribe.mock.calls[0][0].callback;
+      mockMarketData.getLastDeliveredAt.mockReturnValueOnce(null);
+      act(() => subscriberCallback([]));
+
+      expect(result.current.hasResolvedInitialData).toBe(false);
     });
   });
 

--- a/app/components/UI/Perps/hooks/usePerpsMarkets.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarkets.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import { type PerpsMarketData } from '@metamask/perps-controller';
 import { usePerpsStream } from '../providers/PerpsStreamManager';
@@ -7,6 +7,7 @@ import {
   getPreloadedData,
 } from './stream/hasCachedPerpsData';
 import { filterAndSortMarkets } from '../utils/filterAndSortMarkets';
+import { usePerpsMarketContext } from './usePerpsMarketContext';
 
 export type PerpsMarketDataWithVolumeNumber = PerpsMarketData & {
   volumeNumber: number;
@@ -25,6 +26,8 @@ export interface UsePerpsMarketsResult {
    * Error state with error message
    */
   error: string | null;
+  /** Whether the current market channel has delivered, including an empty list. */
+  hasResolvedInitialData?: boolean;
   /**
    * Refresh function to manually refetch data
    */
@@ -82,6 +85,8 @@ export const usePerpsMarkets = (
   } = options;
 
   const streamManager = usePerpsStream();
+  const { identityKey: marketIdentityKey, isReady: isMarketContextReady } =
+    usePerpsMarketContext();
   const initialChannelMarkets = streamManager.marketData.getSnapshot();
   const [markets, setMarkets] = useState<PerpsMarketDataWithVolumeNumber[]>(
     () => {
@@ -109,6 +114,29 @@ export const usePerpsMarkets = (
   });
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [hasResolvedInitialData, setHasResolvedInitialData] = useState(
+    () =>
+      skipInitialFetch ||
+      (initialChannelMarkets !== null && initialChannelMarkets !== undefined) ||
+      hasPreloadedData('cachedMarketData'),
+  );
+
+  const previousMarketIdentityKeyRef = useRef(marketIdentityKey);
+  const hasResidentMarketData =
+    previousMarketIdentityKeyRef.current === marketIdentityKey &&
+    hasResolvedInitialData;
+  const isMarketSubscriptionReady =
+    isMarketContextReady || hasResidentMarketData;
+  useEffect(() => {
+    if (previousMarketIdentityKeyRef.current === marketIdentityKey) {
+      return;
+    }
+    previousMarketIdentityKeyRef.current = marketIdentityKey;
+    setMarkets([]);
+    setError(null);
+    setHasResolvedInitialData(skipInitialFetch);
+    setIsLoading(!skipInitialFetch);
+  }, [marketIdentityKey, skipInitialFetch]);
 
   // Helper function to filter and sort markets by volume
   const sortMarketsByVolume = useCallback(
@@ -145,14 +173,28 @@ export const usePerpsMarkets = (
   useEffect(() => {
     if (skipInitialFetch) {
       setIsLoading(false);
+      setHasResolvedInitialData(true);
+      return;
+    }
+    if (!isMarketSubscriptionReady) {
+      setIsLoading(true);
+      setHasResolvedInitialData(false);
       return;
     }
 
+    let isActive = true;
     let isFirstUpdate = true;
     const subscriptionStartTime = Date.now();
 
     const unsubscribe = streamManager.marketData.subscribe({
       callback: (marketData) => {
+        if (!isActive) return;
+        if (marketData !== null && marketData !== undefined) {
+          setHasResolvedInitialData(
+            marketData.length > 0 ||
+              streamManager.marketData.getLastDeliveredAt() !== null,
+          );
+        }
         const receiveTime = Date.now();
         const timeToData = receiveTime - subscriptionStartTime;
         if (marketData && marketData.length > 0) {
@@ -190,9 +232,16 @@ export const usePerpsMarkets = (
     });
 
     return () => {
+      isActive = false;
       unsubscribe();
     };
-  }, [streamManager.marketData, sortMarketsByVolume, skipInitialFetch]);
+  }, [
+    isMarketSubscriptionReady,
+    marketIdentityKey,
+    streamManager.marketData,
+    sortMarketsByVolume,
+    skipInitialFetch,
+  ]);
 
   // Polling effect
   useEffect(() => {
@@ -213,6 +262,7 @@ export const usePerpsMarkets = (
     markets,
     isLoading,
     error,
+    hasResolvedInitialData,
     refresh,
     isRefreshing,
   };

--- a/app/components/Views/Homepage/Sections/Perpetuals/HomepagePerpsHomeSlot.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/HomepagePerpsHomeSlot.test.tsx
@@ -15,6 +15,7 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({
       navigate: jest.fn(),
     }),
+    useIsFocused: () => true,
   };
 });
 

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -1364,6 +1364,7 @@ describe('PerpsSection', () => {
         expect.objectContaining({
           success: true,
           content_state: 'empty',
+          content_variant: 'hidden',
         }),
         'session-id-1',
       );

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen, fireEvent, act } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import useSectionViewportVisible from '../../hooks/useSectionViewportVisible';
 import PerpsSection from './PerpsSection';
 import Routes from '../../../../../constants/navigation/Routes';
 import { MetaMetricsEvents } from '../../../../../core/Analytics/MetaMetrics.events';
@@ -459,6 +460,9 @@ describe('PerpsSection', () => {
         contentVariant: 'trending',
         resolvedSource: 'provider',
       }),
+    );
+    expect(jest.mocked(useSectionViewportVisible)).toHaveBeenCalledWith(
+      expect.any(Object),
     );
   });
 

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -441,6 +441,7 @@ describe('PerpsSection', () => {
 
     expect(mockUseSectionPerformance).toHaveBeenCalledWith(
       expect.objectContaining({
+        acceptReadyContentOnGenerationStart: true,
         tags: expect.objectContaining({
           lifecycle: 'cold_no_cache',
           surface: 'homepage',
@@ -457,6 +458,27 @@ describe('PerpsSection', () => {
         contentReady: true,
         contentVariant: 'trending',
         resolvedSource: 'provider',
+      }),
+    );
+  });
+
+  it('requires fresh readiness for a context-invalidating lifecycle', () => {
+    mockGetActivePerpsLoadingSessionContext.mockReturnValue({
+      id: 'session-id-1',
+      marketSource: 'provider',
+      accountSource: 'memory_cache',
+      lifecycle: 'network_switch',
+      accountGeneration: 1,
+      contextGeneration: 2,
+    });
+
+    renderWithProvider(
+      <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
+    );
+
+    expect(mockUseSectionPerformance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        acceptReadyContentOnGenerationStart: false,
       }),
     );
   });

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, fireEvent } from '@testing-library/react-native';
+import { screen, fireEvent, act } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import PerpsSection from './PerpsSection';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -10,9 +10,68 @@ import {
 } from '@metamask/perps-controller';
 import { selectIsFirstTimePerpsUser } from '../../../../UI/Perps/selectors/perpsController';
 import { createActiveABTestAssignment } from '../../../../../util/analytics/activeABTestAssignments';
+import type {
+  PerpsLoadingLifecycle,
+  PerpsLoadingSessionContext,
+} from '../../../../UI/Perps/utils/perpsLoadingSession';
 
 const mockNavigate = jest.fn();
 const mockTrack = jest.fn();
+const mockUseSectionPerformance = jest.fn((_config: unknown) => undefined);
+const mockUseHomepagePerpsSurfaceMetrics = jest.fn((_config: unknown) => ({
+  onLayout: jest.fn(),
+}));
+const mockFinishPerpsLoadingSession = jest.fn(
+  (_data: unknown, _expectedSessionId?: string) => undefined,
+);
+const mockGetActivePerpsLoadingSessionContext = jest.fn<
+  PerpsLoadingSessionContext | null,
+  []
+>(() => ({
+  id: 'session-id-1',
+  marketSource: 'provider',
+  accountSource: 'memory_cache',
+  lifecycle: 'cold_no_cache',
+  accountGeneration: 1,
+  contextGeneration: 1,
+}));
+
+jest.mock('../../hooks/useSectionPerformance', () => ({
+  useSectionPerformance: (config: unknown) => mockUseSectionPerformance(config),
+}));
+
+jest.mock('../../hooks/useSectionViewportVisible', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ isVisible: true, onLayout: jest.fn() })),
+}));
+
+jest.mock('./hooks/useHomepagePerpsSurfaceMetrics', () => ({
+  useHomepagePerpsSurfaceMetrics: (config: unknown) =>
+    mockUseHomepagePerpsSurfaceMetrics(config),
+}));
+
+jest.mock('../../../../UI/Perps/utils/perpsLoadingSession', () => ({
+  finishPerpsLoadingSession: (data: unknown, expectedSessionId?: string) =>
+    mockFinishPerpsLoadingSession(data, expectedSessionId),
+  resolvePerpsMarketSource: () => 'provider',
+}));
+
+const mockUsePerpsHomepageLoadingSession = jest.fn<
+  {
+    proposedLifecycle: PerpsLoadingLifecycle;
+    sessionContext: PerpsLoadingSessionContext | null;
+    sessionReady: boolean;
+  },
+  []
+>(() => ({
+  proposedLifecycle: 'cold_no_cache',
+  sessionContext: mockGetActivePerpsLoadingSessionContext(),
+  sessionReady: true,
+}));
+
+jest.mock('./hooks/usePerpsHomepageLoadingSession', () => ({
+  usePerpsHomepageLoadingSession: () => mockUsePerpsHomepageLoadingSession(),
+}));
 
 const mockUseHomepagePerpsPillsEmptyTransactionActiveAbTests = jest.fn<
   { key: string; value: string; key_value_pair?: string }[] | undefined,
@@ -61,6 +120,7 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({
       navigate: mockNavigate,
     }),
+    useIsFocused: () => true,
   };
 });
 
@@ -308,6 +368,23 @@ const spyOnUsePerpsFeed = () =>
 describe('PerpsSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetActivePerpsLoadingSessionContext.mockReturnValue({
+      id: 'session-id-1',
+      marketSource: 'provider',
+      accountSource: 'memory_cache',
+      lifecycle: 'cold_no_cache',
+      accountGeneration: 1,
+      contextGeneration: 1,
+    });
+    mockUsePerpsHomepageLoadingSession.mockImplementation(() => ({
+      proposedLifecycle: 'cold_no_cache',
+      sessionContext: mockGetActivePerpsLoadingSessionContext(),
+      sessionReady: true,
+    }));
+    mockUseHomepageSparklines.mockReturnValue({
+      refresh: jest.fn().mockResolvedValue(undefined),
+      sparklines: {},
+    });
     usePerpsConnection.mockReset();
     usePerpsConnection.mockImplementation(() => ({
       isConnected: true,
@@ -355,6 +432,122 @@ describe('PerpsSection', () => {
     );
 
     expect(screen.getByText('Perps')).toBeOnTheScreen();
+  });
+
+  it('correlates the existing section trace with the loading session', () => {
+    renderWithProvider(
+      <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
+    );
+
+    expect(mockUseSectionPerformance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          lifecycle: 'cold_no_cache',
+          surface: 'homepage',
+          market_source: 'provider',
+          account_source: 'memory_cache',
+        }),
+        data: { perps_session_id: 'session-id-1' },
+      }),
+    );
+    expect(mockUseHomepagePerpsSurfaceMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-id-1',
+        lifecycle: 'cold_no_cache',
+        contentReady: true,
+        contentVariant: 'trending',
+        resolvedSource: 'provider',
+      }),
+    );
+  });
+
+  it('delays an immediately-ready TTC until session correlation exists', () => {
+    mockUsePerpsHomepageLoadingSession.mockReturnValue({
+      proposedLifecycle: 'cold_no_cache',
+      sessionContext: null,
+      sessionReady: false,
+    });
+    const view = renderWithProvider(
+      <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
+    );
+
+    expect(mockUseSectionPerformance.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ contentReady: false }),
+    );
+    mockUsePerpsHomepageLoadingSession.mockReturnValue({
+      proposedLifecycle: 'cold_no_cache',
+      sessionContext: mockGetActivePerpsLoadingSessionContext(),
+      sessionReady: true,
+    });
+    view.rerender(<PerpsSection sectionIndex={0} totalSectionsLoaded={1} />);
+    expect(mockUseSectionPerformance).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        contentReady: true,
+        data: { perps_session_id: 'session-id-1' },
+      }),
+    );
+  });
+
+  it('does not start a new session when content changes in place', () => {
+    const view = renderWithProvider(
+      <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
+    );
+    expect(mockUsePerpsHomepageLoadingSession).toHaveBeenCalledTimes(1);
+
+    usePerpsLivePositions.mockReturnValue({
+      positions: [makePosition()],
+      isInitialLoading: false,
+    });
+    view.rerender(<PerpsSection sectionIndex={0} totalSectionsLoaded={1} />);
+
+    expect(mockUsePerpsHomepageLoadingSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the loading-session owner lifecycle after the session finishes', () => {
+    const view = renderWithProvider(
+      <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
+    );
+    mockUsePerpsHomepageLoadingSession.mockReturnValue({
+      proposedLifecycle: 'background_short',
+      sessionContext: null,
+      sessionReady: true,
+    });
+    view.rerender(<PerpsSection sectionIndex={0} totalSectionsLoaded={1} />);
+
+    expect(mockUseSectionPerformance).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        tags: expect.objectContaining({ lifecycle: 'background_short' }),
+      }),
+    );
+  });
+
+  it('finishes a visible error even while loading remains true', () => {
+    usePerpsConnection.mockReturnValue({
+      isConnected: false,
+      isConnecting: false,
+      isInitialized: false,
+      error: new Error('offline'),
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      resetError: jest.fn(),
+      reconnectWithNewContext: mockReconnectWithNewContext,
+    });
+    usePerpsLivePositions.mockReturnValue({
+      positions: [],
+      isInitialLoading: true,
+    });
+
+    renderWithProvider(
+      <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
+    );
+
+    expect(mockFinishPerpsLoadingSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        content_state: 'error',
+      }),
+      'session-id-1',
+    );
   });
 
   it('renders live positions with leverage info', () => {
@@ -735,6 +928,36 @@ describe('PerpsSection', () => {
       expect(screen.getByText('BTC')).toBeOnTheScreen();
       expect(screen.getByText('ETH')).toBeOnTheScreen();
       expect(screen.getByText('SOL')).toBeOnTheScreen();
+    });
+
+    it('refreshes the market list on pull-to-refresh when the trending carousel is showing', async () => {
+      const refresh = jest.fn().mockResolvedValue(undefined);
+      const refreshSparklines = jest.fn().mockResolvedValue(undefined);
+      mockUseHomepageSparklines.mockReturnValue({
+        refresh: refreshSparklines,
+        sparklines: {},
+      });
+      usePerpsMarkets.mockReturnValue({
+        markets: [
+          makeTrendingMarket({ symbol: 'BTC', volumeNumber: 5000000000 }),
+        ],
+        isLoading: false,
+        error: null,
+        refresh,
+        isRefreshing: false,
+      });
+      const ref = React.createRef<{ refresh: () => Promise<void> }>();
+
+      renderWithProvider(
+        <PerpsSection sectionIndex={0} totalSectionsLoaded={1} ref={ref} />,
+      );
+
+      await act(async () => {
+        await ref.current?.refresh();
+      });
+
+      expect(refresh).toHaveBeenCalledTimes(1);
+      expect(refreshSparklines).toHaveBeenCalledTimes(1);
     });
 
     it('does not show trending carousel when user has positions', () => {
@@ -1127,6 +1350,27 @@ describe('PerpsSection', () => {
 
       expect(screen.queryByText('Perps movers')).toBeNull();
       expect(screen.toJSON()).toBeNull();
+      const sectionPerformanceConfig = mockUseSectionPerformance.mock.calls[
+        mockUseSectionPerformance.mock.calls.length - 1
+      ][0] as Record<string, unknown>;
+      expect(sectionPerformanceConfig).toEqual(
+        expect.objectContaining({
+          contentReady: true,
+          enabled: true,
+          isEmpty: true,
+        }),
+      );
+      expect(mockFinishPerpsLoadingSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          content_state: 'empty',
+        }),
+        'session-id-1',
+      );
+      expect(mockFinishPerpsLoadingSession).not.toHaveBeenCalledWith(
+        expect.objectContaining({ failure_stage: 'surface_not_rendered' }),
+        expect.anything(),
+      );
     });
 
     it('renders pills inside the shared section shell when configured', () => {

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
@@ -420,7 +420,9 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
       enabled: Boolean(sessionId),
       generationKey: sessionId,
       acceptReadyContentOnGenerationStart:
-        lifecycle === 'navigate_return' || lifecycle === 'background_short',
+        lifecycle !== 'account_switch' &&
+        lifecycle !== 'network_switch' &&
+        lifecycle !== 'background_reconnect',
       contentReady,
       isEmpty: !hasItems,
       contentStateForTrace: connectionError ? 'error' : undefined,

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
@@ -345,9 +345,7 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
       : 0;
 
     const { isVisible: isSectionVisible, onLayout: handleSectionLayout } =
-      useSectionViewportVisible(sectionViewRef, {
-        isLoading: isLoadingSection,
-      });
+      useSectionViewportVisible(sectionViewRef);
 
     useHomeViewedEvent({
       sectionRef: willRender && !pillsEmptyFeedHidden ? sectionViewRef : null,

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
@@ -419,6 +419,8 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
       sectionId: HomeSectionNames.PERPS,
       enabled: Boolean(sessionId),
       generationKey: sessionId,
+      acceptReadyContentOnGenerationStart:
+        lifecycle === 'navigate_return' || lifecycle === 'background_short',
       contentReady,
       isEmpty: !hasItems,
       contentStateForTrace: connectionError ? 'error' : undefined,
@@ -438,6 +440,7 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
             content_state: 'empty',
             ...completionCountData,
             ...cohortTags,
+            content_variant: 'hidden',
           },
           sessionId,
         );

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
@@ -14,6 +14,7 @@ import {
   SectionHeader,
 } from '@metamask/design-system-react-native';
 import { useSelector } from 'react-redux';
+import { useIsFocused } from '@react-navigation/native';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import {
   type PerpsMarketData,
@@ -29,6 +30,7 @@ import {
   usePerpsLiveOrders,
   usePerpsLiveAccount,
 } from '../../../../UI/Perps/hooks';
+
 import {
   formatPnl,
   formatPercentage,
@@ -48,6 +50,7 @@ import useHomeViewedEvent, {
   HomeSectionNames,
 } from '../../hooks/useHomeViewedEvent';
 import { useSectionPerformance } from '../../hooks/useSectionPerformance';
+import useSectionViewportVisible from '../../hooks/useSectionViewportVisible';
 import type { PerpsSectionProps } from './PerpsSectionWithProvider';
 import HomepageSectionUnrealizedPnlRow, {
   type HomepageUnrealizedPnlTone,
@@ -58,6 +61,35 @@ import { useHomepagePerpsPillsEmptyTransactionActiveAbTests } from '../../hooks/
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { usePerpsFeed } from '../../../TrendingView/feeds/perps/usePerpsFeed';
 import { HOMEPAGE_THROTTLE_MS, MAX_ITEMS } from './constants';
+import {
+  finishPerpsLoadingSession,
+  resolvePerpsMarketSource,
+} from '../../../../UI/Perps/utils/perpsLoadingSession';
+import { usePerpsHomepageLoadingSession } from './hooks/usePerpsHomepageLoadingSession';
+import { useHomepagePerpsSurfaceMetrics } from './hooks/useHomepagePerpsSurfaceMetrics';
+
+type HomepagePerpsContentVariant =
+  | 'positions_and_orders'
+  | 'positions'
+  | 'orders'
+  | 'pills'
+  | 'trending';
+
+const resolveContentVariant = (
+  positionCount: number,
+  orderCount: number,
+  showPills: boolean,
+): HomepagePerpsContentVariant => {
+  if (positionCount > 0 && orderCount > 0) return 'positions_and_orders';
+  if (positionCount > 0) return 'positions';
+  if (orderCount > 0) return 'orders';
+  return showPills ? 'pills' : 'trending';
+};
+
+const resolveContentState = (hasError: boolean, hasItems: boolean) => {
+  if (hasError) return 'error';
+  return hasItems ? 'filled' : 'empty';
+};
 
 /**
  * PerpsSection — single "Perps" section on the homepage.
@@ -77,6 +109,9 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
     },
     ref,
   ) => {
+    const isHomepageFocused = useIsFocused();
+    const { proposedLifecycle, sessionContext, sessionReady } =
+      usePerpsHomepageLoadingSession(isHomepageFocused);
     const sectionViewRef = useRef<View>(null);
     const baseTitle = strings('homepage.sections.perps');
     const usesPillsEmptyState = emptyStateContent === 'pills';
@@ -133,10 +168,16 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
       usesPillsEmptyState && !showSkeleton && !hasItems;
     const shouldLoadMarkets = !shouldShowPillsEmptyState;
 
-    const { markets, marketsLoading, allCarouselMarkets, watchlistSymbolSet } =
-      usePerpsTrendingCarouselData({
-        skipInitialFetch: !shouldLoadMarkets,
-      });
+    const {
+      markets,
+      marketsLoading,
+      hasResolvedInitialData,
+      allCarouselMarkets,
+      watchlistSymbolSet,
+      refreshMarkets,
+    } = usePerpsTrendingCarouselData({
+      skipInitialFetch: !shouldLoadMarkets,
+    });
     const title =
       shouldShowPillsEmptyState && !connectionError
         ? (emptyStateTitleOverride ?? baseTitle)
@@ -190,11 +231,12 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
       !showSkeleton &&
       !hasItems &&
       !shouldShowPillsEmptyState &&
-      marketsLoading;
+      (marketsLoading || !hasResolvedInitialData);
     const showTrending =
       !showSkeleton &&
       !hasItems &&
       !shouldShowPillsEmptyState &&
+      hasResolvedInitialData &&
       !marketsLoading;
     const carouselSymbols = useMemo(
       () => (showTrending ? allCarouselMarkets.map((m) => m.symbol) : []),
@@ -231,6 +273,7 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
             await refetchPerpsPills();
             return;
           }
+          await refreshMarkets();
           refreshSparklines();
         },
       }),
@@ -238,6 +281,7 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
         connectionError,
         refetchPerpsPills,
         reconnectWithNewContext,
+        refreshMarkets,
         refreshSparklines,
         shouldShowPillsEmptyState,
       ],
@@ -270,10 +314,20 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
     );
     // Pass null while loading so the hook uses the immediate-fire path and
     // does not fire from viewport visibility with stale itemCount/isEmpty.
+    const contentVariant = resolveContentVariant(
+      displayPositions.length,
+      displayOrders.length,
+      shouldShowPillsEmptyState,
+    );
+    const isAccountBackedContent =
+      contentVariant === 'positions' ||
+      contentVariant === 'orders' ||
+      contentVariant === 'positions_and_orders';
     const isLoadingSection =
       hookLoading ||
       deferredLoading ||
       pendingTrending ||
+      (isAccountBackedContent && perpsAccountLoading) ||
       (shouldShowPillsEmptyState && isPerpsPillsLoading);
 
     const isEmpty = !hasItems;
@@ -290,7 +344,12 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
       ? displayPositions.length + displayOrders.length
       : 0;
 
-    const { onLayout } = useHomeViewedEvent({
+    const { isVisible: isSectionVisible, onLayout: handleSectionLayout } =
+      useSectionViewportVisible(sectionViewRef, {
+        isLoading: isLoadingSection,
+      });
+
+    useHomeViewedEvent({
       sectionRef: willRender && !pillsEmptyFeedHidden ? sectionViewRef : null,
       isLoading: isLoadingSection,
       sectionName: HomeSectionNames.PERPS,
@@ -298,22 +357,121 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
       totalSectionsLoaded,
       isEmpty,
       itemCount,
+      isVisible: isSectionVisible,
       fireImmediateWhenNoView: !pillsEmptyFeedHidden,
     });
 
+    const lifecycle = sessionContext?.lifecycle ?? proposedLifecycle;
+    const sessionId = sessionContext?.id;
+    const surfaceContentVariant = connectionError ? 'error' : contentVariant;
+    const completionCountData = useMemo<Record<string, number>>(() => {
+      const counts: Record<string, number> = {};
+      if (surfaceContentVariant === 'pills') {
+        counts.pill_count = perpsPillsData.length;
+      } else if (surfaceContentVariant === 'trending') {
+        counts.market_count = allCarouselMarkets.length;
+      } else if (surfaceContentVariant !== 'error') {
+        counts.item_count = displayPositions.length + displayOrders.length;
+      }
+      return counts;
+    }, [
+      allCarouselMarkets.length,
+      displayOrders.length,
+      displayPositions.length,
+      perpsPillsData.length,
+      surfaceContentVariant,
+    ]);
+    const hasSurfaceContent =
+      contentVariant === 'trending'
+        ? allCarouselMarkets.length > 0
+        : contentVariant === 'pills'
+          ? perpsPillsData.length > 0
+          : hasItems;
+    const marketSource = resolvePerpsMarketSource(sessionContext?.marketSource);
+    const accountSource = sessionContext?.accountSource ?? 'unknown';
+    const cohortTags = useMemo(
+      () => ({
+        content_variant: surfaceContentVariant,
+        lifecycle,
+        surface: 'homepage',
+        ...(marketSource === 'unknown' ? {} : { market_source: marketSource }),
+        ...(accountSource === 'unknown'
+          ? {}
+          : { account_source: accountSource }),
+      }),
+      [accountSource, lifecycle, marketSource, surfaceContentVariant],
+    );
+    const contentReady =
+      sessionReady && (Boolean(connectionError) || !isLoadingSection);
+    useHomepagePerpsSurfaceMetrics({
+      isVisible: isSectionVisible,
+      isRendered: !pillsEmptyFeedHidden,
+      isFocused: isHomepageFocused,
+      sessionId,
+      lifecycle,
+      contentVariant: surfaceContentVariant,
+      contentReady,
+      hasError: Boolean(connectionError),
+      marketSource,
+      resolvedSource: isAccountBackedContent ? accountSource : marketSource,
+    });
     useSectionPerformance({
       sectionId: HomeSectionNames.PERPS,
-      contentReady: !isLoadingSection,
+      enabled: Boolean(sessionId),
+      generationKey: sessionId,
+      contentReady,
       isEmpty: !hasItems,
       contentStateForTrace: connectionError ? 'error' : undefined,
       isLoading: isLoadingSection,
+      tags: cohortTags,
+      data: sessionContext
+        ? { perps_session_id: sessionContext.id }
+        : undefined,
     });
+
+    useEffect(() => {
+      if (!sessionReady || !sessionId) return;
+      if (pillsEmptyFeedHidden) {
+        finishPerpsLoadingSession(
+          {
+            success: true,
+            content_state: 'empty',
+            ...completionCountData,
+            ...cohortTags,
+          },
+          sessionId,
+        );
+        return;
+      }
+      if (isLoadingSection && !connectionError) return;
+      finishPerpsLoadingSession(
+        {
+          success: !connectionError,
+          content_state: resolveContentState(
+            Boolean(connectionError),
+            hasSurfaceContent,
+          ),
+          ...completionCountData,
+          ...cohortTags,
+        },
+        sessionId,
+      );
+    }, [
+      cohortTags,
+      completionCountData,
+      connectionError,
+      hasSurfaceContent,
+      isLoadingSection,
+      pillsEmptyFeedHidden,
+      sessionId,
+      sessionReady,
+    ]);
 
     const showsVerticalPositions = showSkeleton || pendingTrending || hasItems;
 
     if (connectionError) {
       return (
-        <View ref={sectionViewRef} onLayout={onLayout}>
+        <View ref={sectionViewRef} onLayout={handleSectionLayout}>
           <Box paddingBottom={3}>
             <SectionDivider />
             <SectionHeader
@@ -365,7 +523,7 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
                 <PerpsPositionSkeleton />
               </SectionRow>
             ) : (
-              <Box testID="homepage-perps-positions">
+              <Box testID="homepage-perps-positions" collapsable={false}>
                 {displayPositions.map((position) => (
                   <PerpsCard
                     key={position.symbol}
@@ -403,7 +561,7 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
     );
 
     return (
-      <View ref={sectionViewRef} onLayout={onLayout}>
+      <View ref={sectionViewRef} onLayout={handleSectionLayout}>
         {showsVerticalPositions ? (
           sectionContent
         ) : (

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionWithProvider.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionWithProvider.test.tsx
@@ -10,6 +10,7 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({
       navigate: jest.fn(),
     }),
+    useIsFocused: () => true,
   };
 });
 

--- a/app/components/Views/Homepage/Sections/Perpetuals/hooks/useHomepagePerpsSurfaceMetrics.test.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/hooks/useHomepagePerpsSurfaceMetrics.test.ts
@@ -1,0 +1,406 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { DevLogger } from '../../../../../../core/SDKConnect/utils/DevLogger';
+import type { PerpsLoadingSessionUpdate } from '../../../../../UI/Perps/utils/perpsLoadingSession';
+import { useHomepagePerpsSurfaceMetrics } from './useHomepagePerpsSurfaceMetrics';
+
+let mockLoadingSessionListener:
+  | ((update: PerpsLoadingSessionUpdate) => void)
+  | undefined;
+let mockNow = 100;
+let mockUuidIndex = 0;
+
+jest.mock('react-native-performance', () => ({
+  __esModule: true,
+  default: { now: jest.fn(() => (mockNow += 10)) },
+}));
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => `demand-${++mockUuidIndex}`),
+}));
+
+jest.mock('../../../../../UI/Perps/utils/perpsLoadingSession', () => ({
+  getPerpsLoadingSessionContext: jest.fn((sessionId: string) => ({
+    id: sessionId,
+    marketSource: 'unknown',
+    accountSource: 'unknown',
+    lifecycle: 'cold_no_cache',
+    accountGeneration: 2,
+    contextGeneration: 4,
+  })),
+  subscribeToPerpsLoadingSession: jest.fn(
+    (listener: typeof mockLoadingSessionListener) => {
+      mockLoadingSessionListener = listener;
+      return jest.fn();
+    },
+  ),
+}));
+
+jest.mock('../../../../../../core/SDKConnect/utils/DevLogger');
+
+const parseStages = () =>
+  (DevLogger.log as jest.Mock).mock.calls.map(([message]) =>
+    JSON.parse(String(message).replace('[PerpsPerf] ', '')),
+  );
+
+type SurfaceMetricsProps = Parameters<typeof useHomepagePerpsSurfaceMetrics>[0];
+
+const defaultProps: SurfaceMetricsProps = {
+  isVisible: true,
+  isRendered: true,
+  isFocused: true,
+  sessionId: 'session-1',
+  lifecycle: 'cold_no_cache' as const,
+  contentVariant: 'trending' as const,
+  contentReady: false,
+  hasError: false,
+  marketSource: 'terminal_v2' as const,
+  resolvedSource: 'terminal_v2',
+};
+
+describe('useHomepagePerpsSurfaceMetrics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoadingSessionListener = undefined;
+    mockNow = 100;
+    mockUuidIndex = 0;
+    global.requestAnimationFrame = jest.fn((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    global.cancelAnimationFrame = jest.fn();
+  });
+
+  it('records demand, committed UI, resolved content, and live content once', () => {
+    const { rerender } = renderHook(
+      (props: SurfaceMetricsProps) => useHomepagePerpsSurfaceMetrics(props),
+      { initialProps: defaultProps },
+    );
+
+    expect(parseStages().map(({ stage }) => stage)).toEqual([
+      'surface_demand',
+      'surface_initial_ui_recorded',
+    ]);
+
+    rerender({ ...defaultProps, contentReady: true });
+    act(() => {
+      mockLoadingSessionListener?.({
+        type: 'finished',
+        context: {
+          id: 'session-1',
+          marketSource: 'terminal_v2',
+          accountSource: 'fresh_socket',
+          lifecycle: 'cold_no_cache',
+          accountGeneration: 2,
+          contextGeneration: 4,
+        },
+      });
+    });
+
+    const records = parseStages();
+    expect(records.map(({ stage }) => stage)).toEqual([
+      'surface_demand',
+      'surface_initial_ui_recorded',
+      'surface_resolved_recorded',
+      'surface_live_recorded',
+    ]);
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          stage: 'surface_live_recorded',
+          demand_id: 'demand-1',
+          perps_session_id: 'session-1',
+          content_variant: 'trending',
+          source: 'terminal_v2',
+          market_source: 'terminal_v2',
+          fresh_for_lifecycle: true,
+          account_generation: 2,
+          context_generation: 4,
+        }),
+      ]),
+    );
+  });
+
+  it('starts a new demand when the session lifecycle upgrades', () => {
+    renderHook(
+      (props: SurfaceMetricsProps) => useHomepagePerpsSurfaceMetrics(props),
+      { initialProps: defaultProps },
+    );
+
+    act(() => {
+      mockLoadingSessionListener?.({
+        type: 'lifecycle',
+        context: {
+          id: 'session-1',
+          marketSource: 'unknown',
+          accountSource: 'unknown',
+          lifecycle: 'background_reconnect',
+          accountGeneration: 2,
+          contextGeneration: 4,
+        },
+      });
+    });
+
+    expect(parseStages().slice(-2)).toEqual([
+      expect.objectContaining({
+        stage: 'surface_demand',
+        demand_id: 'demand-2',
+        lifecycle: 'background_reconnect',
+      }),
+      expect.objectContaining({
+        stage: 'surface_initial_ui_recorded',
+        demand_id: 'demand-2',
+        lifecycle: 'background_reconnect',
+      }),
+    ]);
+  });
+
+  it('records the connection generation for fresh account content', () => {
+    const props: SurfaceMetricsProps = {
+      ...defaultProps,
+      contentVariant: 'positions' as const,
+      contentReady: true,
+      resolvedSource: 'memory_cache',
+    };
+    renderHook(() => useHomepagePerpsSurfaceMetrics(props));
+
+    act(() => {
+      mockLoadingSessionListener?.({
+        type: 'finished',
+        context: {
+          id: 'session-1',
+          marketSource: 'memory_cache',
+          accountSource: 'fresh_socket',
+          lifecycle: 'cold_no_cache',
+          accountGeneration: 2,
+          contextGeneration: 4,
+          connectionGeneration: 3,
+        },
+      });
+    });
+
+    expect(parseStages()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          stage: 'surface_live_recorded',
+          source: 'fresh_socket',
+          account_generation: 2,
+          context_generation: 4,
+          connection_generation: 3,
+        }),
+      ]),
+    );
+  });
+
+  it('records nothing while the section is outside the viewport', () => {
+    renderHook(() =>
+      useHomepagePerpsSurfaceMetrics({
+        ...defaultProps,
+        isVisible: false,
+      }),
+    );
+
+    expect(DevLogger.log).not.toHaveBeenCalled();
+  });
+
+  it('records nothing while another screen covers the homepage', () => {
+    renderHook(() =>
+      useHomepagePerpsSurfaceMetrics({
+        ...defaultProps,
+        isFocused: false,
+      }),
+    );
+
+    expect(DevLogger.log).not.toHaveBeenCalled();
+  });
+
+  it('records nothing after the section stops rendering', () => {
+    const { rerender } = renderHook(
+      (props: SurfaceMetricsProps) => useHomepagePerpsSurfaceMetrics(props),
+      { initialProps: defaultProps },
+    );
+    jest.mocked(DevLogger.log).mockClear();
+
+    rerender({ ...defaultProps, isRendered: false, contentReady: true });
+    act(() => {
+      mockLoadingSessionListener?.({
+        type: 'finished',
+        context: {
+          id: 'session-1',
+          marketSource: 'unknown',
+          accountSource: 'unknown',
+          lifecycle: 'cold_no_cache',
+          accountGeneration: 2,
+          contextGeneration: 4,
+        },
+      });
+    });
+
+    expect(DevLogger.log).not.toHaveBeenCalled();
+  });
+
+  it('does not label unknown-source content as lifecycle-fresh', () => {
+    const props: SurfaceMetricsProps = {
+      ...defaultProps,
+      resolvedSource: 'unknown',
+    };
+    const { rerender } = renderHook(
+      (currentProps: typeof props) =>
+        useHomepagePerpsSurfaceMetrics(currentProps),
+      { initialProps: props },
+    );
+
+    rerender({ ...props, contentReady: true });
+    act(() => {
+      mockLoadingSessionListener?.({
+        type: 'finished',
+        context: {
+          id: 'session-1',
+          marketSource: 'unknown',
+          accountSource: 'unknown',
+          lifecycle: 'network_switch',
+          accountGeneration: 2,
+          contextGeneration: 4,
+        },
+      });
+    });
+
+    expect(parseStages().map(({ stage }) => stage)).toEqual([
+      'surface_demand',
+      'surface_initial_ui_recorded',
+      'surface_resolved_recorded',
+    ]);
+  });
+
+  it('does not label cached Terminal content as lifecycle-fresh', () => {
+    const props: SurfaceMetricsProps = {
+      ...defaultProps,
+      resolvedSource: 'memory_cache',
+    };
+    const { rerender } = renderHook(
+      (currentProps: typeof props) =>
+        useHomepagePerpsSurfaceMetrics(currentProps),
+      { initialProps: props },
+    );
+
+    rerender({ ...props, contentReady: true });
+    act(() => {
+      mockLoadingSessionListener?.({
+        type: 'finished',
+        context: {
+          id: 'session-1',
+          marketSource: 'memory_cache',
+          accountSource: 'unknown',
+          lifecycle: 'navigate_return',
+          accountGeneration: 2,
+          contextGeneration: 4,
+        },
+      });
+    });
+
+    expect(parseStages().map(({ stage }) => stage)).toEqual([
+      'surface_demand',
+      'surface_initial_ui_recorded',
+      'surface_resolved_recorded',
+    ]);
+  });
+
+  it('accepts retained market content for an account-only switch', () => {
+    const props: SurfaceMetricsProps = {
+      ...defaultProps,
+      lifecycle: 'account_switch' as const,
+      contentReady: true,
+      marketSource: 'memory_cache' as const,
+      resolvedSource: 'unknown',
+    };
+    renderHook(() => useHomepagePerpsSurfaceMetrics(props));
+
+    act(() => {
+      mockLoadingSessionListener?.({
+        type: 'finished',
+        context: {
+          id: 'session-1',
+          marketSource: 'unknown',
+          accountSource: 'fresh_socket',
+          lifecycle: 'account_switch',
+          accountGeneration: 3,
+          contextGeneration: 4,
+          connectionGeneration: 5,
+        },
+      });
+    });
+
+    expect(parseStages()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          stage: 'surface_live_recorded',
+          lifecycle: 'account_switch',
+          content_variant: 'trending',
+          source: 'retained_market_context',
+          market_source: 'memory_cache',
+          fresh_for_lifecycle: true,
+        }),
+      ]),
+    );
+  });
+
+  it('starts a new demand when the loading generation changes', () => {
+    const { rerender } = renderHook(
+      (props: SurfaceMetricsProps) => useHomepagePerpsSurfaceMetrics(props),
+      { initialProps: defaultProps },
+    );
+
+    rerender({ ...defaultProps, sessionId: 'session-2' });
+
+    expect(
+      parseStages()
+        .filter(({ stage }) => stage === 'surface_demand')
+        .map(({ demand_id, perps_session_id }) => ({
+          demand_id,
+          perps_session_id,
+        })),
+    ).toEqual([
+      { demand_id: 'demand-1', perps_session_id: 'session-1' },
+      { demand_id: 'demand-2', perps_session_id: 'session-2' },
+    ]);
+  });
+
+  it('retains a known market source for a warm generation without a new market milestone', () => {
+    const { rerender } = renderHook(
+      (props: SurfaceMetricsProps) => useHomepagePerpsSurfaceMetrics(props),
+      { initialProps: defaultProps },
+    );
+
+    act(() => {
+      mockLoadingSessionListener?.({
+        type: 'finished',
+        context: {
+          id: 'session-1',
+          marketSource: 'provider',
+          accountSource: 'fresh_socket',
+          lifecycle: 'cold_no_cache',
+          accountGeneration: 2,
+          contextGeneration: 4,
+        },
+      });
+    });
+
+    rerender({
+      ...defaultProps,
+      sessionId: 'session-2',
+      lifecycle: 'navigate_return',
+      contentReady: true,
+      marketSource: 'unknown',
+      resolvedSource: 'unknown',
+    });
+
+    expect(parseStages()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          stage: 'surface_resolved_recorded',
+          perps_session_id: 'session-2',
+          source: 'provider',
+        }),
+      ]),
+    );
+  });
+});

--- a/app/components/Views/Homepage/Sections/Perpetuals/hooks/useHomepagePerpsSurfaceMetrics.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/hooks/useHomepagePerpsSurfaceMetrics.ts
@@ -1,0 +1,318 @@
+import { useCallback, useEffect, useRef } from 'react';
+import performance from 'react-native-performance';
+import { v4 as uuidv4 } from 'uuid';
+import { DevLogger } from '../../../../../../core/SDKConnect/utils/DevLogger';
+import {
+  getPerpsLoadingSessionContext,
+  subscribeToPerpsLoadingSession,
+  type PerpsLoadingLifecycle,
+  type PerpsLoadingSessionContext,
+} from '../../../../../UI/Perps/utils/perpsLoadingSession';
+import type {
+  PerpsLoadingSource,
+  PerpsSessionAccountSource,
+  PerpsSessionMarketSource,
+} from '../../../../../UI/Perps/utils/perpsLoadingSessionModel';
+
+const FRESH_SOCKET_SOURCE: PerpsLoadingSource = 'fresh_socket';
+const RETAINED_MARKET_CONTEXT_SOURCE = 'retained_market_context' as const;
+
+const retainKnownMarketSource = (
+  context: PerpsLoadingSessionContext,
+  previous?: PerpsLoadingSessionContext | null,
+): PerpsLoadingSessionContext =>
+  context.marketSource === 'unknown' &&
+  previous?.marketSource &&
+  previous.marketSource !== 'unknown'
+    ? { ...context, marketSource: previous.marketSource }
+    : context;
+
+type HomepagePerpsContentVariant =
+  | 'positions_and_orders'
+  | 'positions'
+  | 'orders'
+  | 'pills'
+  | 'trending'
+  | 'error';
+
+interface UseHomepagePerpsSurfaceMetricsOptions {
+  isVisible: boolean;
+  isRendered: boolean;
+  isFocused: boolean;
+  sessionId?: string;
+  lifecycle: PerpsLoadingLifecycle;
+  contentVariant: HomepagePerpsContentVariant;
+  contentReady: boolean;
+  hasError: boolean;
+  marketSource: PerpsSessionMarketSource;
+  resolvedSource: PerpsSessionMarketSource | PerpsSessionAccountSource;
+}
+
+interface ActiveDemand {
+  id: string;
+  sessionId: string;
+  startedAtMs: number;
+  lifecycle: PerpsLoadingLifecycle;
+  dataReadyAtDemand: boolean;
+  accountGeneration: number;
+  contextGeneration: number;
+}
+
+type SurfaceStage =
+  | 'surface_demand'
+  | 'surface_initial_ui_recorded'
+  | 'surface_resolved_recorded'
+  | 'surface_live_recorded';
+
+const logSurfaceStage = (
+  stage: SurfaceStage,
+  demand: ActiveDemand,
+  detail: Record<string, string | number | boolean> = {},
+) => {
+  const now = performance.now();
+  DevLogger.log(
+    `[PerpsPerf] ${JSON.stringify({
+      stage,
+      demand_id: demand.id,
+      perps_session_id: demand.sessionId,
+      lifecycle: demand.lifecycle,
+      account_generation: demand.accountGeneration,
+      context_generation: demand.contextGeneration,
+      monotonic_ms: Number(now.toFixed(3)),
+      ...(stage === 'surface_demand'
+        ? {}
+        : {
+            frame_checkpoint_monotonic_ms: Number(now.toFixed(3)),
+            duration_ms: Number((now - demand.startedAtMs).toFixed(3)),
+          }),
+      ...detail,
+    })}`,
+  );
+};
+
+/**
+ * Emits recipe-only Homepage surface boundaries after native frame checkpoints.
+ * Existing Homepage TTC/DFD traces keep sole ownership of production timing.
+ */
+export function useHomepagePerpsSurfaceMetrics({
+  isVisible,
+  isRendered,
+  isFocused,
+  sessionId,
+  lifecycle,
+  contentVariant,
+  contentReady,
+  hasError,
+  marketSource,
+  resolvedSource,
+}: UseHomepagePerpsSurfaceMetricsOptions) {
+  const activeDemandRef = useRef<ActiveDemand | undefined>(undefined);
+  const contentReadyRef = useRef(contentReady);
+  const contentVariantRef = useRef(contentVariant);
+  const hasErrorRef = useRef(hasError);
+  const marketSourceRef = useRef(marketSource);
+  const resolvedSourceRef = useRef(resolvedSource);
+  const isSurfaceVisible = isRendered && isFocused && isVisible;
+  const isSurfaceVisibleRef = useRef(isSurfaceVisible);
+  const finishedSessionsRef = useRef(new Set<string>());
+  const proofContextRef = useRef<PerpsLoadingSessionContext | null>(null);
+  const recordedStagesRef = useRef(new Set<SurfaceStage>());
+  const frameIdsRef = useRef(new Set<number>());
+  contentReadyRef.current = contentReady;
+  contentVariantRef.current = contentVariant;
+  hasErrorRef.current = hasError;
+  marketSourceRef.current = marketSource;
+  resolvedSourceRef.current = resolvedSource;
+  isSurfaceVisibleRef.current = isSurfaceVisible;
+
+  const afterNextPaint = useCallback((callback: () => void) => {
+    let first = 0;
+    first = requestAnimationFrame(() => {
+      frameIdsRef.current.delete(first);
+      let second = 0;
+      second = requestAnimationFrame(() => {
+        frameIdsRef.current.delete(second);
+        callback();
+      });
+      frameIdsRef.current.add(second);
+    });
+    frameIdsRef.current.add(first);
+  }, []);
+
+  const recordAfterPaint = useCallback(
+    (stage: Exclude<SurfaceStage, 'surface_demand'>) => {
+      const demand = activeDemandRef.current;
+      if (!demand || recordedStagesRef.current.has(stage)) {
+        return;
+      }
+      recordedStagesRef.current.add(stage);
+      afterNextPaint(() => {
+        if (
+          !isSurfaceVisibleRef.current ||
+          activeDemandRef.current?.id !== demand.id
+        ) {
+          return;
+        }
+        const isAccountVariant =
+          contentVariantRef.current === 'positions' ||
+          contentVariantRef.current === 'orders' ||
+          contentVariantRef.current === 'positions_and_orders';
+        const retainsMarketContext =
+          !isAccountVariant && demand.lifecycle === 'account_switch';
+        const sessionMarketSource = proofContextRef.current?.marketSource;
+        const resolvedMarketSource =
+          sessionMarketSource && sessionMarketSource !== 'unknown'
+            ? sessionMarketSource
+            : marketSourceRef.current;
+        const currentResolvedSource =
+          resolvedSourceRef.current === 'unknown'
+            ? resolvedMarketSource
+            : resolvedSourceRef.current;
+        const source =
+          stage === 'surface_live_recorded' &&
+          isAccountVariant &&
+          proofContextRef.current?.connectionGeneration !== undefined
+            ? FRESH_SOCKET_SOURCE
+            : stage === 'surface_live_recorded' && retainsMarketContext
+              ? RETAINED_MARKET_CONTEXT_SOURCE
+              : currentResolvedSource;
+        logSurfaceStage(stage, demand, {
+          content_variant: contentVariantRef.current,
+          source,
+          ...(stage === 'surface_resolved_recorded' ||
+          stage === 'surface_live_recorded'
+            ? { data_ready_at_demand: demand.dataReadyAtDemand }
+            : {}),
+          ...(stage === 'surface_live_recorded'
+            ? {
+                fresh_for_lifecycle: true,
+                market_source: resolvedMarketSource,
+                ...(proofContextRef.current?.connectionGeneration === undefined
+                  ? {}
+                  : {
+                      connection_generation:
+                        proofContextRef.current.connectionGeneration,
+                    }),
+              }
+            : {}),
+        });
+      });
+    },
+    [afterNextPaint],
+  );
+
+  const recordResolvedAndLive = useCallback(() => {
+    const demand = activeDemandRef.current;
+    if (!demand || !contentReadyRef.current) {
+      return;
+    }
+    recordAfterPaint('surface_resolved_recorded');
+    const currentResolvedSource = resolvedSourceRef.current;
+    const isAccountVariant =
+      contentVariantRef.current === 'positions' ||
+      contentVariantRef.current === 'orders' ||
+      contentVariantRef.current === 'positions_and_orders';
+    const isFreshForLifecycle = isAccountVariant
+      ? proofContextRef.current?.connectionGeneration !== undefined
+      : demand.lifecycle === 'account_switch' ||
+        currentResolvedSource === 'terminal_v2' ||
+        currentResolvedSource === 'provider';
+    if (
+      !hasErrorRef.current &&
+      isFreshForLifecycle &&
+      finishedSessionsRef.current.has(demand.sessionId)
+    ) {
+      recordAfterPaint('surface_live_recorded');
+    }
+  }, [recordAfterPaint]);
+
+  const beginDemand = useCallback(
+    (
+      proofContext: PerpsLoadingSessionContext,
+      demandLifecycle: PerpsLoadingLifecycle,
+    ) => {
+      proofContextRef.current = retainKnownMarketSource(
+        proofContext,
+        proofContextRef.current,
+      );
+      const demand = {
+        id: uuidv4(),
+        sessionId: proofContext.id,
+        startedAtMs: performance.now(),
+        lifecycle: demandLifecycle,
+        dataReadyAtDemand: contentReadyRef.current,
+        accountGeneration: proofContext.accountGeneration,
+        contextGeneration: proofContext.contextGeneration,
+      };
+      const sessionAlreadyFinished = finishedSessionsRef.current.has(
+        proofContext.id,
+      );
+      finishedSessionsRef.current.clear();
+      if (sessionAlreadyFinished) {
+        finishedSessionsRef.current.add(proofContext.id);
+      }
+      activeDemandRef.current = demand;
+      recordedStagesRef.current.clear();
+      recordedStagesRef.current.add('surface_demand');
+      logSurfaceStage('surface_demand', demand);
+      recordAfterPaint('surface_initial_ui_recorded');
+      recordResolvedAndLive();
+    },
+    [recordAfterPaint, recordResolvedAndLive],
+  );
+
+  useEffect(
+    () =>
+      subscribeToPerpsLoadingSession((update) => {
+        if (activeDemandRef.current?.sessionId === update.context.id) {
+          proofContextRef.current = retainKnownMarketSource(
+            update.context,
+            proofContextRef.current,
+          );
+          if (
+            update.type === 'lifecycle' &&
+            activeDemandRef.current.lifecycle !== update.context.lifecycle
+          ) {
+            beginDemand(update.context, update.context.lifecycle);
+            return;
+          }
+        }
+        if (update.type === 'finished') {
+          finishedSessionsRef.current.add(update.context.id);
+          recordResolvedAndLive();
+        } else if (update.type === 'cancelled' || update.type === 'timed_out') {
+          finishedSessionsRef.current.delete(update.context.id);
+        }
+      }),
+    [beginDemand, recordResolvedAndLive],
+  );
+
+  useEffect(() => {
+    if (!isSurfaceVisible || !sessionId) {
+      activeDemandRef.current = undefined;
+      recordedStagesRef.current.clear();
+      return;
+    }
+    if (activeDemandRef.current?.sessionId === sessionId) {
+      return;
+    }
+
+    const proofContext = getPerpsLoadingSessionContext(sessionId);
+    if (!proofContext) {
+      return;
+    }
+    beginDemand(proofContext, lifecycle);
+  }, [beginDemand, isSurfaceVisible, lifecycle, sessionId]);
+
+  useEffect(() => {
+    recordResolvedAndLive();
+  }, [contentReady, recordResolvedAndLive, resolvedSource]);
+
+  useEffect(
+    () => () => {
+      frameIdsRef.current.forEach((id) => cancelAnimationFrame(id));
+      frameIdsRef.current.clear();
+    },
+    [],
+  );
+}

--- a/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsHomepageLoadingSession.test.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsHomepageLoadingSession.test.ts
@@ -1,0 +1,347 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { AppState, type AppStateStatus } from 'react-native';
+import { useSelector } from 'react-redux';
+import { selectHip3ConfigVersion } from '../../../../../UI/Perps/selectors/featureFlags';
+import {
+  selectPerpsNetwork,
+  selectPerpsProvider,
+} from '../../../../../UI/Perps/selectors/perpsController';
+import { selectPerpsSelectedAccountAddress } from '../../../../../UI/Perps/selectors/selectedAccountAddress';
+import {
+  cancelPerpsLoadingSession,
+  getActivePerpsLoadingSessionContext,
+  preparePerpsLoadingSession,
+  startPerpsLoadingSession,
+  type PerpsLoadingSessionContext,
+} from '../../../../../UI/Perps/utils/perpsLoadingSession';
+import { usePerpsHomepageLoadingSession } from './usePerpsHomepageLoadingSession';
+
+let mockSessionListener:
+  | ((update: {
+      type: 'started' | 'finished' | 'cancelled' | 'timed_out';
+      context: PerpsLoadingSessionContext;
+    }) => void)
+  | undefined;
+
+jest.mock('react-redux', () => ({ useSelector: jest.fn() }));
+jest.mock('../../../../../UI/Perps/selectors/featureFlags', () => ({
+  selectHip3ConfigVersion: jest.fn(),
+}));
+jest.mock('../../../../../UI/Perps/selectors/selectedAccountAddress', () => ({
+  selectPerpsSelectedAccountAddress: jest.fn(),
+}));
+jest.mock('../../../../../UI/Perps/selectors/perpsController', () => ({
+  selectPerpsNetwork: jest.fn(),
+  selectPerpsProvider: jest.fn(),
+}));
+jest.mock('../../../../../UI/Perps/utils/perpsLifecycleContext', () => ({
+  getPerpsLifecycleContext: jest.fn(() => 'cold_process'),
+}));
+jest.mock('../../../../../UI/Perps/utils/perpsLoadingSession', () => ({
+  cancelPerpsLoadingSession: jest.fn(),
+  createPerpsLoadingSessionIdentity: jest.fn(
+    ({ address, hip3ConfigVersion, network, provider }) => ({
+      marketKey: `${provider}|${network}|${hip3ConfigVersion}`,
+      userKey: `${provider}|${network}|${hip3ConfigVersion}|${address ?? ''}`,
+      accountKey: address ?? '',
+    }),
+  ),
+  getActivePerpsLoadingSessionContext: jest.fn(),
+  preparePerpsLoadingSession: jest.fn(),
+  resolvePerpsLoadingLifecycle: jest.fn(() => 'cold_no_cache'),
+  startPerpsLoadingSession: jest.fn(),
+  subscribeToPerpsLoadingSession: jest.fn((listener) => {
+    mockSessionListener = listener;
+    return jest.fn();
+  }),
+}));
+
+describe('usePerpsHomepageLoadingSession', () => {
+  let address: string | undefined;
+  let network: 'mainnet' | 'testnet';
+  let provider: string | undefined;
+  let hip3ConfigVersion: number;
+  let activeContext: PerpsLoadingSessionContext | null;
+  let appStateListener: ((state: AppStateStatus) => void) | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    address = '0xabc';
+    network = 'mainnet';
+    provider = 'hyperliquid';
+    hip3ConfigVersion = 1;
+    activeContext = null;
+    appStateListener = undefined;
+    mockSessionListener = undefined;
+    Object.defineProperty(AppState, 'currentState', {
+      configurable: true,
+      value: 'active',
+    });
+    jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation((_, listener) => {
+        appStateListener = listener;
+        return { remove: jest.fn() };
+      });
+    jest.mocked(useSelector).mockImplementation((selector) => {
+      if (selector === selectPerpsSelectedAccountAddress) return address;
+      if (selector === selectPerpsNetwork) return network;
+      if (selector === selectPerpsProvider) return provider;
+      if (selector === selectHip3ConfigVersion) return hip3ConfigVersion;
+      return undefined;
+    });
+    jest
+      .mocked(getActivePerpsLoadingSessionContext)
+      .mockImplementation(() => activeContext);
+    jest.mocked(startPerpsLoadingSession).mockImplementation((options) => {
+      activeContext = {
+        id: 'session-id',
+        marketSource: 'unknown',
+        accountSource: 'unknown',
+        lifecycle: options?.lifecycle ?? 'cold_no_cache',
+        accountGeneration: 1,
+        contextGeneration: 1,
+      };
+      mockSessionListener?.({ type: 'started', context: activeContext });
+      return activeContext.id;
+    });
+    jest.mocked(cancelPerpsLoadingSession).mockImplementation(() => {
+      const cancelledContext = activeContext;
+      activeContext = null;
+      if (cancelledContext) {
+        mockSessionListener?.({
+          type: 'cancelled',
+          context: cancelledContext,
+        });
+      }
+    });
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('owns the session only while the homepage surface is mounted', () => {
+    const { result, unmount } = renderHook(() =>
+      usePerpsHomepageLoadingSession(),
+    );
+
+    expect(startPerpsLoadingSession).toHaveBeenCalledWith({
+      lifecycle: 'cold_no_cache',
+      restart: false,
+      surface: 'homepage',
+      identity: expect.any(Object),
+      provider: 'hyperliquid',
+      network: 'mainnet',
+    });
+    expect(result.current.sessionReady).toBe(true);
+
+    unmount();
+    expect(cancelPerpsLoadingSession).toHaveBeenCalledWith('surface_unmounted');
+  });
+
+  it('cancels while covered and starts fresh when homepage focus returns', () => {
+    const { rerender } = renderHook(
+      ({ isFocused }) => usePerpsHomepageLoadingSession(isFocused),
+      { initialProps: { isFocused: true } },
+    );
+
+    rerender({ isFocused: false });
+    expect(cancelPerpsLoadingSession).toHaveBeenCalledWith('surface_unfocused');
+    jest.mocked(startPerpsLoadingSession).mockClear();
+
+    address = '0xdef';
+    rerender({ isFocused: false });
+    expect(startPerpsLoadingSession).not.toHaveBeenCalled();
+
+    rerender({ isFocused: true });
+    expect(startPerpsLoadingSession).toHaveBeenCalledWith({
+      lifecycle: 'cold_no_cache',
+      restart: false,
+      surface: 'homepage',
+      identity: expect.any(Object),
+      provider: 'hyperliquid',
+      network: 'mainnet',
+    });
+  });
+
+  it('cancels before suspension and starts a resume session on return', () => {
+    renderHook(() => usePerpsHomepageLoadingSession());
+    jest.mocked(startPerpsLoadingSession).mockClear();
+
+    act(() => appStateListener?.('background'));
+    expect(cancelPerpsLoadingSession).toHaveBeenCalledWith('app_backgrounded');
+
+    act(() => appStateListener?.('active'));
+    expect(startPerpsLoadingSession).toHaveBeenCalledWith({
+      lifecycle: 'background_short',
+      restart: false,
+      surface: 'homepage',
+      identity: expect.any(Object),
+      provider: 'hyperliquid',
+      network: 'mainnet',
+    });
+  });
+
+  it('cancels for iOS inactive and starts a resume session on return', () => {
+    renderHook(() => usePerpsHomepageLoadingSession());
+    jest.mocked(startPerpsLoadingSession).mockClear();
+    jest.mocked(cancelPerpsLoadingSession).mockClear();
+
+    act(() => appStateListener?.('inactive'));
+    expect(cancelPerpsLoadingSession).toHaveBeenCalledWith('app_backgrounded');
+
+    act(() => appStateListener?.('active'));
+
+    expect(startPerpsLoadingSession).toHaveBeenCalledWith({
+      lifecycle: 'background_short',
+      restart: false,
+      surface: 'homepage',
+      identity: expect.any(Object),
+      provider: 'hyperliquid',
+      network: 'mainnet',
+    });
+  });
+
+  it('seeds identity when a surface mounted while inactive becomes active', () => {
+    Object.defineProperty(AppState, 'currentState', {
+      configurable: true,
+      value: 'inactive',
+    });
+    const { rerender } = renderHook(() => usePerpsHomepageLoadingSession());
+    expect(startPerpsLoadingSession).not.toHaveBeenCalled();
+
+    act(() => appStateListener?.('active'));
+
+    expect(startPerpsLoadingSession).toHaveBeenCalledWith({
+      lifecycle: 'background_short',
+      restart: false,
+      surface: 'homepage',
+      identity: expect.any(Object),
+      provider: 'hyperliquid',
+      network: 'mainnet',
+    });
+
+    jest.mocked(startPerpsLoadingSession).mockClear();
+    address = '0xdef';
+    rerender(undefined);
+
+    expect(startPerpsLoadingSession).toHaveBeenCalledWith(
+      expect.objectContaining({ lifecycle: 'account_switch' }),
+    );
+  });
+
+  it('disarms a prepared buffer when an inactive surface unmounts', () => {
+    Object.defineProperty(AppState, 'currentState', {
+      configurable: true,
+      value: 'inactive',
+    });
+    const { unmount } = renderHook(() => usePerpsHomepageLoadingSession());
+
+    expect(preparePerpsLoadingSession).toHaveBeenCalled();
+    expect(startPerpsLoadingSession).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(cancelPerpsLoadingSession).toHaveBeenCalledWith('surface_unmounted');
+  });
+
+  it('does not adopt or cancel a session owned by another surface', () => {
+    const { result } = renderHook(() => usePerpsHomepageLoadingSession());
+    const ownedContext = activeContext;
+    const foreignContext: PerpsLoadingSessionContext = {
+      id: 'foreign-session',
+      marketSource: 'provider',
+      accountSource: 'fresh_socket',
+      lifecycle: 'navigate_return',
+      accountGeneration: 2,
+      contextGeneration: 2,
+    };
+
+    activeContext = foreignContext;
+    act(() => {
+      mockSessionListener?.({ type: 'started', context: foreignContext });
+    });
+
+    expect(result.current.sessionContext).toEqual(ownedContext);
+    jest.mocked(cancelPerpsLoadingSession).mockClear();
+
+    act(() => appStateListener?.('background'));
+
+    expect(cancelPerpsLoadingSession).not.toHaveBeenCalled();
+  });
+
+  it('restarts for account and provider context changes', () => {
+    const { rerender } = renderHook(() => usePerpsHomepageLoadingSession());
+    jest.mocked(startPerpsLoadingSession).mockClear();
+
+    address = '0xdef';
+    rerender(undefined);
+    expect(startPerpsLoadingSession).toHaveBeenLastCalledWith({
+      lifecycle: 'account_switch',
+      restart: false,
+      surface: 'homepage',
+      identity: expect.any(Object),
+      provider: 'hyperliquid',
+      network: 'mainnet',
+    });
+
+    provider = 'myx';
+    rerender(undefined);
+    expect(startPerpsLoadingSession).toHaveBeenLastCalledWith({
+      lifecycle: 'network_switch',
+      restart: false,
+      surface: 'homepage',
+      identity: expect.any(Object),
+      provider: 'myx',
+      network: 'mainnet',
+    });
+  });
+
+  it('applies an identity change that lands while inactive', () => {
+    const { rerender } = renderHook(() => usePerpsHomepageLoadingSession());
+    jest.mocked(startPerpsLoadingSession).mockClear();
+
+    act(() => appStateListener?.('inactive'));
+    address = '0xdef';
+    rerender(undefined);
+    act(() => appStateListener?.('active'));
+
+    expect(startPerpsLoadingSession).toHaveBeenCalledWith(
+      expect.objectContaining({ lifecycle: 'account_switch' }),
+    );
+  });
+
+  it('clears a timed-out session without waiting for another render', () => {
+    const { result } = renderHook(() => usePerpsHomepageLoadingSession());
+    const timedOutContext = activeContext;
+
+    act(() => {
+      if (timedOutContext) {
+        mockSessionListener?.({
+          type: 'timed_out',
+          context: timedOutContext,
+        });
+      }
+    });
+
+    expect(result.current.sessionReady).toBe(false);
+    expect(result.current.sessionContext).toBeNull();
+  });
+
+  it('retains the completed generation for Homepage TTC and DFD correlation', () => {
+    const { result } = renderHook(() => usePerpsHomepageLoadingSession());
+    const finishedContext = activeContext;
+
+    act(() => {
+      if (finishedContext) {
+        activeContext = null;
+        mockSessionListener?.({
+          type: 'finished',
+          context: finishedContext,
+        });
+      }
+    });
+
+    expect(result.current.sessionReady).toBe(true);
+    expect(result.current.sessionContext?.id).toBe('session-id');
+  });
+});

--- a/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsHomepageLoadingSession.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsHomepageLoadingSession.ts
@@ -1,0 +1,245 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+import { useSelector } from 'react-redux';
+import { selectHip3ConfigVersion } from '../../../../../UI/Perps/selectors/featureFlags';
+import {
+  selectPerpsNetwork,
+  selectPerpsProvider,
+} from '../../../../../UI/Perps/selectors/perpsController';
+import { selectPerpsSelectedAccountAddress } from '../../../../../UI/Perps/selectors/selectedAccountAddress';
+import { getPerpsLifecycleContext } from '../../../../../UI/Perps/utils/perpsLifecycleContext';
+import {
+  cancelPerpsLoadingSession,
+  createPerpsLoadingSessionIdentity,
+  getActivePerpsLoadingSessionContext,
+  preparePerpsLoadingSession,
+  resolvePerpsLoadingLifecycle,
+  startPerpsLoadingSession,
+  subscribeToPerpsLoadingSession,
+  type PerpsLoadingLifecycle,
+  type PerpsLoadingSessionCancellationReason,
+  type PerpsLoadingSessionContext,
+} from '../../../../../UI/Perps/utils/perpsLoadingSession';
+
+interface PerpsContextIdentity {
+  address?: string;
+  network: 'mainnet' | 'testnet';
+  provider?: string;
+  hip3ConfigVersion: number;
+}
+
+interface PerpsHomepageLoadingSession {
+  proposedLifecycle: PerpsLoadingLifecycle;
+  sessionContext: PerpsLoadingSessionContext | null;
+  sessionReady: boolean;
+}
+
+function identitiesMatch(
+  first: PerpsContextIdentity,
+  second: PerpsContextIdentity,
+): boolean {
+  return (
+    first.address === second.address &&
+    first.network === second.network &&
+    first.provider === second.provider &&
+    first.hip3ConfigVersion === second.hip3ConfigVersion
+  );
+}
+
+function lifecycleForIdentityChange(
+  previous: PerpsContextIdentity,
+  current: PerpsContextIdentity,
+): PerpsLoadingLifecycle {
+  const accountOnlyChanged =
+    previous.address !== current.address &&
+    previous.network === current.network &&
+    previous.provider === current.provider &&
+    previous.hip3ConfigVersion === current.hip3ConfigVersion;
+  return accountOnlyChanged ? 'account_switch' : 'network_switch';
+}
+
+export function usePerpsHomepageLoadingSession(
+  isFocused = true,
+): PerpsHomepageLoadingSession {
+  const address = useSelector(selectPerpsSelectedAccountAddress);
+  const network = useSelector(selectPerpsNetwork);
+  const provider = useSelector(selectPerpsProvider);
+  const hip3ConfigVersion = useSelector(selectHip3ConfigVersion);
+  const identity = useMemo<PerpsContextIdentity>(
+    () => ({ address, network, provider, hip3ConfigVersion }),
+    [address, hip3ConfigVersion, network, provider],
+  );
+  const proposedLifecycle = resolvePerpsLoadingLifecycle(
+    getPerpsLifecycleContext(),
+  );
+  const preparedRef = useRef(false);
+  // Arm during render so synchronous stream snapshots published before layout
+  // effects are buffered. The ref and cancel path make StrictMode re-renders
+  // idempotent and prevent an abandoned render from leaking into a later mount.
+  if (isFocused && !preparedRef.current) {
+    preparePerpsLoadingSession();
+    preparedRef.current = true;
+  }
+
+  const previousIdentityRef = useRef<PerpsContextIdentity | null>(null);
+  const identityRef = useRef(identity);
+  identityRef.current = identity;
+  const isFocusedRef = useRef(isFocused);
+  isFocusedRef.current = isFocused;
+  const appStateRef = useRef<AppStateStatus>(AppState.currentState);
+  const wasBackgroundedRef = useRef(AppState.currentState !== 'active');
+  const ownedSessionIdRef = useRef<string | null>(null);
+  const hasOwnedSessionRef = useRef(false);
+  const [sessionContext, setSessionContext] =
+    useState<PerpsLoadingSessionContext | null>(null);
+
+  const cancelOwnedOrPreparedSession = useCallback(
+    (reason: PerpsLoadingSessionCancellationReason) => {
+      const activeContext = getActivePerpsLoadingSessionContext();
+      if (
+        activeContext === null ||
+        activeContext.id === ownedSessionIdRef.current
+      ) {
+        cancelPerpsLoadingSession(reason);
+      }
+      ownedSessionIdRef.current = null;
+      hasOwnedSessionRef.current = false;
+      preparedRef.current = false;
+    },
+    [],
+  );
+
+  const beginSession = useCallback((lifecycle: PerpsLoadingLifecycle) => {
+    preparePerpsLoadingSession();
+    const sessionId = startPerpsLoadingSession({
+      lifecycle,
+      restart: getActivePerpsLoadingSessionContext() !== null,
+      surface: 'homepage',
+      identity: createPerpsLoadingSessionIdentity(identityRef.current),
+      provider: identityRef.current.provider,
+      network: identityRef.current.network,
+    });
+    ownedSessionIdRef.current = sessionId;
+    hasOwnedSessionRef.current = true;
+    preparedRef.current = false;
+    const activeContext = getActivePerpsLoadingSessionContext();
+    if (activeContext?.id === sessionId) {
+      setSessionContext(activeContext);
+    }
+  }, []);
+
+  useEffect(
+    () =>
+      subscribeToPerpsLoadingSession((update) => {
+        if (update.context.id !== ownedSessionIdRef.current) {
+          return;
+        }
+        if (update.type === 'cancelled' || update.type === 'timed_out') {
+          ownedSessionIdRef.current = null;
+          hasOwnedSessionRef.current = false;
+          setSessionContext((current) =>
+            current?.id && current.id !== update.context.id ? current : null,
+          );
+          return;
+        }
+        hasOwnedSessionRef.current = true;
+        setSessionContext(update.context);
+      }),
+    [],
+  );
+
+  useEffect(() => {
+    const previousIdentity = previousIdentityRef.current;
+
+    if (!isFocused) {
+      if (hasOwnedSessionRef.current || preparedRef.current) {
+        cancelOwnedOrPreparedSession('surface_unfocused');
+      }
+      previousIdentityRef.current = null;
+      return;
+    }
+    if (appStateRef.current !== 'active') {
+      return;
+    }
+    if (!previousIdentity) {
+      previousIdentityRef.current = identity;
+      beginSession(proposedLifecycle);
+      return;
+    }
+    if (identitiesMatch(previousIdentity, identity)) {
+      return;
+    }
+
+    previousIdentityRef.current = identity;
+    cancelOwnedOrPreparedSession('context_changed');
+    beginSession(lifecycleForIdentityChange(previousIdentity, identity));
+  }, [
+    beginSession,
+    cancelOwnedOrPreparedSession,
+    identity,
+    isFocused,
+    proposedLifecycle,
+  ]);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      const previousState = appStateRef.current;
+      appStateRef.current = nextState;
+
+      if (nextState !== 'active') {
+        wasBackgroundedRef.current = true;
+        if (hasOwnedSessionRef.current || preparedRef.current) {
+          cancelOwnedOrPreparedSession('app_backgrounded');
+        }
+        return;
+      }
+      if (nextState === 'active' && previousState !== 'active') {
+        if (!isFocusedRef.current) {
+          return;
+        }
+        const previousIdentity = previousIdentityRef.current;
+        const currentIdentity = identityRef.current;
+        if (!previousIdentity) {
+          previousIdentityRef.current = currentIdentity;
+        }
+        if (
+          previousIdentity &&
+          !identitiesMatch(previousIdentity, currentIdentity)
+        ) {
+          previousIdentityRef.current = currentIdentity;
+          wasBackgroundedRef.current = false;
+          cancelOwnedOrPreparedSession('context_changed');
+          beginSession(
+            lifecycleForIdentityChange(previousIdentity, currentIdentity),
+          );
+          return;
+        }
+        if (!wasBackgroundedRef.current && hasOwnedSessionRef.current) {
+          return;
+        }
+        const lifecycle = wasBackgroundedRef.current
+          ? 'background_short'
+          : proposedLifecycle;
+        wasBackgroundedRef.current = false;
+        beginSession(lifecycle);
+      }
+    });
+    return () => subscription.remove();
+  }, [beginSession, cancelOwnedOrPreparedSession, proposedLifecycle]);
+
+  useEffect(
+    () => () => {
+      if (hasOwnedSessionRef.current || preparedRef.current) {
+        cancelOwnedOrPreparedSession('surface_unmounted');
+      }
+      previousIdentityRef.current = null;
+    },
+    [cancelOwnedOrPreparedSession],
+  );
+
+  return {
+    proposedLifecycle,
+    sessionContext,
+    sessionReady: isFocused && sessionContext !== null,
+  };
+}

--- a/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsTrendingCarouselData.test.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsTrendingCarouselData.test.ts
@@ -31,4 +31,17 @@ describe('usePerpsTrendingCarouselData', () => {
 
     expect(result.current).toBe(initialResult);
   });
+
+  it('exposes refreshMarkets as the refresh function from usePerpsMarkets', () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    (usePerpsMarkets as jest.Mock).mockReturnValue({
+      markets: [],
+      isLoading: false,
+      refresh,
+    });
+
+    const { result } = renderHook(() => usePerpsTrendingCarouselData());
+
+    expect(result.current.refreshMarkets).toBe(refresh);
+  });
 });

--- a/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsTrendingCarouselData.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsTrendingCarouselData.ts
@@ -13,10 +13,16 @@ export interface UsePerpsTrendingCarouselDataArgs {
 export function usePerpsTrendingCarouselData({
   skipInitialFetch = false,
 }: UsePerpsTrendingCarouselDataArgs = {}) {
-  const { markets, isLoading: marketsLoading } = usePerpsMarkets({
+  const {
+    markets,
+    isLoading: marketsLoading,
+    hasResolvedInitialData,
+    refresh: refreshMarkets,
+  } = usePerpsMarkets({
     skipInitialFetch,
   });
   const watchlistSymbols = useSelector(selectPerpsWatchlistMarkets);
+  const marketsResolved = hasResolvedInitialData ?? !marketsLoading;
 
   const safeWatchlistSymbols = useMemo(
     () => watchlistSymbols ?? [],
@@ -60,9 +66,18 @@ export function usePerpsTrendingCarouselData({
     () => ({
       markets,
       marketsLoading,
+      hasResolvedInitialData: marketsResolved,
       allCarouselMarkets,
       watchlistSymbolSet,
+      refreshMarkets,
     }),
-    [markets, marketsLoading, allCarouselMarkets, watchlistSymbolSet],
+    [
+      markets,
+      marketsLoading,
+      marketsResolved,
+      allCarouselMarkets,
+      watchlistSymbolSet,
+      refreshMarkets,
+    ],
   );
 }

--- a/app/components/Views/Homepage/Sections/Watchlist/WatchlistSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Watchlist/WatchlistSection.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
 import WatchlistSection from './WatchlistSection';
 import Routes from '../../../../../constants/navigation/Routes';
+import { useSectionPerformance } from '../../hooks/useSectionPerformance';
 
 let mockIsWatchlistEnabled = true;
 const mockNavigate = jest.fn();
@@ -130,6 +131,24 @@ describe('WatchlistSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsWatchlistEnabled = true;
+  });
+
+  it('keeps the shared performance hook on its legacy metadata contract', () => {
+    mockUseTokenWatchlistQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+
+    render(<WatchlistSection sectionIndex={0} totalSectionsLoaded={1} />);
+
+    expect(jest.mocked(useSectionPerformance)).toHaveBeenCalledWith({
+      sectionId: 'watchlist',
+      contentReady: true,
+      isEmpty: true,
+      isLoading: false,
+      enabled: true,
+    });
   });
 
   it('returns null when feature flag is off', () => {

--- a/app/components/Views/Homepage/hooks/useHomeViewedEvent.test.ts
+++ b/app/components/Views/Homepage/hooks/useHomeViewedEvent.test.ts
@@ -647,6 +647,33 @@ describe('useHomeViewedEvent', () => {
       expect(mockSubscribeToScroll).not.toHaveBeenCalled();
     });
 
+    it('does not use stale shared visibility while loading', () => {
+      const mockRef = createMockRef(800, 200);
+      renderHook(() =>
+        useHomeViewedEvent({
+          ...defaultParams,
+          sectionRef: mockRef,
+          isLoading: true,
+          isVisible: true,
+        }),
+      );
+
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not use stale shared visibility after the section is removed', () => {
+      renderHook(() =>
+        useHomeViewedEvent({
+          ...defaultParams,
+          sectionRef: null,
+          isVisible: true,
+          fireImmediateWhenNoView: false,
+        }),
+      );
+
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+
     it('subscribes to scroll when a sectionRef is provided', () => {
       const mockRef = createMockRef(800, 200); // below viewport so no immediate fire
       renderHook(() =>

--- a/app/components/Views/Homepage/hooks/useHomeViewedEvent.test.ts
+++ b/app/components/Views/Homepage/hooks/useHomeViewedEvent.test.ts
@@ -629,6 +629,24 @@ describe('useHomeViewedEvent', () => {
   });
 
   describe('scroll subscription lifecycle', () => {
+    it('uses shared visibility without creating another scroll subscription', () => {
+      const mockRef = createMockRef(800, 200);
+      renderHook(() =>
+        useHomeViewedEvent({
+          ...defaultParams,
+          sectionRef: mockRef,
+          isVisible: true,
+        }),
+      );
+
+      expect(mockNotifySectionViewed).toHaveBeenCalledWith(
+        HomeSectionNames.TOKENS,
+        0,
+        true,
+      );
+      expect(mockSubscribeToScroll).not.toHaveBeenCalled();
+    });
+
     it('subscribes to scroll when a sectionRef is provided', () => {
       const mockRef = createMockRef(800, 200); // below viewport so no immediate fire
       renderHook(() =>

--- a/app/components/Views/Homepage/hooks/useHomeViewedEvent.ts
+++ b/app/components/Views/Homepage/hooks/useHomeViewedEvent.ts
@@ -154,10 +154,10 @@ const useHomeViewedEvent = ({
   }, [sectionRef, isLoading, fireEvent, visitId, fireImmediateWhenNoView]);
 
   useEffect(() => {
-    if (isVisible) {
+    if (sectionRef !== null && !isLoading && isVisible) {
       fireEvent();
     }
-  }, [fireEvent, isVisible]);
+  }, [fireEvent, isLoading, isVisible, sectionRef]);
 
   // Holds the latest checkVisibility so the onLayout callback can re-trigger
   // a check after the native layout pass completes.

--- a/app/components/Views/Homepage/hooks/useHomeViewedEvent.ts
+++ b/app/components/Views/Homepage/hooks/useHomeViewedEvent.ts
@@ -40,6 +40,8 @@ interface UseHomeViewedEventParams {
    * E.g. for Tokens: number of token rows. For NFTs in empty state: 0.
    */
   itemCount: number;
+  /** Optional shared viewport state. When provided, skip this hook's own measurement. */
+  isVisible?: boolean;
   /**
    * When `sectionRef` is `null` and loading has finished, fire `HOME_VIEWED`
    * once (e.g. What's Happening with no items still wants an empty impression).
@@ -71,6 +73,7 @@ const useHomeViewedEvent = ({
   totalSectionsLoaded,
   isEmpty,
   itemCount,
+  isVisible,
   fireImmediateWhenNoView = true,
 }: UseHomeViewedEventParams) => {
   const {
@@ -150,6 +153,12 @@ const useHomeViewedEvent = ({
     fireEvent();
   }, [sectionRef, isLoading, fireEvent, visitId, fireImmediateWhenNoView]);
 
+  useEffect(() => {
+    if (isVisible) {
+      fireEvent();
+    }
+  }, [fireEvent, isVisible]);
+
   // Holds the latest checkVisibility so the onLayout callback can re-trigger
   // a check after the native layout pass completes.
   const checkVisibilityRef = useRef<() => void>(() => undefined);
@@ -158,7 +167,13 @@ const useHomeViewedEvent = ({
   // every scroll event. Uses subscribeToScroll so no React re-renders occur
   // during scrolling.
   useEffect(() => {
-    if (isLoading || !sectionRef?.current || viewportHeight === 0) return;
+    if (
+      isVisible !== undefined ||
+      isLoading ||
+      !sectionRef?.current ||
+      viewportHeight === 0
+    )
+      return;
 
     const checkVisibility = () => {
       if (hasFiredRef.current) return;
@@ -197,6 +212,7 @@ const useHomeViewedEvent = ({
     sectionRef,
     subscribeToScroll,
     fireEvent,
+    isVisible,
     isLoading,
   ]);
 

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
@@ -7,6 +7,8 @@ import { useSectionPerformance } from './useSectionPerformance';
 jest.mock('../../../../util/trace', () => ({
   trace: jest.fn(),
   endTrace: jest.fn(),
+  getTraceContext: jest.fn(),
+  annotateTrace: jest.fn(),
   TraceName: {
     HomepageSectionTimeToContent: 'Homepage Section Time To Content',
     HomepageSectionDataFetch: 'Homepage Section Data Fetch',
@@ -21,9 +23,12 @@ jest.mock('react-native-performance', () => ({
   now: jest.fn(() => mockPerfNowValue),
 }));
 
-const { trace: mockTrace, endTrace: mockEndTrace } = jest.requireMock(
-  '../../../../util/trace',
-);
+const {
+  trace: mockTrace,
+  endTrace: mockEndTrace,
+  getTraceContext: mockGetTraceContext,
+  annotateTrace: mockAnnotateTrace,
+} = jest.requireMock('../../../../util/trace');
 const mockAddBreadcrumb = addBreadcrumb as jest.MockedFunction<
   typeof addBreadcrumb
 >;
@@ -38,19 +43,20 @@ describe('useSectionPerformance', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockPerfNowValue = 0;
+    mockGetTraceContext.mockReturnValue({ spanId: 'section-span' });
   });
 
   describe('Time to Content', () => {
     it('starts a trace on mount', () => {
       renderHook(() => useSectionPerformance(defaultConfig));
 
-      expect(mockTrace).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: TraceName.HomepageSectionTimeToContent,
-          op: TraceOperation.HomepageSectionPerformance,
-          tags: { section_id: HomeSectionNames.TOKENS },
-        }),
-      );
+      expect(mockTrace).toHaveBeenCalledWith({
+        name: TraceName.HomepageSectionTimeToContent,
+        op: TraceOperation.HomepageSectionPerformance,
+        id: expect.any(String),
+        tags: { section_id: HomeSectionNames.TOKENS },
+        data: { section_id: HomeSectionNames.TOKENS },
+      });
     });
 
     it('ends the trace when contentReady flips to true', () => {
@@ -154,6 +160,41 @@ describe('useSectionPerformance', () => {
       );
     });
 
+    it('keeps the latest TTC cohort metadata when unmounted', () => {
+      const { rerender, unmount } = renderHook(
+        ({ lifecycle, sessionId }: { lifecycle: string; sessionId: string }) =>
+          useSectionPerformance({
+            ...defaultConfig,
+            tags: { lifecycle },
+            data: { perps_session_id: sessionId },
+          }),
+        {
+          initialProps: {
+            lifecycle: 'cold_no_cache',
+            sessionId: 'session-id-1',
+          },
+        },
+      );
+
+      rerender({
+        lifecycle: 'background_reconnect',
+        sessionId: 'session-id-2',
+      });
+
+      unmount();
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.HomepageSectionTimeToContent,
+          data: expect.objectContaining({
+            lifecycle: 'background_reconnect',
+            perps_session_id: 'session-id-2',
+            success: false,
+          }),
+        }),
+      );
+    });
+
     it('does not end with failure on unmount if content was already ready', () => {
       const { rerender, unmount } = renderHook(
         ({ contentReady }) =>
@@ -167,6 +208,76 @@ describe('useSectionPerformance', () => {
       unmount();
 
       expect(mockEndTrace).not.toHaveBeenCalled();
+    });
+
+    it('restarts traces without relabelling the cancelled generation', () => {
+      const { rerender } = renderHook(
+        ({ enabled, generationKey, lifecycle, sessionId }) =>
+          useSectionPerformance({
+            ...defaultConfig,
+            enabled,
+            generationKey,
+            isLoading: true,
+            tags: { lifecycle },
+            data: sessionId ? { perps_session_id: sessionId } : undefined,
+          }),
+        {
+          initialProps: {
+            enabled: true,
+            generationKey: 'session-id-1' as string | undefined,
+            lifecycle: 'cold_no_cache',
+            sessionId: 'session-id-1' as string | undefined,
+          },
+        },
+      );
+
+      rerender({
+        enabled: false,
+        generationKey: undefined,
+        lifecycle: 'background_short',
+        sessionId: undefined,
+      });
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.HomepageSectionTimeToContent,
+          data: expect.objectContaining({
+            lifecycle: 'cold_no_cache',
+            perps_session_id: 'session-id-1',
+            reason: 'unfocused',
+            success: false,
+          }),
+        }),
+      );
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.HomepageSectionDataFetch,
+          data: expect.objectContaining({
+            lifecycle: 'cold_no_cache',
+            perps_session_id: 'session-id-1',
+            reason: 'unfocused',
+            success: false,
+          }),
+        }),
+      );
+
+      jest.clearAllMocks();
+      rerender({
+        enabled: true,
+        generationKey: 'session-id-2',
+        lifecycle: 'background_short',
+        sessionId: 'session-id-2',
+      });
+
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.HomepageSectionTimeToContent,
+          tags: expect.objectContaining({ lifecycle: 'background_short' }),
+          data: expect.objectContaining({
+            perps_session_id: 'session-id-2',
+          }),
+        }),
+      );
     });
   });
 
@@ -264,6 +375,42 @@ describe('useSectionPerformance', () => {
           data: expect.objectContaining({
             success: false,
             reason: 'unmounted',
+          }),
+        }),
+      );
+    });
+
+    it('keeps the latest DFD cohort metadata when unmounted', () => {
+      const { rerender, unmount } = renderHook(
+        ({ lifecycle, sessionId }: { lifecycle: string; sessionId: string }) =>
+          useSectionPerformance({
+            ...defaultConfig,
+            isLoading: true,
+            tags: { lifecycle },
+            data: { perps_session_id: sessionId },
+          }),
+        {
+          initialProps: {
+            lifecycle: 'cold_no_cache',
+            sessionId: 'session-id-1',
+          },
+        },
+      );
+
+      rerender({
+        lifecycle: 'background_reconnect',
+        sessionId: 'session-id-2',
+      });
+
+      unmount();
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.HomepageSectionDataFetch,
+          data: expect.objectContaining({
+            lifecycle: 'background_reconnect',
+            perps_session_id: 'session-id-2',
+            success: false,
           }),
         }),
       );
@@ -426,6 +573,202 @@ describe('useSectionPerformance', () => {
       expect(mockEndTrace).not.toHaveBeenCalled();
     });
 
+    it.each([
+      TraceName.HomepageSectionTimeToContent,
+      TraceName.HomepageSectionDataFetch,
+    ])('applies bounded metadata to %s', (traceName) => {
+      const tags = {
+        content_variant: 'trending',
+        market_source: 'provider',
+        account_source: 'memory_cache',
+        lifecycle: 'cold_no_cache',
+      };
+      const { rerender } = renderHook(
+        ({ isLoading, contentReady }) =>
+          useSectionPerformance({
+            ...defaultConfig,
+            contentReady,
+            isLoading,
+            tags,
+            data: { perps_session_id: 'session-id-1' },
+          }),
+        { initialProps: { isLoading: true, contentReady: false } },
+      );
+
+      rerender({ isLoading: false, contentReady: true });
+
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: traceName,
+          tags: expect.objectContaining({
+            ...tags,
+            section_id: HomeSectionNames.TOKENS,
+          }),
+        }),
+      );
+      const start = (mockTrace as jest.Mock).mock.calls.find(
+        (call: [{ name: TraceName }]) => call[0].name === traceName,
+      )?.[0] as {
+        tags: Record<string, unknown>;
+        data: Record<string, unknown>;
+      };
+      expect(start.tags).not.toHaveProperty('success');
+      expect(start.tags).not.toHaveProperty('content_state');
+      expect(start.data).toEqual({
+        perps_session_id: 'session-id-1',
+        section_id: HomeSectionNames.TOKENS,
+      });
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: traceName,
+          data: expect.objectContaining({
+            success: true,
+            content_state: 'filled',
+            perps_session_id: 'session-id-1',
+          }),
+        }),
+      );
+    });
+
+    it.each([
+      TraceName.HomepageSectionTimeToContent,
+      TraceName.HomepageSectionDataFetch,
+    ])('keeps hook-owned fields authoritative on %s', (traceName) => {
+      const { rerender } = renderHook(
+        ({ contentReady, isLoading }) =>
+          useSectionPerformance({
+            ...defaultConfig,
+            contentReady,
+            isLoading,
+            tags: {
+              section_id: 'wrong-section',
+              success: false,
+              content_state: 'error',
+            },
+            data: {
+              section_id: 'wrong-section',
+              success: false,
+              content_state: 'error',
+            },
+          }),
+        { initialProps: { contentReady: false, isLoading: true } },
+      );
+
+      rerender({ contentReady: true, isLoading: false });
+
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: traceName,
+          tags: expect.objectContaining({
+            section_id: HomeSectionNames.TOKENS,
+          }),
+        }),
+      );
+      const start = (mockTrace as jest.Mock).mock.calls.find(
+        (call: [{ name: TraceName }]) => call[0].name === traceName,
+      )?.[0] as { tags: Record<string, unknown> };
+      expect(start.tags).not.toHaveProperty('success');
+      expect(start.tags).not.toHaveProperty('content_state');
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: traceName,
+          data: expect.objectContaining({
+            section_id: HomeSectionNames.TOKENS,
+            success: true,
+            content_state: 'filled',
+          }),
+        }),
+      );
+    });
+
+    it('updates later-resolved tags on the existing span', () => {
+      const initialTags = {
+        content_variant: 'trending',
+        market_source: 'memory_cache',
+        account_source: 'memory_cache',
+        lifecycle: 'cold_no_cache',
+      };
+      const resolvedTags = {
+        content_variant: 'positions',
+        market_source: 'terminal_v2',
+        account_source: 'fresh_socket',
+        lifecycle: 'cold_no_cache',
+      };
+      const span = { spanId: 'ttc-span' };
+      mockGetTraceContext.mockReturnValue(span);
+
+      const { rerender } = renderHook(
+        ({ contentReady, tags }) =>
+          useSectionPerformance({
+            ...defaultConfig,
+            contentReady,
+            tags,
+            data: { perps_session_id: 'session-id-1' },
+          }),
+        { initialProps: { contentReady: false, tags: initialTags } },
+      );
+
+      const ttcStart = (mockTrace as jest.Mock).mock.calls.find(
+        (call: [{ name: string }]) =>
+          call[0].name === TraceName.HomepageSectionTimeToContent,
+      )?.[0] as { id: string };
+
+      rerender({ contentReady: true, tags: resolvedTags });
+
+      expect(mockTrace).toHaveBeenCalledTimes(1);
+      expect(mockGetTraceContext).toHaveBeenCalledWith({
+        name: TraceName.HomepageSectionTimeToContent,
+        id: ttcStart.id,
+      });
+      expect(mockAnnotateTrace).toHaveBeenCalledWith(span, resolvedTags);
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.HomepageSectionTimeToContent,
+          id: ttcStart.id,
+          data: expect.objectContaining(resolvedTags),
+        }),
+      );
+    });
+
+    it('keeps existing error success and content_state when bounded tags are present', () => {
+      const { rerender } = renderHook(
+        ({ contentReady }) =>
+          useSectionPerformance({
+            ...defaultConfig,
+            contentReady,
+            contentStateForTrace: 'error',
+            tags: {
+              content_variant: 'error',
+              market_source: 'provider',
+              account_source: 'fresh_socket',
+              lifecycle: 'cold_no_cache',
+            },
+            data: { perps_session_id: 'session-id-1' },
+          }),
+        { initialProps: { contentReady: false } },
+      );
+
+      rerender({ contentReady: true });
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.HomepageSectionTimeToContent,
+          data: expect.objectContaining({
+            success: true,
+            content_state: 'error',
+            perps_session_id: 'session-id-1',
+          }),
+        }),
+      );
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tags: expect.not.objectContaining({
+            perps_session_id: 'session-id-1',
+          }),
+        }),
+      );
+    });
+
     it('ends TTC with success when enabled becomes true while contentReady is already true', () => {
       const { rerender } = renderHook(
         ({ enabled }) =>
@@ -455,6 +798,43 @@ describe('useSectionPerformance', () => {
             section_id: HomeSectionNames.TOKENS,
             content_state: 'filled',
           }),
+        }),
+      );
+    });
+
+    it('waits for fresh content before ending a restarted TTC', () => {
+      const { rerender } = renderHook(
+        ({ contentReady, generationKey }) =>
+          useSectionPerformance({
+            ...defaultConfig,
+            contentReady,
+            generationKey,
+          }),
+        {
+          initialProps: {
+            contentReady: true,
+            generationKey: 'session-1',
+          },
+        },
+      );
+      jest.clearAllMocks();
+
+      rerender({ contentReady: true, generationKey: 'session-2' });
+
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.HomepageSectionTimeToContent,
+        }),
+      );
+      expect(mockEndTrace).not.toHaveBeenCalled();
+
+      rerender({ contentReady: false, generationKey: 'session-2' });
+      rerender({ contentReady: true, generationKey: 'session-2' });
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.HomepageSectionTimeToContent,
+          data: expect.objectContaining({ success: true }),
         }),
       );
     });

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
@@ -838,5 +838,33 @@ describe('useSectionPerformance', () => {
         }),
       );
     });
+
+    it('accepts ready resident content for an opted-in restarted TTC', () => {
+      const { rerender } = renderHook(
+        ({ generationKey }) =>
+          useSectionPerformance({
+            ...defaultConfig,
+            contentReady: true,
+            generationKey,
+            acceptReadyContentOnGenerationStart: true,
+          }),
+        { initialProps: { generationKey: 'session-1' } },
+      );
+      jest.clearAllMocks();
+
+      rerender({ generationKey: 'session-2' });
+
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.HomepageSectionTimeToContent,
+        }),
+      );
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.HomepageSectionTimeToContent,
+          data: expect.objectContaining({ success: true }),
+        }),
+      );
+    });
   });
 });

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.ts
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import {
+  annotateTrace,
   endTrace,
+  getTraceContext,
   trace,
   TraceName,
   TraceOperation,
@@ -37,10 +39,43 @@ interface UseSectionPerformanceConfig {
   reRenderThreshold?: number;
   /** Sliding window in ms for re-render detection. @default 500 */
   reRenderWindowMs?: number;
+  /** Bounded cohort tags applied to the existing TTC and DFD starts. */
+  tags?: Record<string, string | number | boolean>;
+  /** Trace data/context applied to the existing TTC and DFD ends. */
+  data?: Record<string, string | number | boolean>;
+  /** Restarts TTC/DFD when one mounted surface begins a new data generation. */
+  generationKey?: string;
 }
 
 const DEFAULT_RE_RENDER_THRESHOLD = 3;
 const DEFAULT_RE_RENDER_WINDOW_MS = 500;
+const RESERVED_METADATA_KEYS = new Set([
+  'section_id',
+  'success',
+  'content_state',
+  'reason',
+]);
+
+const sanitizeMetadata = (
+  metadata?: Record<string, string | number | boolean>,
+) =>
+  metadata
+    ? Object.fromEntries(
+        Object.entries(metadata).filter(
+          ([key]) => !RESERVED_METADATA_KEYS.has(key),
+        ),
+      )
+    : undefined;
+
+const resolveCancellationReason = (
+  startedGenerationKey: string | undefined,
+  nextGenerationKey: string | undefined,
+) => {
+  if (nextGenerationKey === startedGenerationKey) {
+    return 'unmounted';
+  }
+  return nextGenerationKey === undefined ? 'unfocused' : 'generation_changed';
+};
 
 /**
  * Reusable performance telemetry for homepage sections.
@@ -61,11 +96,39 @@ export const useSectionPerformance = ({
   enabled = true,
   reRenderThreshold = DEFAULT_RE_RENDER_THRESHOLD,
   reRenderWindowMs = DEFAULT_RE_RENDER_WINDOW_MS,
+  tags,
+  data,
+  generationKey,
 }: UseSectionPerformanceConfig) => {
+  const nextTagsRef = useRef(sanitizeMetadata(tags));
+  nextTagsRef.current = sanitizeMetadata(tags);
+  const nextDataRef = useRef(sanitizeMetadata(data));
+  nextDataRef.current = sanitizeMetadata(data);
+  const pendingGenerationKeyRef = useRef(generationKey);
+  pendingGenerationKeyRef.current = generationKey;
+  const contentReadyRef = useRef(contentReady);
+  contentReadyRef.current = contentReady;
+  const activeGenerationKeyRef = useRef(generationKey);
+  const tagsRef = useRef(nextTagsRef.current);
+  const dataRef = useRef(nextDataRef.current);
+  if (activeGenerationKeyRef.current === generationKey) {
+    tagsRef.current = nextTagsRef.current;
+    dataRef.current = nextDataRef.current;
+  }
+
+  const annotateLatestTags = (name: TraceName, id: string) => {
+    if (!tagsRef.current) {
+      return;
+    }
+    annotateTrace(getTraceContext({ name, id }), tagsRef.current);
+  };
+
   // --- Time to Content refs ---
   const ttcTraceId = useRef(uuidv4());
   const ttcStarted = useRef(false);
   const ttcEnded = useRef(false);
+  const hasStartedTtcGeneration = useRef(false);
+  const ttcReadyForCompletion = useRef(true);
 
   // --- Data Fetch Latency refs ---
   const fetchTraceId = useRef(uuidv4());
@@ -90,45 +153,97 @@ export const useSectionPerformance = ({
   // 1. Time to Content — start span on mount
   // ──────────────────────────────────────────────
   useEffect(() => {
+    activeGenerationKeyRef.current = generationKey;
+    tagsRef.current = nextTagsRef.current;
+    dataRef.current = nextDataRef.current;
+    fetchStarted.current = false;
+    fetchEnded.current = false;
+    prevIsLoading.current = undefined;
     if (!enabled) return;
 
+    const startedGenerationKey = generationKey;
+    const isRestart = hasStartedTtcGeneration.current;
+    hasStartedTtcGeneration.current = true;
+    ttcReadyForCompletion.current = !isRestart || !contentReadyRef.current;
     ttcTraceId.current = uuidv4();
     ttcEnded.current = false;
     trace({
       name: TraceName.HomepageSectionTimeToContent,
       op: TraceOperation.HomepageSectionPerformance,
       id: ttcTraceId.current,
-      tags: { section_id: sectionId },
+      tags: { ...tagsRef.current, section_id: sectionId },
+      data: { ...dataRef.current, section_id: sectionId },
     });
     ttcStarted.current = true;
 
     return () => {
       if (ttcStarted.current && !ttcEnded.current) {
+        annotateLatestTags(
+          TraceName.HomepageSectionTimeToContent,
+          ttcTraceId.current,
+        );
         endTrace({
           name: TraceName.HomepageSectionTimeToContent,
           id: ttcTraceId.current,
-          data: { success: false, reason: 'unmounted', section_id: sectionId },
+          data: {
+            ...tagsRef.current,
+            ...dataRef.current,
+            success: false,
+            reason: resolveCancellationReason(
+              startedGenerationKey,
+              pendingGenerationKeyRef.current,
+            ),
+            section_id: sectionId,
+          },
         });
         ttcStarted.current = false;
       }
       if (fetchStarted.current && !fetchEnded.current) {
+        annotateLatestTags(
+          TraceName.HomepageSectionDataFetch,
+          fetchTraceId.current,
+        );
         endTrace({
           name: TraceName.HomepageSectionDataFetch,
           id: fetchTraceId.current,
-          data: { success: false, reason: 'unmounted', section_id: sectionId },
+          data: {
+            ...tagsRef.current,
+            ...dataRef.current,
+            success: false,
+            reason: resolveCancellationReason(
+              startedGenerationKey,
+              pendingGenerationKeyRef.current,
+            ),
+            section_id: sectionId,
+          },
         });
         fetchStarted.current = false;
       }
     };
-  }, [enabled, sectionId]);
+  }, [enabled, generationKey, sectionId]);
 
   // Time to Content — end span when content is ready
   useEffect(() => {
-    if (enabled && contentReady && ttcStarted.current && !ttcEnded.current) {
+    if (!contentReady) {
+      ttcReadyForCompletion.current = true;
+      return;
+    }
+    if (
+      enabled &&
+      ttcReadyForCompletion.current &&
+      ttcStarted.current &&
+      !ttcEnded.current
+    ) {
+      annotateLatestTags(
+        TraceName.HomepageSectionTimeToContent,
+        ttcTraceId.current,
+      );
       endTrace({
         name: TraceName.HomepageSectionTimeToContent,
         id: ttcTraceId.current,
         data: {
+          ...tagsRef.current,
+          ...dataRef.current,
           success: true,
           section_id: sectionId,
           content_state: traceContentState,
@@ -136,7 +251,7 @@ export const useSectionPerformance = ({
       });
       ttcEnded.current = true;
     }
-  }, [enabled, contentReady, sectionId, traceContentState]);
+  }, [enabled, contentReady, generationKey, sectionId, traceContentState]);
 
   // ──────────────────────────────────────────────
   // 2. Data Fetch Latency — track isLoading transitions
@@ -154,7 +269,8 @@ export const useSectionPerformance = ({
         name: TraceName.HomepageSectionDataFetch,
         op: TraceOperation.HomepageSectionPerformance,
         id: fetchTraceId.current,
-        tags: { section_id: sectionId },
+        tags: { ...tagsRef.current, section_id: sectionId },
+        data: { ...dataRef.current, section_id: sectionId },
       });
       fetchStarted.current = true;
     }
@@ -166,10 +282,16 @@ export const useSectionPerformance = ({
       fetchStarted.current &&
       !fetchEnded.current
     ) {
+      annotateLatestTags(
+        TraceName.HomepageSectionDataFetch,
+        fetchTraceId.current,
+      );
       endTrace({
         name: TraceName.HomepageSectionDataFetch,
         id: fetchTraceId.current,
         data: {
+          ...tagsRef.current,
+          ...dataRef.current,
           success: true,
           section_id: sectionId,
           content_state: traceContentState,
@@ -178,5 +300,5 @@ export const useSectionPerformance = ({
       fetchStarted.current = false;
       fetchEnded.current = true;
     }
-  }, [enabled, isLoading, sectionId, traceContentState]);
+  }, [enabled, generationKey, isLoading, sectionId, traceContentState]);
 };

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.ts
@@ -45,6 +45,8 @@ interface UseSectionPerformanceConfig {
   data?: Record<string, string | number | boolean>;
   /** Restarts TTC/DFD when one mounted surface begins a new data generation. */
   generationKey?: string;
+  /** Accept content that is already valid when a warm generation starts. */
+  acceptReadyContentOnGenerationStart?: boolean;
 }
 
 const DEFAULT_RE_RENDER_THRESHOLD = 3;
@@ -99,6 +101,7 @@ export const useSectionPerformance = ({
   tags,
   data,
   generationKey,
+  acceptReadyContentOnGenerationStart = false,
 }: UseSectionPerformanceConfig) => {
   const nextTagsRef = useRef(sanitizeMetadata(tags));
   nextTagsRef.current = sanitizeMetadata(tags);
@@ -108,6 +111,11 @@ export const useSectionPerformance = ({
   pendingGenerationKeyRef.current = generationKey;
   const contentReadyRef = useRef(contentReady);
   contentReadyRef.current = contentReady;
+  const acceptReadyContentOnGenerationStartRef = useRef(
+    acceptReadyContentOnGenerationStart,
+  );
+  acceptReadyContentOnGenerationStartRef.current =
+    acceptReadyContentOnGenerationStart;
   const activeGenerationKeyRef = useRef(generationKey);
   const tagsRef = useRef(nextTagsRef.current);
   const dataRef = useRef(nextDataRef.current);
@@ -164,7 +172,10 @@ export const useSectionPerformance = ({
     const startedGenerationKey = generationKey;
     const isRestart = hasStartedTtcGeneration.current;
     hasStartedTtcGeneration.current = true;
-    ttcReadyForCompletion.current = !isRestart || !contentReadyRef.current;
+    ttcReadyForCompletion.current =
+      !isRestart ||
+      !contentReadyRef.current ||
+      acceptReadyContentOnGenerationStartRef.current;
     ttcTraceId.current = uuidv4();
     ttcEnded.current = false;
     trace({

--- a/tests/component-view/renderers/perpsViewRenderer.tsx
+++ b/tests/component-view/renderers/perpsViewRenderer.tsx
@@ -159,6 +159,7 @@ type StreamCallback<T> = (data: T | null) => void;
 interface MutableStreamChannel<T> {
   subscribe: (params: { callback: StreamCallback<T> }) => () => void;
   getSnapshot: () => T | null;
+  getLastDeliveredAt: () => number | null;
   emit: (data: T | null) => void;
   refresh: () => Promise<void>;
   clearCache: () => void;
@@ -177,10 +178,12 @@ function mutableChannelWithInitialValue<T>(
   initialValue: T,
 ): MutableStreamChannel<T> {
   let snapshot: T | null = initialValue;
+  let lastDeliveredAt: number | null = null;
   const subscribers = new Set<StreamCallback<T>>();
 
   const emit = (data: T | null) => {
     snapshot = data;
+    lastDeliveredAt = Date.now();
     subscribers.forEach((callback) => callback(snapshot));
   };
 
@@ -188,6 +191,7 @@ function mutableChannelWithInitialValue<T>(
     subscribe: (params: { callback: StreamCallback<T> }): (() => void) => {
       if (params?.callback) {
         subscribers.add(params.callback);
+        lastDeliveredAt = Date.now();
         params.callback(snapshot);
       }
       return () => {
@@ -195,6 +199,7 @@ function mutableChannelWithInitialValue<T>(
       };
     },
     getSnapshot: () => snapshot,
+    getLastDeliveredAt: () => lastDeliveredAt,
     emit,
     refresh: async (): Promise<void> => undefined,
     clearCache: (): void => {

--- a/tests/integration/harnesses/perps/perps-component.tsx
+++ b/tests/integration/harnesses/perps/perps-component.tsx
@@ -229,12 +229,15 @@ const testHardwareWalletValue: HardwareWalletContextValue = {
 };
 
 function channelWithInitialValue<T>(initialValue: T) {
+  let lastDeliveredAt: number | null = null;
   return {
     subscribe: (params: { callback: (data: T) => void }): (() => void) => {
+      lastDeliveredAt = Date.now();
       params.callback(initialValue);
       return noopUnsubscribe;
     },
     getSnapshot: () => initialValue,
+    getLastDeliveredAt: () => lastDeliveredAt,
   };
 }
 


### PR DESCRIPTION
## **Description**

Measures when the Wallet Homepage Perps section is requested, first committed, resolved, and backed by lifecycle-valid live data. The records share one session and generation identity, so account, network, and background changes cannot complete an older measurement.

This is the Homepage integration built on the measurement foundation from #35356. It also keeps resident market data visible during account-only reconnects and reports whether the visible content came from retained context or a fresh provider delivery.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/TAT-3608
Depends on: https://github.com/MetaMask/metamask-mobile/pull/35356

## **Manual testing steps**

```gherkin
Feature: Perps Homepage lifecycle measurement

  Scenario: Account, network, and background transitions produce isolated measurements
    Given the wallet is unlocked on the Perps Homepage
    When the selected account or Perps network changes, or the app reconnects after a long background period
    Then the visible Perps section remains coherent
    And its demand, resolved, and live records share the same lifecycle and generation identity
    And stale data from the previous context cannot complete the measurement
```

## **Device validation**

Initial runtime validation passed on Android Pixel 6 at commit `20cae2a0b98d2acd463bed9286fa0ababa95d645`:

- Account switch: pass
- Mainnet to testnet switch: pass
- Long background reconnect: 37/37 steps pass
- Every run recorded no automatic recovery and no financial mutation

Follow-up review repairs at `70cd518d3924004c659ad69a93b657c185a6832b` close three measurement edge cases: hidden empty pills no longer wait for market data, warm resident content completes only warm lifecycle timing, and stale viewport visibility cannot emit while loading or after removal. The focused behavior suites pass.

Final happy-path proof at `d033ca527f13fd5e291236c0764e88c5bca1a4e9` passed 34/34 on Pixel 6 with released tooling `0.44.1`, `recovered: []`, and `mutations: []`. Cold demand began before data was ready (`data_ready_at_demand=false`), then resolved and live provider data completed after 4.73 seconds with one coherent session and generation identity. Claude and Codex approved the exact head with zero findings.

## **Screenshots/Recordings**

### **Before**

N/A. This PR does not change the UI.

### **After**

N/A. Validation inspected the visible Perps section, raw lifecycle records, and exact source provenance on device.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR. Not required for external contributors.

#### Performance checks

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Perps market data subscribes and how Homepage loading/performance traces complete, which can affect loading UX and metric semantics during account/network switches without altering visible UI layout.
> 
> **Overview**
> Wires **Homepage Perps** into lifecycle-aware loading measurement: the section owns a **loading session** (focus, app background, account/network identity), correlates **TTC/DFD** traces via `perps_session_id` and cohort tags, emits **dev-only surface stage** logs, and **finishes** sessions for filled, empty, hidden, and error outcomes.
> 
> Adds **`usePerpsMarketContext`** so UI knows when the selected market identity matches an initialized connection generation. **`usePerpsMarkets`** defers subscription until context is ready, exposes **`hasResolvedInitialData`**, resets on identity change, and **keeps resident markets** visible across account reconnects without tearing down the stream.
> 
> Extends shared **`useSectionPerformance`** (generation restarts, bounded tags/data, `acceptReadyContentOnGenerationStart`) and **`useHomeViewedEvent`** (optional shared **`isVisible`**). Trending carousel gains **`refreshMarkets`** for section pull-to-refresh. Test doubles add **`getLastDeliveredAt`** on market streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd5be4dc8685370b48cdee39b34499e0035bba82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->