### PR TITLE
fix(perps): preserve Terminal categories on snapshot fallback

### DIFF
--- a/.yarn/patches/@metamask-perps-controller-npm-13.0.0-438f476ec4.patch
+++ b/.yarn/patches/@metamask-perps-controller-npm-13.0.0-438f476ec4.patch
@@ -1,0 +1,236 @@
+diff --git a/dist/constants/hyperLiquidConfig.cjs b/dist/constants/hyperLiquidConfig.cjs
+index 96c6436963c201e05f4837bd36f90b384eb1a7c7..1d578198ceccf59f19c054e1c90884c802aeaeb2 100644
+--- a/dist/constants/hyperLiquidConfig.cjs
++++ b/dist/constants/hyperLiquidConfig.cjs
+@@ -336,8 +336,8 @@ exports.HIP3_ASSET_MARKET_TYPES = {
+     'xyz:SOFTBANK': index_js_1.MarketCategory.Stock,
+     'xyz:KIOXIA': index_js_1.MarketCategory.Stock,
+     // xyz DEX - Pre-IPO
+-    'xyz:CBRS': index_js_1.MarketCategory.PreIpo,
+-    'xyz:SPCX': index_js_1.MarketCategory.PreIpo,
++    'xyz:CBRS': index_js_1.MarketCategory.Stock,
++    'xyz:SPCX': index_js_1.MarketCategory.Stock,
+     'xyz:IPOP': index_js_1.MarketCategory.PreIpo,
+     // xyz DEX - Indices
+     'xyz:SP500': index_js_1.MarketCategory.Index,
+diff --git a/dist/constants/hyperLiquidConfig.mjs b/dist/constants/hyperLiquidConfig.mjs
+index 6500e230f7cedc25170b04618ae3e12d83a0b828..396881b06cb95db22783f216274e430df79abb1b 100644
+--- a/dist/constants/hyperLiquidConfig.mjs
++++ b/dist/constants/hyperLiquidConfig.mjs
+@@ -326,8 +326,8 @@ export const HIP3_ASSET_MARKET_TYPES = {
+     'xyz:SOFTBANK': MarketCategory.Stock,
+     'xyz:KIOXIA': MarketCategory.Stock,
+     // xyz DEX - Pre-IPO
+-    'xyz:CBRS': MarketCategory.PreIpo,
+-    'xyz:SPCX': MarketCategory.PreIpo,
++    'xyz:CBRS': MarketCategory.Stock,
++    'xyz:SPCX': MarketCategory.Stock,
+     'xyz:IPOP': MarketCategory.PreIpo,
+     // xyz DEX - Indices
+     'xyz:SP500': MarketCategory.Index,
+diff --git a/dist/services/MarketDataService.cjs b/dist/services/MarketDataService.cjs
+index 83fc9cd4c9a93e718cd4aa8d31cdfc4c6dd7b3d2..b65fe9328632234c4413a8b46747631fb4b85ceb 100644
+--- a/dist/services/MarketDataService.cjs
++++ b/dist/services/MarketDataService.cjs
+@@ -728,9 +728,9 @@ class MarketDataService {
+                 },
+             });
+             // Prefer a separately configured atomic snapshot only for an exact,
+-            // still-current provider/network/DEX identity. A rejected snapshot has
+-            // one lexical fallback to the provider below and is not followed by a
+-            // second legacy Terminal request.
++            // still-current provider/network/DEX identity. When the snapshot cannot
++            // supply prices, retain Terminal metadata through the legacy endpoint
++            // while falling back to provider prices below.
+             let snapshotAttempted = false;
+             if (globalSnapshot &&
+                 __classPrivateFieldGet(this, _MarketDataService_deps, "f").terminalMarketService?.fetchGlobalSnapshot) {
+@@ -759,12 +759,10 @@ class MarketDataService {
+                     __classPrivateFieldGet(this, _MarketDataService_deps, "f").terminalMarketService.logError(snapshotError, 'getMarketDataWithPrices.globalSnapshot');
+                 }
+             }
+-            // Fetch Terminal API metadata before provider data when enabled.
+-            // Terminal metadata enriches the provider result (name, keywords, tags,
+-            // categories) but never replaces live pricing / funding data.
++            // Fetch Terminal metadata before provider data when enabled, or when the
++            // configured snapshot failed and provider prices need metadata parity.
+             let terminalMetadata;
+-            if (!snapshotAttempted &&
+-                useTerminalApi &&
++            if ((useTerminalApi || snapshotAttempted) &&
+                 __classPrivateFieldGet(this, _MarketDataService_deps, "f").terminalMarketService) {
+                 try {
+                     const result = await __classPrivateFieldGet(this, _MarketDataService_deps, "f").terminalMarketService.fetchMarkets();
+@@ -1127,7 +1125,10 @@ _MarketDataService_deps = new WeakMap(), _MarketDataService_instances = new Weak
+             ...(meta.description !== undefined && {
+                 description: meta.description,
+             }),
+-            ...(meta.marketType !== undefined && { marketType: meta.marketType }),
++            ...(meta.marketType !== undefined && {
++                marketType: meta.marketType,
++                ...(market.isNewMarket === true && { isNewMarket: false }),
++            }),
+             ...(meta.keywords !== undefined && { keywords: meta.keywords }),
+             ...(meta.tags !== undefined && { tags: meta.tags }),
+             ...(meta.categories !== undefined && { categories: meta.categories }),
+diff --git a/dist/services/MarketDataService.mjs b/dist/services/MarketDataService.mjs
+index 93a12e15b60edf1942e197da3f0ea9e84eb50aae..53f22f50dd97dd22aca1b33d7f8f040ff6e5f10b 100644
+--- a/dist/services/MarketDataService.mjs
++++ b/dist/services/MarketDataService.mjs
+@@ -725,9 +725,9 @@ export class MarketDataService {
+                 },
+             });
+             // Prefer a separately configured atomic snapshot only for an exact,
+-            // still-current provider/network/DEX identity. A rejected snapshot has
+-            // one lexical fallback to the provider below and is not followed by a
+-            // second legacy Terminal request.
++            // still-current provider/network/DEX identity. When the snapshot cannot
++            // supply prices, retain Terminal metadata through the legacy endpoint
++            // while falling back to provider prices below.
+             let snapshotAttempted = false;
+             if (globalSnapshot &&
+                 __classPrivateFieldGet(this, _MarketDataService_deps, "f").terminalMarketService?.fetchGlobalSnapshot) {
+@@ -756,12 +756,10 @@ export class MarketDataService {
+                     __classPrivateFieldGet(this, _MarketDataService_deps, "f").terminalMarketService.logError(snapshotError, 'getMarketDataWithPrices.globalSnapshot');
+                 }
+             }
+-            // Fetch Terminal API metadata before provider data when enabled.
+-            // Terminal metadata enriches the provider result (name, keywords, tags,
+-            // categories) but never replaces live pricing / funding data.
++            // Fetch Terminal metadata before provider data when enabled, or when the
++            // configured snapshot failed and provider prices need metadata parity.
+             let terminalMetadata;
+-            if (!snapshotAttempted &&
+-                useTerminalApi &&
++            if ((useTerminalApi || snapshotAttempted) &&
+                 __classPrivateFieldGet(this, _MarketDataService_deps, "f").terminalMarketService) {
+                 try {
+                     const result = await __classPrivateFieldGet(this, _MarketDataService_deps, "f").terminalMarketService.fetchMarkets();
+@@ -1123,7 +1121,10 @@ _MarketDataService_deps = new WeakMap(), _MarketDataService_instances = new Weak
+             ...(meta.description !== undefined && {
+                 description: meta.description,
+             }),
+-            ...(meta.marketType !== undefined && { marketType: meta.marketType }),
++            ...(meta.marketType !== undefined && {
++                marketType: meta.marketType,
++                ...(market.isNewMarket === true && { isNewMarket: false }),
++            }),
+             ...(meta.keywords !== undefined && { keywords: meta.keywords }),
+             ...(meta.tags !== undefined && { tags: meta.tags }),
+             ...(meta.categories !== undefined && { categories: meta.categories }),
+diff --git a/dist/services/TerminalMarketService.cjs b/dist/services/TerminalMarketService.cjs
+index e0e1af306ade3cfcb8d5fd1971dc1876ed7a10c8..86157ed52b19881e41191ea3c80a64f145a36ed2 100644
+--- a/dist/services/TerminalMarketService.cjs
++++ b/dist/services/TerminalMarketService.cjs
+@@ -10,7 +10,7 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
+     if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+     return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+ };
+-var _TerminalMarketService_instances, _TerminalMarketService_deps, _TerminalMarketService_cache, _TerminalMarketService_globalSnapshotCache, _TerminalMarketService_globalSnapshotInFlight, _TerminalMarketService_globalSnapshotGeneration, _TerminalMarketService_fetchAndValidateGlobalSnapshot, _TerminalMarketService_validateAndMapGlobalSnapshot, _TerminalMarketService_validateRequestedIdentity, _TerminalMarketService_buildGlobalSnapshotUrl, _TerminalMarketService_normalizeDexes, _TerminalMarketService_createFingerprint, _TerminalMarketService_validateSnapshotMarket, _TerminalMarketService_mapSnapshotMarket, _TerminalMarketService_marketTypeFor, _TerminalMarketService_cloneGlobalSnapshotResult, _TerminalMarketService_isNonNegativeSafeInteger, _TerminalMarketService_isPositiveSafeInteger, _TerminalMarketService_validateItems, _TerminalMarketService_mapToMarketInfo, _TerminalMarketService_extractMetadata;
++var _TerminalMarketService_instances, _TerminalMarketService_deps, _TerminalMarketService_cache, _TerminalMarketService_globalSnapshotCache, _TerminalMarketService_globalSnapshotInFlight, _TerminalMarketService_globalSnapshotGeneration, _TerminalMarketService_fetchAndValidateGlobalSnapshot, _TerminalMarketService_validateAndMapGlobalSnapshot, _TerminalMarketService_validateRequestedIdentity, _TerminalMarketService_buildGlobalSnapshotUrl, _TerminalMarketService_normalizeDexes, _TerminalMarketService_createFingerprint, _TerminalMarketService_validateSnapshotMarket, _TerminalMarketService_mapSnapshotMarket, _TerminalMarketService_categoryToMarketType, _TerminalMarketService_marketTypeFor, _TerminalMarketService_cloneGlobalSnapshotResult, _TerminalMarketService_isNonNegativeSafeInteger, _TerminalMarketService_isPositiveSafeInteger, _TerminalMarketService_validateItems, _TerminalMarketService_mapToMarketInfo, _TerminalMarketService_extractMetadata;
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.TerminalMarketService = void 0;
+ const superstruct_1 = require("@metamask/superstruct");
+@@ -92,6 +92,7 @@ const TerminalPerpetualItemStruct = (0, superstruct_1.type)({
+     minimumOrderSize: (0, superstruct_1.optional)((0, superstruct_1.number)()),
+     keywords: (0, superstruct_1.optional)((0, superstruct_1.nullable)((0, superstruct_1.array)((0, superstruct_1.string)()))),
+     tags: (0, superstruct_1.optional)((0, superstruct_1.nullable)((0, superstruct_1.array)((0, superstruct_1.string)()))),
++    category: (0, superstruct_1.optional)((0, superstruct_1.nullable)((0, superstruct_1.string)())),
+     categories: (0, superstruct_1.optional)((0, superstruct_1.nullable)((0, superstruct_1.array)((0, superstruct_1.string)()))),
+     marketType: (0, superstruct_1.optional)((0, superstruct_1.nullable)((0, superstruct_1.string)())),
+     listedAt: (0, superstruct_1.optional)((0, superstruct_1.nullable)((0, superstruct_1.union)([(0, superstruct_1.number)(), (0, superstruct_1.string)()]))),
+@@ -518,10 +519,7 @@ _TerminalMarketService_deps = new WeakMap(), _TerminalMarketService_cache = new
+         dataSource: 'terminal-global-snapshot-mark',
+         sourceExpiresAt,
+     };
+-}, _TerminalMarketService_marketTypeFor = function _TerminalMarketService_marketTypeFor(dex, category) {
+-    if (dex === 'main') {
+-        return index_js_1.MarketCategory.CryptoCurrency;
+-    }
++}, _TerminalMarketService_categoryToMarketType = function _TerminalMarketService_categoryToMarketType(category) {
+     if (category === 'stocks') {
+         return index_js_1.MarketCategory.Stock;
+     }
+@@ -532,6 +530,11 @@ _TerminalMarketService_deps = new WeakMap(), _TerminalMarketService_cache = new
+         return category;
+     }
+     return undefined;
++}, _TerminalMarketService_marketTypeFor = function _TerminalMarketService_marketTypeFor(dex, category) {
++    if (dex === 'main') {
++        return index_js_1.MarketCategory.CryptoCurrency;
++    }
++    return __classPrivateFieldGet(this, _TerminalMarketService_instances, "m", _TerminalMarketService_categoryToMarketType).call(this, category);
+ }, _TerminalMarketService_cloneGlobalSnapshotResult = function _TerminalMarketService_cloneGlobalSnapshotResult(result) {
+     return {
+         expiresAt: result.expiresAt,
+@@ -608,6 +611,12 @@ _TerminalMarketService_deps = new WeakMap(), _TerminalMarketService_cache = new
+             entry.marketType =
+                 item.marketType;
+         }
++        else {
++            const fromCategory = __classPrivateFieldGet(this, _TerminalMarketService_instances, "m", _TerminalMarketService_categoryToMarketType).call(this, item.category);
++            if (fromCategory) {
++                entry.marketType = fromCategory;
++            }
++        }
+         if (item.listedAt !== null && item.listedAt !== undefined) {
+             const listedAtMs = typeof item.listedAt === 'number'
+                 ? item.listedAt
+diff --git a/dist/services/TerminalMarketService.mjs b/dist/services/TerminalMarketService.mjs
+index 76d974e101214201595ac34c44327408c841d7c3..447339eba7368176d7b1152f88b5aa73d499a86f 100644
+--- a/dist/services/TerminalMarketService.mjs
++++ b/dist/services/TerminalMarketService.mjs
+@@ -9,7 +9,7 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
+     if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+     return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+ };
+-var _TerminalMarketService_instances, _TerminalMarketService_deps, _TerminalMarketService_cache, _TerminalMarketService_globalSnapshotCache, _TerminalMarketService_globalSnapshotInFlight, _TerminalMarketService_globalSnapshotGeneration, _TerminalMarketService_fetchAndValidateGlobalSnapshot, _TerminalMarketService_validateAndMapGlobalSnapshot, _TerminalMarketService_validateRequestedIdentity, _TerminalMarketService_buildGlobalSnapshotUrl, _TerminalMarketService_normalizeDexes, _TerminalMarketService_createFingerprint, _TerminalMarketService_validateSnapshotMarket, _TerminalMarketService_mapSnapshotMarket, _TerminalMarketService_marketTypeFor, _TerminalMarketService_cloneGlobalSnapshotResult, _TerminalMarketService_isNonNegativeSafeInteger, _TerminalMarketService_isPositiveSafeInteger, _TerminalMarketService_validateItems, _TerminalMarketService_mapToMarketInfo, _TerminalMarketService_extractMetadata;
++var _TerminalMarketService_instances, _TerminalMarketService_deps, _TerminalMarketService_cache, _TerminalMarketService_globalSnapshotCache, _TerminalMarketService_globalSnapshotInFlight, _TerminalMarketService_globalSnapshotGeneration, _TerminalMarketService_fetchAndValidateGlobalSnapshot, _TerminalMarketService_validateAndMapGlobalSnapshot, _TerminalMarketService_validateRequestedIdentity, _TerminalMarketService_buildGlobalSnapshotUrl, _TerminalMarketService_normalizeDexes, _TerminalMarketService_createFingerprint, _TerminalMarketService_validateSnapshotMarket, _TerminalMarketService_mapSnapshotMarket, _TerminalMarketService_categoryToMarketType, _TerminalMarketService_marketTypeFor, _TerminalMarketService_cloneGlobalSnapshotResult, _TerminalMarketService_isNonNegativeSafeInteger, _TerminalMarketService_isPositiveSafeInteger, _TerminalMarketService_validateItems, _TerminalMarketService_mapToMarketInfo, _TerminalMarketService_extractMetadata;
+ import { array, boolean, is, nullable, number, object, optional, string, tuple, type, union } from "@metamask/superstruct";
+ import { bytesToHex, sha256, stringToBytes } from "@metamask/utils";
+ import { canonicalizeHyperLiquidDexes } from "../constants/hyperLiquidConfig.mjs";
+@@ -89,6 +89,7 @@ const TerminalPerpetualItemStruct = type({
+     minimumOrderSize: optional(number()),
+     keywords: optional(nullable(array(string()))),
+     tags: optional(nullable(array(string()))),
++    category: optional(nullable(string())),
+     categories: optional(nullable(array(string()))),
+     marketType: optional(nullable(string())),
+     listedAt: optional(nullable(union([number(), string()]))),
+@@ -514,10 +515,7 @@ _TerminalMarketService_deps = new WeakMap(), _TerminalMarketService_cache = new
+         dataSource: 'terminal-global-snapshot-mark',
+         sourceExpiresAt,
+     };
+-}, _TerminalMarketService_marketTypeFor = function _TerminalMarketService_marketTypeFor(dex, category) {
+-    if (dex === 'main') {
+-        return MarketCategory.CryptoCurrency;
+-    }
++}, _TerminalMarketService_categoryToMarketType = function _TerminalMarketService_categoryToMarketType(category) {
+     if (category === 'stocks') {
+         return MarketCategory.Stock;
+     }
+@@ -528,6 +526,11 @@ _TerminalMarketService_deps = new WeakMap(), _TerminalMarketService_cache = new
+         return category;
+     }
+     return undefined;
++}, _TerminalMarketService_marketTypeFor = function _TerminalMarketService_marketTypeFor(dex, category) {
++    if (dex === 'main') {
++        return MarketCategory.CryptoCurrency;
++    }
++    return __classPrivateFieldGet(this, _TerminalMarketService_instances, "m", _TerminalMarketService_categoryToMarketType).call(this, category);
+ }, _TerminalMarketService_cloneGlobalSnapshotResult = function _TerminalMarketService_cloneGlobalSnapshotResult(result) {
+     return {
+         expiresAt: result.expiresAt,
+@@ -604,6 +607,12 @@ _TerminalMarketService_deps = new WeakMap(), _TerminalMarketService_cache = new
+             entry.marketType =
+                 item.marketType;
+         }
++        else {
++            const fromCategory = __classPrivateFieldGet(this, _TerminalMarketService_instances, "m", _TerminalMarketService_categoryToMarketType).call(this, item.category);
++            if (fromCategory) {
++                entry.marketType = fromCategory;
++            }
++        }
+         if (item.listedAt !== null && item.listedAt !== undefined) {
+             const listedAtMs = typeof item.listedAt === 'number'
+                 ? item.listedAt

--- a/package.json
+++ b/package.json
@@ -356,7 +356,7 @@
     "@metamask/network-enablement-controller": "patch:@metamask/network-enablement-controller@npm%3A5.4.1#~/.yarn/patches/@metamask-network-enablement-controller-npm-5.4.1-020a82a308.patch",
     "@metamask/notification-services-controller": "^26.0.0",
     "@metamask/permission-controller": "^13.1.1",
-    "@metamask/perps-controller": "^13.0.0",
+    "@metamask/perps-controller": "patch:@metamask/perps-controller@npm%3A13.0.0#~/.yarn/patches/@metamask-perps-controller-npm-13.0.0-438f476ec4.patch",
     "@metamask/phishing-controller": "^17.3.1",
     "@metamask/post-message-stream": "^10.0.0",
     "@metamask/preferences-controller": "^23.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9607,7 +9607,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/perps-controller@npm:^13.0.0":
+"@metamask/perps-controller@npm:13.0.0":
   version: 13.0.0
   resolution: "@metamask/perps-controller@npm:13.0.0"
   dependencies:
@@ -9626,6 +9626,28 @@ __metadata:
     "@myx-trade/sdk":
       optional: true
   checksum: 10/1203a718f27a570912ffbea756a5c62d9c89383475789c66d12d3993e4143f0058c2ba285474b21762472b5e0dc7fe32257d4c9ad463fdc459fa197b1b462805
+  languageName: node
+  linkType: hard
+
+"@metamask/perps-controller@patch:@metamask/perps-controller@npm%3A13.0.0#~/.yarn/patches/@metamask-perps-controller-npm-13.0.0-438f476ec4.patch":
+  version: 13.0.0
+  resolution: "@metamask/perps-controller@patch:@metamask/perps-controller@npm%3A13.0.0#~/.yarn/patches/@metamask-perps-controller-npm-13.0.0-438f476ec4.patch::version=13.0.0&hash=1d5df0"
+  dependencies:
+    "@metamask/abi-utils": "npm:^2.0.3"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/superstruct": "npm:^3.4.1"
+    "@metamask/utils": "npm:^11.11.0"
+    "@myx-trade/sdk": "npm:^0.1.265"
+    "@nktkas/hyperliquid": "npm:^0.33.1"
+    bignumber.js: "npm:^9.1.2"
+    reselect: "npm:^5.1.1"
+    uuid: "npm:^8.3.2"
+  dependenciesMeta:
+    "@myx-trade/sdk":
+      optional: true
+  checksum: 10/eba8d020c1c538fdf3955e3cd44a12c01d66b062187b529baa5f45efa4c514cfc7207a0c5affa142046481d8903ced86c7e75714dadfcfd04365bfb831a3b75a
   languageName: node
   linkType: hard
 
@@ -35797,7 +35819,7 @@ __metadata:
     "@metamask/notification-services-controller": "npm:^26.0.0"
     "@metamask/object-multiplex": "npm:^1.1.0"
     "@metamask/permission-controller": "npm:^13.1.1"
-    "@metamask/perps-controller": "npm:^13.0.0"
+    "@metamask/perps-controller": "patch:@metamask/perps-controller@npm%3A13.0.0#~/.yarn/patches/@metamask-perps-controller-npm-13.0.0-438f476ec4.patch"
     "@metamask/phishing-controller": "npm:^17.3.1"
     "@metamask/post-message-stream": "npm:^10.0.0"
     "@metamask/preferences-controller": "npm:^23.0.0"


### PR DESCRIPTION
## **Description**

`@metamask/perps-controller@13.0.0` drops Terminal v1 `category` when `marketType` is absent. It also skips v1 metadata when the configured v2 snapshot fails. The fallback then keeps live provider prices but can lose Terminal's category mapping.

This temporary Yarn patch backports the controller fix while the next package release is prepared:

- map `pre_ipo` to `pre-ipo` and `stocks` to `stock`;
- fetch v1 metadata after a failed v2 snapshot while retaining provider prices;
- clear stale `isNewMarket` when Terminal supplies a category;
- classify CBRS and SPCX as stocks in the static fallback. IPOP remains Pre-IPO.

Validated on a Pixel 6 with a forced v2 failure. Unitree, CXMT, and SKHY resolved to Pre-IPO; CBRS and SPCX resolved to Stocks. All five retained prices and none used the v2 snapshot data source.

This supersedes [Mobile #35313](https://github.com/MetaMask/metamask-mobile/pull/35313), whose patch targets controller v12. Remove this patch after a controller release contains [Core #9987](https://github.com/MetaMask/core/pull/9987), which combines the category mapping and snapshot-fallback fix.

## **Changelog**

CHANGELOG entry: Fixed Perps market categories when Terminal snapshot fallback is used

## **Related issues**

Refs: [MetaMask/core#9987](https://github.com/MetaMask/core/pull/9987)

## **Manual testing steps**

```gherkin
Feature: Perps categories survive Terminal snapshot fallback

  Scenario: Terminal v2 fails while provider prices remain available
    Given Perps is using Hyperliquid on mainnet
    And the Terminal v2 snapshot request fails
    When market data loads through Terminal v1 metadata and provider prices
    Then Unitree, CXMT, and SKHY are classified as Pre-IPO
    And CBRS and SPCX are classified as Stocks
    And all five markets have current prices
    And none of the five markets remains marked as new
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Perps market-data fallback and category labeling for real markets; wrong metadata could mis-filter or mis-label markets, though pricing still comes from the provider.
> 
> **Overview**
> Adds a **temporary Yarn patch** on `@metamask/perps-controller@13.0.0` (wired through `package.json` / `yarn.lock`) until an upstream release includes the Core fix.
> 
> The patch changes how Perps loads Terminal market metadata when the **v2 global snapshot** is tried but cannot supply prices: it now still calls the **legacy Terminal markets API** so categories and related fields stay aligned while **live provider prices** are used. It also derives **`marketType` from Terminal’s `category`** when `marketType` is missing, and clears stale **`isNewMarket`** when Terminal metadata applies a type.
> 
> Static HIP-3 fallbacks reclassify **`xyz:CBRS`** and **`xyz:SPCX`** from Pre-IPO to **Stock** (`IPOP` stays Pre-IPO).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 484a064ed4ee8e5cb39cd701fe240b4070688d1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->