### PR TITLE
fix(assets): refresh token list

### DIFF
--- a/app/components/UI/Tokens/hooks/useRefreshTokens.test.ts
+++ b/app/components/UI/Tokens/hooks/useRefreshTokens.test.ts
@@ -1,16 +1,16 @@
 import { renderHook, act } from '@testing-library/react-native';
-import { BtcScope, EthScope, SolScope } from '@metamask/keyring-api';
-import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
-import type { Hex } from '@metamask/utils';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
+import type { Hex } from '@metamask/utils';
 import Logger from '../../../../util/Logger';
 import { selectIsAssetsUnifyStateEnabled } from '../../../../selectors/featureFlagController/assetsUnifyState';
+import { selectSelectedAccountGroupInternalAccounts } from '../../../../selectors/multichainAccounts/accountTreeController';
+import { selectEnabledNetworks } from '../../../../selectors/networkEnablementController';
+import { selectEvmNetworkConfigurationsByChainId } from '../../../../selectors/networkController';
 import { useRefreshTokens } from './useRefreshTokens';
 
 const mockGetAssets = jest.fn().mockResolvedValue({});
 const mockUpdateBalance = jest.fn().mockResolvedValue(undefined);
 const mockPerformEvmTokenRefresh = jest.fn().mockResolvedValue(undefined);
-const mockAccountByScope = jest.fn();
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn((selector: (state: Record<string, never>) => unknown) =>
@@ -25,8 +25,19 @@ jest.mock(
   }),
 );
 
-jest.mock('../../../../selectors/multichainAccounts/accounts', () => ({
-  selectSelectedInternalAccountByScope: jest.fn(() => mockAccountByScope),
+jest.mock(
+  '../../../../selectors/multichainAccounts/accountTreeController',
+  () => ({
+    selectSelectedAccountGroupInternalAccounts: jest.fn(),
+  }),
+);
+
+jest.mock('../../../../selectors/networkEnablementController', () => ({
+  selectEnabledNetworks: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/networkController', () => ({
+  selectEvmNetworkConfigurationsByChainId: jest.fn(),
 }));
 
 jest.mock('../../../../core/Engine', () => ({
@@ -49,13 +60,26 @@ jest.mock('../util/tokenRefreshUtils', () => ({
     mockPerformEvmTokenRefresh(...args),
 }));
 
+jest.mock('../../../../core/Assets/accountGroupAssetLoader', () => ({
+  FUNGIBLE_ASSET_TYPES: ['fungible'],
+}));
+
+const SOLANA_CHAIN_ID = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+const BITCOIN_CHAIN_ID = 'bip122:000000000019d6689c085ae165831e93';
+
 const evmNetworkConfigurationsByChainId = {
   '0x1': { chainId: '0x1' as Hex, nativeCurrency: 'ETH' },
   '0x89': { chainId: '0x89' as Hex, nativeCurrency: 'POL' },
-} as const;
+};
 
-const makeAccount = (id: string): InternalAccount =>
-  ({ id, address: '0xabc', type: 'eip155:eoa' }) as InternalAccount;
+const makeAccount = (
+  id: string,
+  type: InternalAccount['type'] = 'eip155:eoa',
+): InternalAccount => ({ id, address: '0xabc', type }) as InternalAccount;
+
+const evmAccount = makeAccount('evm-account');
+const solAccount = makeAccount('sol-account', 'solana:data-account');
+const btcAccount = makeAccount('btc-account', 'bip122:p2wpkh');
 
 describe('useRefreshTokens', () => {
   beforeEach(() => {
@@ -63,45 +87,33 @@ describe('useRefreshTokens', () => {
     (selectIsAssetsUnifyStateEnabled as unknown as jest.Mock).mockReturnValue(
       true,
     );
-    mockAccountByScope.mockImplementation((scope: unknown) => {
-      if (scope === EthScope.Mainnet) {
-        return makeAccount('evm-account');
-      }
-      if (scope === SolScope.Mainnet) {
-        return makeAccount('sol-account');
-      }
-      if (scope === BtcScope.Mainnet) {
-        return makeAccount('btc-account');
-      }
-      return undefined;
-    });
+    (
+      selectSelectedAccountGroupInternalAccounts as unknown as jest.Mock
+    ).mockReturnValue([evmAccount, solAccount, btcAccount]);
+    (selectEnabledNetworks as unknown as jest.Mock).mockReturnValue([
+      'eip155:1',
+      'eip155:137',
+      SOLANA_CHAIN_ID,
+      BITCOIN_CHAIN_ID,
+    ]);
+    (
+      selectEvmNetworkConfigurationsByChainId as unknown as jest.Mock
+    ).mockReturnValue(evmNetworkConfigurationsByChainId);
   });
 
-  it('calls AssetsController.getAssets with chain ids and fungible asset types when unified assets are enabled', async () => {
-    const { result } = renderHook(() =>
-      useRefreshTokens({
-        evmNetworkConfigurationsByChainId,
-      }),
-    );
+  it('calls AssetsController.getAssets with selected group accounts and all enabled chains when unified assets are enabled', async () => {
+    const { result } = renderHook(() => useRefreshTokens());
 
     await act(async () => {
       await result.current.refresh();
     });
 
-    const expectedChainIds = Object.values(
-      evmNetworkConfigurationsByChainId,
-    ).map((config) => toEvmCaipChainId(config.chainId));
-
     expect(mockGetAssets).toHaveBeenCalledTimes(1);
     expect(mockGetAssets).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ id: 'evm-account' }),
-        expect.objectContaining({ id: 'sol-account' }),
-        expect.objectContaining({ id: 'btc-account' }),
-      ]),
+      [evmAccount, solAccount, btcAccount],
       {
         forceUpdate: true,
-        chainIds: expectedChainIds,
+        chainIds: ['eip155:1', 'eip155:137', SOLANA_CHAIN_ID, BITCOIN_CHAIN_ID],
         assetTypes: ['fungible'],
       },
     );
@@ -109,112 +121,62 @@ describe('useRefreshTokens', () => {
     expect(mockUpdateBalance).not.toHaveBeenCalled();
   });
 
-  it('skips AssetsController.getAssets when unified assets state is disabled', async () => {
+  it('refreshes via the legacy token controllers when unified assets state is disabled', async () => {
     (selectIsAssetsUnifyStateEnabled as unknown as jest.Mock).mockReturnValue(
       false,
     );
-    const { result } = renderHook(() =>
-      useRefreshTokens({
-        evmNetworkConfigurationsByChainId,
-      }),
-    );
+    const { result } = renderHook(() => useRefreshTokens());
 
     await act(async () => {
       await result.current.refresh();
     });
 
     expect(mockGetAssets).not.toHaveBeenCalled();
+    expect(mockUpdateBalance).toHaveBeenCalledTimes(2);
+    expect(mockUpdateBalance).toHaveBeenCalledWith('sol-account');
+    expect(mockUpdateBalance).toHaveBeenCalledWith('btc-account');
+    expect(mockPerformEvmTokenRefresh).toHaveBeenCalledTimes(1);
     expect(mockPerformEvmTokenRefresh).toHaveBeenCalledWith(
       evmNetworkConfigurationsByChainId,
     );
   });
 
-  it('skips AssetsController.getAssets when no scoped accounts exist', async () => {
-    mockAccountByScope.mockReturnValue(undefined);
-    const { result } = renderHook(() =>
-      useRefreshTokens({
-        evmNetworkConfigurationsByChainId,
-      }),
-    );
-
-    await act(async () => {
-      await result.current.refresh();
-    });
-
-    expect(mockGetAssets).not.toHaveBeenCalled();
-    expect(mockPerformEvmTokenRefresh).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not call MultichainBalancesController.updateBalance when the group has no Solana or Bitcoin scoped account', async () => {
-    mockAccountByScope.mockImplementation((scope: unknown) => {
-      if (scope === EthScope.Mainnet) {
-        return makeAccount('evm-only');
-      }
-      return undefined;
-    });
-
-    const { result } = renderHook(() =>
-      useRefreshTokens({
-        evmNetworkConfigurationsByChainId,
-      }),
-    );
-
-    await act(async () => {
-      await result.current.refresh();
-    });
-
-    expect(mockGetAssets).toHaveBeenCalledTimes(1);
-    expect(mockGetAssets).toHaveBeenCalledWith(
-      [expect.objectContaining({ id: 'evm-only' })],
-      expect.objectContaining({
-        forceUpdate: true,
-        assetTypes: ['fungible'],
-      }),
-    );
-    expect(mockUpdateBalance).not.toHaveBeenCalled();
-    expect(mockPerformEvmTokenRefresh).not.toHaveBeenCalled();
-  });
-
-  it('calls MultichainBalancesController.updateBalance for each present non-EVM scoped account when unified assets state is disabled', async () => {
+  it('does not call MultichainBalancesController.updateBalance for EVM-only groups when unified assets state is disabled', async () => {
     (selectIsAssetsUnifyStateEnabled as unknown as jest.Mock).mockReturnValue(
       false,
     );
-    mockAccountByScope.mockImplementation((scope: unknown) => {
-      if (scope === EthScope.Mainnet) {
-        return makeAccount('evm-1');
-      }
-      if (scope === SolScope.Mainnet) {
-        return makeAccount('sol-1');
-      }
-      if (scope === BtcScope.Mainnet) {
-        return undefined;
-      }
-      return undefined;
-    });
-
-    const { result } = renderHook(() =>
-      useRefreshTokens({
-        evmNetworkConfigurationsByChainId,
-      }),
-    );
+    (
+      selectSelectedAccountGroupInternalAccounts as unknown as jest.Mock
+    ).mockReturnValue([evmAccount]);
+    const { result } = renderHook(() => useRefreshTokens());
 
     await act(async () => {
       await result.current.refresh();
     });
 
     expect(mockGetAssets).not.toHaveBeenCalled();
-    expect(mockUpdateBalance).toHaveBeenCalledTimes(1);
-    expect(mockUpdateBalance).toHaveBeenCalledWith('sol-1');
+    expect(mockUpdateBalance).not.toHaveBeenCalled();
     expect(mockPerformEvmTokenRefresh).toHaveBeenCalledTimes(1);
   });
 
-  it('logs and continues when AssetsController.getAssets rejects', async () => {
+  it('does nothing when the selected group has no accounts and unified assets are enabled', async () => {
+    (
+      selectSelectedAccountGroupInternalAccounts as unknown as jest.Mock
+    ).mockReturnValue([]);
+    const { result } = renderHook(() => useRefreshTokens());
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockGetAssets).not.toHaveBeenCalled();
+    expect(mockPerformEvmTokenRefresh).not.toHaveBeenCalled();
+    expect(mockUpdateBalance).not.toHaveBeenCalled();
+  });
+
+  it('logs when AssetsController.getAssets rejects', async () => {
     mockGetAssets.mockRejectedValueOnce(new Error('network'));
-    const { result } = renderHook(() =>
-      useRefreshTokens({
-        evmNetworkConfigurationsByChainId,
-      }),
-    );
+    const { result } = renderHook(() => useRefreshTokens());
 
     await act(async () => {
       await result.current.refresh();
@@ -224,30 +186,14 @@ describe('useRefreshTokens', () => {
       expect.any(Error),
       'useRefreshTokens: AssetsController.getAssets failed',
     );
-    expect(mockPerformEvmTokenRefresh).not.toHaveBeenCalled();
-    expect(mockUpdateBalance).not.toHaveBeenCalled();
   });
 
-  it('logs per-account errors when MultichainBalancesController.updateBalance rejects', async () => {
+  it('logs and continues when MultichainBalancesController.updateBalance rejects', async () => {
     (selectIsAssetsUnifyStateEnabled as unknown as jest.Mock).mockReturnValue(
       false,
     );
-    mockUpdateBalance.mockRejectedValueOnce(new Error('sol-down'));
-    mockAccountByScope.mockImplementation((scope: unknown) => {
-      if (scope === EthScope.Mainnet) {
-        return makeAccount('evm-1');
-      }
-      if (scope === SolScope.Mainnet) {
-        return makeAccount('sol-1');
-      }
-      return undefined;
-    });
-
-    const { result } = renderHook(() =>
-      useRefreshTokens({
-        evmNetworkConfigurationsByChainId,
-      }),
-    );
+    mockUpdateBalance.mockRejectedValueOnce(new Error('rpc'));
+    const { result } = renderHook(() => useRefreshTokens());
 
     await act(async () => {
       await result.current.refresh();
@@ -255,9 +201,8 @@ describe('useRefreshTokens', () => {
 
     expect(Logger.error).toHaveBeenCalledWith(
       expect.any(Error),
-      'useRefreshTokens: failed to refresh balance for non-EVM account sol-1',
+      'useRefreshTokens: failed to refresh balance for non-EVM account sol-account',
     );
     expect(mockPerformEvmTokenRefresh).toHaveBeenCalledTimes(1);
-    expect(mockGetAssets).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Tokens/hooks/useRefreshTokens.ts
+++ b/app/components/UI/Tokens/hooks/useRefreshTokens.ts
@@ -1,101 +1,101 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import { BtcScope, EthScope, SolScope } from '@metamask/keyring-api';
-import { CaipChainId, Hex } from '@metamask/utils';
-import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
+import { isEvmAccountType } from '@metamask/keyring-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
 import { selectIsAssetsUnifyStateEnabled } from '../../../../selectors/featureFlagController/assetsUnifyState';
-import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
+import { selectSelectedAccountGroupInternalAccounts } from '../../../../selectors/multichainAccounts/accountTreeController';
+import { selectEnabledNetworks } from '../../../../selectors/networkEnablementController';
+import { selectEvmNetworkConfigurationsByChainId } from '../../../../selectors/networkController';
 import { performEvmTokenRefresh } from '../util/tokenRefreshUtils';
 import { FUNGIBLE_ASSET_TYPES } from '../../../../core/Assets/accountGroupAssetLoader';
 
-interface UseRefreshTokensOptions {
-  /** EVM network configurations restricted to the chains that should be polled. */
-  evmNetworkConfigurationsByChainId: Record<
-    string,
-    { chainId: Hex; nativeCurrency: string }
-  >;
-}
+const refreshUnifiedAssets = async (
+  accounts: readonly InternalAccount[],
+  enabledChainIds: ReturnType<typeof selectEnabledNetworks>,
+) => {
+  if (accounts.length === 0) {
+    return;
+  }
 
-/**
- * Refreshes tokens for the currently selected account group across all supported scopes (EVM, Solana, Bitcoin).
- *
- * When the unified assets state flag is enabled and the group has at least one scoped account, force-refreshes
- * `AssetsController` only, then returns (no legacy multichain or EVM controller refresh).
- *
- * Otherwise triggers `MultichainBalancesController.updateBalance` for every non-EVM scoped account (Solana,
- * Bitcoin, …) and runs the EVM token detection / balance / rate refresh in parallel.
- */
-export const useRefreshTokens = ({
-  evmNetworkConfigurationsByChainId,
-}: UseRefreshTokensOptions) => {
-  const isAssetsUnifyStateEnabled = useSelector(
-    selectIsAssetsUnifyStateEnabled,
+  try {
+    await Engine.context.AssetsController.getAssets([...accounts], {
+      forceUpdate: true,
+      chainIds: enabledChainIds,
+      assetTypes: FUNGIBLE_ASSET_TYPES,
+    });
+  } catch (error) {
+    Logger.error(
+      error as Error,
+      'useRefreshTokens: AssetsController.getAssets failed',
+    );
+  }
+};
+
+const refreshLegacyTokenControllers = async (
+  accounts: readonly InternalAccount[],
+  evmNetworkConfigurationsByChainId: Parameters<
+    typeof performEvmTokenRefresh
+  >[0],
+) => {
+  const nonEvmAccounts = accounts.filter(
+    (account) => !isEvmAccountType(account.type),
   );
-  const accountByScope = useSelector(selectSelectedInternalAccountByScope);
 
-  // Resolve every scoped account that exists in the selected group.
-  // Missing scopes (e.g. group with no Bitcoin account) resolve to undefined.
-  const evmAccount = accountByScope(EthScope.Mainnet);
-  const solanaAccount = accountByScope(SolScope.Mainnet);
-  const bitcoinAccount = accountByScope(BtcScope.Mainnet);
-
-  const refresh = useCallback(async () => {
-    const { AssetsController, MultichainBalancesController } = Engine.context;
-
-    const scopedAccounts: InternalAccount[] = [
-      evmAccount,
-      solanaAccount,
-      bitcoinAccount,
-    ].filter((account): account is InternalAccount => Boolean(account));
-
-    // Legacy path only: unified refresh returns above.
-    const nonEvmAccounts: InternalAccount[] = [
-      solanaAccount,
-      bitcoinAccount,
-    ].filter((account): account is InternalAccount => Boolean(account));
-
-    if (isAssetsUnifyStateEnabled && scopedAccounts.length > 0) {
-      const chainIds: CaipChainId[] = Object.values(
-        evmNetworkConfigurationsByChainId,
-      ).map(({ chainId }) => toEvmCaipChainId(chainId));
-
+  await Promise.all([
+    ...nonEvmAccounts.map(async (account) => {
       try {
-        await AssetsController.getAssets(scopedAccounts, {
-          forceUpdate: true,
-          chainIds,
-          assetTypes: FUNGIBLE_ASSET_TYPES,
-        });
+        await Engine.context.MultichainBalancesController.updateBalance(
+          account.id,
+        );
       } catch (error) {
         Logger.error(
           error as Error,
-          'useRefreshTokens: AssetsController.getAssets failed',
+          `useRefreshTokens: failed to refresh balance for non-EVM account ${account.id}`,
         );
       }
+    }),
+    performEvmTokenRefresh(evmNetworkConfigurationsByChainId),
+  ]);
+};
 
+/**
+ * Refreshes tokens for every account in the selected group.
+ *
+ * When the unified assets state flag is enabled, force-refreshes
+ * `AssetsController` only.
+ *
+ * Otherwise triggers `MultichainBalancesController.updateBalance` for every
+ * non-EVM account in the group and runs the EVM token detection / balance /
+ * rate refresh in parallel.
+ */
+export const useRefreshTokens = () => {
+  const isAssetsUnifyStateEnabled = useSelector(
+    selectIsAssetsUnifyStateEnabled,
+  );
+  const selectedAccountGroupAccounts = useSelector(
+    selectSelectedAccountGroupInternalAccounts,
+  );
+  const enabledChainIds = useSelector(selectEnabledNetworks);
+  const evmNetworkConfigurationsByChainId = useSelector(
+    selectEvmNetworkConfigurationsByChainId,
+  );
+
+  const refresh = useCallback(async () => {
+    if (isAssetsUnifyStateEnabled) {
+      await refreshUnifiedAssets(selectedAccountGroupAccounts, enabledChainIds);
       return;
     }
 
-    await Promise.all([
-      ...nonEvmAccounts.map(async (account) => {
-        try {
-          await MultichainBalancesController.updateBalance(account.id);
-        } catch (error) {
-          Logger.error(
-            error as Error,
-            `useRefreshTokens: failed to refresh balance for non-EVM account ${account.id}`,
-          );
-        }
-      }),
-      performEvmTokenRefresh(evmNetworkConfigurationsByChainId),
-    ]);
+    await refreshLegacyTokenControllers(
+      selectedAccountGroupAccounts,
+      evmNetworkConfigurationsByChainId ?? {},
+    );
   }, [
     isAssetsUnifyStateEnabled,
-    evmAccount,
-    solanaAccount,
-    bitcoinAccount,
+    selectedAccountGroupAccounts,
+    enabledChainIds,
     evmNetworkConfigurationsByChainId,
   ]);
 

--- a/app/components/UI/Tokens/index.test.tsx
+++ b/app/components/UI/Tokens/index.test.tsx
@@ -24,11 +24,14 @@ import * as TokenListControlBarModule from './TokenListControlBar/TokenListContr
 // eslint-disable-next-line import-x/no-namespace
 import * as AssetsListSelectorsModule from '../../../selectors/assets/assets-list';
 // eslint-disable-next-line import-x/no-namespace
-import * as RefreshTokensModule from './util/refreshTokens';
-// eslint-disable-next-line import-x/no-namespace
 import * as RemoveEvmTokenModule from './util/removeEvmToken';
 // eslint-disable-next-line import-x/no-namespace
 import * as RemoveNonEvmTokenModule from './util/removeNonEvmToken';
+
+const mockRefreshTokensForGroup = jest.fn().mockResolvedValue(undefined);
+jest.mock('./hooks/useRefreshTokens', () => ({
+  useRefreshTokens: () => ({ refresh: mockRefreshTokensForGroup }),
+}));
 
 // Mocking versioning for some selectors
 jest.mock('react-native-device-info', () => ({
@@ -230,16 +233,12 @@ describe('Tokens', () => {
   });
 
   it('performs token refresh', async () => {
-    const mockRefreshTokens = jest
-      .spyOn(RefreshTokensModule, 'refreshTokens')
-      .mockResolvedValue();
     const { getByTestId } = renderComponent(initialState);
 
     fireEvent.press(getByTestId('MOCK_TEST_REFRESH_BUTTON'));
 
-    // Wait for async refresh to complete
     await waitFor(() => {
-      expect(mockRefreshTokens).toHaveBeenCalled();
+      expect(mockRefreshTokensForGroup).toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -16,27 +16,22 @@ import {
 import { useSelector } from 'react-redux';
 import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../core/Analytics';
-import {
-  selectChainId,
-  selectEvmNetworkConfigurationsByChainId,
-} from '../../../selectors/networkController';
+import { selectChainId } from '../../../selectors/networkController';
 import { getDecimalChainId } from '../../../util/networks';
 import { TokenList } from './TokenList/TokenList';
 import { WalletViewSelectorsIDs } from '../../Views/Wallet/WalletView.testIds';
-import { refreshTokens, goToAddEvmToken } from './util';
+import { goToAddEvmToken } from './util';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Box } from '@metamask/design-system-react-native';
 import { TokenListControlBar } from './TokenListControlBar/TokenListControlBar';
-import { selectSelectedInternalAccountId } from '../../../selectors/accountsController';
 import { ScamWarningModal } from './TokenList/ScamWarningModal/ScamWarningModal';
 import TokenListSkeleton from './TokenList/TokenListSkeleton/TokenListSkeleton';
 import { selectSortedAssetsBySelectedAccountGroup } from '../../../selectors/assets/assets-list';
-import { selectSelectedInternalAccountByScope } from '../../../selectors/multichainAccounts/accounts';
-import { SolScope } from '@metamask/keyring-api';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useRemoveToken } from './hooks/useRemoveToken';
+import { useRefreshTokens } from './hooks/useRefreshTokens';
 import { TokensEmptyState } from '../TokensEmptyState';
 import { isMusdToken } from '../Earn/constants/musd';
 import RemoveTokenBottomSheet from './TokenList/RemoveTokenBottomSheet';
@@ -99,19 +94,10 @@ const Tokens = forwardRef<TabRefreshHandle, TokensProps>(
     const { trackEvent, createEventBuilder } = useAnalytics();
     const tw = useTailwind();
 
-    // evm
-    const evmNetworkConfigurationsByChainId = useSelector(
-      selectEvmNetworkConfigurationsByChainId,
-    );
     const currentChainId = useSelector(selectChainId);
 
     const [refreshing, setRefreshing] = useState(false);
-    const selectedAccountId = useSelector(selectSelectedInternalAccountId);
-
-    const selectedSolanaAccount =
-      useSelector(selectSelectedInternalAccountByScope)(SolScope.Mainnet) ||
-      null;
-    const isSolanaSelected = selectedSolanaAccount !== null;
+    const { refresh: refreshTokensForGroup } = useRefreshTokens();
 
     const shouldExcludeMusdFromMainList = useSelector(
       selectMoneyHubEnabledFlag,
@@ -201,19 +187,11 @@ const Tokens = forwardRef<TabRefreshHandle, TokensProps>(
         });
 
         // Then await the actual refresh
-        await refreshTokens({
-          isSolanaSelected,
-          evmNetworkConfigurationsByChainId,
-          selectedAccountId,
-        });
+        await refreshTokensForGroup();
       } finally {
         setRefreshing(false);
       }
-    }, [
-      isSolanaSelected,
-      evmNetworkConfigurationsByChainId,
-      selectedAccountId,
-    ]);
+    }, [refreshTokensForGroup]);
 
     useImperativeHandle(ref, () => ({
       refresh: onRefresh,

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
@@ -27,13 +27,10 @@ import { TokenListItem } from '../../../../UI/Tokens/TokenList/TokenListItem/Tok
 import RemoveTokenBottomSheet from '../../../../UI/Tokens/TokenList/RemoveTokenBottomSheet';
 import { ScamWarningModal } from '../../../../UI/Tokens/TokenList/ScamWarningModal/ScamWarningModal';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
-import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
 import { SectionRefreshHandle } from '../../types';
 import { strings } from '../../../../../../locales/i18n';
 import { PopularTokensList } from './components';
 import { selectSelectedInternalAccountId } from '../../../../../selectors/accountsController';
-import { toHex } from '@metamask/controller-utils';
-import type { Hex } from '@metamask/utils';
 import TokenListSkeleton from '../../../../UI/Tokens/TokenList/TokenListSkeleton/TokenListSkeleton';
 import { useRemoveToken } from '../../../../UI/Tokens/hooks/useRemoveToken';
 import { useRefreshTokens } from '../../../../UI/Tokens/hooks/useRefreshTokens';
@@ -116,28 +113,9 @@ const TokensSection = forwardRef<SectionRefreshHandle, TokensSectionProps>(
       setShowScamWarningModal,
     } = useRemoveToken();
 
-    const evmNetworkConfigurationsByChainId = useSelector(
-      selectEvmNetworkConfigurationsByChainId,
-    );
-
-    // Restrict refresh to popular EVM networks so we only poll/refresh those chains.
-    const evmNetworkConfigurationsForRefresh = useMemo(() => {
-      const allowedEvmChainIds = new Set<string>(
-        popularChainIds
-          .filter((id) => id.startsWith('eip155:'))
-          .map((id) => toHex(id.slice(7)) as Hex),
-      );
-      return Object.fromEntries(
-        Object.entries(evmNetworkConfigurationsByChainId).filter(([chainId]) =>
-          allowedEvmChainIds.has(chainId),
-        ),
-      );
-    }, [evmNetworkConfigurationsByChainId, popularChainIds]);
     const selectedAccountId = useSelector(selectSelectedInternalAccountId);
 
-    const { refresh: refreshTokensForGroup } = useRefreshTokens({
-      evmNetworkConfigurationsByChainId: evmNetworkConfigurationsForRefresh,
-    });
+    const { refresh: refreshTokensForGroup } = useRefreshTokens();
 
     const prevAccountIdRef = useRef(selectedAccountId);
     // Reset section error when account changes (not on initial mount) so the new account gets a fresh state

--- a/app/selectors/networkEnablementController/index.test.ts
+++ b/app/selectors/networkEnablementController/index.test.ts
@@ -4,6 +4,7 @@ import {
   selectEVMEnabledNetworks,
   selectEvmEnabledCaipNetworks,
   selectNonEVMEnabledNetworks,
+  selectEnabledNetworks,
 } from './index';
 import { RootState } from '../../reducers';
 
@@ -249,6 +250,18 @@ describe('NetworkEnablementController Selectors', () => {
       const result = selectEvmEnabledCaipNetworks(mockState);
 
       expect(result).toEqual(['eip155:1', 'eip155:8453']);
+    });
+  });
+
+  describe('selectEnabledNetworks', () => {
+    it('returns enabled EVM and non-EVM networks as CAIP-2 chain IDs', () => {
+      const result = selectEnabledNetworks(mockState);
+
+      expect(result).toEqual([
+        'eip155:1',
+        'eip155:8453',
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+      ]);
     });
   });
 

--- a/app/selectors/networkEnablementController/index.ts
+++ b/app/selectors/networkEnablementController/index.ts
@@ -1,5 +1,5 @@
 import { NetworkEnablementControllerState } from '@metamask/network-enablement-controller';
-import { Hex, KnownCaipNamespace } from '@metamask/utils';
+import { CaipChainId, Hex, KnownCaipNamespace } from '@metamask/utils';
 import { RootState } from '../../reducers';
 import { createDeepEqualSelector } from '../util';
 
@@ -49,4 +49,24 @@ export const selectNonEVMEnabledNetworks = createDeepEqualSelector(
       .flat();
     return enabledNonEvmChainIds as string[];
   },
+);
+
+/**
+ * All currently enabled networks as CAIP-2 chain IDs (EVM and non-EVM).
+ */
+export const selectEnabledNetworks = createDeepEqualSelector(
+  selectEnabledNetworksByNamespace,
+  (
+    enabledNetworksByNamespace: NetworkEnablementControllerState['enabledNetworkMap'],
+  ): CaipChainId[] =>
+    Object.entries(enabledNetworksByNamespace).flatMap(
+      ([namespace, namespaceNetworks]) =>
+        Object.entries(namespaceNetworks)
+          .filter(([, enabled]) => Boolean(enabled))
+          .map(([chainId]) =>
+            namespace === KnownCaipNamespace.Eip155
+              ? (`${KnownCaipNamespace.Eip155}:${Number.parseInt(chainId, 16)}` as CaipChainId)
+              : (chainId as CaipChainId),
+          ),
+    ),
 );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Current behavior
https://www.loom.com/share/416f7ffe7a6c42b3a78006c0847087a9


Behavior after PR:
https://www.loom.com/share/91585b2b02e44fdc84bd07802ad1b7ea

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which chains and accounts are refreshed on pull-to-refresh, which can affect balance accuracy and RPC load; legacy and unified-assets paths both changed.
> 
> **Overview**
> **Token list pull-to-refresh** now goes through `useRefreshTokens()` everywhere (wallet Tokens tab and homepage Tokens section), replacing the older `refreshTokens` util wiring on the main Tokens screen.
> 
> **`useRefreshTokens` no longer takes options** — it reads Redux for the selected account group’s accounts, user-enabled networks, and EVM network configs. With **unified assets** enabled, refresh calls `AssetsController.getAssets` for **all accounts in the group** and **`selectEnabledNetworks`** CAIP chain IDs (EVM + Solana + Bitcoin, etc.), not only EVM chains derived from network configuration. With unified assets off, non-EVM accounts are identified via **`isEvmAccountType`** instead of fixed Sol/BTC mainnet scopes.
> 
> Homepage **TokensSection** drops the “popular EVM chains only” filter that was passed into refresh; refresh behavior now matches global network enablement.
> 
> Adds **`selectEnabledNetworks`** (enabled EVM and non-EVM networks as CAIP-2 IDs) with unit tests; hook and UI tests are updated for the new data sources and no-arg hook API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d4281e991b83c9f67f92362b516986f18be78f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->