### PR TITLE
fix(metamask-pay): hide money account option if no balance

### DIFF
--- a/app/components/Views/confirmations/components/info-root/info-root.test.tsx
+++ b/app/components/Views/confirmations/components/info-root/info-root.test.tsx
@@ -59,7 +59,7 @@ jest.mock('../../hooks/pay/useTransactionPayAutoFiatSubmission');
 // The withdraw info components call `useDefaultPaySelectedSection`, which
 // otherwise reaches the Money Account balance query and its QueryClient.
 jest.mock('../../hooks/pay/usePayMoneyAccountAvailable', () => ({
-  usePayMoneyAccountAvailable: jest.fn().mockReturnValue(true),
+  usePayMoneyAccountAvailable: () => ({ isAvailable: true, isPending: false }),
 }));
 
 jest.mock('../../../../hooks/useRefreshSmartTransactionsLiveness', () => ({

--- a/app/components/Views/confirmations/components/info-root/info-root.test.tsx
+++ b/app/components/Views/confirmations/components/info-root/info-root.test.tsx
@@ -56,6 +56,11 @@ jest.mock('../info/custom-amount-info', () => ({
 jest.mock('../../hooks/gas/useGasFeeToken');
 jest.mock('../../hooks/tokens/useTokenWithBalance');
 jest.mock('../../hooks/pay/useTransactionPayAutoFiatSubmission');
+// The withdraw info components call `useDefaultPaySelectedSection`, which
+// otherwise reaches the Money Account balance query and its QueryClient.
+jest.mock('../../hooks/pay/usePayMoneyAccountAvailable', () => ({
+  usePayMoneyAccountAvailable: jest.fn().mockReturnValue(true),
+}));
 
 jest.mock('../../../../hooks/useRefreshSmartTransactionsLiveness', () => ({
   useRefreshSmartTransactionsLiveness: jest.fn(),

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -87,6 +87,11 @@ jest.mock('../../../hooks/pay/useTransactionPayWithdraw', () => ({
 jest.mock('../../../hooks/transactions/useTransactionAccountOverride');
 jest.mock('../../../hooks/pay/useMoneyNoFeeTokens');
 jest.mock('../../../hooks/pay/sections/usePayWithMoneyAccountSection');
+// Reaches the Money Account balance query via `useIsMoneyAccountFlagDefault`,
+// which the `usePayWithMoneyAccountSection` mock above does not intercept.
+jest.mock('../../../hooks/pay/usePayMoneyAccountAvailable', () => ({
+  usePayMoneyAccountAvailable: jest.fn().mockReturnValue(true),
+}));
 jest.mock('../../rows/perps-account-picker-row', () => ({
   PerpsAccountPickerRow: () => null,
 }));

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -90,7 +90,8 @@ jest.mock('../../../hooks/pay/sections/usePayWithMoneyAccountSection');
 // Reaches the Money Account balance query via `useIsMoneyAccountFlagDefault`,
 // which the `usePayWithMoneyAccountSection` mock above does not intercept.
 jest.mock('../../../hooks/pay/usePayMoneyAccountAvailable', () => ({
-  usePayMoneyAccountAvailable: jest.fn().mockReturnValue(true),
+  // Not a jest.fn(): `jest.resetAllMocks()` below would wipe its return value.
+  usePayMoneyAccountAvailable: () => ({ isAvailable: true, isPending: false }),
 }));
 jest.mock('../../rows/perps-account-picker-row', () => ({
   PerpsAccountPickerRow: () => null,

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook, act } from '@testing-library/react-hooks';
+import BigNumber from 'bignumber.js';
 import { TransactionType } from '@metamask/transaction-controller';
 import { PaymentOverride } from '@metamask/transaction-pay-controller';
 import { useSelector } from 'react-redux';
@@ -88,6 +89,7 @@ describe('usePayWithMoneyAccountSection', () => {
 
     useMoneyAccountBalanceMock.mockReturnValue({
       withdrawableFiatFormatted: '$100.00',
+      withdrawableMusd: new BigNumber(100),
     } as never);
   });
 
@@ -206,6 +208,91 @@ describe('usePayWithMoneyAccountSection', () => {
     expect(result.current).toBeNull();
   });
 
+  describe('when the money account funds the transaction', () => {
+    it.each([TransactionType.perpsDeposit, TransactionType.predictDeposit])(
+      'returns null for %s when the withdrawable balance is zero',
+      (txType) => {
+        useTransactionMetadataRequestMock.mockReturnValue({
+          id: 'tx-1',
+          type: txType,
+          txParams: {},
+        } as never);
+
+        useMoneyAccountBalanceMock.mockReturnValue({
+          withdrawableFiatFormatted: '$0.00',
+          withdrawableMusd: new BigNumber(0),
+        } as never);
+
+        const { result } = renderHook(() => usePayWithMoneyAccountSection());
+
+        expect(result.current).toBeNull();
+      },
+    );
+
+    it('returns null when the balance is still loading', () => {
+      useMoneyAccountBalanceMock.mockReturnValue({
+        isBalanceLoading: true,
+        withdrawableFiatFormatted: undefined,
+        withdrawableMusd: undefined,
+      } as never);
+
+      const { result } = renderHook(() => usePayWithMoneyAccountSection());
+
+      expect(result.current).toBeNull();
+    });
+
+    it('returns null when the balance could not be fetched', () => {
+      useMoneyAccountBalanceMock.mockReturnValue({
+        isBalanceFetchError: true,
+        withdrawableFiatFormatted: undefined,
+        withdrawableMusd: undefined,
+      } as never);
+
+      const { result } = renderHook(() => usePayWithMoneyAccountSection());
+
+      expect(result.current).toBeNull();
+    });
+  });
+
+  describe('when the money account receives the transaction', () => {
+    it.each([
+      TransactionType.perpsWithdraw,
+      TransactionType.predictWithdraw,
+      TransactionType.moneyAccountWithdraw,
+    ])('renders the section for %s despite a zero balance', (txType) => {
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: 'tx-1',
+        type: txType,
+        txParams: {},
+      } as never);
+
+      useSelectorMock.mockImplementation((selector) => {
+        if (selector === selectPrimaryMoneyAccount) {
+          return moneyAccountMock;
+        }
+        if (selector === selectMetaMaskPayFlags) {
+          return {
+            enableMoneyAccountTransactions: {
+              moneyAccountWithdraw: true,
+              perpsWithdraw: true,
+              predictWithdraw: true,
+            },
+          };
+        }
+        return undefined;
+      });
+
+      useMoneyAccountBalanceMock.mockReturnValue({
+        withdrawableFiatFormatted: '$0.00',
+        withdrawableMusd: new BigNumber(0),
+      } as never);
+
+      const { result } = renderHook(() => usePayWithMoneyAccountSection());
+
+      expect(result.current?.rows).toHaveLength(1);
+    });
+  });
+
   it.each([
     TransactionType.perpsDeposit,
     TransactionType.predictDeposit,
@@ -246,6 +333,7 @@ describe('usePayWithMoneyAccountSection', () => {
   it('renders subtitle with formatted balance', () => {
     useMoneyAccountBalanceMock.mockReturnValue({
       withdrawableFiatFormatted: '$250.50',
+      withdrawableMusd: new BigNumber(250.5),
     } as never);
 
     const { result } = renderHook(() => usePayWithMoneyAccountSection());
@@ -256,6 +344,7 @@ describe('usePayWithMoneyAccountSection', () => {
   it('renders undefined subtitle when withdrawableFiatFormatted is falsy', () => {
     useMoneyAccountBalanceMock.mockReturnValue({
       withdrawableFiatFormatted: '',
+      withdrawableMusd: new BigNumber(100),
     } as never);
 
     const { result } = renderHook(() => usePayWithMoneyAccountSection());

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
@@ -14,6 +14,7 @@ import useMoneyAccountBalance from '../../../../../UI/Money/hooks/useMoneyAccoun
 import { useTransactionMetadataRequest } from '../../transactions/useTransactionMetadataRequest';
 import { getTransactionType } from '../../../utils/transaction';
 import { applyMoneyAccountOverride } from '../../../utils/transaction-pay';
+import { usePayMoneyAccountAvailable } from '../usePayMoneyAccountAvailable';
 import {
   PayWithRowConfig,
   PayWithSectionConfig,
@@ -38,6 +39,7 @@ export function usePayWithMoneyAccountSection(): PayWithSectionConfig | null {
     selectMetaMaskPayFlags,
   );
   const { withdrawableFiatFormatted } = useMoneyAccountBalance();
+  const isMoneyAccountAvailable = usePayMoneyAccountAvailable();
 
   const paymentOverride = useSelector((state: RootState) =>
     selectPaymentOverrideByTransactionId(state, transactionId),
@@ -62,7 +64,7 @@ export function usePayWithMoneyAccountSection(): PayWithSectionConfig | null {
   }, [moneyAccount?.address, navigation, transactionId, transactionMeta]);
 
   return useMemo(() => {
-    if (!isEnabled || !moneyAccount) {
+    if (!isEnabled || !isMoneyAccountAvailable) {
       return null;
     }
 
@@ -93,10 +95,10 @@ export function usePayWithMoneyAccountSection(): PayWithSectionConfig | null {
       rows: [row],
     };
   }, [
-    isEnabled,
     handlePress,
+    isEnabled,
+    isMoneyAccountAvailable,
     isMoneyAccountSelected,
-    moneyAccount,
     withdrawableFiatFormatted,
   ]);
 }

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
@@ -39,7 +39,8 @@ export function usePayWithMoneyAccountSection(): PayWithSectionConfig | null {
     selectMetaMaskPayFlags,
   );
   const { withdrawableFiatFormatted } = useMoneyAccountBalance();
-  const isMoneyAccountAvailable = usePayMoneyAccountAvailable();
+  const { isAvailable: isMoneyAccountAvailable } =
+    usePayMoneyAccountAvailable();
 
   const paymentOverride = useSelector((state: RootState) =>
     selectPaymentOverrideByTransactionId(state, transactionId),

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticMoneyAccountPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticMoneyAccountPayToken.test.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import { TransactionType } from '@metamask/transaction-controller';
 import { PaymentOverride } from '@metamask/transaction-pay-controller';
@@ -108,6 +109,7 @@ describe('useAutomaticMoneyAccountPayToken', () => {
     useMoneyAccountBalanceMock.mockReturnValue({
       isBalanceLoading,
       withdrawableFiatRaw: isBalanceLoading ? undefined : balance,
+      withdrawableMusd: isBalanceLoading ? undefined : new BigNumber(balance),
     } as never);
   }
 
@@ -124,6 +126,7 @@ describe('useAutomaticMoneyAccountPayToken', () => {
     useMoneyAccountBalanceMock.mockReturnValue({
       isBalanceLoading: false,
       withdrawableFiatRaw: undefined,
+      withdrawableMusd: undefined,
     } as never);
     useTransactionMetadataRequestMock.mockReturnValue({
       id: transactionIdMock,
@@ -197,6 +200,7 @@ describe('useAutomaticMoneyAccountPayToken', () => {
     useMoneyAccountBalanceMock.mockReturnValue({
       isBalanceLoading: false,
       withdrawableFiatRaw: '7.61',
+      withdrawableMusd: new BigNumber('7.61'),
     } as never);
 
     rerender(undefined);

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticMoneyAccountPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticMoneyAccountPayToken.ts
@@ -15,10 +15,10 @@ import {
   isHardwareAccount,
   isQRHardwareAccount,
 } from '../../../../../util/address';
-import useMoneyAccountBalance from '../../../../UI/Money/hooks/useMoneyAccountBalance';
 import { getTransactionType } from '../../utils/transaction';
 import { applyMoneyAccountOverride } from '../../utils/transaction-pay';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { usePayMoneyAccountAvailable } from './usePayMoneyAccountAvailable';
 
 const log = createProjectLogger('transaction-pay');
 
@@ -66,6 +66,8 @@ export function useAutomaticMoneyAccountPayToken({
   const moneyAccount = useSelector(selectPrimaryMoneyAccount);
   const transactionType = getTransactionType(transactionMeta);
 
+  // Whether the Money Account is an eligible fallback here at all. Account
+  // existence and balance are answered by `usePayMoneyAccountAvailable`.
   const canUseMoneyAccountPay =
     !autoSelectFiatPayment &&
     !isHardwareWallet &&
@@ -73,17 +75,11 @@ export function useAutomaticMoneyAccountPayToken({
     paymentOverride !== PaymentOverride.MoneyAccount &&
     !hasTokenBalance &&
     hasTransactionType(transactionMeta, MONEY_ACCOUNT_FALLBACK_DEPOSIT_TYPES) &&
-    Boolean(
-      transactionType && enableMoneyAccountTransactions[transactionType],
-    ) &&
-    Boolean(moneyAccount);
+    Boolean(transactionType && enableMoneyAccountTransactions[transactionType]);
 
-  const { isBalanceLoading, withdrawableFiatRaw } = useMoneyAccountBalance({
+  const { isAvailable: shouldSelect, isPending } = usePayMoneyAccountAvailable({
     enabled: canUseMoneyAccountPay,
   });
-  const moneyAccountBalance = Number(withdrawableFiatRaw ?? 0);
-  const isPending = canUseMoneyAccountPay && isBalanceLoading;
-  const shouldSelect = canUseMoneyAccountPay && moneyAccountBalance > 0;
 
   useEffect(() => {
     if (
@@ -104,15 +100,12 @@ export function useAutomaticMoneyAccountPayToken({
       transactionMeta,
     );
     isUpdated.current = transactionId;
-    log('Automatically selected money account (no token balance)', {
-      moneyAccountBalance,
-    });
+    log('Automatically selected money account (no token balance)');
   }, [
     disable,
     hasFiatPaymentSelected,
     isPending,
     moneyAccount?.address,
-    moneyAccountBalance,
     payTokenSelected,
     shouldSelect,
     transactionId,

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
@@ -1775,8 +1775,13 @@ describe('useAutomaticTransactionPayToken', () => {
         shouldSelect: false,
       });
       useTransactionPayAvailableTokensMock.mockReturnValue({
-        availableTokens: [] as AssetType[],
-        hasTokens: false,
+        availableTokens: [
+          {
+            address: TOKEN_ADDRESS_1_MOCK,
+            chainId: CHAIN_ID_1_MOCK,
+          },
+        ] as AssetType[],
+        hasTokens: true,
       });
 
       runHook();

--- a/app/components/Views/confirmations/hooks/pay/useIsMoneyAccountFlagDefault.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsMoneyAccountFlagDefault.test.ts
@@ -45,7 +45,10 @@ describe('useIsMoneyAccountFlagDefault', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useParams as jest.Mock).mockReturnValue({});
-    (usePayMoneyAccountAvailable as jest.Mock).mockReturnValue(true);
+    (usePayMoneyAccountAvailable as jest.Mock).mockReturnValue({
+      isAvailable: true,
+      isPending: false,
+    });
     (selectMetaMaskPayFlags as unknown as jest.Mock).mockReturnValue(
       DEFAULT_FLAGS,
     );
@@ -88,7 +91,10 @@ describe('useIsMoneyAccountFlagDefault', () => {
   );
 
   it('returns false when the money account is unavailable (missing or unfunded)', () => {
-    (usePayMoneyAccountAvailable as jest.Mock).mockReturnValue(false);
+    (usePayMoneyAccountAvailable as jest.Mock).mockReturnValue({
+      isAvailable: false,
+      isPending: false,
+    });
     (selectMetaMaskPayFlags as unknown as jest.Mock).mockReturnValue(
       MONEY_ACCOUNT_FLAG,
     );

--- a/app/components/Views/confirmations/hooks/pay/useIsMoneyAccountFlagDefault.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsMoneyAccountFlagDefault.test.ts
@@ -2,7 +2,7 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import { useIsMoneyAccountFlagDefault } from './useIsMoneyAccountFlagDefault';
 import { useParams } from '../../../../../util/navigation/navUtils';
-import { selectPrimaryMoneyAccount } from '../../../../../selectors/moneyAccountController';
+import { usePayMoneyAccountAvailable } from './usePayMoneyAccountAvailable';
 import { selectMetaMaskPayFlags } from '../../../../../selectors/featureFlagController/confirmations';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { PayWithOption } from '../../components/confirm/confirm-component';
@@ -12,8 +12,8 @@ jest.mock('../../../../../util/navigation/navUtils', () => ({
   useParams: jest.fn(),
 }));
 
-jest.mock('../../../../../selectors/moneyAccountController', () => ({
-  selectPrimaryMoneyAccount: jest.fn(),
+jest.mock('./usePayMoneyAccountAvailable', () => ({
+  usePayMoneyAccountAvailable: jest.fn(),
 }));
 
 jest.mock(
@@ -26,8 +26,6 @@ jest.mock(
 jest.mock('../transactions/useTransactionMetadataRequest', () => ({
   useTransactionMetadataRequest: jest.fn(),
 }));
-
-const MONEY_ACCOUNT_ADDRESS = '0xabc1111111111111111111111111111111111111';
 
 const MONEY_ACCOUNT_FLAG = {
   defaultPaySelectedSection: {
@@ -47,9 +45,7 @@ describe('useIsMoneyAccountFlagDefault', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useParams as jest.Mock).mockReturnValue({});
-    (selectPrimaryMoneyAccount as unknown as jest.Mock).mockReturnValue({
-      address: MONEY_ACCOUNT_ADDRESS,
-    });
+    (usePayMoneyAccountAvailable as jest.Mock).mockReturnValue(true);
     (selectMetaMaskPayFlags as unknown as jest.Mock).mockReturnValue(
       DEFAULT_FLAGS,
     );
@@ -91,10 +87,8 @@ describe('useIsMoneyAccountFlagDefault', () => {
     },
   );
 
-  it('returns false when flag is "money-account" but no money account', () => {
-    (selectPrimaryMoneyAccount as unknown as jest.Mock).mockReturnValue(
-      undefined,
-    );
+  it('returns false when the money account is unavailable (missing or unfunded)', () => {
+    (usePayMoneyAccountAvailable as jest.Mock).mockReturnValue(false);
     (selectMetaMaskPayFlags as unknown as jest.Mock).mockReturnValue(
       MONEY_ACCOUNT_FLAG,
     );

--- a/app/components/Views/confirmations/hooks/pay/useIsMoneyAccountFlagDefault.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsMoneyAccountFlagDefault.ts
@@ -3,12 +3,12 @@ import {
   TransactionType,
   hasTransactionType,
 } from '@metamask/transaction-controller';
-import { selectPrimaryMoneyAccount } from '../../../../../selectors/moneyAccountController';
 import { selectMetaMaskPayFlags } from '../../../../../selectors/featureFlagController/confirmations';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { ConfirmationParams } from '../../components/confirm/confirm-component';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { getTransactionType } from '../../utils/transaction';
+import { usePayMoneyAccountAvailable } from './usePayMoneyAccountAvailable';
 
 const PERPS_PREDICT_TRANSACTION_TYPES: TransactionType[] = [
   TransactionType.perpsDeposit,
@@ -19,20 +19,25 @@ const PERPS_PREDICT_TRANSACTION_TYPES: TransactionType[] = [
 
 /**
  * Returns `true` when the `defaultPaySelectedSection` feature flag is
- * `"money-account"` and the user has a money account, while no explicit
- * `payWithOption` nav-param overrides the selection.
+ * `"money-account"` and the Money Account is available as a payment source,
+ * while no explicit `payWithOption` nav-param overrides the selection.
  *
  * Only applies to perps / predict transaction types so that the flag
  * does not accidentally default money-account for unrelated flows.
+ *
+ * Account existence and balance are both delegated to
+ * `usePayMoneyAccountAvailable`. Deposit types are in scope here, so the flag
+ * alone could otherwise default an *unfunded* Money Account and seed a quote
+ * that reverts on simulation.
  *
  * This value is derived synchronously at render time so consumers can
  * use it on the very first render — no effect delay, no flash.
  */
 export function useIsMoneyAccountFlagDefault(): boolean {
   const { payWithOption } = useParams<ConfirmationParams>({});
-  const moneyAccount = useSelector(selectPrimaryMoneyAccount);
   const { defaultPaySelectedSection } = useSelector(selectMetaMaskPayFlags);
   const transactionMeta = useTransactionMetadataRequest();
+  const isMoneyAccountAvailable = usePayMoneyAccountAvailable();
 
   const isPerpsOrPredict = hasTransactionType(
     transactionMeta,
@@ -47,7 +52,7 @@ export function useIsMoneyAccountFlagDefault(): boolean {
   return (
     !payWithOption &&
     sectionForType === 'money-account' &&
-    !!moneyAccount &&
-    isPerpsOrPredict
+    isPerpsOrPredict &&
+    isMoneyAccountAvailable
   );
 }

--- a/app/components/Views/confirmations/hooks/pay/useIsMoneyAccountFlagDefault.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsMoneyAccountFlagDefault.ts
@@ -37,7 +37,8 @@ export function useIsMoneyAccountFlagDefault(): boolean {
   const { payWithOption } = useParams<ConfirmationParams>({});
   const { defaultPaySelectedSection } = useSelector(selectMetaMaskPayFlags);
   const transactionMeta = useTransactionMetadataRequest();
-  const isMoneyAccountAvailable = usePayMoneyAccountAvailable();
+  const { isAvailable: isMoneyAccountAvailable } =
+    usePayMoneyAccountAvailable();
 
   const isPerpsOrPredict = hasTransactionType(
     transactionMeta,

--- a/app/components/Views/confirmations/hooks/pay/usePayMoneyAccountAvailable.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayMoneyAccountAvailable.test.ts
@@ -1,0 +1,110 @@
+import BigNumber from 'bignumber.js';
+import { TransactionType } from '@metamask/transaction-controller';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { selectPrimaryMoneyAccount } from '../../../../../selectors/moneyAccountController';
+import useMoneyAccountBalance from '../../../../UI/Money/hooks/useMoneyAccountBalance';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { usePayMoneyAccountAvailable } from './usePayMoneyAccountAvailable';
+
+jest.mock('../../../../../selectors/moneyAccountController', () => ({
+  selectPrimaryMoneyAccount: jest.fn(),
+}));
+
+jest.mock('../../../../UI/Money/hooks/useMoneyAccountBalance');
+
+jest.mock('../transactions/useTransactionMetadataRequest', () => ({
+  useTransactionMetadataRequest: jest.fn(),
+}));
+
+const MONEY_ACCOUNT = {
+  address: '0xabc1111111111111111111111111111111111111',
+};
+
+const mockBalance = (withdrawableMusd: BigNumber | undefined) => {
+  jest.mocked(useMoneyAccountBalance).mockReturnValue({
+    withdrawableMusd,
+  } as never);
+};
+
+const mockTransactionType = (type: TransactionType | undefined) => {
+  (useTransactionMetadataRequest as jest.Mock).mockReturnValue(
+    type ? { id: 'tx-1', type, txParams: {} } : undefined,
+  );
+};
+
+const render = () =>
+  renderHookWithProvider(() => usePayMoneyAccountAvailable());
+
+describe('usePayMoneyAccountAvailable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (selectPrimaryMoneyAccount as unknown as jest.Mock).mockReturnValue(
+      MONEY_ACCOUNT,
+    );
+    mockBalance(new BigNumber(100));
+    mockTransactionType(TransactionType.perpsDeposit);
+  });
+
+  it('returns false when there is no money account', () => {
+    (selectPrimaryMoneyAccount as unknown as jest.Mock).mockReturnValue(
+      undefined,
+    );
+
+    expect(render().result.current).toBe(false);
+  });
+
+  describe('funding flows', () => {
+    it.each([TransactionType.perpsDeposit, TransactionType.predictDeposit])(
+      'returns true for %s when the balance is positive',
+      (type) => {
+        mockTransactionType(type);
+
+        expect(render().result.current).toBe(true);
+      },
+    );
+
+    it.each([TransactionType.perpsDeposit, TransactionType.predictDeposit])(
+      'returns false for %s when the balance is zero',
+      (type) => {
+        mockTransactionType(type);
+        mockBalance(new BigNumber(0));
+
+        expect(render().result.current).toBe(false);
+      },
+    );
+
+    it('returns false when the balance is unknown, e.g. loading or fetch error', () => {
+      mockBalance(undefined);
+
+      expect(render().result.current).toBe(false);
+    });
+  });
+
+  describe('post-quote flows', () => {
+    it.each([
+      TransactionType.perpsWithdraw,
+      TransactionType.predictWithdraw,
+      TransactionType.moneyAccountWithdraw,
+    ])('returns true for %s despite a zero balance', (type) => {
+      mockTransactionType(type);
+      mockBalance(new BigNumber(0));
+
+      expect(render().result.current).toBe(true);
+    });
+  });
+
+  describe('outside a confirmation', () => {
+    it('requires a balance when there is no transaction metadata', () => {
+      mockTransactionType(undefined);
+      mockBalance(new BigNumber(0));
+
+      expect(render().result.current).toBe(false);
+    });
+
+    it('is available when there is no transaction metadata and a balance exists', () => {
+      mockTransactionType(undefined);
+
+      expect(render().result.current).toBe(true);
+    });
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/usePayMoneyAccountAvailable.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayMoneyAccountAvailable.test.ts
@@ -20,8 +20,12 @@ const MONEY_ACCOUNT = {
   address: '0xabc1111111111111111111111111111111111111',
 };
 
-const mockBalance = (withdrawableMusd: BigNumber | undefined) => {
+const mockBalance = (
+  withdrawableMusd: BigNumber | undefined,
+  isBalanceLoading = false,
+) => {
   jest.mocked(useMoneyAccountBalance).mockReturnValue({
+    isBalanceLoading,
     withdrawableMusd,
   } as never);
 };
@@ -32,8 +36,8 @@ const mockTransactionType = (type: TransactionType | undefined) => {
   );
 };
 
-const render = () =>
-  renderHookWithProvider(() => usePayMoneyAccountAvailable());
+const render = (options?: { enabled?: boolean }) =>
+  renderHookWithProvider(() => usePayMoneyAccountAvailable(options));
 
 describe('usePayMoneyAccountAvailable', () => {
   beforeEach(() => {
@@ -45,38 +49,59 @@ describe('usePayMoneyAccountAvailable', () => {
     mockTransactionType(TransactionType.perpsDeposit);
   });
 
-  it('returns false when there is no money account', () => {
+  it('is unavailable when there is no money account', () => {
     (selectPrimaryMoneyAccount as unknown as jest.Mock).mockReturnValue(
       undefined,
     );
 
-    expect(render().result.current).toBe(false);
+    expect(render().result.current).toStrictEqual({
+      isAvailable: false,
+      isPending: false,
+    });
   });
 
   describe('funding flows', () => {
     it.each([TransactionType.perpsDeposit, TransactionType.predictDeposit])(
-      'returns true for %s when the balance is positive',
+      'is available for %s when the balance is positive',
       (type) => {
         mockTransactionType(type);
 
-        expect(render().result.current).toBe(true);
+        expect(render().result.current).toStrictEqual({
+          isAvailable: true,
+          isPending: false,
+        });
       },
     );
 
     it.each([TransactionType.perpsDeposit, TransactionType.predictDeposit])(
-      'returns false for %s when the balance is zero',
+      'is unavailable for %s when the balance is zero',
       (type) => {
         mockTransactionType(type);
         mockBalance(new BigNumber(0));
 
-        expect(render().result.current).toBe(false);
+        expect(render().result.current).toStrictEqual({
+          isAvailable: false,
+          isPending: false,
+        });
       },
     );
 
-    it('returns false when the balance is unknown, e.g. loading or fetch error', () => {
+    it('is pending while the balance is loading', () => {
+      mockBalance(undefined, true);
+
+      expect(render().result.current).toStrictEqual({
+        isAvailable: false,
+        isPending: true,
+      });
+    });
+
+    it('is unavailable and settled when the balance cannot be fetched', () => {
       mockBalance(undefined);
 
-      expect(render().result.current).toBe(false);
+      expect(render().result.current).toStrictEqual({
+        isAvailable: false,
+        isPending: false,
+      });
     });
   });
 
@@ -85,11 +110,39 @@ describe('usePayMoneyAccountAvailable', () => {
       TransactionType.perpsWithdraw,
       TransactionType.predictWithdraw,
       TransactionType.moneyAccountWithdraw,
-    ])('returns true for %s despite a zero balance', (type) => {
+    ])('is available for %s despite a zero balance', (type) => {
       mockTransactionType(type);
       mockBalance(new BigNumber(0));
 
-      expect(render().result.current).toBe(true);
+      expect(render().result.current).toStrictEqual({
+        isAvailable: true,
+        isPending: false,
+      });
+    });
+
+    it('does not fetch a balance it cannot use', () => {
+      mockTransactionType(TransactionType.perpsWithdraw);
+
+      render();
+
+      expect(useMoneyAccountBalance).toHaveBeenCalledWith({ enabled: false });
+    });
+  });
+
+  describe('when disabled', () => {
+    it('reports neither available nor pending', () => {
+      mockBalance(undefined, true);
+
+      expect(render({ enabled: false }).result.current).toStrictEqual({
+        isAvailable: false,
+        isPending: false,
+      });
+    });
+
+    it('does not fetch a balance', () => {
+      render({ enabled: false });
+
+      expect(useMoneyAccountBalance).toHaveBeenCalledWith({ enabled: false });
     });
   });
 
@@ -98,13 +151,13 @@ describe('usePayMoneyAccountAvailable', () => {
       mockTransactionType(undefined);
       mockBalance(new BigNumber(0));
 
-      expect(render().result.current).toBe(false);
+      expect(render().result.current.isAvailable).toBe(false);
     });
 
     it('is available when there is no transaction metadata and a balance exists', () => {
       mockTransactionType(undefined);
 
-      expect(render().result.current).toBe(true);
+      expect(render().result.current.isAvailable).toBe(true);
     });
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/usePayMoneyAccountAvailable.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayMoneyAccountAvailable.ts
@@ -1,0 +1,48 @@
+import { useSelector } from 'react-redux';
+import { selectPrimaryMoneyAccount } from '../../../../../selectors/moneyAccountController';
+import useMoneyAccountBalance from '../../../../UI/Money/hooks/useMoneyAccountBalance';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { isTransactionPayWithdraw } from '../../utils/transaction';
+
+/**
+ * Whether the Money Account is available as a payment source.
+ *
+ * Centralises the check for the MetaMask Pay decision points that independently
+ * route payment to the Money Account: the pay-with listing
+ * (`usePayWithMoneyAccountSection`) and the `defaultPaySelectedSection` feature
+ * flag (`useIsMoneyAccountFlagDefault`). Both decide on their own, so both
+ * consult this rather than re-deriving their own rules.
+ *
+ * The `payWithOption` nav-param path is deliberately *not* covered here: it
+ * originates from Money home, whose transfer entry point is already disabled
+ * unless there is a spendable balance, so the param is a trusted signal.
+ *
+ * Selecting an unfunded Money Account produces a quote whose nested delegation
+ * redeems against an empty (often codeless) account, which reverts during
+ * simulation.
+ *
+ * Two cases are deliberately distinguished. Funding flows (deposits) pay *from*
+ * the Money Account, so they require a confirmed positive balance. Post-quote
+ * flows (`perpsWithdraw`, `predictWithdraw`, `moneyAccountWithdraw`) pay *into*
+ * it, where a zero balance is expected and must not make it unavailable.
+ *
+ * Outside a confirmation there is no transaction metadata, which correctly
+ * falls through to the stricter funding case.
+ *
+ * Fails closed while the balance is loading or unavailable: `withdrawableMusd`
+ * is `undefined` in both cases, and an unverifiable balance cannot safely seed
+ * a quote.
+ */
+export function usePayMoneyAccountAvailable(): boolean {
+  const transactionMeta = useTransactionMetadataRequest();
+  const moneyAccount = useSelector(selectPrimaryMoneyAccount);
+  const { withdrawableMusd } = useMoneyAccountBalance();
+
+  if (!moneyAccount) {
+    return false;
+  }
+
+  const isFundingSource = !isTransactionPayWithdraw(transactionMeta);
+
+  return !isFundingSource || Boolean(withdrawableMusd?.isGreaterThan(0));
+}

--- a/app/components/Views/confirmations/hooks/pay/usePayMoneyAccountAvailable.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayMoneyAccountAvailable.ts
@@ -4,45 +4,53 @@ import useMoneyAccountBalance from '../../../../UI/Money/hooks/useMoneyAccountBa
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { isTransactionPayWithdraw } from '../../utils/transaction';
 
+export interface PayMoneyAccountAvailability {
+  isAvailable: boolean;
+  /**
+   * The balance is still loading. Callers that would otherwise select a
+   * different payment source must wait rather than treat this as unavailable,
+   * or they win the race every time.
+   */
+  isPending: boolean;
+}
+
 /**
  * Whether the Money Account is available as a payment source.
  *
- * Centralises the check for the MetaMask Pay decision points that independently
- * route payment to the Money Account: the pay-with listing
- * (`usePayWithMoneyAccountSection`) and the `defaultPaySelectedSection` feature
- * flag (`useIsMoneyAccountFlagDefault`). Both decide on their own, so both
- * consult this rather than re-deriving their own rules.
+ * Selecting an unfunded Money Account produces a quote that reverts during
+ * simulation, so this fails closed.
  *
- * The `payWithOption` nav-param path is deliberately *not* covered here: it
- * originates from Money home, whose transfer entry point is already disabled
- * unless there is a spendable balance, so the param is a trusted signal.
+ * Only funding flows require a balance. Post-quote flows pay *into* the Money
+ * Account, where a zero balance is expected and must not make it unavailable.
  *
- * Selecting an unfunded Money Account produces a quote whose nested delegation
- * redeems against an empty (often codeless) account, which reverts during
- * simulation.
- *
- * Two cases are deliberately distinguished. Funding flows (deposits) pay *from*
- * the Money Account, so they require a confirmed positive balance. Post-quote
- * flows (`perpsWithdraw`, `predictWithdraw`, `moneyAccountWithdraw`) pay *into*
- * it, where a zero balance is expected and must not make it unavailable.
- *
- * Outside a confirmation there is no transaction metadata, which correctly
- * falls through to the stricter funding case.
- *
- * Fails closed while the balance is loading or unavailable: `withdrawableMusd`
- * is `undefined` in both cases, and an unverifiable balance cannot safely seed
- * a quote.
+ * @param options - Hook options.
+ * @param options.enabled - Set `false` when the caller has already ruled the
+ * Money Account out, to skip fetching a balance that cannot change the answer.
  */
-export function usePayMoneyAccountAvailable(): boolean {
+export function usePayMoneyAccountAvailable({
+  enabled = true,
+}: { enabled?: boolean } = {}): PayMoneyAccountAvailability {
   const transactionMeta = useTransactionMetadataRequest();
   const moneyAccount = useSelector(selectPrimaryMoneyAccount);
-  const { withdrawableMusd } = useMoneyAccountBalance();
 
-  if (!moneyAccount) {
-    return false;
-  }
-
+  const isApplicable = enabled && Boolean(moneyAccount);
   const isFundingSource = !isTransactionPayWithdraw(transactionMeta);
 
-  return !isFundingSource || Boolean(withdrawableMusd?.isGreaterThan(0));
+  const { isBalanceLoading, withdrawableMusd } = useMoneyAccountBalance({
+    enabled: isApplicable && isFundingSource,
+  });
+
+  if (!isApplicable) {
+    return { isAvailable: false, isPending: false };
+  }
+
+  // Receiving flows do not spend from the account, so no balance is required.
+  if (!isFundingSource) {
+    return { isAvailable: true, isPending: false };
+  }
+
+  return {
+    isAvailable: Boolean(withdrawableMusd?.isGreaterThan(0)),
+    isPending: isBalanceLoading,
+  };
 }


### PR DESCRIPTION
## **Description**

The Money Account can be selected as a MetaMask Pay payment source without any check that it holds a balance. Paying from an unfunded account produces a quote whose nested delegation redeems against an empty — often codeless — account, which reverts during simulation. The user only discovers this after committing to the flow.

Adds `usePayMoneyAccountAvailable`, a single hook answering whether the Money Account can actually pay, and consults it from the three paths that independently route payment to it: the pay-with listing, the `defaultPaySelectedSection` flag default, and the no-token-balance fallback. The fallback previously derived its own balance check; that rule now lives in one place.

### Notes for reviewers

- The balance requirement applies only to **funding** flows. Post-quote types (`perpsWithdraw`, `predictWithdraw`, `moneyAccountWithdraw`) use the Money Account as the *recipient*, where a zero balance is expected and legitimate.
- The hook fails closed while the balance loads, and exposes `isPending` so the fallback can wait. Treating a loading balance as unavailable lets the token path latch first and win the race permanently.

## **Changelog**

CHANGELOG entry: Fixed the Money Account being offered as a payment source when it has no available balance

## **Related issues**

Fixes: [CONF-1899](https://consensyssoftware.atlassian.net/browse/CONF-1899)

## **Manual testing steps**

```gherkin
Feature: Money Account payment source availability

  Scenario: user with an empty Money Account opens a perps deposit
    Given the user has a Money Account with no balance
    When the user opens a Perps deposit confirmation
    Then the Money Account is not listed as a payment source
    And the Money Account is not pre-selected as the payment source

  Scenario: user with a funded Money Account opens a perps deposit
    Given the user has a Money Account with a positive balance
    When the user opens a Perps deposit confirmation
    Then the Money Account is listed as a payment source
    And the Money Account is pre-selected where the feature flag defaults to it

  Scenario: user with an empty Money Account withdraws from perps
    Given the user has a Money Account with no balance
    When the user opens a Perps withdraw confirmation
    Then the Money Account is still offered and defaulted as the destination
```

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[CONF-1899]: https://consensyssoftware.atlassian.net/browse/CONF-1899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared payment-source selection for Money Account across confirmations; incorrect gating could hide a valid payer or pre-select an unfunded account, though behavior is fail-closed and covered by new unit tests.
> 
> **Overview**
> Introduces **`usePayMoneyAccountAvailable`** as the single gate for whether the Money Account may be used in MetaMask Pay. **Funding** flows (e.g. perps/predict deposits) require a primary Money Account and **positive** `withdrawableMusd`; **withdraw / receive** flows stay available with a zero balance because the account is the destination, not the payer.
> 
> That hook replaces ad‑hoc checks in **`usePayWithMoneyAccountSection`** (pay-with sheet row), **`useIsMoneyAccountFlagDefault`** (`defaultPaySelectedSection`), and **`useAutomaticMoneyAccountPayToken`** (no-token fallback). The auto-select path drops its inline balance math and uses the hook’s **`isPending`** so token auto-select does not win while balance is loading.
> 
> Tests cover funding vs receiving, loading/error balance states, and component tests stub the new hook to avoid hitting the Money Account balance query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a69e71c5e590ec8938191191af2ea3384d9e1cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->