### PR TITLE
test: ActivityScreen Monad bridge status + details CV coverage (MMQA-2325, MMQA-2329)

### DIFF
--- a/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
+++ b/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
@@ -1,13 +1,15 @@
 import '../../../../tests/component-view/mocks';
-import { fireEvent, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, waitFor, within } from '@testing-library/react-native';
 
 import Routes from '../../../constants/navigation/Routes';
 import Engine from '../../../core/Engine';
+import { updateBgState } from '../../../core/redux/slices/engine';
 import { getRouteProbeTestId } from '../../../../tests/component-view/render';
 import { describeForPlatforms } from '../../../../tests/component-view/platform';
 import {
   renderActivityScreenView,
   renderActivityScreenViewWithRoutes,
+  ActivityDetailsWithProviders,
 } from '../../../../tests/component-view/renderers/activity';
 import {
   ACTIVITY_CV_ACCOUNT,
@@ -22,16 +24,21 @@ import {
   LINEA_ACTIVITY_HASH,
   MAINNET_ACTIVITY_HASH,
   activityCvBridgeHistoryEntry,
+  activityCvBridgeMonToBaseHistoryEntry,
   activityCvCrossChainSwapBridgeHistoryEntry,
+  activityCvPendingBridgeMonToBaseHistoryEntry,
   activityCvPerpsCanceledTakeProfitRowHash,
   activityCvPerpsFundingRowHash,
   activityCvPerpsTradeRowHash,
   activityLineaNetworkOverride,
+  activityMonToBaseTokenRatesOverride,
+  activityMonadBaseNetworkOverride,
   activityPerpsTradingEnabledFlag,
   activityPredictTradingEnabledFlag,
   buildActivityCvPerpsOverviewEngineSeed,
   buildActivityCvRampBuyMusdOrder,
   buildActivityCvRampSellEthOrder,
+  buildConfirmedLocalBridgeMonToBaseTransaction,
   buildConfirmedLocalBridgeTransaction,
   buildConfirmedLocalContractInteractionTransaction,
   buildConfirmedLocalCrossChainSwapTransaction,
@@ -43,6 +50,7 @@ import {
   buildConfirmedLocalUsdcRevokeTransaction,
   buildConfirmedLocalUsdcSendTransaction,
   buildConfirmedLocalUsdcUnlimitedApproveTransaction,
+  buildPendingLocalBridgeMonToBaseTransaction,
   buildPredictBuyActivity,
   buildPredictClaimActivity,
   buildPredictSellActivity,
@@ -61,8 +69,49 @@ import { ACTIVITY_TYPE_FILTER_LABEL_KEY } from './components/ActivityTypeFilterS
 import { PERPS_ACTIVITY_FILTER_LABEL_KEY } from './components/PerpsActivityFilterSheet';
 import { ActivityTypeFilter, PerpsActivityFilter } from './types';
 
+// Details testIDs mirrored locally so this route suite does not import from the
+// sibling ActivityDetails route (ADR 0020).
+const ACTIVITY_DETAILS_SCREEN = 'activity-details-screen';
+const ACTIVITY_DETAILS_AMOUNT_HEADER = 'activity-details-amount-header';
+const ACTIVITY_DETAILS_STATUS_PILL = 'activity-details-status-pill';
+const ACTIVITY_DETAILS_NETWORK_ROW = 'activity-details-network-row';
+const ACTIVITY_DETAILS_FEE_ROW = 'activity-details-fee-row';
+const ACTIVITY_DETAILS_TOTAL_ROW = 'activity-details-total-row';
+
+const monToBaseBridgeState = (
+  transaction: ReturnType<typeof buildPendingLocalBridgeMonToBaseTransaction>,
+  historyEntry:
+    | typeof activityCvPendingBridgeMonToBaseHistoryEntry
+    | typeof activityCvBridgeMonToBaseHistoryEntry,
+) =>
+  initialStateActivityWithLocalTransactions([transaction])
+    .withRemoteFeatureFlags({
+      // List redesign + details redesign (both required for list → ActivityDetails nav).
+      tmcuActivityRedesignEnabled: true,
+      tmcuTransactionsRedesignEnabled: true,
+    })
+    .withOverrides(activityMonadBaseNetworkOverride)
+    .withOverrides(activityMonToBaseTokenRatesOverride)
+    .withOverrides({
+      engine: {
+        backgroundState: {
+          PreferencesController: {
+            privacyMode: false,
+          },
+          BridgeStatusController: {
+            txHistory: {
+              [transaction.id]: historyEntry,
+            },
+          },
+        },
+      },
+    } as never)
+    .build();
+
 // Row testIDs mirror ActivityListItemRow markup. Defined locally so this route
 // suite does not import from the sibling ActivityList route (ADR 0020).
+const activityListRowItemTestId = (index: number): string =>
+  `transaction-item-${index}`;
 const activityListRowTitleTestId = (hash: string): string =>
   `activity-title-${hash}`;
 const activityListRowSubtitleTestId = (hash: string): string =>
@@ -75,6 +124,39 @@ const activityListRowAvatarSingleTestId = (hash: string): string =>
   `activity-row-avatar-single-${hash}`;
 const activityListRowAvatarStackTestId = (hash: string): string =>
   `activity-row-avatar-stack-${hash}`;
+// Container wraps the a11y-hidden spinner (PendingActivityListItemRow).
+const activityListRowPendingSpinnerTestId = (hash: string): string =>
+  `activity-pending-spinner-container-${hash}`;
+
+/** Patch Engine.state then UPDATE_BG_STATE so Redux selectors see live controller updates. */
+const syncEngineControllerState = (
+  store: ReturnType<typeof renderActivityScreenViewWithRoutes>['store'],
+  key: 'TransactionController' | 'BridgeStatusController',
+  patch: Record<string, unknown>,
+) => {
+  const engineWithState = Engine as unknown as {
+    state?: Record<string, unknown>;
+  };
+  const backgroundState = store.getState().engine.backgroundState as Record<
+    string,
+    unknown
+  >;
+  const existing =
+    (backgroundState[key] as Record<string, unknown> | undefined) ?? {};
+  const existingEngine =
+    (engineWithState.state?.[key] as Record<string, unknown> | undefined) ?? {};
+
+  engineWithState.state = {
+    ...(engineWithState.state ?? {}),
+    [key]: {
+      ...existing,
+      ...existingEngine,
+      ...patch,
+    },
+  };
+
+  store.dispatch(updateBgState({ key }));
+};
 
 /** Trade fills append `-${index}` in transformFillsToTransactions. */
 const activityListRowTitleTestIdPattern = (hashPrefix: string): RegExp =>
@@ -1549,5 +1631,128 @@ describeForPlatforms('ActivityScreen — perps funding', () => {
     expect(
       queryByTestId(activityListRowTitleTestIdPattern(tradeHash)),
     ).not.toBeOnTheScreen();
+  });
+});
+
+describeForPlatforms('ActivityScreen — Monad bridge status', () => {
+  afterEach(() => {
+    clearAccountsTransactionsApiMocks();
+  });
+
+  const assertPendingList = async (
+    screen: ReturnType<typeof renderActivityScreenViewWithRoutes>,
+    bridgeHash: string,
+  ) => {
+    expect(
+      await screen.findByTestId(activityListRowTitleTestId(bridgeHash)),
+    ).toHaveTextContent('Bridging USDC');
+    expect(
+      await screen.findByTestId(activityListRowSubtitleTestId(bridgeHash)),
+    ).toHaveTextContent('Monad → Base');
+    expect(
+      await screen.findByTestId(
+        activityListRowPendingSpinnerTestId(bridgeHash),
+      ),
+    ).toBeOnTheScreen();
+    expect(screen.queryByText('Swapping')).toBeNull();
+    expect(screen.queryByText('Swapped')).toBeNull();
+  };
+
+  const assertBridgedList = async (
+    screen: ReturnType<typeof renderActivityScreenViewWithRoutes>,
+    bridgeHash: string,
+  ) => {
+    expect(
+      await screen.findByTestId(activityListRowTitleTestId(bridgeHash)),
+    ).toHaveTextContent('Bridged USDC');
+    expect(
+      await screen.findByTestId(activityListRowSubtitleTestId(bridgeHash)),
+    ).toHaveTextContent('Monad → Base');
+    expect(
+      screen.queryByTestId(activityListRowPendingSpinnerTestId(bridgeHash)),
+    ).not.toBeOnTheScreen();
+    expect(screen.queryByText('Swapping')).toBeNull();
+    expect(screen.queryByText('Swapped')).toBeNull();
+  };
+
+  const assertDetailsAmountFeeTotal = async (
+    screen: ReturnType<typeof renderActivityScreenViewWithRoutes>,
+  ) => {
+    expect(
+      await screen.findByTestId(ACTIVITY_DETAILS_SCREEN),
+    ).toBeOnTheScreen();
+    expect(await screen.findByText('Bridged USDC')).toBeOnTheScreen();
+
+    const amountHeader = await screen.findByTestId(
+      ACTIVITY_DETAILS_AMOUNT_HEADER,
+    );
+    expect(
+      screen.getByText(strings('activity_details.you_sent')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('activity_details.you_received')),
+    ).toBeOnTheScreen();
+    expect(within(amountHeader).getByText(/^-.*MON/)).toBeOnTheScreen();
+    expect(within(amountHeader).getByText(/^\+.*USDC/)).toBeOnTheScreen();
+
+    expect(
+      await screen.findByTestId(ACTIVITY_DETAILS_STATUS_PILL),
+    ).toHaveTextContent(strings('transaction.confirmed'));
+
+    const networkRow = screen.getByTestId(ACTIVITY_DETAILS_NETWORK_ROW);
+    expect(networkRow).toHaveTextContent('Monad', { exact: false });
+    expect(networkRow).toHaveTextContent('Base', { exact: false });
+
+    await waitFor(() => {
+      expect(screen.getByTestId(ACTIVITY_DETAILS_FEE_ROW)).toHaveTextContent(
+        /\$/,
+      );
+    });
+    expect(screen.getByTestId(ACTIVITY_DETAILS_TOTAL_ROW)).toHaveTextContent(
+      /\$/,
+    );
+  };
+
+  // One tree: pending list → live controller update → Bridged → press → Details
+  // (requires both tmcuActivityRedesignEnabled + tmcuTransactionsRedesignEnabled).
+  it('shows Bridging then Bridged after dest completes, not Swap, with Amount Fee Total via details nav', async () => {
+    setupAccountsTransactionsApiMock([]);
+
+    const pendingBridge = buildPendingLocalBridgeMonToBaseTransaction();
+    const confirmedBridge = buildConfirmedLocalBridgeMonToBaseTransaction();
+    const bridgeHash = pendingBridge.hash as string;
+
+    const screen = renderActivityScreenViewWithRoutes({
+      state: monToBaseBridgeState(
+        pendingBridge,
+        activityCvPendingBridgeMonToBaseHistoryEntry,
+      ),
+      extraRoutes: [
+        {
+          name: Routes.ACTIVITY_DETAILS,
+          Component: ActivityDetailsWithProviders,
+        },
+      ],
+    });
+
+    await assertPendingList(screen, bridgeHash);
+
+    act(() => {
+      syncEngineControllerState(screen.store, 'TransactionController', {
+        transactions: [confirmedBridge],
+        swapsTransactions: {},
+      });
+      syncEngineControllerState(screen.store, 'BridgeStatusController', {
+        txHistory: {
+          [confirmedBridge.id]: activityCvBridgeMonToBaseHistoryEntry,
+        },
+      });
+    });
+
+    await assertBridgedList(screen, bridgeHash);
+
+    fireEvent.press(screen.getByTestId(activityListRowItemTestId(1)));
+
+    await assertDetailsAmountFeeTotal(screen);
   });
 });

--- a/tests/component-view/presets/activity.ts
+++ b/tests/component-view/presets/activity.ts
@@ -551,6 +551,200 @@ export const activityCvPendingCrossChainSwapBridgeHistoryEntry = {
   startTime: 1_716_367_789_500,
 };
 
+/** Monad mainnet — bridge Activity CV. */
+export const ACTIVITY_CV_MONAD_CHAIN_ID = '0x8f';
+
+/** Base mainnet — Monad bridge destination for Activity CV. */
+export const ACTIVITY_CV_BASE_CHAIN_ID = '0x2105';
+
+/** Base USDC — Monad→Base bridge destination asset. */
+export const ACTIVITY_CV_BASE_USDC =
+  '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+const ACTIVITY_CV_MON_TO_BASE_BRIDGE_ID = 'activity-cv-bridge-mon-to-base';
+const ACTIVITY_CV_MON_TO_BASE_BRIDGE_HASH = '0xactivitycvbridgemontobase';
+const ACTIVITY_CV_MON_TO_BASE_DEST_HASH = '0xactivitycvbridgemontobasedest';
+
+/**
+ * Submitted Monad→Base bridge for ActivityScreen pending→complete CV.
+ * Source stays submitted until dest completion overrides status via history.
+ */
+export const buildPendingLocalBridgeMonToBaseTransaction =
+  (): TransactionMeta =>
+    ({
+      id: ACTIVITY_CV_MON_TO_BASE_BRIDGE_ID,
+      hash: ACTIVITY_CV_MON_TO_BASE_BRIDGE_HASH,
+      chainId: ACTIVITY_CV_MONAD_CHAIN_ID,
+      status: TransactionStatus.submitted,
+      time: 1_716_367_810_000,
+      type: TransactionType.bridge,
+      txParams: {
+        from: ACTIVITY_CV_ACCOUNT,
+        to: ACTIVITY_CV_BASE_USDC,
+        value: '0xde0b6b3a7640000',
+        nonce: '0x20',
+      },
+    }) as unknown as TransactionMeta;
+
+/**
+ * Confirmed Monad→Base bridge with gas for Activity Details Fee/Total CV.
+ * Same id/hash as {@link buildPendingLocalBridgeMonToBaseTransaction}.
+ */
+export const buildConfirmedLocalBridgeMonToBaseTransaction =
+  (): TransactionMeta =>
+    ({
+      id: ACTIVITY_CV_MON_TO_BASE_BRIDGE_ID,
+      hash: ACTIVITY_CV_MON_TO_BASE_BRIDGE_HASH,
+      chainId: ACTIVITY_CV_MONAD_CHAIN_ID,
+      status: TransactionStatus.confirmed,
+      time: 1_716_367_810_000,
+      type: TransactionType.bridge,
+      txParams: {
+        from: ACTIVITY_CV_ACCOUNT,
+        to: ACTIVITY_CV_BASE_USDC,
+        value: '0xde0b6b3a7640000',
+        nonce: '0x20',
+      },
+      txReceipt: { ...ACTIVITY_CV_GAS_RECEIPT },
+    }) as unknown as TransactionMeta;
+
+const activityCvMonToBaseBridgeQuote = {
+  srcChainId: 143,
+  destChainId: 8453,
+  srcAsset: {
+    symbol: 'MON',
+    decimals: 18,
+    assetId: 'eip155:143/slip44:60',
+  },
+  destAsset: {
+    symbol: 'USDC',
+    decimals: 6,
+    assetId: `eip155:8453/erc20:${ACTIVITY_CV_BASE_USDC.toLowerCase()}`,
+  },
+  srcTokenAmount: '2000000000000000000',
+  destTokenAmount: '3500000',
+};
+
+/** In-flight Monad→Base history — no dest txHash keeps Activity pending. */
+export const activityCvPendingBridgeMonToBaseHistoryEntry = {
+  txMetaId: ACTIVITY_CV_MON_TO_BASE_BRIDGE_ID,
+  account: ACTIVITY_CV_ACCOUNT,
+  quote: activityCvMonToBaseBridgeQuote,
+  status: {
+    srcChain: {
+      chainId: 143,
+      txHash: ACTIVITY_CV_MON_TO_BASE_BRIDGE_HASH,
+    },
+    destChain: {
+      chainId: 8453,
+    },
+  },
+  startTime: 1_716_367_810_000,
+  estimatedProcessingTimeInSeconds: 60,
+  slippagePercentage: 0,
+};
+
+/** Completed Monad→Base history for Bridged list + details Fee/Total. */
+export const activityCvBridgeMonToBaseHistoryEntry = {
+  txMetaId: ACTIVITY_CV_MON_TO_BASE_BRIDGE_ID,
+  account: ACTIVITY_CV_ACCOUNT,
+  quote: activityCvMonToBaseBridgeQuote,
+  status: {
+    srcChain: {
+      chainId: 143,
+      txHash: ACTIVITY_CV_MON_TO_BASE_BRIDGE_HASH,
+    },
+    destChain: {
+      chainId: 8453,
+      txHash: ACTIVITY_CV_MON_TO_BASE_DEST_HASH,
+    },
+  },
+  startTime: 1_716_367_810_000,
+  estimatedProcessingTimeInSeconds: 60,
+  slippagePercentage: 0,
+};
+
+/** NetworkController configs so Monad/Base names and native MON resolve. */
+export const activityMonadBaseNetworkOverride = {
+  engine: {
+    backgroundState: {
+      NetworkController: {
+        networkConfigurationsByChainId: {
+          [ACTIVITY_CV_MONAD_CHAIN_ID]: {
+            chainId: ACTIVITY_CV_MONAD_CHAIN_ID,
+            rpcEndpoints: [
+              {
+                networkClientId: 'monad-mainnet',
+                url: 'https://monad-mainnet.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+                name: 'Monad default RPC',
+              },
+            ],
+            defaultRpcEndpointIndex: 0,
+            blockExplorerUrls: ['https://monadscan.com'],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Monad',
+            nativeCurrency: 'MON',
+          },
+          [ACTIVITY_CV_BASE_CHAIN_ID]: {
+            chainId: ACTIVITY_CV_BASE_CHAIN_ID,
+            rpcEndpoints: [
+              {
+                networkClientId: 'base-mainnet',
+                url: 'https://base-mainnet.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+                name: 'Base default RPC',
+              },
+            ],
+            defaultRpcEndpointIndex: 0,
+            blockExplorerUrls: ['https://basescan.org'],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Base',
+            nativeCurrency: 'ETH',
+          },
+        },
+      },
+      NetworkEnablementController: {
+        enabledNetworkMap: {
+          eip155: {
+            '0x1': true,
+            [ACTIVITY_CV_MONAD_CHAIN_ID]: true,
+            [ACTIVITY_CV_BASE_CHAIN_ID]: true,
+          },
+        },
+      },
+      CurrencyRateController: {
+        currentCurrency: 'USD',
+        currencyRates: {
+          ETH: {
+            conversionRate: 2500,
+            usdConversionRate: 2500,
+          },
+          MON: {
+            conversionRate: 5,
+            usdConversionRate: 5,
+          },
+        },
+      },
+    },
+  },
+} as unknown as DeepPartial<RootState>;
+
+/** TokenRates so Monad→Base bridge Total can resolve USDC fiat. */
+export const activityMonToBaseTokenRatesOverride = {
+  engine: {
+    backgroundState: {
+      TokenRatesController: {
+        marketData: {
+          [ACTIVITY_CV_BASE_CHAIN_ID]: {
+            [ACTIVITY_CV_BASE_USDC]: { price: 1 },
+          },
+        },
+      },
+    },
+  },
+} as unknown as DeepPartial<RootState>;
+
 /** Solana mainnet scope — Activity Details EVM→nonEVM bridge and non-EVM fiat CV. */
 export const ACTIVITY_CV_SOLANA_CHAIN_ID =
   'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';

--- a/tests/component-view/renderers/activity.ts
+++ b/tests/component-view/renderers/activity.ts
@@ -142,6 +142,9 @@ function ActivityDetailsWithProviders() {
   );
 }
 
+/** ActivityDetails wrapped for CV route registration (HardwareWalletProvider). */
+export { ActivityDetailsWithProviders };
+
 function buildActivityState(options: {
   overrides?: DeepPartial<RootState>;
   state?: DeepPartial<RootState>;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Adds component-view coverage for **MMQA-2325** (`[MOB-2] Bridge MON → other, Activity type + updates`) and **MMQA-2329** (`[MOB-7] Monad bridge details — Amount/Fee/Total accuracy`) in one ActivityScreen journey.

Covers a representative Monad (`0x8f`) → Base (`0x2105`) native MON → Base USDC bridge:

1. Pending list shows **Bridging USDC** / `Monad → Base` with spinner (not Swap)
2. Live `TransactionController` + `BridgeStatusController` update flips the same tree to **Bridged USDC**
3. Row press navigates to ActivityDetails and asserts Amount (MON/USDC), Fee, and Total

Includes Monad/Base network + rate presets and exports `ActivityDetailsWithProviders` for true list → details nav (both redesign flags required).

### Tests added (`ActivityScreen — Monad bridge status`)

| Case | Suite | Regression prevented |
| --- | --- | --- |
| Monad→Base bridge pending → Bridged (not Swap) | `ActivityScreen — Monad bridge status` | Monad-originated bridges mislabeled as Swap, or stuck on outdated Bridging status after dest completes (**MMQA-2325** / MOB-2) |
| Bridged details Amount / Fee / Total after list nav | `ActivityScreen — Monad bridge status` | Incorrect or missing Amount, Fee, or Total on Monad bridge Activity Details (**MMQA-2329** / MOB-7) |

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: MMQA-2325
Refs: MMQA-2329

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — coverage is component-view only; verified with:

```bash
yarn jest -c jest.config.view.js app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx -t "Monad bridge status" --runInBand --coverage=false
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — test-only change; no end-user UI diff.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.