### PR TITLE
feat(subscriptions): show plan-specific ATM fees copy for monthly vs annual

### DIFF
--- a/app/components/Views/ProSubscription/screens/Benefits/Benefits.constants.ts
+++ b/app/components/Views/ProSubscription/screens/Benefits/Benefits.constants.ts
@@ -44,6 +44,8 @@ export interface BenefitDetailItem {
   title: string;
   /** i18n key for the main description paragraph. */
   description: string;
+  /** i18n key for monthly-plan variant of the description (used when plan = monthly). */
+  descriptionMonthly?: string;
   /** i18n keys for bullet-point list items (cashback, member_pricing). */
   points?: string[];
   /** i18n key for the secondary description paragraph (protection). */
@@ -86,6 +88,8 @@ export const BENEFIT_DETAILS: BenefitDetailItem[] = [
     id: 'atm_fees',
     title: 'pro_subscription.benefits.atm_fees.title',
     description: 'pro_subscription.benefits_description.atm_fees.description',
+    descriptionMonthly:
+      'pro_subscription.benefits_description.atm_fees.description_monthly',
   },
   {
     id: 'protection',

--- a/app/components/Views/ProSubscription/screens/Benefits/Benefits.test.tsx
+++ b/app/components/Views/ProSubscription/screens/Benefits/Benefits.test.tsx
@@ -316,4 +316,45 @@ describe('Benefits', () => {
       );
     });
   });
+
+  // ── Plan-specific content ──────────────────────────────────────────────────
+
+  describe('Plan-specific ATM fees content', () => {
+    it('shows monthly subtitle and description for atm_fees when monthly plan is selected', () => {
+      const { getByTestId, getByText, queryByText } = renderBenefits();
+
+      // Default is annual — verify annual subtitle is shown
+      expect(
+        getByText(strings('pro_subscription.benefits.atm_fees.subtitle')),
+      ).toBeOnTheScreen();
+
+      // Switch to monthly plan
+      fireEvent.press(getByTestId(BenefitsTestIds.PLAN_CARD('monthly')));
+
+      // Subtitle should now be the monthly variant
+      expect(
+        getByText(
+          strings('pro_subscription.benefits.atm_fees.subtitle_monthly'),
+        ),
+      ).toBeOnTheScreen();
+      expect(
+        queryByText(strings('pro_subscription.benefits.atm_fees.subtitle')),
+      ).not.toBeOnTheScreen();
+
+      // Open ATM fees detail sheet — description should be monthly variant
+      fireEvent.press(getByTestId(BenefitsTestIds.BENEFIT_ROW('atm_fees')));
+      expect(
+        getByText(
+          strings(
+            'pro_subscription.benefits_description.atm_fees.description_monthly',
+          ),
+        ),
+      ).toBeOnTheScreen();
+      expect(
+        queryByText(
+          strings('pro_subscription.benefits_description.atm_fees.description'),
+        ),
+      ).not.toBeOnTheScreen();
+    });
+  });
 });

--- a/app/components/Views/ProSubscription/screens/Benefits/Benefits.tsx
+++ b/app/components/Views/ProSubscription/screens/Benefits/Benefits.tsx
@@ -90,6 +90,7 @@ const Benefits = ({ onSuccess, initialPlan }: BenefitsProps) => {
               key={item.id}
               item={item}
               onPress={() => handleBenefitPress(item.id)}
+              selectedPlan={selectedPlan}
             />
           ))}
         </Box>
@@ -121,6 +122,7 @@ const Benefits = ({ onSuccess, initialPlan }: BenefitsProps) => {
         <BenefitDetails
           onClose={handleBenefitDetailSheetClose}
           details={selectedBenfitDetail}
+          selectedPlan={selectedPlan}
         />
       )}
     </Box>

--- a/app/components/Views/ProSubscription/screens/Benefits/components/BenefitDetails.tsx
+++ b/app/components/Views/ProSubscription/screens/Benefits/components/BenefitDetails.tsx
@@ -14,9 +14,18 @@ import { BenefitsTestIds } from '../Benefits.testIds';
 interface BenefitDetailsProps {
   onClose: () => void;
   details: BenefitDetailItem;
+  selectedPlan?: string;
 }
 
-const BenefitDetails = ({ onClose, details }: BenefitDetailsProps) => {
+const BenefitDetails = ({
+  onClose,
+  details,
+  selectedPlan,
+}: BenefitDetailsProps) => {
+  const descriptionKey =
+    selectedPlan === 'monthly' && details?.descriptionMonthly
+      ? details.descriptionMonthly
+      : details.description;
   const handleLearnMorePress = useCallback(() => {
     if (details.learnMoreUrl) {
       Linking.openURL(details.learnMoreUrl);
@@ -41,7 +50,7 @@ const BenefitDetails = ({ onClose, details }: BenefitDetailsProps) => {
           color={TextColor.TextAlternative}
           twClassName="mb-4"
         >
-          {strings(details.description)}
+          {strings(descriptionKey)}
         </Text>
         {details.subDescription && (
           <Text

--- a/app/components/Views/shared/pro/BenefitRow.tsx
+++ b/app/components/Views/shared/pro/BenefitRow.tsx
@@ -23,13 +23,20 @@ interface BenefitRowProps {
   onPress?: (item: BenefitItem) => void;
   /** Trailing disclosure arrow. Defaults to true when `onPress` is provided. */
   showArrow?: boolean;
+  /** Selected plan — used to resolve plan-specific copy variants. */
+  selectedPlan?: string;
 }
 
 const BenefitRow = ({
   item,
   onPress,
   showArrow = Boolean(onPress),
+  selectedPlan,
 }: BenefitRowProps) => {
+  const subtitleKey =
+    selectedPlan === 'monthly' && item.subtitleMonthly
+      ? item.subtitleMonthly
+      : item.subtitle;
   const content = (
     <Box
       flexDirection={BoxFlexDirection.Row}
@@ -48,7 +55,7 @@ const BenefitRow = ({
           {strings(item.title)}
         </Text>
         <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
-          {strings(item.subtitle)}
+          {strings(subtitleKey)}
         </Text>
       </Box>
 

--- a/app/components/Views/shared/pro/benefits.constants.ts
+++ b/app/components/Views/shared/pro/benefits.constants.ts
@@ -9,6 +9,8 @@ export interface BenefitItem {
   title: string;
   /** i18n key passed to `strings()` for the row subtitle. */
   subtitle: string;
+  /** i18n key for monthly-plan variant of the subtitle (used when plan = monthly). */
+  subtitleMonthly?: string;
 }
 
 export const BENEFITS: BenefitItem[] = [
@@ -31,6 +33,7 @@ export const BENEFITS: BenefitItem[] = [
     id: 'atm_fees',
     title: 'pro_subscription.benefits.atm_fees.title',
     subtitle: 'pro_subscription.benefits.atm_fees.subtitle',
+    subtitleMonthly: 'pro_subscription.benefits.atm_fees.subtitle_monthly',
   },
   {
     id: 'protection',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -11216,7 +11216,8 @@
       },
       "atm_fees": {
         "title": "No added ATM or FX fees",
-        "subtitle": "Physical card included"
+        "subtitle": "Physical card included",
+        "subtitle_monthly": "Physical card available separately"
       },
       "protection": {
         "title": "Up to $10,000 in protection",
@@ -11261,7 +11262,8 @@
         ]
       },
       "atm_fees": {
-        "description": "MetaMask Card ships free for annual members. Use it at 150M+ merchants globally, anywhere Mastercard is accepted—no ATM fees or foreign transaction fees from MetaMask."
+        "description": "MetaMask Card ships free for annual members. Use it at 150M+ merchants globally, anywhere Mastercard is accepted—no ATM fees or foreign transaction fees from MetaMask.",
+        "description_monthly": "MetaMask Card is available separately for monthly members. Use it at 150M+ merchants globally, anywhere Mastercard is accepted—no ATM fees or foreign transaction fees from MetaMask."
       },
       "protection": {
         "description": "Get protection on up to 100 MetaMask extension transactions per month, up to $10,000.",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- When the monthly plan is selected on the Pro Subscription Benefits screen, the ATM fees benefit row and detail sheet now show monthly-specific copy ("Physical card available separately" / "MetaMask Card is available separately for monthly members...") instead of the annual defaults.
- Added `subtitleMonthly` and `descriptionMonthly` optional fields to the benefit data models so plan-aware content can be defined per benefit item.
- Passes `selectedPlan` from `Benefits` to `BenefitRow` and `BenefitDetails` components.


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: show plan-specific ATM fees copy for monthly vs annual- #35371


## **Related issues**

<!-- mms-check: type=issue-link required=true -->


## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Content changes as per plan selection
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — navigation-stack guard only; no UI change.

### **After**


https://github.com/user-attachments/assets/b242a94a-5a75-49e2-b5f3-300c34c39cec



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)