### PR TITLE
fix: use wallet to grab account instead of accessing keyring directly

### DIFF
--- a/app/actions/multiSrp/index.test.ts
+++ b/app/actions/multiSrp/index.test.ts
@@ -7,7 +7,7 @@ import { TraceName, TraceOperation } from '../../util/trace';
 import ReduxService from '../../core/redux/ReduxService';
 import { RootState } from '../../reducers';
 import { EncAccountDataType } from '@metamask/seedless-onboarding-controller';
-import { EntropySourceId } from '@metamask/keyring-api';
+import { EntropySourceId, EthAccountType } from '@metamask/keyring-api';
 import { waitFor } from '@testing-library/react-native';
 import { toMultichainAccountWalletId } from '@metamask/account-api';
 import { mnemonicPhraseToBytes } from '@metamask/key-tree';
@@ -143,18 +143,20 @@ jest.mock('../../core/Engine', () => ({
 
 jest.mocked(Engine);
 
+const mockEvmAccount = {
+  address: mockAddress,
+  type: EthAccountType.Eoa,
+};
+
 const mockMultichainAccountGroup = {
-  getAccounts: jest.fn().mockReturnValue([
-    {
-      address: mockAddress,
-    },
-  ]),
+  getAccounts: jest.fn().mockReturnValue([mockEvmAccount]),
+  get: jest.fn().mockReturnValue(mockEvmAccount),
 };
 
 const mockMultichainAccountWallet = {
   id: toMultichainAccountWalletId(mockEntropySource),
   entropySource: mockEntropySource,
-  getAccountGroup: () => mockMultichainAccountGroup,
+  getMultichainAccountGroup: () => mockMultichainAccountGroup,
 };
 
 describe('MultiSRP Actions', () => {

--- a/app/actions/multiSrp/index.ts
+++ b/app/actions/multiSrp/index.ts
@@ -9,7 +9,7 @@ import { discoverAccounts } from '../../multichain-accounts/discovery';
 import { captureException } from '@sentry/core';
 import { Authentication } from '../../core';
 import { mnemonicPhraseToBytes } from '@metamask/key-tree';
-import type { EntropySourceId } from '@metamask/keyring-api';
+import { EthAccountType, type EntropySourceId } from '@metamask/keyring-api';
 
 export interface ImportNewSecretRecoveryPhraseOptions {
   shouldSelectAccount: boolean;
@@ -47,14 +47,16 @@ export async function importNewSecretRecoveryPhrase(
     type: 'import',
     mnemonic,
   });
+
   const entropySource = wallet.entropySource;
 
-  const [newAccount] = await KeyringController.withKeyringV2(
-    {
-      id: entropySource,
-    },
-    async ({ keyring }) => keyring.getAccounts(),
-  );
+  const newAccount = wallet
+    .getMultichainAccountGroup(0)
+    ?.get({ type: EthAccountType.Eoa });
+
+  if (!newAccount) {
+    throw new Error('Failed to create new account');
+  }
 
   const { SeedlessOnboardingController } = Engine.context;
 

--- a/app/actions/multiSrp/index.ts
+++ b/app/actions/multiSrp/index.ts
@@ -36,7 +36,7 @@ export async function importNewSecretRecoveryPhrase(
     options: ImportNewSecretRecoveryPhraseReturnType & { error?: Error },
   ) => Promise<void>,
 ): Promise<ImportNewSecretRecoveryPhraseReturnType> {
-  const { KeyringController, MultichainAccountService } = Engine.context;
+  const { MultichainAccountService } = Engine.context;
   const { shouldSelectAccount, skipDiscovery = false } = options;
 
   // Convert mnemonic


### PR DESCRIPTION
## **Description**

Currently, the import logic is using `withKeyringV2` to attain the first imported account's address. This method attempts to grab the KeyringController's lock which at that point has already been acquired from the non-evm account alignment process that has started in `createMultichainAccountWallet`. Just using the returned wallet's own group method to get an account through the `AccountController` should prove to be more efficient.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the post-import address is resolved on a core onboarding path; wrong account selection or the new throw would break SRP import or seedless backup flows.
> 
> **Overview**
> **SRP import** no longer calls `KeyringController.withKeyringV2` to read the first EVM address after `createMultichainAccountWallet`. It now reads the EOA from the returned wallet via `getMultichainAccountGroup(0)?.get({ type: EthAccountType.Eoa })`, and throws if that account is missing.
> 
> Tests were updated to mock `getMultichainAccountGroup`, group `get`, and `EthAccountType.Eoa` instead of the old `getAccountGroup` / bare address shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e580547922f216edb3524d1aaa674acd3a392b6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->