### PR TITLE
fix(perps): correct local market classification

### DIFF
--- a/.yarn/patches/@metamask-perps-controller-npm-13.0.0-438f476ec4.patch
+++ b/.yarn/patches/@metamask-perps-controller-npm-13.0.0-438f476ec4.patch
@@ -1,0 +1,30 @@
+diff --git a/dist/constants/hyperLiquidConfig.cjs b/dist/constants/hyperLiquidConfig.cjs
+index 96c6436963c201e05f4837bd36f90b384eb1a7c7..e9632ca36f0d98ec42d10ee6ef74cf71cf65ccd9 100644
+--- a/dist/constants/hyperLiquidConfig.cjs
++++ b/dist/constants/hyperLiquidConfig.cjs
+@@ -336,8 +336,8 @@ exports.HIP3_ASSET_MARKET_TYPES = {
+     'xyz:SOFTBANK': index_js_1.MarketCategory.Stock,
+     'xyz:KIOXIA': index_js_1.MarketCategory.Stock,
+     // xyz DEX - Pre-IPO
+-    'xyz:CBRS': index_js_1.MarketCategory.PreIpo,
+-    'xyz:SPCX': index_js_1.MarketCategory.PreIpo,
++    'xyz:CBRS': index_js_1.MarketCategory.Stock,
++    'xyz:SPCX': index_js_1.MarketCategory.Stock,
+     'xyz:IPOP': index_js_1.MarketCategory.PreIpo,
+     // xyz DEX - Indices
+     'xyz:SP500': index_js_1.MarketCategory.Index,
+diff --git a/dist/constants/hyperLiquidConfig.mjs b/dist/constants/hyperLiquidConfig.mjs
+index 6500e230f7cedc25170b04618ae3e12d83a0b828..9f963b1452931054a7e14d740f54aff2d09a36a0 100644
+--- a/dist/constants/hyperLiquidConfig.mjs
++++ b/dist/constants/hyperLiquidConfig.mjs
+@@ -326,8 +326,8 @@ export const HIP3_ASSET_MARKET_TYPES = {
+     'xyz:SOFTBANK': MarketCategory.Stock,
+     'xyz:KIOXIA': MarketCategory.Stock,
+     // xyz DEX - Pre-IPO
+-    'xyz:CBRS': MarketCategory.PreIpo,
+-    'xyz:SPCX': MarketCategory.PreIpo,
++    'xyz:CBRS': MarketCategory.Stock,
++    'xyz:SPCX': MarketCategory.Stock,
+     'xyz:IPOP': MarketCategory.PreIpo,
+     // xyz DEX - Indices
+     'xyz:SP500': MarketCategory.Index,

--- a/package.json
+++ b/package.json
@@ -356,7 +356,7 @@
     "@metamask/network-enablement-controller": "patch:@metamask/network-enablement-controller@npm%3A5.4.1#~/.yarn/patches/@metamask-network-enablement-controller-npm-5.4.1-020a82a308.patch",
     "@metamask/notification-services-controller": "^26.0.0",
     "@metamask/permission-controller": "^13.1.1",
-    "@metamask/perps-controller": "^13.0.0",
+    "@metamask/perps-controller": "patch:@metamask/perps-controller@npm%3A13.0.0#~/.yarn/patches/@metamask-perps-controller-npm-13.0.0-438f476ec4.patch",
     "@metamask/phishing-controller": "^17.3.1",
     "@metamask/post-message-stream": "^10.0.0",
     "@metamask/preferences-controller": "^23.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9607,7 +9607,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/perps-controller@npm:^13.0.0":
+"@metamask/perps-controller@npm:13.0.0":
   version: 13.0.0
   resolution: "@metamask/perps-controller@npm:13.0.0"
   dependencies:
@@ -9626,6 +9626,28 @@ __metadata:
     "@myx-trade/sdk":
       optional: true
   checksum: 10/1203a718f27a570912ffbea756a5c62d9c89383475789c66d12d3993e4143f0058c2ba285474b21762472b5e0dc7fe32257d4c9ad463fdc459fa197b1b462805
+  languageName: node
+  linkType: hard
+
+"@metamask/perps-controller@patch:@metamask/perps-controller@npm%3A13.0.0#~/.yarn/patches/@metamask-perps-controller-npm-13.0.0-438f476ec4.patch":
+  version: 13.0.0
+  resolution: "@metamask/perps-controller@patch:@metamask/perps-controller@npm%3A13.0.0#~/.yarn/patches/@metamask-perps-controller-npm-13.0.0-438f476ec4.patch::version=13.0.0&hash=ec5e07"
+  dependencies:
+    "@metamask/abi-utils": "npm:^2.0.3"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/superstruct": "npm:^3.4.1"
+    "@metamask/utils": "npm:^11.11.0"
+    "@myx-trade/sdk": "npm:^0.1.265"
+    "@nktkas/hyperliquid": "npm:^0.33.1"
+    bignumber.js: "npm:^9.1.2"
+    reselect: "npm:^5.1.1"
+    uuid: "npm:^8.3.2"
+  dependenciesMeta:
+    "@myx-trade/sdk":
+      optional: true
+  checksum: 10/a281c9a32a5be9dd5942ca73b738a38edec2a6e214ea850f0f70f38686e3854f3330c3c4776bd8c70c7d506b51c220bac557b62ac600faccd1d8a97988899581
   languageName: node
   linkType: hard
 
@@ -35797,7 +35819,7 @@ __metadata:
     "@metamask/notification-services-controller": "npm:^26.0.0"
     "@metamask/object-multiplex": "npm:^1.1.0"
     "@metamask/permission-controller": "npm:^13.1.1"
-    "@metamask/perps-controller": "npm:^13.0.0"
+    "@metamask/perps-controller": "patch:@metamask/perps-controller@npm%3A13.0.0#~/.yarn/patches/@metamask-perps-controller-npm-13.0.0-438f476ec4.patch"
     "@metamask/phishing-controller": "npm:^17.3.1"
     "@metamask/post-message-stream": "npm:^10.0.0"
     "@metamask/preferences-controller": "npm:^23.0.0"


### PR DESCRIPTION
## **Description**

The controller v13 local fallback classifies CBRS and SPCX as Pre-IPO. Both are stocks.

This temporary Yarn patch changes only those two `HIP3_ASSET_MARKET_TYPES` entries in the package's CJS and MJS builds. It does not change Terminal requests or provider fallback behavior. Remove it after the matching Core change ships in a controller release.

This replaces #35379, which incorrectly added a deprecated Terminal v1 request.

## **Changelog**

CHANGELOG entry: Fixed CBRS and SPCX classification when Perps uses local market metadata

## **Related issues**

Refs: #35379

## **Manual testing steps**

```gherkin
Feature: Local Perps market classification

  Scenario: Local market metadata is used
    Given Terminal v2 data is unavailable
    When Hyperliquid market data loads
    Then CBRS and SPCX are classified as stocks
    And IPOP remains classified as Pre-IPO
```

Validation at `ffb3b210fbe`:

- `yarn install --immutable --mode=skip-build`
- Installed CJS export: CBRS `stock`, SPCX `stock`, IPOP `pre-ipo`
- Installed MJS export: CBRS `stock`, SPCX `stock`, IPOP `pre-ipo`
- Compared the original and patched Yarn archives. Only `dist/constants/hyperLiquidConfig.cjs` and `.mjs` differ.

## **Screenshots/Recordings**

### **Before**

N/A. This changes fallback metadata only.

### **After**

N/A. This changes fallback metadata only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A. This metadata-only patch is verified from both installed runtime exports.
- [x] I've tested with a power user scenario
  - N/A. Wallet size cannot affect these static constants.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A. This patch changes static classification values.

For performance guidelines and tooling, see the [Performance Guide](https://consenssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
