### PR TITLE
chore: TSA-1042 add leaderboard landing feed A/B test

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
@@ -107,6 +107,20 @@ jest.mock('../../../../../selectors/notifications', () => ({
   selectIsMetamaskNotificationsEnabled: () => mockIsMasterNotificationsEnabled,
 }));
 
+// TSA-1042 landing A/B test. Defaults to control (leaderboard landing); the
+// treatment cases override the resolved variant per test.
+const mockUseABTest = jest.fn(
+  (_flagKey: string, variants: Record<string, unknown>) => ({
+    variant: variants.control,
+    variantName: 'control',
+    isActive: false,
+  }),
+);
+jest.mock('../../../../../hooks/useABTest', () => ({
+  useABTest: (...args: [string, Record<string, unknown>]) =>
+    mockUseABTest(...args),
+}));
+
 const mockNavigateToSocialLeaderboard = jest.fn();
 jest.mock(
   '../../../SocialLeaderboard/Onboarding/socialLeaderboardOnboardingNavigation',
@@ -219,6 +233,11 @@ const channelsDisabledPreferences = {
 describe('TopTradersSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseABTest.mockImplementation((_flagKey, variants) => ({
+      variant: variants.control,
+      variantName: 'control',
+      isActive: false,
+    }));
     mockSelectSocialLeaderboardEnabled.mockImplementation(() => true);
     mockSelectSocialLeaderboardPerpsEnabled.mockImplementation(() => true);
     mockIsMasterNotificationsEnabled = true;
@@ -459,7 +478,51 @@ describe('TopTradersSection', () => {
 
     expect(mockNavigateToSocialLeaderboard).toHaveBeenCalledWith(
       expect.any(Function),
-      { source: 'home_carousel' },
+      {
+        source: 'home_carousel',
+        landingTab: 'leaderboard',
+        landingFeedAudience: undefined,
+      },
+    );
+  });
+
+  it('lands the section header on the Feed tab with the All audience for the treatment variant', () => {
+    mockUseABTest.mockImplementation((_flagKey, variants) => ({
+      variant: variants.treatment,
+      variantName: 'treatment',
+      isActive: true,
+    }));
+    renderWithProvider(<TopTradersSection {...defaultProps} />);
+
+    fireEvent.press(screen.getByText('Top traders'));
+
+    expect(mockNavigateToSocialLeaderboard).toHaveBeenCalledWith(
+      expect.any(Function),
+      {
+        source: 'home_carousel',
+        landingTab: 'feed',
+        landingFeedAudience: 'all',
+      },
+    );
+  });
+
+  it('lands the view-more card on the Feed tab with the All audience for the treatment variant', () => {
+    mockUseABTest.mockImplementation((_flagKey, variants) => ({
+      variant: variants.treatment,
+      variantName: 'treatment',
+      isActive: true,
+    }));
+    renderWithProvider(<TopTradersSection {...defaultProps} />);
+
+    fireEvent.press(screen.getByTestId('top-traders-view-more-card'));
+
+    expect(mockNavigateToSocialLeaderboard).toHaveBeenCalledWith(
+      expect.any(Function),
+      {
+        source: 'home_carousel',
+        landingTab: 'feed',
+        landingFeedAudience: 'all',
+      },
     );
   });
 

--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -44,6 +44,12 @@ import { useFollowWithNotificationSetup } from '../../../SocialLeaderboard/hooks
 import { navigateToSocialLeaderboard } from '../../../SocialLeaderboard/Onboarding/socialLeaderboardOnboardingNavigation';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { rankTradersByMetric } from '../../../SocialLeaderboard/TopTradersView/traderMetric';
+import {
+  LEADERBOARD_LANDING_FEED_AB_KEY,
+  LEADERBOARD_LANDING_FEED_VARIANTS,
+  // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+} from '../../../SocialLeaderboard/SocialTradersTabsView/abTestConfig';
+import { useABTest } from '../../../../../hooks/useABTest';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { WalletViewSelectorsIDs } from '../../../Wallet/WalletView.testIds';
 
@@ -210,11 +216,22 @@ const TopTradersSection = forwardRef<
     return items;
   }, [traders, showViewMore]);
 
+  // TSA-1042: where this entry point lands inside Follow Trading. Exposure is
+  // emitted by the destination once it receives these params, so rendering the
+  // homepage carousel does not count a user as exposed.
+  const { variant: landingVariant } = useABTest(
+    LEADERBOARD_LANDING_FEED_AB_KEY,
+    LEADERBOARD_LANDING_FEED_VARIANTS,
+    { trackExposure: false },
+  );
+
   const handleViewAll = useCallback(() => {
     navigateToSocialLeaderboard(navigation.navigate, {
       source: 'home_carousel',
+      landingTab: landingVariant.landingTab,
+      landingFeedAudience: landingVariant.landingFeedAudience,
     });
-  }, [navigation]);
+  }, [navigation, landingVariant]);
 
   const handleTraderPress = useCallback(
     (traderId: string, traderName: string) => {

--- a/app/components/Views/SocialLeaderboard/FeedView/FeedView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/FeedView.test.tsx
@@ -154,6 +154,15 @@ jest.mock('../components/Filters', () => {
   };
 });
 
+/** Left-to-right order of the audience toggle segments as rendered. */
+const getAudienceToggleOrder = () =>
+  screen
+    .getAllByRole('button')
+    .map((option) => option.props.testID as string | undefined)
+    .filter((id): id is string =>
+      Boolean(id?.startsWith(`${FeedViewSelectorsIDs.AUDIENCE_TOGGLE}-`)),
+    );
+
 describe('FeedView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -334,6 +343,24 @@ describe('FeedView', () => {
       MetaMetricsEvents.SOCIAL_TRADER_FEED_SCREEN_VIEWED,
       expect.objectContaining({ feed_audience: 'all' }),
     );
+  });
+
+  it('puts the preselected audience first in the toggle', () => {
+    renderWithProvider(<FeedView initialAudience="all" />);
+
+    const toggleOptions = getAudienceToggleOrder();
+
+    expect(toggleOptions[0]).toBe(getFeedAudienceOptionTestId('all'));
+    expect(toggleOptions[1]).toBe(getFeedAudienceOptionTestId('following'));
+  });
+
+  it('keeps Following first in the toggle by default', () => {
+    renderWithProvider(<FeedView />);
+
+    const toggleOptions = getAudienceToggleOrder();
+
+    expect(toggleOptions[0]).toBe(getFeedAudienceOptionTestId('following'));
+    expect(toggleOptions[1]).toBe(getFeedAudienceOptionTestId('all'));
   });
 
   it('tracks audience filter changes via Trader Feed Interaction', () => {

--- a/app/components/Views/SocialLeaderboard/FeedView/FeedView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/FeedView.test.tsx
@@ -105,8 +105,12 @@ const buildResult = (
 
 let mockFeedResult: UseTraderFeedResult = buildResult();
 
+const mockUseTraderFeed = jest.fn();
 jest.mock('./hooks/useTraderFeed', () => ({
-  useTraderFeed: () => mockFeedResult,
+  useTraderFeed: (options: unknown) => {
+    mockUseTraderFeed(options);
+    return mockFeedResult;
+  },
 }));
 
 jest.mock('@react-navigation/native', () => ({
@@ -301,6 +305,34 @@ describe('FeedView', () => {
         feed_audience: 'following',
         feed_type_filter: 'all',
       }),
+    );
+  });
+
+  it('opens on the Following audience by default', () => {
+    renderWithProvider(<FeedView />);
+
+    expect(mockUseTraderFeed).toHaveBeenCalledWith(
+      expect.objectContaining({ audience: 'following' }),
+    );
+    expect(
+      screen.getByTestId(getFeedAudienceOptionTestId('following')).props
+        .accessibilityState?.selected,
+    ).toBe(true);
+  });
+
+  it('opens on the audience requested by the entry point', () => {
+    renderWithProvider(<FeedView initialAudience="all" />);
+
+    expect(mockUseTraderFeed).toHaveBeenCalledWith(
+      expect.objectContaining({ audience: 'all' }),
+    );
+    expect(
+      screen.getByTestId(getFeedAudienceOptionTestId('all')).props
+        .accessibilityState?.selected,
+    ).toBe(true);
+    expect(mockTrack).toHaveBeenCalledWith(
+      MetaMetricsEvents.SOCIAL_TRADER_FEED_SCREEN_VIEWED,
+      expect.objectContaining({ feed_audience: 'all' }),
     );
   });
 

--- a/app/components/Views/SocialLeaderboard/FeedView/FeedView.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/FeedView.tsx
@@ -97,6 +97,12 @@ export interface FeedViewProps {
    */
   isActive?: boolean;
   /**
+   * Audience the feed opens on. Set by the tabs container when an entry point
+   * requests a specific landing scope (TSA-1042 lands the homepage carousel on
+   * the Feed tab with "All" selected). Defaults to `following`.
+   */
+  initialAudience?: FeedAudience;
+  /**
    * Opens the QuickBuy sheet for a spot token. The sheet is hosted by the
    * parent (above the tab `PagerView`) rather than inside this page so it isn't
    * clipped by the pager and can leave the content behind it interactive (no
@@ -133,6 +139,7 @@ export interface FeedViewProps {
  */
 const FeedView: React.FC<FeedViewProps> = ({
   isActive = true,
+  initialAudience = 'following',
   onQuickBuy,
   onSpotAvailabilityChange,
   onScroll,
@@ -149,9 +156,9 @@ const FeedView: React.FC<FeedViewProps> = ({
   const { track } = useSocialLeaderboardAnalytics();
   const source = route.params?.source ?? 'nav_tab';
 
-  // Default to "Following": the backend "leaderboard" scope isn't implemented
-  // yet, so the feed opens on the Following scope (the only one the API serves).
-  const [audience, setAudience] = useState<FeedAudience>('following');
+  // Defaults to "Following" unless the entry point requested a landing scope
+  // (see `initialAudience`).
+  const [audience, setAudience] = useState<FeedAudience>(initialAudience);
   const [typeFilter, setTypeFilter] = useState<FeedTypeFilter>('all');
   const audienceRef = useRef(audience);
   const typeFilterRef = useRef(typeFilter);

--- a/app/components/Views/SocialLeaderboard/FeedView/FeedView.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/FeedView.tsx
@@ -57,7 +57,10 @@ import {
 } from '../analytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import type { QuickBuyTarget } from '../../../UI/QuickBuy';
-import FeedAudienceToggle from './components/FeedAudienceToggle';
+import FeedAudienceToggle, {
+  DEFAULT_FEED_AUDIENCE_ORDER,
+  type FeedAudienceOrder,
+} from './components/FeedAudienceToggle';
 import FeedItemRow from './components/FeedItemRow';
 import FeedItemRowSkeleton from './components/FeedItemRowSkeleton';
 import FeedTypeEmptyState from './components/FeedTypeEmptyState';
@@ -159,6 +162,16 @@ const FeedView: React.FC<FeedViewProps> = ({
   // Defaults to "Following" unless the entry point requested a landing scope
   // (see `initialAudience`).
   const [audience, setAudience] = useState<FeedAudience>(initialAudience);
+  // Keep the preselected audience as the leftmost segment. Read from the
+  // landing audience only (not the live selection) so toggling never reshuffles
+  // the segments under the user's finger.
+  const audienceOrder = useMemo<FeedAudienceOrder>(
+    () =>
+      initialAudience === 'all'
+        ? ['all', 'following']
+        : DEFAULT_FEED_AUDIENCE_ORDER,
+    [initialAudience],
+  );
   const [typeFilter, setTypeFilter] = useState<FeedTypeFilter>('all');
   const audienceRef = useRef(audience);
   const typeFilterRef = useRef(typeFilter);
@@ -506,10 +519,14 @@ const FeedView: React.FC<FeedViewProps> = ({
           value={typeFilter}
           onPress={() => setIsTypeSheetOpen(true)}
         />
-        <FeedAudienceToggle value={audience} onChange={handleAudienceChange} />
+        <FeedAudienceToggle
+          value={audience}
+          order={audienceOrder}
+          onChange={handleAudienceChange}
+        />
       </Box>
     ),
-    [typeFilter, audience, handleAudienceChange],
+    [typeFilter, audience, audienceOrder, handleAudienceChange],
   );
 
   const content = useMemo(() => {

--- a/app/components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.test.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.test.tsx
@@ -38,6 +38,55 @@ describe('FeedAudienceToggle', () => {
     ).toBeOnTheScreen();
   });
 
+  it('renders Following first by default', () => {
+    renderWithProvider(<FeedAudienceToggle value="all" onChange={jest.fn()} />);
+
+    expect(
+      screen.getAllByRole('button').map((option) => option.props.testID),
+    ).toEqual([
+      getFeedAudienceOptionTestId('following'),
+      getFeedAudienceOptionTestId('all'),
+    ]);
+  });
+
+  it('renders the segments in the requested order', () => {
+    renderWithProvider(
+      <FeedAudienceToggle
+        value="all"
+        order={['all', 'following']}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getAllByRole('button').map((option) => option.props.testID),
+    ).toEqual([
+      getFeedAudienceOptionTestId('all'),
+      getFeedAudienceOptionTestId('following'),
+    ]);
+  });
+
+  it('still switches the selection when the order is reversed', () => {
+    const onChange = jest.fn();
+    renderWithProvider(
+      <FeedAudienceToggle
+        value="all"
+        order={['all', 'following']}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.press(
+      screen.getByTestId(getFeedAudienceOptionTestId('following')),
+    );
+
+    expect(onChange).toHaveBeenCalledWith('following');
+    expect(
+      screen.getByTestId(getFeedAudienceOptionTestId('following')).props
+        .accessibilityState?.selected,
+    ).toBe(true);
+  });
+
   it('calls onChange and plays a selection haptic when a different option is pressed', () => {
     const onChange = jest.fn();
     renderWithProvider(<FeedAudienceToggle value="all" onChange={onChange} />);

--- a/app/components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx
@@ -44,6 +44,19 @@ const SPRING_CONFIG = {
  */
 const SEGMENT_TW_CLASS = 'rounded-xl px-6 h-8 items-center justify-center';
 
+const AUDIENCE_LABEL_KEYS: Record<FeedAudience, string> = {
+  following: 'social_leaderboard.feed.following',
+  all: 'social_leaderboard.feed.all',
+};
+
+/** Left-to-right segment order. Both options are always rendered. */
+export type FeedAudienceOrder = readonly [FeedAudience, FeedAudience];
+
+export const DEFAULT_FEED_AUDIENCE_ORDER: FeedAudienceOrder = [
+  'following',
+  'all',
+];
+
 const styles = StyleSheet.create({
   row: {
     position: 'relative',
@@ -77,6 +90,14 @@ const styles = StyleSheet.create({
 export interface FeedAudienceToggleProps {
   value: FeedAudience;
   onChange: (value: FeedAudience) => void;
+  /**
+   * Left-to-right segment order. Defaults to Following then All; the feed passes
+   * the preselected audience first so the active segment is the leftmost one.
+   * Treated as fixed for the lifetime of the toggle — the slide math reads the
+   * first segment's measured width, so reordering mid-life would animate from a
+   * stale offset.
+   */
+  order?: FeedAudienceOrder;
   testID?: string;
 }
 
@@ -88,24 +109,29 @@ export interface FeedAudienceToggleProps {
  * the pill, so the colour tracks the slide rather than snapping. The scope
  * change is dispatched in a transition so the toggle paints before the feed
  * re-renders.
+ *
+ * `slideProgress` runs 0 -> 1 from the first to the second segment in `order`,
+ * so all the animation math is expressed in positional (first/second) terms
+ * rather than in audience names.
  */
 const FeedAudienceToggle: React.FC<FeedAudienceToggleProps> = ({
   value,
   onChange,
+  order = DEFAULT_FEED_AUDIENCE_ORDER,
   testID = FeedViewSelectorsIDs.AUDIENCE_TOGGLE,
 }) => {
   const { colors } = useTheme();
+  const [firstOption, secondOption] = order;
 
-  const slideProgress = useSharedValue(value === 'all' ? 1 : 0);
-  const followingWidthSV = useSharedValue(0);
-  const followingXSV = useSharedValue(0);
-  const allWidthSV = useSharedValue(0);
+  const slideProgress = useSharedValue(value === secondOption ? 1 : 0);
+  const firstWidthSV = useSharedValue(0);
+  const firstXSV = useSharedValue(0);
+  const secondWidthSV = useSharedValue(0);
 
   const prevValueRef = useRef<FeedAudience | null>(null);
   const [displayValue, setDisplayValue] = useState(value);
-  const [followingLayout, setFollowingLayout] =
-    useState<LayoutRectangle | null>(null);
-  const [allWidth, setAllWidth] = useState(0);
+  const [firstLayout, setFirstLayout] = useState<LayoutRectangle | null>(null);
+  const [secondWidth, setSecondWidth] = useState(0);
 
   useEffect(() => {
     setDisplayValue(value);
@@ -113,14 +139,14 @@ const FeedAudienceToggle: React.FC<FeedAudienceToggleProps> = ({
 
   const animateSlideTo = useCallback(
     (next: FeedAudience) => {
-      if (!followingLayout) {
+      if (!firstLayout) {
         return;
       }
-      const target = next === 'following' ? 0 : 1;
+      const target = next === firstOption ? 0 : 1;
       prevValueRef.current = next;
       slideProgress.value = withSpring(target, SPRING_CONFIG);
     },
-    [followingLayout, slideProgress],
+    [firstLayout, firstOption, slideProgress],
   );
 
   const handlePress = (next: FeedAudience) => {
@@ -142,10 +168,10 @@ const FeedAudienceToggle: React.FC<FeedAudienceToggleProps> = ({
   };
 
   useEffect(() => {
-    if (!followingLayout) {
+    if (!firstLayout) {
       return;
     }
-    const target = value === 'following' ? 0 : 1;
+    const target = value === firstOption ? 0 : 1;
 
     if (prevValueRef.current === null) {
       slideProgress.value = target;
@@ -157,24 +183,24 @@ const FeedAudienceToggle: React.FC<FeedAudienceToggleProps> = ({
       prevValueRef.current = value;
       slideProgress.value = withSpring(target, SPRING_CONFIG);
     }
-  }, [value, followingLayout, slideProgress]);
+  }, [value, firstLayout, firstOption, slideProgress]);
 
   const sliderStyle = useAnimatedStyle(() => ({
-    left: followingXSV.value,
+    left: firstXSV.value,
     width: interpolate(
       slideProgress.value,
       [0, 1],
-      [followingWidthSV.value, allWidthSV.value],
+      [firstWidthSV.value, secondWidthSV.value],
     ),
-    transform: [{ translateX: slideProgress.value * followingWidthSV.value }],
+    transform: [{ translateX: slideProgress.value * firstWidthSV.value }],
   }));
 
   // Cross-fade the active (white) label in sync with the pill: driven by the
   // same spring, so the colour transition tracks the slide instead of snapping.
-  const followingActiveStyle = useAnimatedStyle(() => ({
+  const firstActiveStyle = useAnimatedStyle(() => ({
     opacity: Math.max(0, Math.min(1, 1 - slideProgress.value)),
   }));
-  const allActiveStyle = useAnimatedStyle(() => ({
+  const secondActiveStyle = useAnimatedStyle(() => ({
     opacity: Math.max(0, Math.min(1, slideProgress.value)),
   }));
 
@@ -182,15 +208,72 @@ const FeedAudienceToggle: React.FC<FeedAudienceToggleProps> = ({
   // selected tab shows a single label. Leaving the base at full opacity under
   // the active overlay double-renders the text (different weight + colour),
   // which reads as a faint drop shadow / ghosting on the selected side.
-  const followingBaseStyle = useAnimatedStyle(() => ({
+  const firstBaseStyle = useAnimatedStyle(() => ({
     opacity: Math.max(0, Math.min(1, slideProgress.value)),
   }));
-  const allBaseStyle = useAnimatedStyle(() => ({
+  const secondBaseStyle = useAnimatedStyle(() => ({
     opacity: Math.max(0, Math.min(1, 1 - slideProgress.value)),
   }));
 
   const sliderWidth =
-    displayValue === 'following' ? (followingLayout?.width ?? 0) : allWidth;
+    displayValue === firstOption ? (firstLayout?.width ?? 0) : secondWidth;
+
+  // Plain render helper (not a component) so both segments keep sharing the
+  // hook-created animated styles above.
+  const renderSegment = (
+    option: FeedAudience,
+    isFirst: boolean,
+    activeStyle: ReturnType<typeof useAnimatedStyle>,
+    baseStyle: ReturnType<typeof useAnimatedStyle>,
+  ) => (
+    <TouchableOpacity
+      key={option}
+      onPress={() => handlePress(option)}
+      onLayout={(e) => {
+        const layout = e.nativeEvent.layout;
+        if (isFirst) {
+          setFirstLayout(layout);
+          firstWidthSV.value = layout.width;
+          firstXSV.value = layout.x;
+          return;
+        }
+        setSecondWidth(layout.width);
+        secondWidthSV.value = layout.width;
+      }}
+      accessibilityRole="button"
+      accessibilityState={{ selected: displayValue === option }}
+      testID={getFeedAudienceOptionTestId(option)}
+      style={styles.touchable}
+    >
+      <Box twClassName={SEGMENT_TW_CLASS}>
+        <Box style={styles.labelWrap}>
+          {/* In-flow Medium label sets the segment width so the wider
+              selected weight never clips (e.g. Android "Followin[g]"). */}
+          <Animated.View style={activeStyle}>
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextDefault}
+            >
+              {strings(AUDIENCE_LABEL_KEYS[option])}
+            </Text>
+          </Animated.View>
+          <Animated.View
+            style={[styles.labelActive, baseStyle]}
+            pointerEvents="none"
+          >
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Regular}
+              color={TextColor.TextAlternative}
+            >
+              {strings(AUDIENCE_LABEL_KEYS[option])}
+            </Text>
+          </Animated.View>
+        </Box>
+      </Box>
+    </TouchableOpacity>
+  );
 
   return (
     <Box
@@ -200,7 +283,7 @@ const FeedAudienceToggle: React.FC<FeedAudienceToggleProps> = ({
       testID={testID}
     >
       <Box flexDirection={BoxFlexDirection.Row} style={styles.row}>
-        {followingLayout && sliderWidth > 0 && (
+        {firstLayout && sliderWidth > 0 && (
           <Animated.View
             style={[
               styles.slider,
@@ -210,86 +293,8 @@ const FeedAudienceToggle: React.FC<FeedAudienceToggleProps> = ({
           />
         )}
 
-        <TouchableOpacity
-          onPress={() => handlePress('following')}
-          onLayout={(e) => {
-            const layout = e.nativeEvent.layout;
-            setFollowingLayout(layout);
-            followingWidthSV.value = layout.width;
-            followingXSV.value = layout.x;
-          }}
-          accessibilityRole="button"
-          accessibilityState={{ selected: displayValue === 'following' }}
-          testID={getFeedAudienceOptionTestId('following')}
-          style={styles.touchable}
-        >
-          <Box twClassName={SEGMENT_TW_CLASS}>
-            <Box style={styles.labelWrap}>
-              {/* In-flow Medium label sets the segment width so the wider
-                  selected weight never clips (e.g. Android "Followin[g]"). */}
-              <Animated.View style={followingActiveStyle}>
-                <Text
-                  variant={TextVariant.BodyMd}
-                  fontWeight={FontWeight.Medium}
-                  color={TextColor.TextDefault}
-                >
-                  {strings('social_leaderboard.feed.following')}
-                </Text>
-              </Animated.View>
-              <Animated.View
-                style={[styles.labelActive, followingBaseStyle]}
-                pointerEvents="none"
-              >
-                <Text
-                  variant={TextVariant.BodyMd}
-                  fontWeight={FontWeight.Regular}
-                  color={TextColor.TextAlternative}
-                >
-                  {strings('social_leaderboard.feed.following')}
-                </Text>
-              </Animated.View>
-            </Box>
-          </Box>
-        </TouchableOpacity>
-
-        <TouchableOpacity
-          onPress={() => handlePress('all')}
-          onLayout={(e) => {
-            const width = e.nativeEvent.layout.width;
-            setAllWidth(width);
-            allWidthSV.value = width;
-          }}
-          accessibilityRole="button"
-          accessibilityState={{ selected: displayValue === 'all' }}
-          testID={getFeedAudienceOptionTestId('all')}
-          style={styles.touchable}
-        >
-          <Box twClassName={SEGMENT_TW_CLASS}>
-            <Box style={styles.labelWrap}>
-              <Animated.View style={allActiveStyle}>
-                <Text
-                  variant={TextVariant.BodyMd}
-                  fontWeight={FontWeight.Medium}
-                  color={TextColor.TextDefault}
-                >
-                  {strings('social_leaderboard.feed.all')}
-                </Text>
-              </Animated.View>
-              <Animated.View
-                style={[styles.labelActive, allBaseStyle]}
-                pointerEvents="none"
-              >
-                <Text
-                  variant={TextVariant.BodyMd}
-                  fontWeight={FontWeight.Regular}
-                  color={TextColor.TextAlternative}
-                >
-                  {strings('social_leaderboard.feed.all')}
-                </Text>
-              </Animated.View>
-            </Box>
-          </Box>
-        </TouchableOpacity>
+        {renderSegment(firstOption, true, firstActiveStyle, firstBaseStyle)}
+        {renderSegment(secondOption, false, secondActiveStyle, secondBaseStyle)}
       </Box>
     </Box>
   );

--- a/app/components/Views/SocialLeaderboard/Onboarding/socialLeaderboardOnboardingNavigation.ts
+++ b/app/components/Views/SocialLeaderboard/Onboarding/socialLeaderboardOnboardingNavigation.ts
@@ -7,10 +7,13 @@ import { selectAiSocialLeaderboardOnboardingEnabled } from '../../../../selector
 
 /**
  * Params forwarded to the leaderboard when onboarding is not shown. Mirrors the
- * `TopTradersView` route params (only `source` is set by the entry points).
+ * `TopTradersView` route params set by the entry points (`source`, plus the
+ * TSA-1042 landing target for the homepage Top Traders carousel).
  */
 interface SocialLeaderboardViewParams {
   source?: string;
+  landingTab?: 'leaderboard' | 'feed';
+  landingFeedAudience?: 'all' | 'following';
 }
 
 /**

--- a/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.test.tsx
@@ -14,7 +14,21 @@ const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
 const mockOpenSystemSettings = jest.fn();
 const mockHasNotificationPreferences = jest.fn(() => false);
-let mockRouteParams: { showNotificationsBanner?: boolean } = {};
+let mockRouteParams: {
+  showNotificationsBanner?: boolean;
+  landingTab?: 'leaderboard' | 'feed';
+  landingFeedAudience?: 'all' | 'following';
+} = {};
+
+// TSA-1042 landing A/B test. The landing itself is driven by the route params
+// the entry point sends; this mock lets the tests assert the exposure gate.
+const mockUseABTest = jest.fn();
+jest.mock('../../../../hooks/useABTest', () => ({
+  useABTest: (...args: unknown[]) => {
+    mockUseABTest(...args);
+    return { variant: undefined, variantName: 'control', isActive: false };
+  },
+}));
 
 jest.mock('../analytics', () => {
   const actual = jest.requireActual('../analytics');
@@ -131,10 +145,12 @@ jest.mock('../FeedView', () => {
     __esModule: true,
     default: ({
       isActive,
+      initialAudience,
       onQuickBuy,
       onSpotAvailabilityChange,
     }: {
       isActive?: boolean;
+      initialAudience?: 'all' | 'following';
       onQuickBuy?: (target: { tokenSymbol: string }) => void;
       onSpotAvailabilityChange?: (hasSpotItem: boolean) => void;
     }) => {
@@ -145,6 +161,7 @@ jest.mock('../FeedView', () => {
       return (
         <View
           testID="mock-feed"
+          initialAudience={initialAudience}
           accessibilityState={{ selected: isActive === true }}
         >
           <Pressable
@@ -404,6 +421,61 @@ describe('SocialTradersTabsView', () => {
     expect(
       screen.getByTestId('mock-feed').props.accessibilityState?.selected,
     ).toBe(true);
+  });
+
+  describe('landing tab (TSA-1042 A/B test)', () => {
+    it('lands on the leaderboard when no landing tab is requested', () => {
+      renderWithProvider(<SocialTradersTabsView />);
+
+      expect(
+        screen.getByTestId('mock-feed').props.accessibilityState?.selected,
+      ).toBe(false);
+      expect(
+        screen.getByTestId('mock-feed').props.initialAudience,
+      ).toBeUndefined();
+    });
+
+    it('lands on the feed with the requested audience when the entry point asks for it', () => {
+      mockRouteParams = { landingTab: 'feed', landingFeedAudience: 'all' };
+
+      renderWithProvider(<SocialTradersTabsView />);
+
+      expect(
+        screen.getByTestId('mock-feed').props.accessibilityState?.selected,
+      ).toBe(true);
+      expect(screen.getByTestId('mock-feed').props.initialAudience).toBe('all');
+    });
+
+    it('lands on the leaderboard when the entry point requests the leaderboard', () => {
+      mockRouteParams = { landingTab: 'leaderboard' };
+
+      renderWithProvider(<SocialTradersTabsView />);
+
+      expect(
+        screen.getByTestId('mock-feed').props.accessibilityState?.selected,
+      ).toBe(false);
+    });
+
+    it('tracks exposure only for entry points that carry a landing tab', () => {
+      mockRouteParams = { landingTab: 'leaderboard' };
+      renderWithProvider(<SocialTradersTabsView />);
+
+      expect(mockUseABTest).toHaveBeenCalledWith(
+        'socialAiTSA1042AbtestLeaderboardLandingFeed',
+        expect.anything(),
+        expect.objectContaining({ trackExposure: true }),
+      );
+    });
+
+    it('does not track exposure for entry points without a landing tab', () => {
+      renderWithProvider(<SocialTradersTabsView />);
+
+      expect(mockUseABTest).toHaveBeenCalledWith(
+        'socialAiTSA1042AbtestLeaderboardLandingFeed',
+        expect.anything(),
+        expect.objectContaining({ trackExposure: false }),
+      );
+    });
   });
 
   it('holds feed prefetch back until the visible leaderboard query settles', () => {

--- a/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.test.tsx
@@ -456,6 +456,58 @@ describe('SocialTradersTabsView', () => {
       ).toBe(false);
     });
 
+    it('keeps Leaderboard as the leftmost tab by default', () => {
+      renderWithProvider(<SocialTradersTabsView />);
+
+      expect(
+        screen.getByTestId(
+          `${SocialTradersTabsViewSelectorsIDs.TABS}-tab-0-label`,
+        ),
+      ).toHaveTextContent('social_leaderboard.feed.tabs.leaderboard');
+      expect(
+        screen.getByTestId(
+          `${SocialTradersTabsViewSelectorsIDs.TABS}-tab-1-label`,
+        ),
+      ).toHaveTextContent('social_leaderboard.feed.tabs.feed');
+    });
+
+    it('moves Feed to the leftmost tab when the feed is the landing tab', () => {
+      mockRouteParams = { landingTab: 'feed', landingFeedAudience: 'all' };
+
+      renderWithProvider(<SocialTradersTabsView />);
+
+      expect(
+        screen.getByTestId(
+          `${SocialTradersTabsViewSelectorsIDs.TABS}-tab-0-label`,
+        ),
+      ).toHaveTextContent('social_leaderboard.feed.tabs.feed');
+      expect(
+        screen.getByTestId(
+          `${SocialTradersTabsViewSelectorsIDs.TABS}-tab-1-label`,
+        ),
+      ).toHaveTextContent('social_leaderboard.feed.tabs.leaderboard');
+    });
+
+    it('deactivates the feed when the second tab is selected in a feed-first order', () => {
+      mockRouteParams = { landingTab: 'feed', landingFeedAudience: 'all' };
+      renderWithProvider(<SocialTradersTabsView />);
+
+      fireEvent.press(
+        screen.getByTestId(`${SocialTradersTabsViewSelectorsIDs.TABS}-tab-1`),
+      );
+
+      expect(
+        screen.getByTestId('mock-feed').props.accessibilityState?.selected,
+      ).toBe(false);
+      expect(mockTrack).toHaveBeenCalledWith(
+        MetaMetricsEvents.SOCIAL_FOLLOW_TRADING_INTERACTION,
+        expect.objectContaining({
+          interaction_type: 'tab_changed',
+          tab: 'tab_leaderboard',
+        }),
+      );
+    });
+
     it('tracks exposure only for entry points that carry a landing tab', () => {
       mockRouteParams = { landingTab: 'leaderboard' };
       renderWithProvider(<SocialTradersTabsView />);

--- a/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx
+++ b/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx
@@ -66,16 +66,27 @@ import {
   LEADERBOARD_LANDING_FEED_VARIANTS,
 } from './abTestConfig';
 
-const LEADERBOARD_INDEX = 0;
-const FEED_INDEX = 1;
+type SocialTradersTab = 'leaderboard' | 'feed';
+
+/**
+ * Left-to-right tab order. The landing tab comes first so the preselected tab
+ * is always the leftmost one (TSA-1042): the default keeps Leaderboard first,
+ * and a feed landing swaps them.
+ */
+const DEFAULT_TAB_ORDER: readonly SocialTradersTab[] = ['leaderboard', 'feed'];
+const FEED_FIRST_TAB_ORDER: readonly SocialTradersTab[] = [
+  'feed',
+  'leaderboard',
+];
+const LANDING_INDEX = 0;
 
 // How long the post-onboarding "turn on notifications" nudge stays up before it
 // auto-dismisses (ms). Long enough to notice and act on after landing here, but
 // still transient so it never becomes permanent chrome.
 const NOTIFICATIONS_BANNER_AUTO_DISMISS_MS = 20000;
 
-const getTabAnalyticsValue = (index: number) =>
-  index === FEED_INDEX
+const getTabAnalyticsValue = (tab: SocialTradersTab) =>
+  tab === 'feed'
     ? SocialLeaderboardEventValues.TAB.FEED
     : SocialLeaderboardEventValues.TAB.LEADERBOARD;
 
@@ -83,6 +94,10 @@ const getTabAnalyticsValue = (index: number) =>
  * Follow Trading surface: Leaderboard | Feed tabs, collapsing title, and
  * notification bell. The leaderboard page and activity feed sit in swipeable
  * pages under a shared header.
+ *
+ * Tab order follows the entry point's requested landing tab, so the tab the
+ * surface opens on is always the leftmost one. Indices are therefore derived
+ * from `tabOrder` rather than hardcoded.
  */
 const SocialTradersTabsView: React.FC = () => {
   const tw = useTailwind();
@@ -114,12 +129,15 @@ const SocialTradersTabsView: React.FC = () => {
       trackExposure: Boolean(landingTab),
     },
   );
-  // Read once: a param change mid-mount must not yank the user across tabs.
-  const initialIndexRef = useRef(
-    landingTab === 'feed' ? FEED_INDEX : LEADERBOARD_INDEX,
+  // Read once: a param change mid-mount must not reshuffle the tabs or yank the
+  // user across pages.
+  const tabOrderRef = useRef(
+    landingTab === 'feed' ? FEED_FIRST_TAB_ORDER : DEFAULT_TAB_ORDER,
   );
-  const initialIndex = initialIndexRef.current;
-  const [activeIndex, setActiveIndex] = useState(initialIndex);
+  const tabOrder = tabOrderRef.current;
+  const feedIndex = tabOrder.indexOf('feed');
+  // The landing tab is the first one, so the surface always opens on index 0.
+  const [activeIndex, setActiveIndex] = useState(LANDING_INDEX);
 
   // Each page scrolls independently, so keep a scroll offset per tab and let a
   // derived value expose whichever one is currently visible. Sharing a single
@@ -130,9 +148,10 @@ const SocialTradersTabsView: React.FC = () => {
   const feedScrollY = useSharedValue(0);
   const leaderboardPageRef = useRef<SocialTabPageHandle>(null);
   const feedPageRef = useRef<SocialTabPageHandle>(null);
-  const activeIndexSv = useSharedValue(initialIndex);
+  const activeIndexSv = useSharedValue(LANDING_INDEX);
+  const feedIndexSv = useSharedValue(feedIndex);
   const scrollY = useDerivedValue(() =>
-    activeIndexSv.value === FEED_INDEX
+    activeIndexSv.value === feedIndexSv.value
       ? feedScrollY.value
       : leaderboardScrollY.value,
   );
@@ -180,7 +199,7 @@ const SocialTradersTabsView: React.FC = () => {
         return;
       }
 
-      const isFeedIncoming = nextIndex === FEED_INDEX;
+      const isFeedIncoming = nextIndex === feedIndex;
       const outgoingOffset = isFeedIncoming
         ? leaderboardScrollY.value
         : feedScrollY.value;
@@ -210,7 +229,7 @@ const SocialTradersTabsView: React.FC = () => {
       const incomingPage = isFeedIncoming ? feedPageRef : leaderboardPageRef;
       incomingPage.current?.scrollToOffset(target);
     },
-    [titleHeight, leaderboardScrollY, feedScrollY],
+    [titleHeight, feedIndex, leaderboardScrollY, feedScrollY],
   );
 
   // The title, tabs, and pager form one normal-flow column that slides up as
@@ -330,19 +349,16 @@ const SocialTradersTabsView: React.FC = () => {
   // `content` is unused: the pages live in the PagerView below so they stay
   // swipeable, and TabsBar renders the bar only.
   const tabs: TabItem[] = useMemo(
-    () => [
-      {
-        key: 'leaderboard',
-        label: strings('social_leaderboard.feed.tabs.leaderboard'),
+    () =>
+      tabOrder.map((tab) => ({
+        key: tab,
+        label:
+          tab === 'feed'
+            ? strings('social_leaderboard.feed.tabs.feed')
+            : strings('social_leaderboard.feed.tabs.leaderboard'),
         content: null,
-      },
-      {
-        key: 'feed',
-        label: strings('social_leaderboard.feed.tabs.feed'),
-        content: null,
-      },
-    ],
-    [],
+      })),
+    [tabOrder],
   );
 
   const changeTab = useCallback(
@@ -360,7 +376,9 @@ const SocialTradersTabsView: React.FC = () => {
         [SocialLeaderboardEventProperties.INTERACTION_TYPE]:
           SocialLeaderboardEventValues.FOLLOW_TRADING_INTERACTION_TYPE
             .TAB_CHANGED,
-        [SocialLeaderboardEventProperties.TAB]: getTabAnalyticsValue(index),
+        [SocialLeaderboardEventProperties.TAB]: getTabAnalyticsValue(
+          tabOrder[index],
+        ),
         [SocialLeaderboardEventProperties.TAB_CHANGE_METHOD]: tabChangeMethod,
       });
 
@@ -369,7 +387,7 @@ const SocialTradersTabsView: React.FC = () => {
       activeIndexSv.value = index;
       setActiveIndex(index);
     },
-    [activeIndex, activeIndexSv, syncIncomingPageScroll, track],
+    [activeIndex, activeIndexSv, tabOrder, syncIncomingPageScroll, track],
   );
 
   const handleTabPress = useCallback(
@@ -476,40 +494,49 @@ const SocialTradersTabsView: React.FC = () => {
             />
           </Box>
 
+          {/* Pages are rendered in `tabOrder` so the pager positions stay
+              aligned with the tabs bar. */}
           <PagerView
             ref={pagerRef}
             style={tw.style('flex-1')}
-            initialPage={initialIndex}
+            initialPage={LANDING_INDEX}
             onPageSelected={handlePageSelected}
             testID={SocialTradersTabsViewSelectorsIDs.PAGER}
           >
-            <View
-              key="leaderboard"
-              style={tw.style('flex-1')}
-              collapsable={false}
-              testID={SocialTradersTabsViewSelectorsIDs.LEADERBOARD_PAGE}
-            >
-              <TopTradersView
-                onScroll={leaderboardScrollHandler}
-                pageRef={leaderboardPageRef}
-                onVisibleLeaderboardSettled={handleVisibleLeaderboardSettled}
-              />
-            </View>
-            <View
-              key="feed"
-              style={tw.style('flex-1')}
-              collapsable={false}
-              testID={SocialTradersTabsViewSelectorsIDs.FEED_PAGE}
-            >
-              <FeedView
-                isActive={activeIndex === FEED_INDEX}
-                initialAudience={route.params?.landingFeedAudience}
-                onQuickBuy={handleQuickBuy}
-                onSpotAvailabilityChange={handleFeedSpotAvailabilityChange}
-                onScroll={feedScrollHandler}
-                pageRef={feedPageRef}
-              />
-            </View>
+            {tabOrder.map((tab) =>
+              tab === 'leaderboard' ? (
+                <View
+                  key="leaderboard"
+                  style={tw.style('flex-1')}
+                  collapsable={false}
+                  testID={SocialTradersTabsViewSelectorsIDs.LEADERBOARD_PAGE}
+                >
+                  <TopTradersView
+                    onScroll={leaderboardScrollHandler}
+                    pageRef={leaderboardPageRef}
+                    onVisibleLeaderboardSettled={
+                      handleVisibleLeaderboardSettled
+                    }
+                  />
+                </View>
+              ) : (
+                <View
+                  key="feed"
+                  style={tw.style('flex-1')}
+                  collapsable={false}
+                  testID={SocialTradersTabsViewSelectorsIDs.FEED_PAGE}
+                >
+                  <FeedView
+                    isActive={activeIndex === feedIndex}
+                    initialAudience={route.params?.landingFeedAudience}
+                    onQuickBuy={handleQuickBuy}
+                    onSpotAvailabilityChange={handleFeedSpotAvailabilityChange}
+                    onScroll={feedScrollHandler}
+                    pageRef={feedPageRef}
+                  />
+                </View>
+              ),
+            )}
           </PagerView>
         </Animated.View>
       </Box>
@@ -517,7 +544,7 @@ const SocialTradersTabsView: React.FC = () => {
       {feedHasSpotItem && (
         <FeedSpotBuyAction
           ref={setBuyActionRef}
-          isActive={activeIndex === FEED_INDEX}
+          isActive={activeIndex === feedIndex}
         />
       )}
     </SafeAreaView>

--- a/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx
+++ b/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx
@@ -59,6 +59,12 @@ import {
   type TabItem,
 } from '../../../../component-library/components-temp/Tabs';
 import { SocialTradersTabsViewSelectorsIDs } from './SocialTradersTabsView.testIds';
+import { useABTest } from '../../../../hooks/useABTest';
+import {
+  LEADERBOARD_LANDING_FEED_AB_KEY,
+  LEADERBOARD_LANDING_FEED_EXPOSURE_METADATA,
+  LEADERBOARD_LANDING_FEED_VARIANTS,
+} from './abTestConfig';
 
 const LEADERBOARD_INDEX = 0;
 const FEED_INDEX = 1;
@@ -92,7 +98,28 @@ const SocialTradersTabsView: React.FC = () => {
   usePrefetchTraderFeeds(isLeaderboardSettled);
   const pagerRef = useRef<PagerView>(null);
   const programmaticTabChangeRef = useRef(false);
-  const [activeIndex, setActiveIndex] = useState(LEADERBOARD_INDEX);
+
+  // TSA-1042 landing A/B test. The variant is resolved by the entry point and
+  // arrives as route params, so the landing itself is driven by `landingTab`;
+  // this read exists to emit `Experiment Viewed` at the moment the surface
+  // actually opens from that entry point. Entry points that don't send
+  // `landingTab` (nav tab, deeplink, notification, onboarding hand-off) never
+  // count as exposed and keep the leaderboard landing.
+  const landingTab = route.params?.landingTab;
+  useABTest(
+    LEADERBOARD_LANDING_FEED_AB_KEY,
+    LEADERBOARD_LANDING_FEED_VARIANTS,
+    {
+      ...LEADERBOARD_LANDING_FEED_EXPOSURE_METADATA,
+      trackExposure: Boolean(landingTab),
+    },
+  );
+  // Read once: a param change mid-mount must not yank the user across tabs.
+  const initialIndexRef = useRef(
+    landingTab === 'feed' ? FEED_INDEX : LEADERBOARD_INDEX,
+  );
+  const initialIndex = initialIndexRef.current;
+  const [activeIndex, setActiveIndex] = useState(initialIndex);
 
   // Each page scrolls independently, so keep a scroll offset per tab and let a
   // derived value expose whichever one is currently visible. Sharing a single
@@ -103,7 +130,7 @@ const SocialTradersTabsView: React.FC = () => {
   const feedScrollY = useSharedValue(0);
   const leaderboardPageRef = useRef<SocialTabPageHandle>(null);
   const feedPageRef = useRef<SocialTabPageHandle>(null);
-  const activeIndexSv = useSharedValue(LEADERBOARD_INDEX);
+  const activeIndexSv = useSharedValue(initialIndex);
   const scrollY = useDerivedValue(() =>
     activeIndexSv.value === FEED_INDEX
       ? feedScrollY.value
@@ -452,7 +479,7 @@ const SocialTradersTabsView: React.FC = () => {
           <PagerView
             ref={pagerRef}
             style={tw.style('flex-1')}
-            initialPage={LEADERBOARD_INDEX}
+            initialPage={initialIndex}
             onPageSelected={handlePageSelected}
             testID={SocialTradersTabsViewSelectorsIDs.PAGER}
           >
@@ -476,6 +503,7 @@ const SocialTradersTabsView: React.FC = () => {
             >
               <FeedView
                 isActive={activeIndex === FEED_INDEX}
+                initialAudience={route.params?.landingFeedAudience}
                 onQuickBuy={handleQuickBuy}
                 onSpotAvailabilityChange={handleFeedSpotAvailabilityChange}
                 onScroll={feedScrollHandler}

--- a/app/components/Views/SocialLeaderboard/SocialTradersTabsView/abTestConfig.ts
+++ b/app/components/Views/SocialLeaderboard/SocialTradersTabsView/abTestConfig.ts
@@ -9,6 +9,10 @@ import type { FeedAudience } from '../FeedView/types';
 // - control: the Leaderboard tab (current behavior)
 // - treatment: the Feed tab with the "All" audience preselected
 //
+// In both variants the preselected option is the leftmost one, so treatment
+// also swaps the tab order (Feed | Leaderboard) and the audience toggle order
+// (All | Following).
+//
 // The homepage resolves the assignment without emitting exposure and forwards
 // the landing target as route params; `SocialTradersTabsView` emits exposure
 // when it receives those params, so only users who actually opened the surface

--- a/app/components/Views/SocialLeaderboard/SocialTradersTabsView/abTestConfig.ts
+++ b/app/components/Views/SocialLeaderboard/SocialTradersTabsView/abTestConfig.ts
@@ -1,0 +1,69 @@
+import { EVENT_NAME } from '../../../../core/Analytics/MetaMetrics.events';
+import type { ABTestAnalyticsMapping } from '../../../../util/analytics/abTestAnalytics.types';
+import type { FeedAudience } from '../FeedView/types';
+
+// --- Leaderboard Landing Feed A/B Test (TSA-1042) ---
+//
+// Controls where the homepage "Top traders" entry points (section header and
+// the "View more" card) land inside the Follow Trading surface:
+// - control: the Leaderboard tab (current behavior)
+// - treatment: the Feed tab with the "All" audience preselected
+//
+// The homepage resolves the assignment without emitting exposure and forwards
+// the landing target as route params; `SocialTradersTabsView` emits exposure
+// when it receives those params, so only users who actually opened the surface
+// from the homepage carousel are counted (nav-tab, deeplink, and notification
+// entries never resolve this experiment).
+
+export const LEADERBOARD_LANDING_FEED_AB_KEY =
+  'socialAiTSA1042AbtestLeaderboardLandingFeed';
+
+export enum LeaderboardLandingFeedVariant {
+  Control = 'control',
+  Treatment = 'treatment',
+}
+
+/** Tab the Follow Trading surface opens on. */
+export type SocialTradersLandingTab = 'leaderboard' | 'feed';
+
+interface LeaderboardLandingFeedVariantConfig {
+  landingTab: SocialTradersLandingTab;
+  /** Audience preselected on the Feed tab. Omitted for leaderboard landings. */
+  landingFeedAudience?: FeedAudience;
+}
+
+export const LEADERBOARD_LANDING_FEED_VARIANTS: Record<
+  LeaderboardLandingFeedVariant,
+  LeaderboardLandingFeedVariantConfig
+> = {
+  [LeaderboardLandingFeedVariant.Control]: { landingTab: 'leaderboard' },
+  [LeaderboardLandingFeedVariant.Treatment]: {
+    landingTab: 'feed',
+    landingFeedAudience: 'all',
+  },
+};
+
+export const LEADERBOARD_LANDING_FEED_EXPOSURE_METADATA: {
+  experimentName: string;
+  variationNames: Partial<Record<LeaderboardLandingFeedVariant, string>>;
+} = {
+  experimentName: 'Leaderboard Landing Feed',
+  variationNames: {
+    [LeaderboardLandingFeedVariant.Control]: 'Lands on Leaderboard tab',
+    [LeaderboardLandingFeedVariant.Treatment]: 'Lands on Feed tab (All)',
+  },
+};
+
+export const LEADERBOARD_LANDING_FEED_AB_TEST_ANALYTICS_MAPPING: ABTestAnalyticsMapping =
+  {
+    flagKey: LEADERBOARD_LANDING_FEED_AB_KEY,
+    validVariants: Object.values(LeaderboardLandingFeedVariant),
+    eventNames: [
+      EVENT_NAME.SOCIAL_TRADER_LEADERBOARD_SCREEN_VIEWED,
+      EVENT_NAME.SOCIAL_TRADER_LEADERBOARD_TRADER_CLICKED,
+      EVENT_NAME.SOCIAL_TRADER_FEED_SCREEN_VIEWED,
+      EVENT_NAME.SOCIAL_TRADER_FEED_INTERACTION,
+      EVENT_NAME.SOCIAL_TRADER_FEED_ITEM_TRADE_CLICKED,
+      EVENT_NAME.SOCIAL_FOLLOW_TRADING_INTERACTION,
+    ],
+  };

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -1002,6 +1002,12 @@ export type RootStackParamList = {
          * OS denied permission. Shows a one-shot, auto-dismissing nudge banner
          * on the leaderboard with a CTA to open device settings. */
         showNotificationsBanner?: boolean;
+        /** Tab the Follow Trading surface should open on. Set by the homepage
+         * Top Traders entry points from the TSA-1042 landing A/B test; absent
+         * for every other entry point, which keeps the leaderboard landing. */
+        landingTab?: 'leaderboard' | 'feed';
+        /** Audience preselected on the Feed tab when `landingTab` is `feed`. */
+        landingFeedAudience?: 'all' | 'following';
       }
     | undefined;
   TraderProfileView: {

--- a/app/util/analytics/abTestAnalyticsRegistry.ts
+++ b/app/util/analytics/abTestAnalyticsRegistry.ts
@@ -17,6 +17,7 @@ import {
 } from '../../components/UI/TokenDetails/components/abTestConfig';
 import { SOCIAL_AI_QUICK_BUY_AB_TEST_ANALYTICS_MAPPING } from '../../components/UI/QuickBuy/abTestConfig';
 import { TOP_TRADERS_BUY_ACTION_AB_TEST_ANALYTICS_MAPPING } from '../../components/Views/SocialLeaderboard/TraderPositionView/abTestConfig';
+import { LEADERBOARD_LANDING_FEED_AB_TEST_ANALYTICS_MAPPING } from '../../components/Views/SocialLeaderboard/SocialTradersTabsView/abTestConfig';
 import { WHATS_HAPPENING_EXPLORE_AB_TEST_ANALYTICS_MAPPING } from '../../components/Views/TrendingView/abTestConfig';
 import { EXPLORE_QUICK_BUY_AB_TEST_ANALYTICS_MAPPING } from '../../components/Views/TrendingView/search/abTestConfig';
 import { ONBOARDING_INTEREST_QUESTIONNAIRE_AB_TEST_ANALYTICS_MAPPING } from '../../components/Views/OnboardingInterestQuestionnaire/abTestConfig';
@@ -58,6 +59,7 @@ export const AB_TEST_ANALYTICS_MAPPINGS: readonly ABTestAnalyticsMapping[] = [
 
   // Top Traders (Social Leaderboard)
   TOP_TRADERS_BUY_ACTION_AB_TEST_ANALYTICS_MAPPING,
+  LEADERBOARD_LANDING_FEED_AB_TEST_ANALYTICS_MAPPING,
 
   // Perps
   BUTTON_COLOR_AB_TEST_ANALYTICS_MAPPING,

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -4839,6 +4839,14 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  socialAiTSA1042AbtestLeaderboardLandingFeed: {
+    name: 'socialAiTSA1042AbtestLeaderboardLandingFeed',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: 'control',
+    status: FeatureFlagStatus.Active,
+  },
+
   socialAiTSA612AbtestQuickBuy: {
     name: 'socialAiTSA612AbtestQuickBuy',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Today, tapping the homepage **Top traders** section header or its **View more** card always lands the user on the **Leaderboard** tab of the Follow Trading surface. We want to measure whether the activity **Feed** is a better landing surface for that entry point.

This adds the `socialAiTSA1042AbtestLeaderboardLandingFeed` A/B test:

- **control** — lands on the Leaderboard tab (current behavior, and the fallback when the flag is missing, invalid, or unresolved)
- **treatment** — lands on the Feed tab with the **All** audience preselected

In both variants the preselected option is the leftmost one, so treatment also swaps the tab order (**Feed | Leaderboard**) and the audience toggle order (**All | Following**).

Implementation notes:

- Test definition (flag key, variant enum, variant config, exposure metadata, analytics mapping) is centralized in a new `SocialTradersTabsView/abTestConfig.ts`, per `docs/ab-testing.md`.
- The homepage carousel resolves the assignment via `useABTest` with `trackExposure: false` and forwards the landing target as `landingTab` / `landingFeedAudience` route params. `SocialTradersTabsView` emits `Experiment Viewed` only when those params are present, so exposure is scoped to users who actually opened the surface from the homepage carousel — nav-tab, deeplink, notification, and onboarding hand-off entries never resolve the experiment and keep the Leaderboard landing.
- `FeedView` gains an optional `initialAudience` prop (defaults to `following`) so the tabs container can seed the landing scope, and derives the toggle order from it.
- `SocialTradersTabsView` no longer hardcodes tab indices: they are derived from a `tabOrder` read once at mount, which keeps the tabs bar, the pager pages, the per-tab scroll sync, and the tab-change analytics aligned under either order.
- `FeedAudienceToggle` takes an optional `order` prop (defaults to Following | All). Its slide/cross-fade math was rewritten in positional (first/second segment) terms instead of audience names, so the animation is correct under either order.
- Business events are auto-enriched with `active_ab_tests` through the shared registry (`app/util/analytics/abTestAnalyticsRegistry.ts`); no custom tracker path is involved, so no manual `active_ab_tests` attachment and no new `ab_tests` payloads.
- Registered in `tests/feature-flags/feature-flag-registry.ts` with a production default of `control` so E2E runs keep today's behavior.

Note for metric definition: `TopTradersView` fires `Trader Leaderboard Screen Viewed` on mount regardless of the active tab (the pager mounts both pages), so treatment sessions log both leaderboard-viewed and feed-viewed. That is pre-existing behavior for tab swipes as well and was intentionally left unchanged here.

The LaunchDarkly JSON flag itself is created outside this repo.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

Refs: TSA-1042

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Top traders landing tab A/B test

  Scenario: control lands on the Leaderboard tab
    Given the socialAiTSA1042AbtestLeaderboardLandingFeed flag resolves to "control"
    And the user is on the homepage with the "Top traders" section visible

    When user taps the "Top traders" section header
    Then the Follow Trading surface opens on the "Leaderboard" tab

    When user goes back and taps the "View more" card in the carousel
    Then the Follow Trading surface opens on the "Leaderboard" tab

  Scenario: treatment lands on the Feed tab with the All audience
    Given the socialAiTSA1042AbtestLeaderboardLandingFeed flag resolves to "treatment"
    And the user is on the homepage with the "Top traders" section visible

    When user taps the "Top traders" section header
    Then the Follow Trading surface opens on the "Feed" tab
    And "Feed" is the leftmost tab and "Leaderboard" the second one
    And the "All" audience is selected in the feed audience toggle
    And "All" is the leftmost segment and "Following" the second one

    When user taps the "Leaderboard" tab
    Then the leaderboard page is shown and the pill animation tracks the swap

    When user goes back and taps the "View more" card in the carousel
    Then the Follow Trading surface opens on the "Feed" tab
    And the "All" audience is selected in the feed audience toggle

  Scenario: other entry points are unaffected
    Given the socialAiTSA1042AbtestLeaderboardLandingFeed flag resolves to "treatment"

    When user opens Follow Trading from a deeplink, a notification, or the Traders action button
    Then the surface opens on the "Leaderboard" tab
    And the tab order stays "Leaderboard | Feed" with the toggle order "Following | All"
    And no "Experiment Viewed" event is emitted for this experiment
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no new UI. Existing Leaderboard landing is unchanged for control.

### **After**

N/A — treatment reuses the existing Feed tab and audience toggle; the only visual difference is the left-to-right order of the two tabs and of the two audience segments.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped A/B navigation and analytics on an existing Follow Trading surface; other entry points unchanged and default remains Leaderboard.
> 
> **Overview**
> Adds **`socialAiTSA1042AbtestLeaderboardLandingFeed`** so homepage **Top traders** header and **View more** can land on **Leaderboard** (control) or **Feed** with **All** (treatment).
> 
> The homepage resolves the flag with **`trackExposure: false`** and passes **`landingTab`** / **`landingFeedAudience`** through **`navigateToSocialLeaderboard`**. **`SocialTradersTabsView`** opens on the requested tab, reorders tabs (**Feed | Leaderboard** when treatment), records exposure only when those params are present, and passes **`initialAudience`** into **`FeedView`**. **`FeedAudienceToggle`** supports a configurable segment order so the preselected audience stays leftmost.
> 
> Config lives in **`abTestConfig.ts`**, with route typing, analytics registry wiring, and the feature-flag registry defaulting to **control**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91b46777a385ac631d8f8c0eb827b9c45695a553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->