### PR TITLE
feat(predict): add Live Now carousel series priorityOrder (PRED-1243)

### DIFF
--- a/app/components/UI/Predict/constants/flags.ts
+++ b/app/components/UI/Predict/constants/flags.ts
@@ -22,6 +22,7 @@ export const DEFAULT_PREDICT_FEED_CAROUSEL_FLAG: PredictFeedCarouselConfig = {
   enabled: false,
   minimumVersion: '',
   mode: 'live',
+  priorityOrder: [],
   contentSource: {
     composition: 'query-results',
     queryParams: '',

--- a/app/components/UI/Predict/schemas/flags.test.ts
+++ b/app/components/UI/Predict/schemas/flags.test.ts
@@ -25,6 +25,7 @@ describe('PredictFeedCarouselSchema', () => {
     mode: 'custom',
     title: 'Wimbledon',
     deeplink: 'https://link.metamask.io/predict?feed=sports&tab=tennis',
+    priorityOrder: ['10684'],
     contentSource: {
       composition: 'query-results',
       queryParams: 'tag_slug=tennis&title_search=Wimbledon',
@@ -68,11 +69,26 @@ describe('PredictFeedCarouselSchema', () => {
     });
   });
 
+  it('defaults an omitted priorityOrder to an empty list', () => {
+    const { priorityOrder } = create(
+      {
+        enabled: true,
+        minimumVersion: '1.0.0',
+        mode: 'custom',
+        title: 'Top markets',
+      },
+      PredictFeedCarouselSchema,
+    );
+
+    expect(priorityOrder).toEqual([]);
+  });
+
   it.each([
     ['mode', 'automatic'],
     ['minimumVersion', 'not-semver'],
     ['title', 123],
     ['deeplink', false],
+    ['priorityOrder', ['10684', 2]],
   ])('throws for unsupported %s value', (field, value) => {
     const input = { ...validFlag, [field]: value };
 

--- a/app/components/UI/Predict/schemas/flags.ts
+++ b/app/components/UI/Predict/schemas/flags.ts
@@ -61,6 +61,10 @@ export const PredictFeedCarouselSchema = defaulted(
     ),
     title: optional(string()),
     deeplink: optional(string()),
+    priorityOrder: defaulted(
+      array(string()),
+      () => DEFAULT_PREDICT_FEED_CAROUSEL_FLAG.priorityOrder,
+    ),
     contentSource: defaulted(
       type({
         composition: defaulted(

--- a/app/components/UI/Predict/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.test.ts
@@ -1998,6 +1998,7 @@ describe('Predict Feature Flag Selectors', () => {
       mode: 'custom',
       title: '  Wimbledon  ',
       deeplink: '  https://link.metamask.io/predict?feed=sports&tab=tennis  ',
+      priorityOrder: [' 10684 ', '10684', ' ', '10683'],
       contentSource: {
         composition: 'query-results',
         queryParams: '  ?tag_slug=tennis&order=volume24hr  ',
@@ -2022,6 +2023,7 @@ describe('Predict Feature Flag Selectors', () => {
         ...validFlag,
         title: 'Wimbledon',
         deeplink: 'https://link.metamask.io/predict?feed=sports&tab=tennis',
+        priorityOrder: ['10684', '10683'],
         contentSource: {
           composition: 'query-results',
           queryParams: 'tag_slug=tennis&order=volume24hr',
@@ -2069,9 +2071,28 @@ describe('Predict Feature Flag Selectors', () => {
       expect(result).toBe(DEFAULT_PREDICT_FEED_CAROUSEL_FLAG);
     });
 
+    it('applies priorityOrder in live mode', () => {
+      const result = selectPredictFeedCarouselConfig(
+        createState({
+          enabled: true,
+          minimumVersion: '1.0.0',
+          mode: 'live',
+          priorityOrder: [' 10684 ', '10684', ' ', '10683'],
+        }),
+      );
+
+      expect(result).toStrictEqual({
+        ...DEFAULT_PREDICT_FEED_CAROUSEL_FLAG,
+        enabled: true,
+        minimumVersion: '1.0.0',
+        mode: 'live',
+        priorityOrder: ['10684', '10683'],
+      });
+    });
+
     it.each([
       { ...validFlag, enabled: false },
-      { ...validFlag, mode: 'live' },
+      { ...validFlag, mode: 'live', priorityOrder: [] },
       { ...validFlag, deeplink: 'https://example.com/predict' },
       { ...validFlag, deeplink: 'metamask://connect?channelId=test' },
       {
@@ -2092,6 +2113,7 @@ describe('Predict Feature Flag Selectors', () => {
           excludedMarketIds: ['market-1', 2],
         },
       },
+      { ...validFlag, priorityOrder: ['10684', 2] },
       { ...validFlag, minimumVersion: 'not-semver' },
       { ...validFlag, minimumVersion: '99.0.0' },
     ])('returns live mode for unavailable or malformed config %#', (flag) => {

--- a/app/components/UI/Predict/selectors/featureFlags/index.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.ts
@@ -220,11 +220,28 @@ export const selectPredictFeedCarouselConfig = createSelector(
       DEFAULT_PREDICT_FEED_CAROUSEL_FLAG,
     );
 
-    if (
-      parsedFlag.mode !== 'custom' ||
-      !validatedVersionGatedFeatureFlag(parsedFlag)
-    ) {
+    if (!validatedVersionGatedFeatureFlag(parsedFlag)) {
       return DEFAULT_PREDICT_FEED_CAROUSEL_FLAG;
+    }
+
+    const priorityOrder = [
+      ...new Set(
+        parsedFlag.priorityOrder.map((id) => id.trim()).filter(Boolean),
+      ),
+    ];
+
+    if (parsedFlag.mode !== 'custom') {
+      if (priorityOrder.length === 0) {
+        return DEFAULT_PREDICT_FEED_CAROUSEL_FLAG;
+      }
+
+      return {
+        ...DEFAULT_PREDICT_FEED_CAROUSEL_FLAG,
+        enabled: true,
+        minimumVersion: parsedFlag.minimumVersion,
+        mode: 'live',
+        priorityOrder,
+      };
     }
 
     const title = parsedFlag.title?.trim() || undefined;
@@ -238,6 +255,7 @@ export const selectPredictFeedCarouselConfig = createSelector(
       ...parsedFlag,
       title,
       deeplink,
+      priorityOrder,
       contentSource: {
         ...parsedFlag.contentSource,
         queryParams: parsedFlag.contentSource.queryParams

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -22,6 +22,12 @@ export interface PredictFeedCarouselConfig extends VersionGatedFeatureFlag {
   mode: 'live' | 'custom';
   title?: string;
   deeplink?: string;
+  /**
+   * Series IDs pinned to the front of the Live Now carousel, first = highest
+   * priority. Unknown IDs are ignored. Empty keeps the default composition
+   * order (sports interleaved with crypto).
+   */
+  priorityOrder: string[];
   contentSource: {
     /** `live-now` reuses PRED-834 composition; `query-results` renders results directly. */
     composition: 'query-results' | 'live-now';

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.test.tsx
@@ -180,6 +180,7 @@ const createCustomConfig = (
   minimumVersion: '1.0.0',
   mode: 'custom',
   title: 'Wimbledon',
+  priorityOrder: [],
   contentSource: {
     composition: 'query-results',
     queryParams: 'tag_slug=tennis',

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/liveNowPriorityOrder.test.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/liveNowPriorityOrder.test.ts
@@ -1,0 +1,70 @@
+import type { PredictMarket } from '../../../../types';
+import { applySeriesPriorityOrder } from './liveNowPriorityOrder';
+
+const createMarket = (id: string, seriesId?: string): PredictMarket =>
+  ({
+    id,
+    ...(seriesId ? { series: { id: seriesId, slug: id, title: id } } : {}),
+  }) as unknown as PredictMarket;
+
+const idsOf = (markets: PredictMarket[]) => markets.map((market) => market.id);
+
+describe('applySeriesPriorityOrder', () => {
+  it('returns the original order when priorityOrder is empty', () => {
+    const markets = [createMarket('L1', 's1'), createMarket('C1', 's2')];
+
+    const result = applySeriesPriorityOrder(markets, []);
+
+    expect(result).toBe(markets);
+  });
+
+  it('returns the original order when no markets match', () => {
+    const markets = [createMarket('L1', 's1'), createMarket('L2')];
+
+    const result = applySeriesPriorityOrder(markets, ['missing']);
+
+    expect(result).toBe(markets);
+  });
+
+  it('pins matching series to the front in priorityOrder', () => {
+    const markets = [
+      createMarket('L1', 'sports'),
+      createMarket('C1', '10684'),
+      createMarket('L2', 'sports'),
+      createMarket('C2', '10683'),
+    ];
+
+    const result = applySeriesPriorityOrder(markets, ['10684', '10683']);
+
+    expect(idsOf(result)).toEqual(['C1', 'C2', 'L1', 'L2']);
+  });
+
+  it('keeps relative order for multiple markets in the same series', () => {
+    const markets = [
+      createMarket('L1', 'nba'),
+      createMarket('C1', '10684'),
+      createMarket('L2', 'nba'),
+    ];
+
+    const result = applySeriesPriorityOrder(markets, ['nba']);
+
+    expect(idsOf(result)).toEqual(['L1', 'L2', 'C1']);
+  });
+
+  it('ignores unknown series IDs and duplicate priority entries', () => {
+    const markets = [
+      createMarket('L1'),
+      createMarket('C1', '10684'),
+      createMarket('C2', '10683'),
+    ];
+
+    const result = applySeriesPriorityOrder(markets, [
+      'missing',
+      '10683',
+      '10683',
+      '10684',
+    ]);
+
+    expect(idsOf(result)).toEqual(['C2', 'C1', 'L1']);
+  });
+});

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/liveNowPriorityOrder.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/liveNowPriorityOrder.ts
@@ -1,0 +1,47 @@
+import type { PredictMarket } from '../../../../types';
+
+/**
+ * Pins markets whose `series.id` appears in `priorityOrder` to the front of
+ * the Live Now carousel. Earlier IDs win. Markets without a matching series
+ * keep their relative order after the pinned cards. Unknown IDs are ignored.
+ */
+export const applySeriesPriorityOrder = (
+  markets: PredictMarket[],
+  priorityOrder: readonly string[],
+): PredictMarket[] => {
+  if (priorityOrder.length === 0 || markets.length === 0) {
+    return markets;
+  }
+
+  const prioritySeriesIds = new Set(priorityOrder);
+  const prioritizedBySeries = new Map<string, PredictMarket[]>();
+  const rest: PredictMarket[] = [];
+
+  for (const market of markets) {
+    const seriesId = market.series?.id;
+    if (seriesId && prioritySeriesIds.has(seriesId)) {
+      const bucket = prioritizedBySeries.get(seriesId) ?? [];
+      bucket.push(market);
+      prioritizedBySeries.set(seriesId, bucket);
+      continue;
+    }
+
+    rest.push(market);
+  }
+
+  if (prioritizedBySeries.size === 0) {
+    return markets;
+  }
+
+  const prioritized: PredictMarket[] = [];
+  for (const seriesId of priorityOrder) {
+    const bucket = prioritizedBySeries.get(seriesId);
+    if (!bucket) {
+      continue;
+    }
+    prioritized.push(...bucket);
+    prioritizedBySeries.delete(seriesId);
+  }
+
+  return [...prioritized, ...rest];
+};

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/usePredictLiveNowSection.test.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/usePredictLiveNowSection.test.ts
@@ -41,11 +41,11 @@ const createLiveMarket = (id: string): PredictMarket =>
 const createRegularMarket = (id: string): PredictMarket =>
   ({ id }) as unknown as PredictMarket;
 
-const createCryptoMarket = (id: string): PredictMarket =>
+const createCryptoMarket = (id: string, seriesId = id): PredictMarket =>
   ({
     id,
     tags: [CRYPTO_TAG, UP_OR_DOWN_TAG],
-    series: { id, slug: 'crypto-up-or-down', recurrence: '5m' },
+    series: { id: seriesId, slug: 'crypto-up-or-down', recurrence: '5m' },
   }) as unknown as PredictMarket;
 
 const setLiveMarketList = (
@@ -111,12 +111,14 @@ const setCustomConfig = (
   queryParams = '',
   excludedMarketIds: string[] = [],
   composition: 'query-results' | 'live-now' = 'query-results',
+  priorityOrder: string[] = [],
 ) => {
   feedCarouselConfig = {
     enabled: true,
     minimumVersion: '1.0.0',
     mode: 'custom',
     title: 'Wimbledon',
+    priorityOrder,
     contentSource: {
       composition,
       queryParams,
@@ -341,6 +343,81 @@ describe('usePredictLiveNowSection', () => {
       'L6',
       'BTC15M',
     ]);
+  });
+
+  it('pins matching series to the front of the interleaved Live Now rail', () => {
+    setUpDownEnabled(true);
+    feedCarouselConfig = {
+      ...DEFAULT_PREDICT_FEED_CAROUSEL_FLAG,
+      priorityOrder: [BTC_UP_OR_DOWN_5M_SERIES.id, ETH_UP_OR_DOWN_5M_SERIES.id],
+    };
+    syncSelectors();
+    setLiveMarketList({
+      markets: [
+        createLiveMarket('L1'),
+        createLiveMarket('L2'),
+        createLiveMarket('L3'),
+        createLiveMarket('L4'),
+        createLiveMarket('L5'),
+        createLiveMarket('L6'),
+      ],
+    });
+    setCryptoMarketsBySeries({
+      [BTC_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket(
+        'BTC5M',
+        BTC_UP_OR_DOWN_5M_SERIES.id,
+      ),
+      [ETH_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket(
+        'ETH5M',
+        ETH_UP_OR_DOWN_5M_SERIES.id,
+      ),
+      [BTC_UP_OR_DOWN_15M_SERIES.id]: createCryptoMarket(
+        'BTC15M',
+        BTC_UP_OR_DOWN_15M_SERIES.id,
+      ),
+    });
+
+    const { result } = renderHook(() => usePredictLiveNowSection());
+
+    expect(ids(result.current.items)).toEqual([
+      'BTC5M',
+      'ETH5M',
+      'L1',
+      'L2',
+      'L3',
+      'L4',
+      'L5',
+      'L6',
+      'BTC15M',
+    ]);
+  });
+
+  it('pins matching series in custom live-now composition after exclusions', () => {
+    setCustomConfig('live=true&order=volume24hr', ['L1'], 'live-now', [
+      ETH_UP_OR_DOWN_5M_SERIES.id,
+    ]);
+    setUpDownEnabled(true);
+    setLiveMarketList({
+      markets: [
+        createLiveMarket('L1'),
+        createLiveMarket('L2'),
+        createLiveMarket('L3'),
+      ],
+    });
+    setCryptoMarketsBySeries({
+      [BTC_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket(
+        'BTC5M',
+        BTC_UP_OR_DOWN_5M_SERIES.id,
+      ),
+      [ETH_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket(
+        'ETH5M',
+        ETH_UP_OR_DOWN_5M_SERIES.id,
+      ),
+    });
+
+    const { result } = renderHook(() => usePredictLiveNowSection());
+
+    expect(ids(result.current.items)).toEqual(['ETH5M', 'L2', 'L3', 'BTC5M']);
   });
 
   it('reports loading while the live list loads even if crypto already resolved', () => {

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/usePredictLiveNowSection.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/usePredictLiveNowSection.ts
@@ -15,6 +15,7 @@ import type { PredictMarket, PredictMarketListParams } from '../../../../types';
 import type { PredictFeedCarouselConfig } from '../../../../types/flags';
 import { isCryptoUpDown } from '../../../../utils/cryptoUpDown';
 import { interleaveLiveNowMarkets } from './liveNowInterleave';
+import { applySeriesPriorityOrder } from './liveNowPriorityOrder';
 
 /**
  * Over-fetch live markets so client-side filtering (keep sports game markets
@@ -65,6 +66,10 @@ export interface UsePredictLiveNowSectionResult {
  * Alongside, the BTC 5m / ETH 5m / BTC 15m Up/Down crypto markets are resolved
  * from their series and interleaved (`2 live, 1 crypto, ...`) by
  * {@link interleaveLiveNowMarkets} (crypto capped at 3).
+ *
+ * `priorityOrder` then pins matching `series.id` cards to the front of the
+ * rail (use case: crypto Up/Down first) without changing which markets are
+ * fetched.
  *
  * Crypto is only included when the Up/Down feature flag is on — `PredictMarket`
  * itself only renders the crypto card when that flag is enabled, so gating here
@@ -159,13 +164,19 @@ export const usePredictLiveNowSection = (): UsePredictLiveNowSectionResult => {
     excludedMarketIds,
   ]);
 
-  const items = useMemo(
-    () =>
-      usesLiveNowComposition
-        ? interleaveLiveNowMarkets(liveMarkets, cryptoMarkets)
-        : customMarkets,
-    [cryptoMarkets, customMarkets, liveMarkets, usesLiveNowComposition],
-  );
+  const items = useMemo(() => {
+    const composed = usesLiveNowComposition
+      ? interleaveLiveNowMarkets(liveMarkets, cryptoMarkets)
+      : customMarkets;
+
+    return applySeriesPriorityOrder(composed, config.priorityOrder);
+  }, [
+    config.priorityOrder,
+    cryptoMarkets,
+    customMarkets,
+    liveMarkets,
+    usesLiveNowComposition,
+  ]);
 
   const isCryptoLoading =
     btc5m.isLoading || eth5m.isLoading || btc15m.isLoading;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Growth wants Crypto Up/Down cards at the front of Predict home Live Now without switching the carousel to custom mode. Event IDs rotate every 5m/15m, so the pin list has to be series IDs (`10684` BTC 5m, `10683` ETH 5m, `10192` BTC 15m).

This PR adds `priorityOrder: string[]` to the existing `predictFeedCarousel` LaunchDarkly flag. After the current 2-live / 1-crypto composition, matching `market.series.id` cards are moved to the front. Unknown, blank, and duplicate IDs are ignored. An empty list keeps today's order.

Live mode can now carry `priorityOrder` without becoming `custom`. Fetch set, display caps, and the Up/Down gate are unchanged: this only reorders cards that already made the rail.

Example LD value to pin crypto first:

```json
{
  "enabled": true,
  "minimumVersion": "8.8.0",
  "mode": "live",
  "priorityOrder": ["10684", "10683", "10192"]
}
```

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated the Predict Live Now carousel so featured markets can be pinned to the front.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-1243

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Live Now series priorityOrder

  Scenario: default live order is unchanged
    Given predictFeedCarousel is live with an empty priorityOrder
    And Crypto Up/Down is enabled
    When the user opens Predict home
    Then Live Now still uses the 2 sports / 1 crypto interleave

  Scenario: live mode pins matching series to the front
    Given OVERRIDE_REMOTE_FEATURE_FLAGS is off
    And predictFeedCarousel is
      """
      {
        "enabled": true,
        "minimumVersion": "8.8.0",
        "mode": "live",
        "priorityOrder": ["10684", "10683", "10192"]
      }
      """
    And Crypto Up/Down is enabled
    When the user opens Predict home
    Then BTC 5m, ETH 5m, and BTC 15m appear first in that order
    And remaining sports cards keep their relative order after the pinned cards

  Scenario: unknown series IDs are ignored
    Given priorityOrder includes an ID that is not in the rail
    When the user opens Predict home
    Then the unknown ID does not add a card
    And matched series still pin to the front
```

Local note: `.js.env` `OVERRIDE_REMOTE_FEATURE_FLAGS=true` blocks remote LD. Turn it off before verifying the live pin.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

N/A — default Live Now order is unchanged until LaunchDarkly `priorityOrder` is set. Reorder is covered by unit tests on the selector, helper, and Live Now hook.

### **Before**

Default 2 sports / 1 crypto interleave (unchanged when `priorityOrder` is empty).

### **After**

With `priorityOrder: ["10684", "10683", "10192"]`, matching Crypto Up/Down cards move to the front of the same rail.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A: in-memory reorder of the existing Live Now list; no platform-specific rendering change.
- [x] I've tested with a power user scenario
  - N/A: carousel order does not depend on wallet size.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A: no new performance-sensitive path; pin is an O(n) pass over an already-capped list.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote-flag-driven display reorder only; no auth, payments, or fetch logic changes. Misconfigured LD values fall back to defaults or ignore bad series IDs.
> 
> **Overview**
> Adds **`priorityOrder`** to the `predictFeedCarousel` remote flag so Growth can pin **series IDs** (e.g. Crypto Up/Down) at the front of Predict home **Live Now** without switching to custom carousel mode.
> 
> The flag is validated and normalized (trim, dedupe); **live** mode now accepts a non-empty `priorityOrder` while empty lists keep the default live config. After the existing sports/crypto composition, **`applySeriesPriorityOrder`** reorders cards whose `market.series.id` matches—unknown IDs are ignored and fetch/caps stay the same.
> 
> **Tests** cover the schema, selector, reorder helper, and `usePredictLiveNowSection` for live and custom `live-now` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bed8e3d588d04b6c9131235a7787f6454c1f8564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->