### PR TITLE
fix: Update `eth-sig-util` to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,8 @@
     "@react-native/babel-preset@npm:0.83.6": "patch:@react-native/babel-preset@npm%3A0.83.6#~/.yarn/patches/@react-native-babel-preset-npm-0.83.6-90eed53ffb.patch",
     "@metamask/network-enablement-controller@npm:^5.4.1": "patch:@metamask/network-enablement-controller@npm%3A5.4.1#~/.yarn/patches/@metamask-network-enablement-controller-npm-5.4.1-020a82a308.patch",
     "@ledgerhq/context-module/ethers": "^6.16.0",
-    "@ledgerhq/device-signer-kit-ethereum/ethers": "^6.16.0"
+    "@ledgerhq/device-signer-kit-ethereum/ethers": "^6.16.0",
+    "@metamask/eth-sig-util": "^9.0.0"
   },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",
@@ -315,7 +316,7 @@
     "@metamask/eth-money-keyring": "^4.0.0",
     "@metamask/eth-qr-keyring": "^2.1.0",
     "@metamask/eth-query": "^4.0.0",
-    "@metamask/eth-sig-util": "^8.0.0",
+    "@metamask/eth-sig-util": "^9.0.0",
     "@metamask/eth-snap-keyring": "^24.1.0",
     "@metamask/etherscan-link": "^2.0.0",
     "@metamask/ethjs-contract": "^0.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8639,9 +8639,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-sig-util@npm:^8.0.0, @metamask/eth-sig-util@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "@metamask/eth-sig-util@npm:8.2.0"
+"@metamask/eth-sig-util@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@metamask/eth-sig-util@npm:9.0.0"
   dependencies:
     "@ethereumjs/rlp": "npm:^4.0.1"
     "@ethereumjs/util": "npm:^8.1.0"
@@ -8650,7 +8650,7 @@ __metadata:
     "@scure/base": "npm:~1.1.3"
     ethereum-cryptography: "npm:^2.1.2"
     tweetnacl: "npm:^1.0.3"
-  checksum: 10/385df1ec541116e1bd725a1df1a519996bad167f99d1b2677126e398cdfda6fc3f03d2ff8f1ca523966bc0aae3ea92a9050953a45d5a7711f4128aacf9242bfc
+  checksum: 10/b4e0bc59fd306ee7d6308e9a21920ade79efbb2d157af06a71cf3fab2621e7373ea5e14159a18e28b21208ef5b949fef68e98ae54874ed07cef728f3a38f7d46
   languageName: node
   linkType: hard
 
@@ -35713,7 +35713,7 @@ __metadata:
     "@metamask/eth-money-keyring": "npm:^4.0.0"
     "@metamask/eth-qr-keyring": "npm:^2.1.0"
     "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/eth-sig-util": "npm:^8.0.0"
+    "@metamask/eth-sig-util": "npm:^9.0.0"
     "@metamask/eth-snap-keyring": "npm:^24.1.0"
     "@metamask/etherscan-link": "npm:^2.0.0"
     "@metamask/ethjs-contract": "npm:^0.4.1"


### PR DESCRIPTION
## **Description**

`@metamask/eth-sig-util` v9.0.0 introduces strict `bool` validation in `signTypedData`: ambiguous values like `0`, `1`, `'0'`, `'1'`, `''`, and `'False'` are now rejected instead of being silently coerced via `Boolean()`. This was a signing integrity footgun — a dApp could supply `flag: 'false'` (which `Boolean()` coerces to `true`) and get a user to sign the opposite of what was displayed in the confirmation UI.

This PR adds a Yarn resolution to force `@metamask/eth-sig-util@^9.0.0` across all transitive dependencies while the upstream cascade lands. The immediate blocker is `@metamask/eth-simple-keyring` (and other keyrings in [MetaMask/accounts#626](https://github.com/MetaMask/accounts/pull/626)) which still declare `^8.2.0` — without the resolution, `eth-simple-keyring` installs its own nested copy of v8.2.0 and `normalizeBool()` is never reached during signing.

**Dependency update cascade:**
- `eth-sig-util@9.0.0` update: [MetaMask/eth-sig-util CHANGELOG](https://github.com/MetaMask/eth-sig-util/blob/main/CHANGELOG.md#900)
- Core controllers: [MetaMask/core#9999](https://github.com/MetaMask/core/pull/9999)
- Keyring updates: [MetaMask/accounts#626](https://github.com/MetaMask/accounts/pull/626)
- Mobile resolution: this PR
- Extension resolution: [MetaMask/metamask-extension#45854](https://github.com/MetaMask/metamask-extension/pull/45854)

The resolution will be removed in a follow-up PR once the upstream packages ship and are consumed here.

## **Changelog**

CHANGELOG entry: null

## **Test results**

<img width="1086" height="1731" alt="1" src="https://github.com/user-attachments/assets/98163300-b13f-451d-9dd8-0329ce0a914c" />
<img width="1080" height="1742" alt="2" src="https://github.com/user-attachments/assets/555c2b5f-b73f-4149-9837-70745349fcf1" />
<img width="1089" height="684" alt="3" src="https://github.com/user-attachments/assets/39caa174-a686-43ba-9ed2-b30ae5475063" />

## **Related issues**

Fixes: CONF-1807

## **Manual testing steps**

1. Install the app from this branch
2. Navigate to any dApp that uses `eth_signTypedData_v4` with a `bool` field
3. Attempt to sign a typed message where a `bool` field is set to an ambiguous value such as `0`, `1`, `'0'`, or `'1'`
4. Verify the signing request is rejected with an error — MetaMask should not present a confirmation dialog for invalid bool values
5. Attempt to sign with valid values (`true`, `false`, `'true'`, `'false'`) and verify the signing confirmation appears and completes successfully

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and MetaMask Mobile Coding Standards.
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signing and typed-data validation across the dependency tree; stricter bool rejection may break dApps that relied on old coercion, but that is the intended security fix.
> 
> **Overview**
> Bumps **`@metamask/eth-sig-util`** from **^8.0.0** to **^9.0.0** in direct dependencies and adds a **`resolutions`** entry so every transitive consumer (e.g. keyrings still on **^8.2.0**) resolves to a single **9.0.0** install. **`yarn.lock`** is updated accordingly.
> 
> This lands **v9**’s stricter **`signTypedData`** handling for **`bool`** fields: ambiguous values like **`0`**, **`1`**, or string variants are rejected instead of being coerced with **`Boolean()`**, closing a signing/UI mismatch risk. No application source changes—behavior changes only where the app already pulls in **`eth-sig-util`** (typed-data signing, personal-signature recovery, confirmation flows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d136a92f3c1ada1f65a06504dbec17b5d89d37a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->