### PR TITLE
feat: recurring swaps minor fixes and changes

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyFooterView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyFooterView.test.tsx
@@ -11,6 +11,8 @@ import { createBridgeTestState } from '../../../testUtils';
 import type { RootState } from '../../../../../../reducers';
 import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
 import { BridgeRecurringBuyFooterView } from './BridgeRecurringBuyFooterView';
+import { strings } from '../../../../../../../locales/i18n';
+import { initialRecurringState } from '../../../utils/recurringSchedule';
 
 jest.mock(
   '../../../../../../multichain-accounts/controllers/account-tree-controller',
@@ -140,5 +142,78 @@ describe('BridgeRecurringBuyFooterView', () => {
     expect(
       getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON),
     ).toBeOnTheScreen();
+  });
+
+  it('renders the spend summary for the default schedule', () => {
+    const { getByTestId } = renderFooter(buildActiveQuoteState());
+
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.RECURRING_SPEND_SUMMARY),
+    ).toHaveTextContent(
+      strings('bridge.recurring.spend_summary', {
+        amount: '1.0',
+        symbol: 'ETH',
+        everyValue: '1',
+        unit: strings('bridge.recurring.unit.hour'),
+        repeatCount: '10',
+      }),
+    );
+  });
+
+  it('uses the plural unit when every is greater than 1', () => {
+    const { getByTestId } = renderFooter(
+      buildActiveQuoteState({
+        bridgeReducerOverrides: {
+          recurring: {
+            ...initialRecurringState,
+            everyValue: '2',
+          },
+        },
+      }),
+    );
+
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.RECURRING_SPEND_SUMMARY),
+    ).toHaveTextContent(
+      strings('bridge.recurring.spend_summary', {
+        amount: '1.0',
+        symbol: 'ETH',
+        everyValue: '2',
+        unit: strings('bridge.recurring.unit_plural.hour'),
+        repeatCount: '10',
+      }),
+    );
+  });
+
+  it('hides the spend summary when repeat count is empty', () => {
+    const { getByTestId, queryByTestId } = renderFooter(
+      buildActiveQuoteState({
+        bridgeReducerOverrides: {
+          recurring: {
+            ...initialRecurringState,
+            repeatCount: '',
+          },
+        },
+      }),
+    );
+
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(BridgeViewSelectorsIDs.RECURRING_SPEND_SUMMARY),
+    ).toBeNull();
+  });
+
+  it('hides the spend summary when source amount is missing', () => {
+    const { queryByTestId } = renderFooter(
+      buildActiveQuoteState({
+        bridgeReducerOverrides: { sourceAmount: undefined },
+      }),
+    );
+
+    expect(
+      queryByTestId(BridgeViewSelectorsIDs.RECURRING_SPEND_SUMMARY),
+    ).toBeNull();
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyFooterView.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyFooterView.tsx
@@ -5,25 +5,58 @@ import {
   selectSourceAmount,
   selectSourceToken,
   selectBridgeControllerState,
+  selectRecurringEveryUnit,
+  selectRecurringEveryValue,
+  selectRecurringRepeatCount,
 } from '../../../../../../core/redux/slices/bridge';
 import { useBridgeQuoteDataContext } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import {
   Box,
   BoxAlignItems,
   BoxJustifyContent,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../../locales/i18n';
 import { SwapsRecurringBuyConfirmButton } from '../../../components/SwapsRecurringBuyConfirmButton/index.tsx';
 import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
+import { formatAmountWithLocaleSeparators } from '../../../utils/formatAmountWithLocaleSeparators';
+import { parsePositiveInteger } from '../../../utils/recurringSchedule';
 
 export const BridgeRecurringBuyFooterView = () => {
   const { bottom: bottomInset } = useSafeAreaInsets();
   const sourceAmount = useSelector(selectSourceAmount);
   const sourceToken = useSelector(selectSourceToken);
+  const everyValue = useSelector(selectRecurringEveryValue);
+  const everyUnit = useSelector(selectRecurringEveryUnit);
+  const repeatCount = useSelector(selectRecurringRepeatCount);
   const { activeQuote, isLoading, needsNewQuote } = useBridgeQuoteDataContext();
   const { quotesLastFetched } = useSelector(selectBridgeControllerState);
 
   const isValidSourceAmount =
     sourceAmount !== undefined && sourceAmount !== '.' && sourceToken?.decimals;
+
+  const hasValidEvery = parsePositiveInteger(everyValue) !== undefined;
+  const hasValidRepeat = parsePositiveInteger(repeatCount) !== undefined;
+  const spendSummary =
+    isValidSourceAmount &&
+    hasValidEvery &&
+    hasValidRepeat &&
+    sourceAmount &&
+    sourceToken?.symbol
+      ? strings('bridge.recurring.spend_summary', {
+          amount: formatAmountWithLocaleSeparators(sourceAmount),
+          symbol: sourceToken.symbol,
+          everyValue,
+          unit: strings(
+            everyValue === '1'
+              ? `bridge.recurring.unit.${everyUnit}`
+              : `bridge.recurring.unit_plural.${everyUnit}`,
+          ),
+          repeatCount,
+        })
+      : undefined;
 
   if (isLoading && !activeQuote && !needsNewQuote) {
     return null;
@@ -49,6 +82,16 @@ export const BridgeRecurringBuyFooterView = () => {
         label="test"
         testID={BridgeViewSelectorsIDs.CONFIRM_BUTTON}
       />
+      {spendSummary ? (
+        <Text
+          variant={TextVariant.BodyXs}
+          color={TextColor.TextDefault}
+          twClassName="text-center"
+          testID={BridgeViewSelectorsIDs.RECURRING_SPEND_SUMMARY}
+        >
+          {spendSummary}
+        </Text>
+      ) : null}
     </Box>
   );
 };

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
@@ -96,6 +96,21 @@ async function openEveryKeypad(
   });
 }
 
+async function openRepeatKeypad(
+  renderResult: ReturnType<typeof renderBridgeView>,
+) {
+  fireEvent(
+    renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT),
+    'pressIn',
+  );
+
+  await waitFor(() => {
+    expect(
+      renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+    ).toBeOnTheScreen();
+  });
+}
+
 async function openAmountKeypad(
   renderResult: ReturnType<typeof renderBridgeView>,
 ) {
@@ -321,6 +336,11 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
     expect(
       renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
     ).toHaveStyle({ color: errorColor });
+    expect(
+      renderResult.queryByTestId(
+        RecurringScheduleFieldsSelectorsIDs.EVERY_ERROR,
+      ),
+    ).not.toBeOnTheScreen();
   });
 
   it('keeps repeat at 0 and invalid after the keypad is closed', async () => {
@@ -371,6 +391,11 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
         RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
       ),
     ).toHaveStyle({ color: errorColor });
+    expect(
+      renderResult.queryByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_ERROR,
+      ),
+    ).not.toBeOnTheScreen();
   });
 
   it('keeps a 0 every value after leaving and returning to the recurring tab', async () => {
@@ -622,46 +647,115 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
     ).toHaveDisplayValue('1');
   });
 
-  it('marks the every value invalid when it exceeds the unit max', async () => {
+  it('shows Max is 24 when every exceeds the hour unit max', async () => {
     const renderResult = renderBridgeView();
 
     await openRecurringTab(renderResult);
     await openEveryKeypad(renderResult);
-    fireEvent.press(renderResult.getByTestId('keypad-key-5'));
+    fireEvent.press(
+      renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+    );
+    fireEvent.press(renderResult.getByTestId('keypad-key-2'));
     fireEvent.press(renderResult.getByTestId('keypad-key-5'));
     await waitFor(() => {
       expect(
         renderResult.getByTestId(
           RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT,
         ),
-      ).toHaveDisplayValue('155');
+      ).toHaveDisplayValue('25');
     });
 
     expect(
       renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
     ).toHaveStyle({ color: errorColor });
     expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_ERROR),
+    ).toHaveTextContent(strings('bridge.recurring.max_is', { max: 24 }));
+    expect(
       renderResult.getByTestId(
         RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
       ),
     ).not.toHaveStyle({ color: errorColor });
+    expect(
+      renderResult.queryByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_ERROR,
+      ),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('shows Max is 180 on repeat when 1 day times 181 exceeds 180 days', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
+      ),
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(RecurringIntervalSheetSelectorsIDs.SHEET),
+      ).toBeOnTheScreen();
+    });
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringIntervalSheetSelectorsIDs.OPTION('day'),
+      ),
+    );
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringIntervalSheetSelectorsIDs.CONFIRM_BUTTON,
+      ),
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
+        ),
+      ).toHaveTextContent(strings('bridge.recurring.unit.day'));
+    });
+
+    await openRepeatKeypad(renderResult);
+    fireEvent.press(
+      renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+    );
+    fireEvent.press(
+      renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+    );
+    fireEvent.press(renderResult.getByTestId('keypad-key-1'));
+    fireEvent.press(renderResult.getByTestId('keypad-key-8'));
+    fireEvent.press(renderResult.getByTestId('keypad-key-1'));
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+        ),
+      ).toHaveDisplayValue('181');
+    });
+
+    expect(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+      ),
+    ).toHaveStyle({ color: errorColor });
+    expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.REPEAT_ERROR),
+    ).toHaveTextContent(strings('bridge.recurring.max_is', { max: 180 }));
+    expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
+    ).not.toHaveStyle({ color: errorColor });
+    expect(
+      renderResult.queryByTestId(
+        RecurringScheduleFieldsSelectorsIDs.EVERY_ERROR,
+      ),
+    ).not.toBeOnTheScreen();
   });
 
   it('marks the repeat value invalid when it is 0', async () => {
     const renderResult = renderBridgeView();
 
     await openRecurringTab(renderResult);
-    fireEvent(
-      renderResult.getByTestId(
-        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
-      ),
-      'pressIn',
-    );
-    await waitFor(() => {
-      expect(
-        renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
-      ).toBeOnTheScreen();
-    });
+    await openRepeatKeypad(renderResult);
     fireEvent.press(
       renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
     );
@@ -684,6 +778,11 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
     expect(
       renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
     ).not.toHaveStyle({ color: errorColor });
+    expect(
+      renderResult.queryByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_ERROR,
+      ),
+    ).not.toBeOnTheScreen();
   });
 
   describe('swap inputs', () => {

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
@@ -739,7 +739,9 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
       ),
     ).toHaveStyle({ color: errorColor });
     expect(
-      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.REPEAT_ERROR),
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_ERROR,
+      ),
     ).toHaveTextContent(strings('bridge.recurring.max_is', { max: 180 }));
     expect(
       renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
@@ -8,6 +8,7 @@ import { setRecurringPriceRange } from '../../../../../../core/redux/slices/brid
 import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
 import { RecurringScheduleFieldsSelectorsIDs } from '../../../components/RecurringScheduleFields';
 import { RecurringIntervalSheetSelectorsIDs } from '../../../components/RecurringIntervalSheet';
+import { RecurringRepeatInfoSheetSelectorsIDs } from '../../../components/RecurringRepeatInfoSheet';
 import { PriceRangeRowSelectorsIDs } from '../../../components/PriceRangeRow';
 import { PriceRangeSheetSelectorsIDs } from '../../../components/PriceRangeSheet';
 import { OrdersTabsSelectorsIDs } from '../../../components/OrdersTabs';
@@ -486,6 +487,53 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
           RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
         ),
       ).toHaveTextContent(strings('bridge.recurring.unit.month'));
+    });
+  });
+
+  it('opens the repeat info sheet from the info icon', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INFO_BUTTON,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(RecurringRepeatInfoSheetSelectorsIDs.SHEET),
+      ).toBeOnTheScreen();
+    });
+    expect(
+      renderResult.getByTestId(RecurringRepeatInfoSheetSelectorsIDs.BODY),
+    ).toHaveTextContent(strings('bridge.recurring.repeat_info_body'));
+  });
+
+  it('closes the repeat info sheet from the close button', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INFO_BUTTON,
+      ),
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(RecurringRepeatInfoSheetSelectorsIDs.SHEET),
+      ).toBeOnTheScreen();
+    });
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringRepeatInfoSheetSelectorsIDs.CLOSE_BUTTON,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(
+        renderResult.queryByTestId(RecurringRepeatInfoSheetSelectorsIDs.SHEET),
+      ).not.toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
@@ -455,6 +455,40 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
     });
   });
 
+  it('commits month as the interval unit on confirm', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
+      ),
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(RecurringIntervalSheetSelectorsIDs.SHEET),
+      ).toBeOnTheScreen();
+    });
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringIntervalSheetSelectorsIDs.OPTION('month'),
+      ),
+    );
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringIntervalSheetSelectorsIDs.CONFIRM_BUTTON,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
+        ),
+      ).toHaveTextContent(strings('bridge.recurring.unit.month'));
+    });
+  });
+
   it('keeps the previous interval unit when the sheet is dismissed', async () => {
     const renderResult = renderBridgeView();
 

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
@@ -5,8 +5,10 @@ import { Box } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   selectBridgeBalanceRefreshKey,
+  selectRecurringEveryUnit,
   selectRecurringPriceRange,
   selectSourceToken,
+  setRecurringEveryUnit,
   setRecurringPriceRange,
 } from '../../../../../../core/redux/slices/bridge';
 import { selectCurrentCurrency } from '../../../../../../selectors/currencyRateController';
@@ -15,6 +17,7 @@ import { GaslessQuickPickOptions } from '../../../components/GaslessQuickPickOpt
 import OrdersTabs from '../../../components/OrdersTabs';
 import PriceRangeRow from '../../../components/PriceRangeRow';
 import PriceRangeSheet from '../../../components/PriceRangeSheet';
+import RecurringIntervalSheet from '../../../components/RecurringIntervalSheet';
 import RecurringScheduleFields from '../../../components/RecurringScheduleFields';
 import {
   HardwareWalletUnsupportedBanner,
@@ -35,6 +38,7 @@ import {
   isPriceRangeInCurrentCurrency,
   type RecurringPriceRange,
 } from '../../../utils/priceRange';
+import type { RecurringIntervalUnit } from '../../../utils/recurringSchedule';
 import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
 import { useRecurringBuyKeypad } from './useRecurringBuyKeypad';
 import { useRecurringBuySwapInputs } from './useRecurringBuySwapInputs';
@@ -54,6 +58,7 @@ const BridgeRecurringBuyViewContent = ({
   const inputRef = useRef<TokenInputAreaRef>(null);
   const [isPriceRangeSheetVisible, setIsPriceRangeSheetVisible] =
     useState(false);
+  const [isIntervalSheetVisible, setIsIntervalSheetVisible] = useState(false);
 
   const {
     destToken,
@@ -73,6 +78,7 @@ const BridgeRecurringBuyViewContent = ({
   } = useRecurringBuySwapInputs({ latestSourceBalance });
 
   const priceRange = useSelector(selectRecurringPriceRange);
+  const everyUnit = useSelector(selectRecurringEveryUnit);
   const currentCurrency = useSelector(selectCurrentCurrency);
   const sourceFiatRate = useTokenFiatRate(sourceToken);
   const destFiatRate = useTokenFiatRate(destToken);
@@ -119,6 +125,22 @@ const BridgeRecurringBuyViewContent = ({
   const handlePriceRangeConfirm = useCallback(
     (nextPriceRange?: RecurringPriceRange) => {
       dispatch(setRecurringPriceRange(nextPriceRange));
+    },
+    [dispatch],
+  );
+
+  const handleUnitPress = useCallback(() => {
+    dismissInputAndKeypad();
+    setIsIntervalSheetVisible(true);
+  }, [dismissInputAndKeypad]);
+
+  const handleIntervalSheetClosed = useCallback(() => {
+    setIsIntervalSheetVisible(false);
+  }, []);
+
+  const handleIntervalConfirm = useCallback(
+    (unit: RecurringIntervalUnit) => {
+      dispatch(setRecurringEveryUnit(unit));
     },
     [dispatch],
   );
@@ -184,6 +206,7 @@ const BridgeRecurringBuyViewContent = ({
             onEveryPress={focusEvery}
             onRepeatPress={focusRepeat}
             onDismissKeypad={dismissInputAndKeypad}
+            onUnitPress={handleUnitPress}
           />
 
           <PriceRangeRow
@@ -238,6 +261,13 @@ const BridgeRecurringBuyViewContent = ({
           initialMax={effectiveRange?.max}
           onClose={handlePriceRangeSheetClosed}
           onConfirm={handlePriceRangeConfirm}
+        />
+
+        <RecurringIntervalSheet
+          isVisible={isIntervalSheetVisible}
+          currentUnit={everyUnit}
+          onClose={handleIntervalSheetClosed}
+          onConfirm={handleIntervalConfirm}
         />
       </Box>
     </Box>

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
@@ -18,6 +18,7 @@ import OrdersTabs from '../../../components/OrdersTabs';
 import PriceRangeRow from '../../../components/PriceRangeRow';
 import PriceRangeSheet from '../../../components/PriceRangeSheet';
 import RecurringIntervalSheet from '../../../components/RecurringIntervalSheet';
+import RecurringRepeatInfoSheet from '../../../components/RecurringRepeatInfoSheet';
 import RecurringScheduleFields from '../../../components/RecurringScheduleFields';
 import {
   HardwareWalletUnsupportedBanner,
@@ -59,6 +60,8 @@ const BridgeRecurringBuyViewContent = ({
   const [isPriceRangeSheetVisible, setIsPriceRangeSheetVisible] =
     useState(false);
   const [isIntervalSheetVisible, setIsIntervalSheetVisible] = useState(false);
+  const [isRepeatInfoSheetVisible, setIsRepeatInfoSheetVisible] =
+    useState(false);
 
   const {
     destToken,
@@ -145,6 +148,15 @@ const BridgeRecurringBuyViewContent = ({
     [dispatch],
   );
 
+  const handleRepeatInfoPress = useCallback(() => {
+    dismissInputAndKeypad();
+    setIsRepeatInfoSheetVisible(true);
+  }, [dismissInputAndKeypad]);
+
+  const handleRepeatInfoSheetClosed = useCallback(() => {
+    setIsRepeatInfoSheetVisible(false);
+  }, []);
+
   return (
     <Box twClassName="flex-1 bg-default">
       <Box
@@ -207,6 +219,7 @@ const BridgeRecurringBuyViewContent = ({
             onRepeatPress={focusRepeat}
             onDismissKeypad={dismissInputAndKeypad}
             onUnitPress={handleUnitPress}
+            onRepeatInfoPress={handleRepeatInfoPress}
           />
 
           <PriceRangeRow
@@ -268,6 +281,11 @@ const BridgeRecurringBuyViewContent = ({
           currentUnit={everyUnit}
           onClose={handleIntervalSheetClosed}
           onConfirm={handleIntervalConfirm}
+        />
+
+        <RecurringRepeatInfoSheet
+          isVisible={isRepeatInfoSheetVisible}
+          onClose={handleRepeatInfoSheetClosed}
         />
       </Box>
     </Box>

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.testIds.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.testIds.ts
@@ -34,6 +34,7 @@ export const BridgeViewSelectorsIDs = {
   RECURRING_DEST_TOKEN_AREA: 'recurring-dest-token-area',
   RECURRING_DEST_TOKEN_INPUT: 'recurring-dest-token-area-input',
   RECURRING_DEST_YOU_GET: 'recurring-dest-you-get',
+  RECURRING_SPEND_SUMMARY: 'recurring-spend-summary',
 } as const;
 
 export type BridgeViewSelectorsIDsType = typeof BridgeViewSelectorsIDs;

--- a/app/components/UI/Bridge/components/RecurringRepeatInfoSheet/RecurringRepeatInfoSheet.testIds.ts
+++ b/app/components/UI/Bridge/components/RecurringRepeatInfoSheet/RecurringRepeatInfoSheet.testIds.ts
@@ -1,0 +1,5 @@
+export const RecurringRepeatInfoSheetSelectorsIDs = {
+  SHEET: 'recurring-repeat-info-sheet',
+  CLOSE_BUTTON: 'recurring-repeat-info-sheet-close',
+  BODY: 'recurring-repeat-info-sheet-body',
+} as const;

--- a/app/components/UI/Bridge/components/RecurringRepeatInfoSheet/RecurringRepeatInfoSheet.tsx
+++ b/app/components/UI/Bridge/components/RecurringRepeatInfoSheet/RecurringRepeatInfoSheet.tsx
@@ -1,0 +1,57 @@
+import React, { useCallback, useRef } from 'react';
+import {
+  BottomSheet,
+  BottomSheetHeader,
+  Box,
+  Text,
+  TextColor,
+  TextVariant,
+  type BottomSheetRef,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { RecurringRepeatInfoSheetSelectorsIDs } from './RecurringRepeatInfoSheet.testIds';
+import type { RecurringRepeatInfoSheetProps } from './RecurringRepeatInfoSheet.types';
+
+const RecurringRepeatInfoSheet = ({
+  isVisible,
+  onClose,
+}: RecurringRepeatInfoSheetProps) => {
+  const sheetRef = useRef<BottomSheetRef>(null);
+
+  const closeSheet = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      testID={RecurringRepeatInfoSheetSelectorsIDs.SHEET}
+      onClose={onClose}
+    >
+      <BottomSheetHeader
+        onClose={closeSheet}
+        closeButtonProps={{
+          testID: RecurringRepeatInfoSheetSelectorsIDs.CLOSE_BUTTON,
+        }}
+      >
+        {strings('bridge.recurring.repeat_info_title')}
+      </BottomSheetHeader>
+      <Box paddingHorizontal={4} paddingBottom={4}>
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          twClassName="text-center"
+          testID={RecurringRepeatInfoSheetSelectorsIDs.BODY}
+        >
+          {strings('bridge.recurring.repeat_info_body')}
+        </Text>
+      </Box>
+    </BottomSheet>
+  );
+};
+
+export default RecurringRepeatInfoSheet;

--- a/app/components/UI/Bridge/components/RecurringRepeatInfoSheet/RecurringRepeatInfoSheet.types.ts
+++ b/app/components/UI/Bridge/components/RecurringRepeatInfoSheet/RecurringRepeatInfoSheet.types.ts
@@ -1,0 +1,4 @@
+export interface RecurringRepeatInfoSheetProps {
+  isVisible: boolean;
+  onClose: () => void;
+}

--- a/app/components/UI/Bridge/components/RecurringRepeatInfoSheet/index.ts
+++ b/app/components/UI/Bridge/components/RecurringRepeatInfoSheet/index.ts
@@ -1,0 +1,3 @@
+export { default } from './RecurringRepeatInfoSheet';
+export type { RecurringRepeatInfoSheetProps } from './RecurringRepeatInfoSheet.types';
+export { RecurringRepeatInfoSheetSelectorsIDs } from './RecurringRepeatInfoSheet.testIds';

--- a/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.testIds.ts
+++ b/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.testIds.ts
@@ -6,6 +6,7 @@ export const RecurringScheduleFieldsSelectorsIDs = {
   REPEAT_CARD: 'recurring-repeat-card',
   REPEAT_INPUT: 'recurring-repeat-input',
   REPEAT_TIMES_LABEL: 'recurring-repeat-times',
+  REPEAT_INFO_BUTTON: 'recurring-repeat-info-button',
 } as const;
 
 export type RecurringScheduleFieldsSelectorsIDsType =

--- a/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.testIds.ts
+++ b/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.testIds.ts
@@ -7,6 +7,8 @@ export const RecurringScheduleFieldsSelectorsIDs = {
   REPEAT_INPUT: 'recurring-repeat-input',
   REPEAT_TIMES_LABEL: 'recurring-repeat-times',
   REPEAT_INFO_BUTTON: 'recurring-repeat-info-button',
+  EVERY_ERROR: 'recurring-every-error',
+  REPEAT_ERROR: 'recurring-repeat-error',
 } as const;
 
 export type RecurringScheduleFieldsSelectorsIDsType =

--- a/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
+++ b/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
@@ -7,6 +7,9 @@ import {
   BoxJustifyContent,
   ButtonBase,
   ButtonBaseSize,
+  ButtonIcon,
+  ButtonIconSize,
+  IconColor,
   IconName,
   IconSize,
   Input,
@@ -30,10 +33,12 @@ interface RecurringScheduleFieldsProps {
   onRepeatPress: () => void;
   onDismissKeypad: () => void;
   onUnitPress: () => void;
+  onRepeatInfoPress: () => void;
 }
 
 function RecurringNumberCard({
   label,
+  labelAccessory,
   value,
   testID,
   inputTestID,
@@ -42,6 +47,7 @@ function RecurringNumberCard({
   hasError,
 }: {
   label: string;
+  labelAccessory?: React.ReactNode;
   value: string;
   testID: string;
   inputTestID: string;
@@ -58,9 +64,16 @@ function RecurringNumberCard({
       padding={3}
       twClassName="min-w-px flex-1 rounded-2xl bg-muted"
     >
-      <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-        {label}
-      </Text>
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={1}
+      >
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+          {label}
+        </Text>
+        {labelAccessory}
+      </Box>
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
@@ -94,6 +107,7 @@ const RecurringScheduleFields = ({
   onRepeatPress,
   onDismissKeypad,
   onUnitPress,
+  onRepeatInfoPress,
 }: RecurringScheduleFieldsProps) => {
   const everyValue = useSelector(selectRecurringEveryValue);
   const everyUnit = useSelector(selectRecurringEveryUnit);
@@ -144,6 +158,16 @@ const RecurringScheduleFields = ({
         />
         <RecurringNumberCard
           label={strings('bridge.recurring.repeat')}
+          labelAccessory={
+            <ButtonIcon
+              iconName={IconName.Info}
+              iconProps={{ color: IconColor.IconAlternative }}
+              size={ButtonIconSize.Sm}
+              onPress={onRepeatInfoPress}
+              testID={RecurringScheduleFieldsSelectorsIDs.REPEAT_INFO_BUTTON}
+              accessibilityLabel={strings('bridge.recurring.repeat_info_title')}
+            />
+          }
           value={repeatCount}
           testID={RecurringScheduleFieldsSelectorsIDs.REPEAT_CARD}
           inputTestID={RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT}

--- a/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
+++ b/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useRef, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import {
   Box,
   BoxAlignItems,
@@ -21,19 +21,15 @@ import {
   selectRecurringEveryValue,
   selectRecurringRepeatCount,
   selectRecurringScheduleValidation,
-  setRecurringEveryUnit,
 } from '../../../../../core/redux/slices/bridge';
-import RecurringIntervalSheet from '../RecurringIntervalSheet';
-import {
-  RecurringScheduleErrorCode,
-  type RecurringIntervalUnit,
-} from '../../utils/recurringSchedule';
+import { RecurringScheduleErrorCode } from '../../utils/recurringSchedule';
 import { RecurringScheduleFieldsSelectorsIDs } from './RecurringScheduleFields.testIds';
 
 interface RecurringScheduleFieldsProps {
   onEveryPress: () => void;
   onRepeatPress: () => void;
   onDismissKeypad: () => void;
+  onUnitPress: () => void;
 }
 
 function RecurringNumberCard({
@@ -97,9 +93,8 @@ const RecurringScheduleFields = ({
   onEveryPress,
   onRepeatPress,
   onDismissKeypad,
+  onUnitPress,
 }: RecurringScheduleFieldsProps) => {
-  const dispatch = useDispatch();
-  const [isIntervalSheetVisible, setIsIntervalSheetVisible] = useState(false);
   const everyValue = useSelector(selectRecurringEveryValue);
   const everyUnit = useSelector(selectRecurringEveryUnit);
   const repeatCount = useSelector(selectRecurringRepeatCount);
@@ -116,22 +111,6 @@ const RecurringScheduleFields = ({
     (error) =>
       error === RecurringScheduleErrorCode.RepeatInvalid ||
       error === RecurringScheduleErrorCode.DurationExceedsMax,
-  );
-
-  const handleUnitPress = useCallback(() => {
-    onDismissKeypad();
-    setIsIntervalSheetVisible(true);
-  }, [onDismissKeypad]);
-
-  const handleIntervalSheetClosed = useCallback(() => {
-    setIsIntervalSheetVisible(false);
-  }, []);
-
-  const handleIntervalConfirm = useCallback(
-    (unit: RecurringIntervalUnit) => {
-      dispatch(setRecurringEveryUnit(unit));
-    },
-    [dispatch],
   );
 
   return (
@@ -153,7 +132,7 @@ const RecurringScheduleFields = ({
               size={ButtonBaseSize.Sm}
               endIconName={IconName.ArrowDown}
               endIconProps={{ size: IconSize.Sm }}
-              onPress={handleUnitPress}
+              onPress={onUnitPress}
               testID={RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON}
               accessibilityLabel={strings(
                 `bridge.recurring.unit_option.${everyUnit}`,
@@ -181,12 +160,6 @@ const RecurringScheduleFields = ({
           }
         />
       </Box>
-      <RecurringIntervalSheet
-        isVisible={isIntervalSheetVisible}
-        currentUnit={everyUnit}
-        onClose={handleIntervalSheetClosed}
-        onConfirm={handleIntervalConfirm}
-      />
     </Box>
   );
 };

--- a/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
+++ b/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
@@ -25,7 +25,12 @@ import {
   selectRecurringRepeatCount,
   selectRecurringScheduleValidation,
 } from '../../../../../core/redux/slices/bridge';
-import { RecurringScheduleErrorCode } from '../../utils/recurringSchedule';
+import {
+  RecurringScheduleErrorCode,
+  RECURRING_EVERY_MAX_BY_UNIT,
+  getMaxRepeatCount,
+  parsePositiveInteger,
+} from '../../utils/recurringSchedule';
 import { RecurringScheduleFieldsSelectorsIDs } from './RecurringScheduleFields.testIds';
 
 interface RecurringScheduleFieldsProps {
@@ -39,6 +44,8 @@ interface RecurringScheduleFieldsProps {
 function RecurringNumberCard({
   label,
   labelAccessory,
+  errorMessage,
+  errorTestID,
   value,
   testID,
   inputTestID,
@@ -48,6 +55,8 @@ function RecurringNumberCard({
 }: {
   label: string;
   labelAccessory?: React.ReactNode;
+  errorMessage?: string;
+  errorTestID?: string;
   value: string;
   testID: string;
   inputTestID: string;
@@ -73,6 +82,15 @@ function RecurringNumberCard({
           {label}
         </Text>
         {labelAccessory}
+        {errorMessage ? (
+          <Text
+            variant={TextVariant.BodySm}
+            color={TextColor.ErrorDefault}
+            testID={errorTestID}
+          >
+            {errorMessage}
+          </Text>
+        ) : null}
       </Box>
       <Box
         flexDirection={BoxFlexDirection.Row}
@@ -115,17 +133,30 @@ const RecurringScheduleFields = ({
   const { errors: scheduleErrors } = useSelector(
     selectRecurringScheduleValidation,
   );
-  const hasEveryError = scheduleErrors.some(
-    (error) =>
-      error === RecurringScheduleErrorCode.EveryInvalid ||
-      error === RecurringScheduleErrorCode.EveryExceedsUnitMax ||
-      error === RecurringScheduleErrorCode.DurationExceedsMax,
+  const hasEveryUnitMax = scheduleErrors.includes(
+    RecurringScheduleErrorCode.EveryExceedsUnitMax,
   );
-  const hasRepeatError = scheduleErrors.some(
-    (error) =>
-      error === RecurringScheduleErrorCode.RepeatInvalid ||
-      error === RecurringScheduleErrorCode.DurationExceedsMax,
+  const hasDurationMax = scheduleErrors.includes(
+    RecurringScheduleErrorCode.DurationExceedsMax,
   );
+  const hasEveryError =
+    scheduleErrors.includes(RecurringScheduleErrorCode.EveryInvalid) ||
+    hasEveryUnitMax;
+  const hasRepeatError =
+    scheduleErrors.includes(RecurringScheduleErrorCode.RepeatInvalid) ||
+    hasDurationMax;
+  const every = parsePositiveInteger(everyValue);
+  const everyErrorMessage = hasEveryUnitMax
+    ? strings('bridge.recurring.max_is', {
+        max: RECURRING_EVERY_MAX_BY_UNIT[everyUnit],
+      })
+    : undefined;
+  const repeatErrorMessage =
+    hasDurationMax && every !== undefined
+      ? strings('bridge.recurring.max_is', {
+          max: getMaxRepeatCount(every, everyUnit),
+        })
+      : undefined;
 
   return (
     <Box
@@ -136,6 +167,8 @@ const RecurringScheduleFields = ({
       <Box padding={4} flexDirection={BoxFlexDirection.Row} gap={2}>
         <RecurringNumberCard
           label={strings('bridge.recurring.every')}
+          errorMessage={everyErrorMessage}
+          errorTestID={RecurringScheduleFieldsSelectorsIDs.EVERY_ERROR}
           value={everyValue}
           testID={RecurringScheduleFieldsSelectorsIDs.EVERY_CARD}
           inputTestID={RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT}
@@ -168,6 +201,8 @@ const RecurringScheduleFields = ({
               accessibilityLabel={strings('bridge.recurring.repeat_info_title')}
             />
           }
+          errorMessage={repeatErrorMessage}
+          errorTestID={RecurringScheduleFieldsSelectorsIDs.REPEAT_ERROR}
           value={repeatCount}
           testID={RecurringScheduleFieldsSelectorsIDs.REPEAT_CARD}
           inputTestID={RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT}

--- a/app/components/UI/Bridge/utils/recurringSchedule.test.ts
+++ b/app/components/UI/Bridge/utils/recurringSchedule.test.ts
@@ -1,5 +1,6 @@
 import {
   capRecurringKeypadValue,
+  getMaxRepeatCount,
   parsePositiveInteger,
   RecurringScheduleErrorCode,
   RECURRING_MAX_DURATION_MINUTES,
@@ -103,7 +104,7 @@ describe('validateRecurringSchedule', () => {
     { unit: 'minute' as const, max: '60' },
     { unit: 'hour' as const, max: '24' },
     { unit: 'day' as const, max: '7' },
-    { unit: 'week' as const, max: '25' },
+    { unit: 'week' as const, max: '4' },
     { unit: 'month' as const, max: '6' },
   ])('accepts the max every value of $max for $unit', ({ unit, max }) => {
     const schedule = makeSchedule({
@@ -215,5 +216,15 @@ describe('validateRecurringSchedule', () => {
       RecurringScheduleErrorCode.EveryExceedsUnitMax,
       RecurringScheduleErrorCode.DurationExceedsMax,
     ]);
+  });
+});
+
+describe('getMaxRepeatCount', () => {
+  it('returns 180 for every 1 day', () => {
+    expect(getMaxRepeatCount(1, 'day')).toBe(180);
+  });
+
+  it('returns 90 for every 2 days', () => {
+    expect(getMaxRepeatCount(2, 'day')).toBe(90);
   });
 });

--- a/app/components/UI/Bridge/utils/recurringSchedule.test.ts
+++ b/app/components/UI/Bridge/utils/recurringSchedule.test.ts
@@ -104,6 +104,7 @@ describe('validateRecurringSchedule', () => {
     { unit: 'hour' as const, max: '24' },
     { unit: 'day' as const, max: '7' },
     { unit: 'week' as const, max: '25' },
+    { unit: 'month' as const, max: '6' },
   ])('accepts the max every value of $max for $unit', ({ unit, max }) => {
     const schedule = makeSchedule({
       everyValue: max,
@@ -128,6 +129,48 @@ describe('validateRecurringSchedule', () => {
     const result = validateRecurringSchedule(schedule);
 
     expect(result).toEqual({ isValid: true, errors: [] });
+  });
+
+  it('accepts 1 month repeated 6 times', () => {
+    const schedule = makeSchedule({
+      everyValue: '1',
+      everyUnit: 'month',
+      repeatCount: '6',
+    });
+
+    const result = validateRecurringSchedule(schedule);
+
+    expect(result).toEqual({ isValid: true, errors: [] });
+  });
+
+  it('returns duration_exceeds_max for 1 month repeated 7 times', () => {
+    const schedule = makeSchedule({
+      everyValue: '1',
+      everyUnit: 'month',
+      repeatCount: '7',
+    });
+
+    const result = validateRecurringSchedule(schedule);
+
+    expect(result.errors).toContain(
+      RecurringScheduleErrorCode.DurationExceedsMax,
+    );
+    expect(result.isValid).toBe(false);
+  });
+
+  it('returns every_exceeds_unit_max when months exceed 6', () => {
+    const schedule = makeSchedule({
+      everyValue: '7',
+      everyUnit: 'month',
+      repeatCount: '1',
+    });
+
+    const result = validateRecurringSchedule(schedule);
+
+    expect(result.errors).toContain(
+      RecurringScheduleErrorCode.EveryExceedsUnitMax,
+    );
+    expect(result.isValid).toBe(false);
   });
 
   it('returns duration_exceeds_max for 1 day repeated 181 times', () => {

--- a/app/components/UI/Bridge/utils/recurringSchedule.ts
+++ b/app/components/UI/Bridge/utils/recurringSchedule.ts
@@ -5,6 +5,7 @@ export const RECURRING_INTERVAL_UNITS = [
   'hour',
   'day',
   'week',
+  'month',
 ] as const;
 
 export type RecurringIntervalUnit = (typeof RECURRING_INTERVAL_UNITS)[number];
@@ -38,6 +39,7 @@ export const RECURRING_EVERY_MAX_BY_UNIT: Record<
   hour: 24,
   day: 7,
   week: 25,
+  month: 6,
 };
 
 export const RECURRING_INTERVAL_MINUTES: Record<RecurringIntervalUnit, number> =
@@ -46,6 +48,7 @@ export const RECURRING_INTERVAL_MINUTES: Record<RecurringIntervalUnit, number> =
     hour: 60,
     day: 1440,
     week: 10080,
+    month: 30 * 1440,
   };
 
 export const RECURRING_MAX_DURATION_DAYS = 180;

--- a/app/components/UI/Bridge/utils/recurringSchedule.ts
+++ b/app/components/UI/Bridge/utils/recurringSchedule.ts
@@ -38,7 +38,7 @@ export const RECURRING_EVERY_MAX_BY_UNIT: Record<
   minute: 60,
   hour: 24,
   day: 7,
-  week: 25,
+  week: 4,
   month: 6,
 };
 
@@ -119,4 +119,13 @@ export function validateRecurringSchedule(
     isValid: errors.length === 0,
     errors,
   };
+}
+
+export function getMaxRepeatCount(
+  every: number,
+  unit: RecurringIntervalUnit,
+): number {
+  return Math.floor(
+    RECURRING_MAX_DURATION_MINUTES / (every * RECURRING_INTERVAL_MINUTES[unit]),
+  );
 }

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8723,6 +8723,7 @@
       "confirm": "Confirm",
       "repeat_info_title": "Repeat orders",
       "repeat_info_body": "We randomize your orders in timing and size, so your swaps don't follow a predictable pattern.",
+      "max_is": "Max is {{max}}",
       "price_range": {
         "label": "Price range",
         "not_set": "Not set",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8721,6 +8721,8 @@
       "repeat": "Repeat",
       "times": "times",
       "confirm": "Confirm",
+      "repeat_info_title": "Repeat orders",
+      "repeat_info_body": "We randomize your orders in timing and size, so your swaps don't follow a predictable pattern.",
       "price_range": {
         "label": "Price range",
         "not_set": "Not set",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8744,6 +8744,13 @@
         "week": "week",
         "month": "month"
       },
+      "unit_plural": {
+        "minute": "minutes",
+        "hour": "hours",
+        "day": "days",
+        "week": "weeks",
+        "month": "months"
+      },
       "unit_option": {
         "minute": "Minute",
         "hour": "Hour",
@@ -8753,6 +8760,7 @@
       },
       "pair": "{{source}} → {{dest}}",
       "schedule_summary": "{{interval}} / {{count}} orders",
+      "spend_summary": "You spend {{amount}} {{symbol}} every {{everyValue}} {{unit}} over {{repeatCount}} times",
       "percent_filled": "{{percent}}% filled",
       "filled": "Filled"
     },

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8739,13 +8739,15 @@
         "minute": "minute",
         "hour": "hour",
         "day": "day",
-        "week": "week"
+        "week": "week",
+        "month": "month"
       },
       "unit_option": {
         "minute": "Minute",
         "hour": "Hour",
         "day": "Day",
-        "week": "Week"
+        "week": "Week",
+        "month": "Month"
       },
       "pair": "{{source}} → {{dest}}",
       "schedule_summary": "{{interval}} / {{count}} orders",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Recurring Swaps (Unified Swaps Recurring tab) was missing Figma schedule UI: Month was not an Every unit, the interval sheet floated mid-screen, Repeat had no explainer, the footer did not echo the schedule, and over-max Every/Repeat only turned red with no copy. Duration-over-180-days also painted Every red even when Every itself was valid.

This PR is local Recurring-tab UI only. Interval math stays in `recurringSchedule.ts`. Confirm remains stubbed; no `bridge-controller` payload.

- Add **Month** as a 30-day Every unit (43200 minutes, max 6). Week Every max is **4** (was 25).
- Hoist `RecurringIntervalSheet` to `BridgeRecurringBuyView` so the design-system BottomSheet docks to the screen bottom (same pattern as Price Range).
- Add Repeat-orders info icon + sheet: *We randomize your orders in timing and size, so your swaps don't follow a predictable pattern.* Header + close only.
- Show spend caption under the Recurring footer button: `You spend {{amount}} {{symbol}} every {{everyValue}} {{unit}} over {{repeatCount}} times` (on-screen amount, not amount × repeats). Hidden when amount/every/repeat is missing or invalid. Same visibility as the confirm button.
- Show **Max is N** on Every when over the unit cap, and on Repeat when `every × unit × repeats` exceeds 180 days. Empty/0 still tints the input with no Max copy. Duration over max no longer paints Every red.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added Month interval, Repeat-orders info, spend summary, and Max is N validation to Recurring Swaps

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: No GitHub issue or Jira key on the branch or commits; Recurring Swaps UI polish against Figma SWAP (`1F3yNWYLOVPFpTPeJugH20`)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Recurring Swaps schedule UI

  Background:
    Given I am logged into MetaMask Mobile
    And Recurring Swaps is available
    And I open Swap and switch to the Recurring tab

  Scenario: user selects Month as the Every unit
    Given the Every unit is Hour

    When user taps the Every unit button
    Then the interval sheet is docked to the bottom of the screen
    And Month is listed as an option

    When user selects Month and taps Confirm
    Then the Every unit button shows "month"
    And Every resets to 1

  Scenario: user opens Repeat orders info
    When user taps the info icon next to Repeat
    Then a sheet titled "Repeat orders" opens
    And the body explains that orders are randomized in timing and size
    And there is a close button and no Confirm footer

    When user taps close
    Then the sheet dismisses
    And the Repeat keypad does not open

  Scenario: user sees spend summary under the footer
    Given I have entered a source amount and a quote is available
    And Every is 1 hour and Repeat is 10

    Then the caption under the footer button reads "You spend {amount} {symbol} every 1 hour over 10 times"

    When user changes Every to 2
    Then the caption uses "hours"

  Scenario: user exceeds the Every unit max
    Given Every unit is Hour and Repeat is 10

    When user sets Every to 25
    Then the Every value is red
    And the Every label row shows "Max is 24"
    And Repeat is not in error

  Scenario: user exceeds the week Every max
    Given Every unit is Week

    When user sets Every to 5
    Then the Every label row shows "Max is 4"

  Scenario: user exceeds the 180-day Repeat max
    Given Every is 1 day

    When user sets Repeat to 181
    Then the Repeat value is red
    And the Repeat label row shows "Max is 180"
    And Every is not red

  Scenario: user clears Every or Repeat to 0
    When user sets Every or Repeat to 0
    Then that input is red
    And neither field shows "Max is" copy
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/966ddb84-e72d-471d-b4ff-425341af95b4




## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Recurring-tab UI and client-side schedule validation only; no auth, payments, or bridge-controller submission changes.
> 
> **Overview**
> Polishes the Recurring Swaps tab schedule UI: **month** is a new Every interval (30-day duration math, max 6); **week** Every max drops from 25 to **4**. `getMaxRepeatCount` drives Repeat-side duration caps in copy and validation.
> 
> **Every** interval and **Repeat** info bottom sheets are hoisted to `BridgeRecurringBuyView` (same pattern as price range) so sheets dock correctly; schedule fields delegate via `onUnitPress` / `onRepeatInfoPress`. A new **Repeat orders** info sheet explains randomized timing/size. The recurring footer shows a **spend summary** under confirm (per-order amount, plural units) when amount and schedule are valid.
> 
> Validation UX adds inline **Max is {{max}}** for unit over-max on Every and 180-day over-max on Repeat; duration over-max no longer marks Every red. Empty/zero Every/Repeat still error-tint without Max copy. i18n and unit/component/view tests updated; confirm remains stubbed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbd097820116b03a5390a0f4174f4e6c3f3dbe2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->