### PR TITLE
ci: right-size the Linux CI long tail onto the 4x8 Namespace profile

### DIFF
--- a/.github/workflows/build-android-internal-distribution.yml
+++ b/.github/workflows/build-android-internal-distribution.yml
@@ -54,7 +54,7 @@ jobs:
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
          vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     outputs:
       apk_artifact_name: ${{ steps.rename.outputs.apk_artifact_name }}

--- a/.github/workflows/build-ios-upload-to-browserstack.yml
+++ b/.github/workflows/build-ios-upload-to-browserstack.yml
@@ -127,7 +127,7 @@ jobs:
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
          vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     needs: [check-builds-needed, trigger-ios-with-srp-build, trigger-ios-without-srp-build]
     if: (needs.trigger-ios-with-srp-build.result == 'success' || needs.trigger-ios-with-srp-build.result == 'partial_success') && (needs.trigger-ios-without-srp-build.result == 'success' || needs.trigger-ios-without-srp-build.result == 'partial_success')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -782,7 +782,14 @@ jobs:
     needs:
       - get_requirements
     steps:
+      # Last job in the Linux cohort still cloning from github.com on Namespace;
+      # everything else uses the in-region git mirror. Namespace scales network
+      # bandwidth with machine shape, so an internet clone costs roughly twice
+      # the wall-clock on the 4x8 profile as it did on 8x16.
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
       - uses: actions/checkout@v6
+        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
       - uses: ./.github/actions/setup-ci-js-deps
         with:
           runner_provider: ${{ env.RESOLVED_RUNNER_PROVIDER }}

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -42,7 +42,7 @@ jobs:
         github.event.issue.pull_request &&
         startsWith(github.event.comment.body, '@metamaskbot update-mobile-fixture')
       }}
-    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest' }}
     timeout-minutes: 5
     permissions:
       actions: write
@@ -84,7 +84,7 @@ jobs:
   is-fork-pull-request:
     name: Validate PR
     if: ${{ github.event_name == 'workflow_dispatch' }}
-    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest' }}
     timeout-minutes: 5
     outputs:
       IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
@@ -101,7 +101,7 @@ jobs:
 
   prepare:
     name: Prepare build artifacts
-    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest' }}
     timeout-minutes: 10
     needs: is-fork-pull-request
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
@@ -401,7 +401,7 @@ jobs:
 
   commit-updated-fixtures:
     name: Commit the updated fixtures
-    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest' }}
     timeout-minutes: 10
     permissions:
       contents: write
@@ -479,7 +479,7 @@ jobs:
 
   check-status:
     name: Check whether the fixture update succeeded
-    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest' }}
     timeout-minutes: 5
     if: ${{ !cancelled() && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     needs:
@@ -500,7 +500,7 @@ jobs:
   failure-comment:
     name: Comment about the fixture update failure
     if: ${{ !cancelled() && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
-    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest' }}
     timeout-minutes: 5
     permissions:
       contents: read


### PR DESCRIPTION
## **Description**

Extends the Linux CI cohort moved in #35204 to the remaining long-tail jobs, sending them from `namespace-profile-metamask-ci-linux` (8 vCPU / 16 GB) to `namespace-profile-metamask-ci-linux-small` (4 vCPU / 8 GB, 8 GB swap).

#35204's production numbers justify extending rather than re-litigating. Measured over 2026-08-20 → 08-27 (99,534 instances, `cancelled` excluded), weekday-matched to avoid the weekend trough:

| | result |
| --- | --- |
| cohort per-run cost | **8.65 → 4.81 vCPU-min (−44%)** |
| wall-clock | **+2% to +12%** (median ~+7%; `Smart E2E Selection` −2%) |
| peak RAM | 4.2–5.1 GB against 8 GB (1.6–1.9× headroom) |
| OOM / exit-137 | **zero** |
| keep-list control | **+4%** — unchanged, so the delta is attributable |

Well inside MCWP-813's +25% wall-clock acceptance criterion.

### Moved here (8 job sites, 4 files)

| workflow | job(s) |
| --- | --- |
| `build-android-internal-distribution.yml` | `publish-apk` |
| `build-ios-upload-to-browserstack.yml` | `download-and-upload-to-browserstack` |
| `update-e2e-fixtures.yml` | all six: `dispatch`, `is-fork-pull-request`, `prepare`, `commit-updated-fixtures`, `check-status`, `failure-comment` |

`publish-apk` now has telemetry it lacked when #35204 was scoped: n=3, 0.8 GB peak, 13s p50.

The `update-e2e-fixtures` jobs still have none, so they were assessed from the workflow instead — five are gate/comment-only, `commit-updated-fixtures` runs `setup-e2e-env`, and none of them sets a Node heap ceiling. Their volume is near zero, so the exposure is small either way.

`download-and-upload-to-browserstack` transfers two IPAs. Namespace scales network and disk bandwidth with machine shape (confirmed by Namespace), so this one is likely **cost-neutral with slightly worse latency** rather than a saving. It moves for consistency and is trivial to revert on its own — happy to drop it if a reviewer prefers.

### Also carries a fix that missed #35204

`prepare-ci-js-deps` was the last job in the cohort using bare `actions/checkout` on Namespace, cloning from github.com rather than the in-region git mirror every other cohort job uses. Given bandwidth scales with shape, an internet clone costs roughly twice the wall-clock on 4x8 as it did on 8x16.

### Deliberately not moved

`eas-update-platform.yml` `push-update` runs `yarn expo export` under `NODE_OPTIONS=--max_old_space_size=8192`. An 8 GB V8 ceiling on an 8 GB machine never self-limits before the kernel OOM-kills it — the same defect that had to be fixed for `Integration tests (2)` in #35204. Bundling is also the heaviest memory consumer in this repo (the JS bundle size check peaks at 14.3 GB), and the job produced no instance-report samples in the last seven days, so there is no baseline to size it from. Moving it needs the heap ceiling lowered first, as a separate change.

Every edit keeps the `RESOLVED_RUNNER_PROVIDER` resolution chain and the `ubuntu-latest` fallback intact, so `NAMESPACE_RUNNER_LINUX=current` still rolls the whole fleet back.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MCWP-813
Refs: MCWP-811

## **Manual testing steps**

N/A for app behaviour — CI runner shapes only, no app code. `NAMESPACE_RUNNER_LINUX=namespace`, so jobs resolve to the new profile without a dispatch override.

**Caveat on what this PR's own CI can prove.** None of the eight moved jobs run on a `pull_request` event: `publish-apk` is internal distribution, the BrowserStack upload is release/e2e-triggered, and `update-e2e-fixtures` is comment-dispatched. So a green CI run here validates that nothing regressed, not that the moved jobs work. They need to be exercised on their own triggers.

**1. Nothing regressed.** `ci.yml` is the only file in the diff that PR CI exercises, via the one-line `prepare-ci-js-deps` checkout change. Confirm `Prepare CI JS dependencies` is green and check its `Set up job` banner shows the mirror rather than an internet clone:

```bash
gh run view --job <JOB_ID> --log | grep -E 'Machine Type|Tag:|nscloud-checkout'
```

Expect `Machine Type: 4x8` and `Tag: namespace-profile-metamask-ci-linux-small`.

**2. Exercise the moved jobs on their real triggers.**

- `update-e2e-fixtures`: comment `@metamaskbot update-mobile-fixture` on any PR.
- `publish-apk`: dispatch `build-android-internal-distribution.yml`.
- BrowserStack iOS upload: runs from the release/e2e build chain.

For each, verify `Machine Type: 4x8` in the runner banner and no exit-137.

**3. Confirm shape and headroom afterwards.**

```bash
nsc instance report --start <T0> --repository MetaMask/metamask-mobile \
  --profile namespace-profile-metamask-ci-linux-small --out -
```

Expect `resources_cpu == 4`, `resources_ram_gb == 8`, peak RAM under 8 GB.

> ⚠️ `resources_ram_gb_actual_max_percent` is a fraction **of the allocation**, not an absolute. The allocation halved, so identical memory use reports double the percentage. Multiply by `resources_ram_gb` before comparing against MCWP-813's tables.

**4. Rollback path intact.** Setting `NAMESPACE_RUNNER_LINUX=current` (or dispatching with `runner_provider=current`) must send every job to `ubuntu-latest` with no `namespace-profile-*`.

### Verified locally

- All five touched-or-adjacent workflows parse (`ruby -ryaml`).
- `actionlint -config-file .github/actionlint.yaml`: **19 findings on `main`, 19 on this branch, zero new** (`comm -13`). All 19 pre-exist — 17 deprecated action pins, 2 `if: false` — and surface only under locally-installed actionlint 1.7.12; CI pins 1.7.1, where `Check workflows` is green.
- Only the keep-list remains on 8x16 in `ci.yml`: `js-bundle-size-check`, `unit-tests`, `component-view-tests`, `sonar-cloud`, plus `lint` / `lint:tsc` / `Integration tests (1)` via the matrices.

## **Screenshots/Recordings**

N/A. Not a user facing change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Not applicable: this changes CI runner shapes, no app code.

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI runner sizing and checkout wiring only; no application or auth changes, with rollback via `NAMESPACE_RUNNER_LINUX=current` still intact.
> 
> **Overview**
> Extends the Linux CI runner downsizing from #35204 to **long-tail** workflows: when Namespace is selected, eight job sites now use **`namespace-profile-metamask-ci-linux-small`** (4 vCPU / 8 GB) instead of **`namespace-profile-metamask-ci-linux`** (8 vCPU / 16 GB). **`ubuntu-latest`** and the existing **`RESOLVED_RUNNER_PROVIDER`** / repo-variable rollback paths are unchanged.
> 
> **Workflows touched:** `publish-apk` in internal Android distribution; `download-and-upload-to-browserstack` in the iOS BrowserStack upload chain; all six lightweight Linux jobs in **`update-e2e-fixtures`** (dispatch through failure-comment). The heavy **`update-fixtures`** job stays on the iOS E2E runner.
> 
> **Also in `ci.yml`:** **`prepare-ci-js-deps`** on Namespace now uses **`nscloud-checkout-action`** (in-region git mirror) and skips bare **`actions/checkout`**, matching the rest of the Linux cohort—this was the last job still cloning from github.com on Namespace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d178b510ac341c4673d13380fe60f23e5b4d381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->