### PR TITLE
fix(perps): align recently viewed pill percent with list

### DIFF
--- a/app/components/UI/Perps/components/PerpsRecentlyViewedRail/PerpsRecentlyViewedRail.test.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentlyViewedRail/PerpsRecentlyViewedRail.test.tsx
@@ -16,6 +16,15 @@ jest.mock('../../hooks/usePerpsEventTracking', () => ({
   }),
 }));
 
+jest.mock('../../hooks/stream', () => ({
+  usePerpsLivePrices: jest.fn(() => ({})),
+}));
+
+const { usePerpsLivePrices } = jest.requireMock('../../hooks/stream');
+const mockUsePerpsLivePrices = usePerpsLivePrices as jest.MockedFunction<
+  typeof import('../../hooks/stream').usePerpsLivePrices
+>;
+
 jest.mock('@metamask/design-system-react-native', () => {
   const { Text } = jest.requireActual('react-native');
   return {
@@ -52,6 +61,7 @@ describe('PerpsRecentlyViewedRail', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUsePerpsLivePrices.mockReturnValue({});
   });
 
   it('renders nothing when there are no recently viewed markets', () => {
@@ -105,6 +115,65 @@ describe('PerpsRecentlyViewedRail', () => {
     expect(screen.getByTestId('token-logo-BTC')).toBeOnTheScreen();
     expect(screen.getByText('BTC')).toBeOnTheScreen();
     expect(screen.getByText('+2.50%')).toBeOnTheScreen();
+  });
+
+  it('subscribes to live prices with the same throttle as market list rows', () => {
+    render(
+      <PerpsRecentlyViewedRail
+        markets={[createMarket('BTC')]}
+        onMarketPress={mockOnMarketPress}
+      />,
+    );
+
+    expect(mockUsePerpsLivePrices).toHaveBeenCalledWith({
+      symbols: ['BTC'],
+      throttleMs: 3000,
+    });
+  });
+
+  it('overlays live 24h percent change onto the pill', () => {
+    mockUsePerpsLivePrices.mockReturnValue({
+      BTC: {
+        price: '55000.00',
+        percentChange24h: '5.77',
+      },
+    });
+
+    render(
+      <PerpsRecentlyViewedRail
+        markets={[
+          createMarket('BTC', {
+            change24hPercent: '+1.00%',
+          }),
+        ]}
+        onMarketPress={mockOnMarketPress}
+      />,
+    );
+
+    expect(screen.getByText('+5.77%')).toBeOnTheScreen();
+    expect(screen.queryByText('+1.00%')).toBeNull();
+  });
+
+  it('overlays a live negative 24h percent change onto the pill', () => {
+    mockUsePerpsLivePrices.mockReturnValue({
+      BTC: {
+        price: '48000.00',
+        percentChange24h: '-7.84',
+      },
+    });
+
+    render(
+      <PerpsRecentlyViewedRail
+        markets={[
+          createMarket('BTC', {
+            change24hPercent: '+1.00%',
+          }),
+        ]}
+        onMarketPress={mockOnMarketPress}
+      />,
+    );
+
+    expect(screen.getByText('-7.84%')).toBeOnTheScreen();
   });
 
   it('strips the dex prefix from the displayed symbol', () => {

--- a/app/components/UI/Perps/components/PerpsRecentlyViewedRail/PerpsRecentlyViewedRail.test.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentlyViewedRail/PerpsRecentlyViewedRail.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
-import type { PerpsMarketData } from '@metamask/perps-controller';
+import type { PerpsMarketData, PriceUpdate } from '@metamask/perps-controller';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { PerpsRecentlyViewedRailSelectorsIDs } from '../../Perps.testIds';
 import PerpsRecentlyViewedRail, {
@@ -53,6 +53,16 @@ const createMarket = (
   change24h: '$0.01',
   change24hPercent: '+1.00%',
   volume: '$1M',
+  ...overrides,
+});
+
+const createPriceUpdate = (
+  overrides: Partial<PriceUpdate> = {},
+): PriceUpdate => ({
+  symbol: 'BTC',
+  price: '0',
+  timestamp: 0,
+  isTradable: true,
   ...overrides,
 });
 
@@ -133,10 +143,10 @@ describe('PerpsRecentlyViewedRail', () => {
 
   it('overlays live 24h percent change onto the pill', () => {
     mockUsePerpsLivePrices.mockReturnValue({
-      BTC: {
+      BTC: createPriceUpdate({
         price: '55000.00',
         percentChange24h: '5.77',
-      },
+      }),
     });
 
     render(
@@ -156,10 +166,10 @@ describe('PerpsRecentlyViewedRail', () => {
 
   it('overlays a live negative 24h percent change onto the pill', () => {
     mockUsePerpsLivePrices.mockReturnValue({
-      BTC: {
+      BTC: createPriceUpdate({
         price: '48000.00',
         percentChange24h: '-7.84',
-      },
+      }),
     });
 
     render(

--- a/app/components/UI/Perps/components/PerpsRecentlyViewedRail/PerpsRecentlyViewedRail.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentlyViewedRail/PerpsRecentlyViewedRail.tsx
@@ -18,6 +18,8 @@ import { formatPercentChange } from '../../../Trending/utils/formatPercentChange
 import { ExplorePill } from '../../../Trending/components/ExplorePill';
 import PerpsTokenLogo from '../PerpsTokenLogo/PerpsTokenLogo';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
+import { usePerpsLivePrices } from '../../hooks/stream';
+import { formatPercentage } from '../../utils/formatUtils';
 import { PerpsRecentlyViewedRailSelectorsIDs } from '../../Perps.testIds';
 
 /** `source_section` value for market-details navigation and analytics originating from this rail. */
@@ -49,9 +51,23 @@ const PerpsRecentlyViewedPill: React.FC<{
     onPress(market, index);
   }, [onPress, market, index]);
 
-  const { changeLabel, changeTextColor } = useMemo(
-    () => formatPercentChange(market.change24hPercent),
-    [market.change24hPercent],
+  // Same live-price overlay as PerpsMarketRowItem so the pill % matches the list.
+  const livePrices = usePerpsLivePrices({
+    symbols: [market.symbol],
+    throttleMs: 3000,
+  });
+
+  const change24hPercent = useMemo(() => {
+    const livePercentChange = livePrices[market.symbol]?.percentChange24h;
+    if (livePercentChange === undefined || livePercentChange === '') {
+      return market.change24hPercent;
+    }
+    return formatPercentage(Number.parseFloat(livePercentChange));
+  }, [livePrices, market.change24hPercent, market.symbol]);
+
+  const { changeTextColor } = useMemo(
+    () => formatPercentChange(change24hPercent),
+    [change24hPercent],
   );
 
   return (
@@ -66,7 +82,7 @@ const PerpsRecentlyViewedPill: React.FC<{
         />
       }
       title={getPerpsDisplaySymbol(market.symbol)}
-      changeLabel={changeLabel}
+      changeLabel={change24hPercent}
       changeTextColor={changeTextColor}
     />
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Recently viewed market pills showed a stale snapshot 24h percent while the market list overlays live WebSocket prices, so the same symbol could disagree between the two surfaces.

Each pill now uses `usePerpsLivePrices` with the same 3000ms throttle as `PerpsMarketRowItem` and formats `percentChange24h` with `formatPercentage`, so the pill label matches the list. Color still comes from `formatPercentChange`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed recently viewed Perps market pills showing a stale 24h percent change compared with the market list

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: no tracked GitHub issue — found by comparing recently viewed pills with the Perps market list

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Recently viewed pill 24h percent matches the market list

  Background:
    Given I am logged into MetaMask Mobile
    And Perps is enabled
    And I have viewed at least one Perps market so the Recently Viewed rail is populated

  Scenario: pill percent matches the same market in the list
    Given I am on the Perps market list
    And a recently viewed market also appears in the list below

    When user waits for live prices to tick
    Then the 24h percent on that market's recently viewed pill should match the 24h percent on its list row

  Scenario: pill updates for a negative 24h change
    Given a recently viewed market whose live 24h percent is negative

    When user views the Recently Viewed rail
    Then the pill should show a negative percent with the same formatted value as the list row
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — live percent mismatch is easier to confirm in-app than with a still screenshot

### **After**

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-27 at 17 33 43" src="https://github.com/user-attachments/assets/04ed8180-caaf-416c-ae21-171bc5036a86" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only display fix in the Perps explore rail with tests; no auth, payments, or data-persistence changes.
> 
> **Overview**
> **Recently viewed Perps pills now show live 24h percent change** instead of only the static snapshot from `PerpsMarketData`, so they stay consistent with the market list.
> 
> Each pill subscribes via `usePerpsLivePrices` for its symbol with the same **3000ms** throttle as `PerpsMarketRowItem`. When `percentChange24h` is present on the stream, the label uses `formatPercentage`; otherwise it falls back to `market.change24hPercent`. Pill color still comes from `formatPercentChange` on the resolved value.
> 
> Tests mock `usePerpsLivePrices` and cover subscription args plus positive and negative live overlays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af5859fe7d8d788fdde95f94504aed9874e5f284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->