### PR TITLE
chore: add Predict team as renderer codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -369,7 +369,7 @@ tests/*.js                                                      @MetaMask/qa
 tests/*.ts                                                      @MetaMask/qa
 tests/api-mocking/                                              @MetaMask/qa
 tests/component-view/                                           @MetaMask/qa
-tests/component-view/renderers/predictNext.ts                    @MetaMask/qa @MetaMask/predict
+tests/component-view/renderers/predictNext.ts                   @MetaMask/qa @MetaMask/predict
 tests/controller-mocking/                                       @MetaMask/qa
 tests/feature-flags/                                            @MetaMask/qa
 tests/flows/                                                    @MetaMask/qa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -369,6 +369,7 @@ tests/*.js                                                      @MetaMask/qa
 tests/*.ts                                                      @MetaMask/qa
 tests/api-mocking/                                              @MetaMask/qa
 tests/component-view/                                           @MetaMask/qa
+tests/component-view/renderers/predictNext.ts                    @MetaMask/qa @MetaMask/predict
 tests/controller-mocking/                                       @MetaMask/qa
 tests/feature-flags/                                            @MetaMask/qa
 tests/flows/                                                    @MetaMask/qa


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
-->

## **Description**

Added the Predict team as a codeowner for `tests/component-view/renderers/predictNext.ts`, while retaining the existing QA team ownership.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A — no issue was provided for this maintenance change.

## **Manual testing steps**

1. Reviewed the CODEOWNERS rule for the exact renderer path.
2. Ran `git diff --check`.
3. Confirmed the branch was pushed successfully.

## **Screenshots/Recordings**

N/A — this is a repository metadata-only change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md).) Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android — not applicable to this repository metadata-only change
- [ ] I've tested with a power user scenario — not applicable to this repository metadata-only change
- [ ] I've instrumented key operations with Sentry traces for production performance metrics — not applicable to this repository metadata-only change

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only CODEOWNERS update with no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds **@MetaMask/predict** as a co-codeowner on `tests/component-view/renderers/predictNext.ts` in `.github/CODEOWNERS`, alongside the existing **@MetaMask/qa** ownership for the component-view E2E area.
> 
> This is repository metadata only: PRs touching that Predict Next component-view renderer will require review from both QA and Predict, without changing application or test code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c3b2e5f33c94b408aa76792bf2b543b64e173e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->