### PR TITLE
chore: bump `@metamask/assets-controller` to `^14.0.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -280,7 +280,7 @@
     "@metamask/analytics-controller": "^2.0.0",
     "@metamask/app-metadata-controller": "^2.0.0",
     "@metamask/approval-controller": "^9.0.0",
-    "@metamask/assets-controller": "^14.0.1",
+    "@metamask/assets-controller": "^14.0.2",
     "@metamask/assets-controllers": "^111.1.2",
     "@metamask/authenticated-user-storage": "^3.0.2",
     "@metamask/base-controller": "^9.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7746,7 +7746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controller@npm:^14.0.1, @metamask/assets-controller@npm:^14.0.2":
+"@metamask/assets-controller@npm:^14.0.2":
   version: 14.0.2
   resolution: "@metamask/assets-controller@npm:14.0.2"
   dependencies:
@@ -35670,7 +35670,7 @@ __metadata:
     "@metamask/analytics-controller": "npm:^2.0.0"
     "@metamask/app-metadata-controller": "npm:^2.0.0"
     "@metamask/approval-controller": "npm:^9.0.0"
-    "@metamask/assets-controller": "npm:^14.0.1"
+    "@metamask/assets-controller": "npm:^14.0.2"
     "@metamask/assets-controllers": "npm:^111.1.2"
     "@metamask/authenticated-user-storage": "npm:^3.0.2"
     "@metamask/auto-changelog": "npm:^6.2.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Standalone version bump of `@metamask/assets-controller` onto the latest published `14.x` patch, so that the feature work in [#35328](https://github.com/MetaMask/metamask-mobile/pull/35328) (self-cleaning scam tokens on unlock, currently pinned to `npm:@metamask-previews/assets-controller@14.0.2-preview-db4b81608`) can be reviewed as a pure behaviour diff rather than a bump plus a behaviour change.

| Package | Before | After |
| --- | --- | --- |
| `@metamask/assets-controller` | `^14.0.1` | `^14.0.2` |

Mobile is already on the `14.x` line, so unlike the extension side this needs no other dependency or messenger work:

- `@metamask/account-tree-controller` is already on `^8.0.0` (bumped in an earlier PR).
- The `AssetsController` messenger already delegates the `AccountTreeController:initialized` / `:uninitialized` events that `assets-controller@14` requires — see `app/core/Engine/messengers/assets-controller/assets-controller-messenger.ts`.
- `yarn.lock` already resolved `@metamask/assets-controller` to `14.0.2` transitively through `@metamask/transaction-pay-controller@^27.0.0`, so this bump changes no installed code. It only updates the declared range and drops the now-stale `^14.0.1` descriptor from the lockfile.

`14.0.2` itself is dependency bumps only (`accounts-controller`, `assets-controllers`, `config-registry-controller`, `network-controller`, `network-enablement-controller`, `transaction-controller`) — see the [assets-controller changelog](https://github.com/MetaMask/core/blob/main/packages/assets-controller/CHANGELOG.md).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/pull/35328

## **Manual testing steps**

N/A — dependency range alignment only. The resolved `@metamask/assets-controller` version in `yarn.lock` is unchanged at `14.0.2` both before and after this PR, so there is no runtime behaviour to exercise. CI (typecheck, unit tests, builds) is the meaningful verification here.

## **Screenshots/Recordings**

### **Before**

N/A — no user-facing change.

### **After**

N/A — no user-facing change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!--
#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
-->

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e65b8758-3c24-4e12-bd05-5230cf3dbbeb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e65b8758-3c24-4e12-bd05-5230cf3dbbeb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

