### PR TITLE
feat(predict): remove claim CTA from wallet homepage

### DIFF
--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -13,7 +13,6 @@ import { PredictEventValues } from '../../../../UI/Predict/constants/eventNames'
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 
 const mockNavigate = jest.fn();
-const mockClaim = jest.fn();
 const mockTrackEvent = jest.fn();
 const mockIsFocused = jest.fn(() => true);
 const mockCreateEventBuilder = jest.fn((event: unknown) => ({
@@ -159,10 +158,6 @@ jest.mock(
   }),
 );
 
-jest.mock('../../../../UI/Predict/hooks/usePredictClaim', () => ({
-  usePredictClaim: () => ({ claim: mockClaim }),
-}));
-
 jest.mock('../../../../UI/Predict/hooks/useUnrealizedPnL', () => ({
   useUnrealizedPnL: jest.fn(() => ({
     data: { cashUpnl: 10, percentUpnl: 5, user: '0x0' },
@@ -263,64 +258,24 @@ const mockActivePositions = [
   },
 ];
 
-const mockClaimablePositions = [
-  {
-    outcomeId: 'claimable-outcome-1',
-    outcomeIndex: 0,
-    marketId: 'claimable-market-1',
-    title: 'Claimable Position',
-    outcome: 'Yes',
-    icon: 'https://example.com/icon-claimable.png',
-    initialValue: 10,
-    currentValue: 75,
-    size: 75,
-    percentPnl: 650,
-    claimable: true,
-  },
-  {
-    outcomeId: 'claimable-outcome-2',
-    outcomeIndex: 0,
-    marketId: 'claimable-market-2',
-    title: 'Claimable Position 2',
-    outcome: 'Yes',
-    icon: 'https://example.com/icon-claimable2.png',
-    initialValue: 10,
-    currentValue: 125,
-    size: 125,
-    percentPnl: 1150,
-    claimable: true,
-  },
-];
-
-const mockMarkets = [
-  {
-    id: 'market-1',
-    title: 'Will BTC reach 100k?',
-    endDate: '2026-03-01',
-    outcomes: [
-      {
-        id: 'outcome-1',
-        title: 'Yes',
-        status: 'open' as const,
-        image: 'https://example.com/yes.png',
-        tokens: [{ title: 'Yes', price: 0.55 }],
-      },
-      {
-        id: 'outcome-2',
-        title: 'No',
-        status: 'open' as const,
-        image: 'https://example.com/no.png',
-        tokens: [{ title: 'No', price: 0.45 }],
-      },
-    ],
-  },
-];
+const mockPositionsHookResult = (
+  overrides: {
+    positions?: typeof mockActivePositions;
+    isLoading?: boolean;
+    error?: string | null;
+    refetch?: jest.Mock;
+  } = {},
+) => ({
+  positions: overrides.positions ?? [],
+  isLoading: overrides.isLoading ?? false,
+  error: overrides.error ?? null,
+  refetch: overrides.refetch ?? jest.fn(),
+});
 
 describe('PredictionsSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsFocused.mockReturnValue(true);
-    mockClaim.mockResolvedValue(undefined);
     mockSelectPrivacyMode.mockReturnValue(false);
 
     // Reset mock return value to default (true) to ensure test isolation
@@ -352,15 +307,12 @@ describe('PredictionsSection', () => {
       homepageMarketSlotsMock(),
     );
 
-    mockUsePredictPositionsForHomepage.mockImplementation(
-      (_options: { maxPositions?: number; claimable?: boolean } = {}) => ({
-        positions: [],
-        isLoading: false,
-        error: null,
-        totalClaimableValue: 0,
-        refetch: jest.fn(),
-      }),
-    );
+    mockUsePredictPositionsForHomepage.mockReturnValue({
+      positions: [],
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
     mockUseABTest.mockReturnValue({
       variant: { layout: 'list' as const },
       variantName: 'treatment',
@@ -451,16 +403,8 @@ describe('PredictionsSection', () => {
   });
 
   it('navigates with homepage_positions entry_point when positions section title is pressed', () => {
-    mockUsePredictPositionsForHomepage.mockImplementation(
-      ({
-        claimable = false,
-      }: { maxPositions?: number; claimable?: boolean } = {}) => ({
-        positions: claimable ? [] : mockActivePositions,
-        isLoading: false,
-        error: null,
-        totalClaimableValue: 0,
-        refetch: jest.fn(),
-      }),
+    mockUsePredictPositionsForHomepage.mockReturnValue(
+      mockPositionsHookResult({ positions: mockActivePositions }),
     );
 
     renderWithProvider(
@@ -491,16 +435,8 @@ describe('PredictionsSection', () => {
 
   describe('when user has positions', () => {
     beforeEach(() => {
-      mockUsePredictPositionsForHomepage.mockImplementation(
-        ({
-          claimable = false,
-        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
-          positions: claimable ? [] : mockActivePositions,
-          isLoading: false,
-          error: null,
-          totalClaimableValue: 0,
-          refetch: jest.fn(),
-        }),
+      mockUsePredictPositionsForHomepage.mockReturnValue(
+        mockPositionsHookResult({ positions: mockActivePositions }),
       );
     });
 
@@ -516,24 +452,16 @@ describe('PredictionsSection', () => {
     });
 
     it('renders the current active position values from the hook data', async () => {
-      mockUsePredictPositionsForHomepage.mockImplementation(
-        ({
-          claimable = false,
-        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
-          positions: claimable
-            ? []
-            : [
-                {
-                  ...mockActivePositions[0],
-                  currentValue: 99,
-                  percentPnl: 890,
-                },
-                mockActivePositions[1],
-              ],
-          isLoading: false,
-          error: null,
-          totalClaimableValue: 0,
-          refetch: jest.fn(),
+      mockUsePredictPositionsForHomepage.mockReturnValue(
+        mockPositionsHookResult({
+          positions: [
+            {
+              ...mockActivePositions[0],
+              currentValue: 99,
+              percentPnl: 890,
+            },
+            mockActivePositions[1],
+          ],
         }),
       );
 
@@ -551,16 +479,8 @@ describe('PredictionsSection', () => {
     });
 
     it('shows position skeletons when loading positions', () => {
-      mockUsePredictPositionsForHomepage.mockImplementation(
-        ({
-          claimable = false,
-        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
-          positions: [],
-          isLoading: !claimable, // only active positions loading
-          error: null,
-          totalClaimableValue: 0,
-          refetch: jest.fn(),
-        }),
+      mockUsePredictPositionsForHomepage.mockReturnValue(
+        mockPositionsHookResult({ isLoading: true }),
       );
 
       renderWithProvider(
@@ -568,6 +488,20 @@ describe('PredictionsSection', () => {
       );
 
       expect(screen.queryByText('Test Position 1')).not.toBeOnTheScreen();
+    });
+
+    it('renders unrealized PnL row for open positions', async () => {
+      renderWithProvider(
+        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Position 1')).toBeOnTheScreen();
+      });
+
+      expect(
+        screen.getByTestId('homepage-predict-unrealized-pnl'),
+      ).toBeOnTheScreen();
     });
   });
 
@@ -992,158 +926,33 @@ describe('PredictionsSection', () => {
     });
   });
 
-  describe('claim button', () => {
-    beforeEach(() => {
-      // Show positions so the positions branch renders
-      mockUsePredictPositionsForHomepage.mockImplementation(
-        ({
-          claimable = false,
-        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
-          positions: claimable ? [] : mockActivePositions,
-          isLoading: false,
-          error: null,
-          totalClaimableValue: 0,
-          refetch: jest.fn(),
-        }),
-      );
-    });
-
-    it('does not show claim button when there are no claimable positions', () => {
-      renderWithProvider(
-        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
-      );
-
+  describe('claim CTA', () => {
+    const expectNoClaimCta = () => {
+      expect(
+        screen.queryByTestId(
+          PREDICT_CLAIM_BUTTON_TEST_IDS.PREDICT_CLAIM_BUTTON,
+        ),
+      ).not.toBeOnTheScreen();
       expect(screen.queryByText(/Claim \$/)).not.toBeOnTheScreen();
-    });
-
-    it('shows claim button with total amount when claimable positions exist', async () => {
-      mockUsePredictPositionsForHomepage.mockImplementation(
-        ({
-          claimable = false,
-        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
-          positions: claimable ? mockClaimablePositions : mockActivePositions,
-          isLoading: false,
-          error: null,
-          totalClaimableValue: claimable ? 200 : 0,
-          refetch: jest.fn(),
-        }),
-      );
-
-      renderWithProvider(
-        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
-      });
-    });
-
-    it('does not show claim button while claimable positions are loading', () => {
-      mockUsePredictPositionsForHomepage.mockImplementation(
-        ({
-          claimable = false,
-        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
-          positions: [],
-          isLoading: claimable, // claimable fetch still loading
-          error: null,
-          totalClaimableValue: 0,
-          refetch: jest.fn(),
-        }),
-      );
-
-      renderWithProvider(
-        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
-      );
-
-      expect(screen.queryByText(/Claim \$/)).not.toBeOnTheScreen();
-    });
-
-    it('does not show claim button while active positions are loading', () => {
-      mockUsePredictPositionsForHomepage.mockImplementation(
-        ({
-          claimable = false,
-        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
-          positions: [],
-          isLoading: !claimable, // active fetch still loading
-          error: null,
-          totalClaimableValue: 0,
-          refetch: jest.fn(),
-        }),
-      );
-
-      renderWithProvider(
-        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
-      );
-
-      expect(screen.queryByText(/Claim \$/)).not.toBeOnTheScreen();
-    });
-
-    it('calls claim on press without manual refresh', async () => {
-      mockUsePredictPositionsForHomepage.mockImplementation(
-        ({
-          claimable = false,
-        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
-          positions: claimable ? mockClaimablePositions : mockActivePositions,
-          isLoading: false,
-          error: null,
-          totalClaimableValue: claimable ? 200 : 0,
-          refetch: jest.fn(),
-        }),
-      );
-
-      renderWithProvider(
-        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
-      });
-
-      fireEvent.press(screen.getByText('Claim $200.00'));
-
-      await waitFor(() => {
-        expect(mockClaim).toHaveBeenCalledTimes(1);
-      });
-    });
-  });
-
-  describe('claimable-only (no active positions)', () => {
-    const setupClaimableOnly = () => {
-      mockUsePredictPositionsForHomepage.mockImplementation(
-        ({
-          claimable = false,
-        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
-          positions: claimable ? mockClaimablePositions : [],
-          isLoading: false,
-          error: null,
-          totalClaimableValue: claimable ? 200 : 0,
-          refetch: jest.fn(),
-        }),
-      );
+      expect(screen.queryByText(/Claim winnings/i)).not.toBeOnTheScreen();
     };
 
-    it('renders claim button when only claimable positions exist', async () => {
-      setupClaimableOnly();
-
+    it('does not fetch claimable positions for the homepage section', () => {
       renderWithProvider(
         <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
       );
 
-      await waitFor(() => {
-        expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
+      expect(mockUsePredictPositionsForHomepage).toHaveBeenCalledWith({
+        enabled: true,
       });
+      expect(mockUsePredictPositionsForHomepage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ claimable: true }),
+      );
     });
 
-    it('renders trending carousel above claim button when no active positions', async () => {
-      setupClaimableOnly();
-      mockUsePredictMarketsForHomepage.mockReturnValue({
-        markets: mockMarkets,
-        isLoading: false,
-        error: null,
-        refetch: jest.fn(),
-      });
-      mockUseHomepagePredictMarketSlots.mockReturnValue(
-        homepageMarketSlotsMock(),
+    it('does not render claim button when user has open positions', async () => {
+      mockUsePredictPositionsForHomepage.mockReturnValue(
+        mockPositionsHookResult({ positions: mockActivePositions }),
       );
 
       renderWithProvider(
@@ -1151,99 +960,34 @@ describe('PredictionsSection', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
-        expect(screen.getByText('EPL: 2027 Champion')).toBeOnTheScreen();
+        expect(screen.getByText('Test Position 1')).toBeOnTheScreen();
       });
+
+      expectNoClaimCta();
     });
 
-    it('renders only claim button when no active positions and no markets', async () => {
-      setupClaimableOnly();
-      mockUsePredictMarketsForHomepage.mockReturnValue({
-        markets: [],
-        isLoading: false,
-        error: null,
-        refetch: jest.fn(),
-      });
-      mockUseHomepagePredictMarketSlots.mockReturnValue(
-        homepageMarketSlotsResultMock([]),
-      );
-
+    it('does not render claim button when user has no open positions', async () => {
       renderWithProvider(
         <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
       );
 
       await waitFor(() => {
-        expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
+        expect(screen.getByText('Predictions')).toBeOnTheScreen();
       });
-      expect(
-        screen.queryByText('Pro Football: 2027 Champion'),
-      ).not.toBeOnTheScreen();
-      expect(screen.queryByText('EPL: 2027 Champion')).not.toBeOnTheScreen();
+
+      expectNoClaimCta();
     });
 
-    it('does not render active position rows in claimable-only state', async () => {
-      setupClaimableOnly();
-
-      renderWithProvider(
-        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
-      });
-      expect(screen.queryByText('Test Position 1')).not.toBeOnTheScreen();
-      expect(screen.queryByText('Test Position 2')).not.toBeOnTheScreen();
-    });
-
-    it('does not duplicate the section header when trending carousel is shown above positions', async () => {
-      setupClaimableOnly();
-      mockUsePredictMarketsForHomepage.mockReturnValue({
-        markets: mockMarkets,
-        isLoading: false,
-        error: null,
-        refetch: jest.fn(),
-      });
-      mockUseHomepagePredictMarketSlots.mockReturnValue(
-        homepageMarketSlotsMock(),
+    it('does not render claim button while open positions are loading', () => {
+      mockUsePredictPositionsForHomepage.mockReturnValue(
+        mockPositionsHookResult({ isLoading: true }),
       );
 
       renderWithProvider(
         <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
       );
 
-      await waitFor(() => {
-        expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
-      });
-
-      // Title should appear exactly once — from the discovery list header.
-      // The positions header is gated by showHeader=false in this branch.
-      expect(screen.getAllByText('Predictions')).toHaveLength(1);
-    });
-
-    it('does not show unrealized PnL row when trending carousel is above positions', async () => {
-      setupClaimableOnly();
-      mockUsePredictMarketsForHomepage.mockReturnValue({
-        markets: mockMarkets,
-        isLoading: false,
-        error: null,
-        refetch: jest.fn(),
-      });
-      mockUseHomepagePredictMarketSlots.mockReturnValue(
-        homepageMarketSlotsMock(),
-      );
-
-      renderWithProvider(
-        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
-      });
-
-      // showHeader=false when discovery list is above positions,
-      // so the unrealized PnL row must not render even if the hook returns data
-      expect(screen.queryByText(/P&L/i)).not.toBeOnTheScreen();
-      expect(screen.queryByText(/PnL/i)).not.toBeOnTheScreen();
+      expectNoClaimCta();
     });
   });
 
@@ -1253,16 +997,8 @@ describe('PredictionsSection', () => {
     });
 
     it('hides monetary values on position rows', async () => {
-      mockUsePredictPositionsForHomepage.mockImplementation(
-        ({
-          claimable = false,
-        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
-          positions: claimable ? [] : mockActivePositions,
-          isLoading: false,
-          error: null,
-          totalClaimableValue: 0,
-          refetch: jest.fn(),
-        }),
+      mockUsePredictPositionsForHomepage.mockReturnValue(
+        mockPositionsHookResult({ positions: mockActivePositions }),
       );
 
       renderWithProvider(
@@ -1279,42 +1015,6 @@ describe('PredictionsSection', () => {
       expect(screen.queryByText('-40%')).toBeNull();
       expect(screen.queryAllByText(/•+/).length).toBeGreaterThan(0);
     });
-
-    it('masks claim amount and still invokes claim on press', async () => {
-      mockUsePredictPositionsForHomepage.mockImplementation(
-        ({
-          claimable = false,
-        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
-          positions: claimable ? mockClaimablePositions : mockActivePositions,
-          isLoading: false,
-          error: null,
-          totalClaimableValue: claimable ? 200 : 0,
-          refetch: jest.fn(),
-        }),
-      );
-
-      renderWithProvider(
-        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
-      );
-
-      await waitFor(() => {
-        expect(
-          screen.getByTestId(
-            PREDICT_CLAIM_BUTTON_TEST_IDS.PREDICT_CLAIM_BUTTON,
-          ),
-        ).toBeOnTheScreen();
-      });
-
-      expect(screen.queryByText('Claim $200.00')).toBeNull();
-
-      fireEvent.press(
-        screen.getByTestId(PREDICT_CLAIM_BUTTON_TEST_IDS.PREDICT_CLAIM_BUTTON),
-      );
-
-      await waitFor(() => {
-        expect(mockClaim).toHaveBeenCalledTimes(1);
-      });
-    });
   });
 
   describe('refresh functionality', () => {
@@ -1322,14 +1022,8 @@ describe('PredictionsSection', () => {
       const mockRefetchPositions = jest.fn().mockResolvedValue(undefined);
       const mockRefetchMarkets = jest.fn().mockResolvedValue(undefined);
 
-      mockUsePredictPositionsForHomepage.mockImplementation(
-        (_options: { maxPositions?: number; claimable?: boolean } = {}) => ({
-          positions: [],
-          isLoading: false,
-          error: null,
-          totalClaimableValue: 0,
-          refetch: mockRefetchPositions,
-        }),
+      mockUsePredictPositionsForHomepage.mockReturnValue(
+        mockPositionsHookResult({ refetch: mockRefetchPositions }),
       );
       mockUsePredictMarketsForHomepage.mockReturnValue({
         markets: [],

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -37,15 +37,11 @@ import {
 import { usePredictionsDefaultSectionModel } from './hooks/usePredictionsDefaultSectionModel';
 import { useTreatmentDiscoveryFeedsLoading } from './hooks/useTreatmentDiscoveryFeedsLoading';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
-import { usePredictClaim } from '../../../../UI/Predict/hooks/usePredictClaim';
 import { useUnrealizedPnL } from '../../../../UI/Predict/hooks/useUnrealizedPnL';
 import { getPredictHomepageUnrealizedPnlRowState } from './utils/getPredictHomepageUnrealizedPnlRowState';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
-import {
-  PredictEventProperties,
-  PredictEventValues,
-} from '../../../../UI/Predict/constants/eventNames';
+import { PredictEventProperties } from '../../../../UI/Predict/constants/eventNames';
 import {
   PredictPositionsEmptyStateVariant,
   type PredictEmptyStateCtaName,
@@ -198,7 +194,6 @@ const PredictionsSectionShell = forwardRef<
 /** Co-located so `usePredictPositionsForHomepage` resolves through `jest.mock('./hooks')` in tests. */
 const usePredictPositionsSectionData = (homepageQueriesEnabled: boolean) => {
   const privacyMode = useSelector(selectPrivacyMode);
-  const { claim } = usePredictClaim();
 
   const {
     positions,
@@ -208,17 +203,6 @@ const usePredictPositionsSectionData = (homepageQueriesEnabled: boolean) => {
   } = usePredictPositionsForHomepage({
     enabled: homepageQueriesEnabled,
   });
-  const { totalClaimableValue, isLoading: isLoadingClaimable } =
-    usePredictPositionsForHomepage({
-      claimable: true,
-      enabled: homepageQueriesEnabled,
-    });
-
-  const handleClaim = useCallback(async () => {
-    await claim({
-      entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
-    });
-  }, [claim]);
 
   const hasPositions = positions.length > 0;
   const {
@@ -250,9 +234,6 @@ const usePredictPositionsSectionData = (homepageQueriesEnabled: boolean) => {
     isLoadingPositions,
     positionsError,
     refetchPositions,
-    totalClaimableValue,
-    isLoadingClaimable,
-    handleClaim,
     hasPositions,
     predictHomepageUnrealizedPnl,
   };
@@ -281,9 +262,6 @@ const PredictionsSectionDefault = forwardRef<
       isLoadingPositions,
       positionsError,
       refetchPositions,
-      totalClaimableValue,
-      isLoadingClaimable,
-      handleClaim,
       hasPositions,
       predictHomepageUnrealizedPnl,
     } = usePredictPositionsSectionData(isPredictEnabled);
@@ -326,7 +304,6 @@ const PredictionsSectionDefault = forwardRef<
     } = usePredictionsDefaultSectionModel({
       isPredictEnabled,
       isLoadingPositions,
-      isLoadingClaimable,
       isLoadingMarkets,
       isTreatmentDiscovery,
       isLoadingWorldCupHomepage: isLoadingMarketSlots,
@@ -335,7 +312,6 @@ const PredictionsSectionDefault = forwardRef<
       positionsError,
       marketsError,
       marketsLength: markets.length,
-      totalClaimableValue,
     });
 
     useSectionPerformance({
@@ -384,8 +360,7 @@ const PredictionsSectionDefault = forwardRef<
       refetchHomepageMarketSlots,
     ]);
 
-    const positionsLayout =
-      hasAnyPositions || isLoadingPositions || isLoadingClaimable;
+    const positionsLayout = hasAnyPositions || isLoadingPositions;
     const discoveryHasNothingToShow =
       !isTreatmentDiscovery && !isLoadingMarkets && markets.length === 0;
     const enabled =
@@ -436,10 +411,7 @@ const PredictionsSectionDefault = forwardRef<
               privacyMode={privacyMode}
               isLoadingPositions={isLoadingPositions}
               positions={positions}
-              isLoadingClaimable={isLoadingClaimable}
-              totalClaimableValue={totalClaimableValue}
               predictHomepageUnrealizedPnl={predictHomepageUnrealizedPnl}
-              onClaim={handleClaim}
               onPositionPress={handlePositionPress}
               showHeader={!showTrendingAbove}
             />

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictPositions.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictPositions.tsx
@@ -8,7 +8,6 @@ import {
 import { WalletViewSelectorsIDs } from '../../../../Wallet/WalletView.testIds';
 import { strings } from '../../../../../../../locales/i18n';
 import type { PredictPosition } from '../../../../../UI/Predict/types';
-import { PredictClaimButton } from '../../../../../UI/Predict/components/PredictActionButtons';
 import HomepageSectionUnrealizedPnlRow from '../../../components/HomepageSectionUnrealizedPnlRow';
 import type { PredictHomepageUnrealizedPnlRowState } from '../predictionsSectionTypes';
 import {
@@ -22,10 +21,7 @@ export interface HomepagePredictPositionsProps {
   privacyMode: boolean;
   isLoadingPositions: boolean;
   positions: PredictPosition[];
-  isLoadingClaimable: boolean;
-  totalClaimableValue: number;
   predictHomepageUnrealizedPnl: PredictHomepageUnrealizedPnlRowState;
-  onClaim: () => Promise<void>;
   onPositionPress: (position: PredictPosition) => void;
   /** When false the section header is omitted (e.g. carousel shown above positions). */
   showHeader?: boolean;
@@ -37,10 +33,7 @@ const HomepagePredictPositions = ({
   privacyMode,
   isLoadingPositions,
   positions,
-  isLoadingClaimable,
-  totalClaimableValue,
   predictHomepageUnrealizedPnl,
-  onClaim,
   onPositionPress,
   showHeader = true,
 }: HomepagePredictPositionsProps) => (
@@ -81,16 +74,6 @@ const HomepagePredictPositions = ({
           />
         ))
       )}
-      {!isLoadingPositions &&
-        !isLoadingClaimable &&
-        totalClaimableValue > 0 && (
-          <Box paddingHorizontal={4} paddingTop={1} paddingBottom={3}>
-            <PredictClaimButton
-              amount={privacyMode ? undefined : totalClaimableValue}
-              onPress={onClaim}
-            />
-          </Box>
-        )}
     </Box>
   </>
 );

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.test.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.test.ts
@@ -1,9 +1,6 @@
-import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { renderHook } from '@testing-library/react-native';
 import { usePredictPositionsForHomepage } from './usePredictPositionsForHomepage';
-import {
-  PredictPositionStatus,
-  type PredictPosition,
-} from '../../../../../UI/Predict/types';
+import type { PredictPosition } from '../../../../../UI/Predict/types';
 
 const mockRefetch = jest.fn().mockResolvedValue(undefined);
 const mockUsePredictPositions = jest.fn();
@@ -38,7 +35,6 @@ const createMockPosition = (id: string, currentValue = 12): PredictPosition =>
     icon: `https://example.com/icon-${id}.png`,
     initialValue: 10,
     currentValue,
-    status: PredictPositionStatus.WON,
     size: 15,
     percentPnl: 20,
   }) as unknown as PredictPosition;
@@ -137,87 +133,23 @@ describe('usePredictPositionsForHomepage', () => {
     expect(mockRefetch).toHaveBeenCalledTimes(1);
   });
 
-  describe('claimable option', () => {
-    it('defaults claimable to false', () => {
-      const { result } = renderHook(() => usePredictPositionsForHomepage());
+  it('requests active positions with live price updates', () => {
+    renderHook(() => usePredictPositionsForHomepage());
 
-      expect(result.current.totalClaimableValue).toBe(0);
+    expect(mockUsePredictPositions).toHaveBeenCalledWith({
+      claimable: false,
+      enabled: true,
+      livePriceUpdates: true,
     });
+  });
 
-    it('computes totalClaimableValue as sum of actionable currentValue when claimable is true', () => {
-      mockUsePredictPositionsReturn.data = [
-        createMockPosition('c1', 5),
-        createMockPosition('c2', 10),
-        createMockPosition('c3', 3),
-      ];
+  it('forwards enabled false to usePredictPositions', () => {
+    renderHook(() => usePredictPositionsForHomepage({ enabled: false }));
 
-      const { result } = renderHook(() =>
-        usePredictPositionsForHomepage({ claimable: true }),
-      );
-
-      expect(result.current.totalClaimableValue).toBe(18);
-    });
-
-    it('returns totalClaimableValue 0 for lost-only claimable positions', () => {
-      mockUsePredictPositionsReturn.data = [
-        {
-          ...createMockPosition('lost', 25),
-          status: PredictPositionStatus.LOST,
-        },
-      ];
-
-      const { result } = renderHook(() =>
-        usePredictPositionsForHomepage({ claimable: true }),
-      );
-
-      expect(result.current.totalClaimableValue).toBe(0);
-    });
-
-    it('returns totalClaimableValue 0 when claimable is false', () => {
-      mockUsePredictPositionsReturn.data = [createMockPosition('1', 100)];
-
-      const { result } = renderHook(() =>
-        usePredictPositionsForHomepage({ claimable: false }),
-      );
-
-      expect(result.current.totalClaimableValue).toBe(0);
-    });
-
-    it('enables live updates for active positions', () => {
-      renderHook(() => usePredictPositionsForHomepage({ claimable: false }));
-
-      expect(mockUsePredictPositions).toHaveBeenCalledWith(
-        expect.objectContaining({
-          claimable: false,
-          livePriceUpdates: true,
-        }),
-      );
-    });
-
-    it('disables live updates for claimable positions', () => {
-      renderHook(() => usePredictPositionsForHomepage({ claimable: true }));
-
-      expect(mockUsePredictPositions).toHaveBeenCalledWith(
-        expect.objectContaining({
-          claimable: true,
-          livePriceUpdates: false,
-        }),
-      );
-    });
-
-    it('treats undefined currentValue as 0 in totalClaimableValue sum', () => {
-      mockUsePredictPositionsReturn.data = [
-        {
-          ...createMockPosition('c1', 5),
-          currentValue: undefined,
-        } as unknown as PredictPosition,
-      ];
-
-      const { result } = renderHook(() =>
-        usePredictPositionsForHomepage({ claimable: true }),
-      );
-
-      expect(result.current.totalClaimableValue).toBe(0);
+    expect(mockUsePredictPositions).toHaveBeenCalledWith({
+      claimable: false,
+      enabled: false,
+      livePriceUpdates: true,
     });
   });
 });

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.ts
@@ -1,14 +1,9 @@
 import { useMemo } from 'react';
 import { usePredictPositions } from '../../../../../UI/Predict/hooks/usePredictPositions';
-import {
-  PredictPositionStatus,
-  type PredictPosition,
-} from '../../../../../UI/Predict/types';
+import type { PredictPosition } from '../../../../../UI/Predict/types';
 
 export interface UsePredictPositionsForHomepageResult {
   positions: PredictPosition[];
-  /** Sum of currentValue across won, positive-value claimable positions. */
-  totalClaimableValue: number;
   isLoading: boolean;
   error: string | null;
   refetch: () => Promise<unknown>;
@@ -16,13 +11,12 @@ export interface UsePredictPositionsForHomepageResult {
 
 interface UsePredictPositionsForHomepageOptions {
   maxPositions?: number;
-  claimable?: boolean;
   enabled?: boolean;
 }
 
 /**
  * Lightweight wrapper around the Predict team's usePredictPositions hook,
- * adapted for homepage display with optional slicing and claimable value sum.
+ * adapted for homepage display with optional slicing.
  *
  * Pass `enabled: false` when the Predict feature flag is off so the parent can
  * keep `PredictionsSection` mounted without subscribing to positions queries.
@@ -30,12 +24,12 @@ interface UsePredictPositionsForHomepageOptions {
 export const usePredictPositionsForHomepage = (
   options: UsePredictPositionsForHomepageOptions = {},
 ): UsePredictPositionsForHomepageResult => {
-  const { maxPositions, claimable = false, enabled = true } = options;
+  const { maxPositions, enabled = true } = options;
 
   const { data, isLoading, error, refetch } = usePredictPositions({
-    claimable,
+    claimable: false,
     enabled,
-    livePriceUpdates: !claimable,
+    livePriceUpdates: true,
   });
 
   const allPositions = useMemo(() => data ?? [], [data]);
@@ -48,24 +42,8 @@ export const usePredictPositionsForHomepage = (
     [allPositions, maxPositions],
   );
 
-  const totalClaimableValue = useMemo(
-    () =>
-      claimable
-        ? allPositions.reduce(
-            (sum, position) =>
-              position.status === PredictPositionStatus.WON &&
-              (position.currentValue ?? 0) > 0
-                ? sum + (position.currentValue ?? 0)
-                : sum,
-            0,
-          )
-        : 0,
-    [claimable, allPositions],
-  );
-
   return {
     positions,
-    totalClaimableValue,
     isLoading,
     error: error
       ? error instanceof Error

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictionsDefaultSectionModel.test.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictionsDefaultSectionModel.test.ts
@@ -7,7 +7,6 @@ const createInput = (
 ): Parameters<typeof usePredictionsDefaultSectionModel>[0] => ({
   isPredictEnabled: true,
   isLoadingPositions: false,
-  isLoadingClaimable: false,
   isLoadingMarkets: false,
   isTreatmentDiscovery: false,
   isLoadingWorldCupHomepage: false,
@@ -16,7 +15,6 @@ const createInput = (
   positionsError: null,
   marketsError: null,
   marketsLength: 1,
-  totalClaimableValue: 0,
   ...overrides,
 });
 
@@ -44,5 +42,33 @@ describe('usePredictionsDefaultSectionModel', () => {
 
     expect(result.isLoading).toBe(true);
     expect(result.predictTimeToContentReady).toBe(false);
+  });
+
+  it('treats claimable-only users as having no homepage positions', () => {
+    const result = usePredictionsDefaultSectionModel(
+      createInput({
+        hasPositions: false,
+        positionsLength: 0,
+        marketsLength: 2,
+      }),
+    );
+
+    expect(result.hasAnyPositions).toBe(false);
+    expect(result.showTrendingAbove).toBe(true);
+    expect(result.itemCount).toBe(2);
+  });
+
+  it('counts open positions when the user has them', () => {
+    const result = usePredictionsDefaultSectionModel(
+      createInput({
+        hasPositions: true,
+        positionsLength: 3,
+        marketsLength: 2,
+      }),
+    );
+
+    expect(result.hasAnyPositions).toBe(true);
+    expect(result.showTrendingAbove).toBe(false);
+    expect(result.itemCount).toBe(3);
   });
 });

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictionsDefaultSectionModel.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictionsDefaultSectionModel.ts
@@ -1,7 +1,6 @@
 export interface UsePredictionsDefaultSectionModelInput {
   isPredictEnabled: boolean;
   isLoadingPositions: boolean;
-  isLoadingClaimable: boolean;
   isLoadingMarkets: boolean;
   isTreatmentDiscovery: boolean;
   isLoadingWorldCupHomepage: boolean;
@@ -10,7 +9,6 @@ export interface UsePredictionsDefaultSectionModelInput {
   positionsError: string | null;
   marketsError: string | null;
   marketsLength: number;
-  totalClaimableValue: number;
 }
 
 export interface PredictionsDefaultSectionModel {
@@ -27,7 +25,6 @@ export interface PredictionsDefaultSectionModel {
 export function usePredictionsDefaultSectionModel({
   isPredictEnabled,
   isLoadingPositions,
-  isLoadingClaimable,
   isLoadingMarkets,
   isTreatmentDiscovery,
   isLoadingWorldCupHomepage,
@@ -36,31 +33,25 @@ export function usePredictionsDefaultSectionModel({
   positionsError,
   marketsError,
   marketsLength,
-  totalClaimableValue,
 }: UsePredictionsDefaultSectionModelInput): PredictionsDefaultSectionModel {
-  const hasClaimablePositions = !isLoadingClaimable && totalClaimableValue > 0;
-  const hasAnyPositions = hasPositions || hasClaimablePositions;
-  const inPositionsLayout =
-    hasAnyPositions || isLoadingPositions || isLoadingClaimable;
+  const inPositionsLayout = hasPositions || isLoadingPositions;
 
   const hasError = Boolean(
     !isLoadingPositions &&
       !isLoadingMarkets &&
-      !isLoadingClaimable &&
-      !hasAnyPositions &&
+      !hasPositions &&
       marketsLength === 0 &&
       (positionsError || (!isTreatmentDiscovery && marketsError)),
   );
 
   const isLoading =
     isLoadingPositions ||
-    isLoadingClaimable ||
     (isTreatmentDiscovery && isLoadingWorldCupHomepage) ||
     (!isTreatmentDiscovery && isLoadingMarkets);
 
   const isEmpty =
     !isLoading &&
-    !hasAnyPositions &&
+    !hasPositions &&
     !hasError &&
     !isTreatmentDiscovery &&
     marketsLength === 0;
@@ -84,18 +75,16 @@ export function usePredictionsDefaultSectionModel({
     isPredictEnabled &&
     !hasError &&
     !isLoading &&
-    (hasAnyPositions || marketsLength > 0 || isTreatmentDiscovery);
+    (hasPositions || marketsLength > 0 || isTreatmentDiscovery);
 
   const itemCount = hasPositions
     ? positionsLength
-    : hasClaimablePositions
-      ? marketsLength || 1
-      : isTreatmentDiscovery
-        ? 1
-        : marketsLength;
+    : isTreatmentDiscovery
+      ? 1
+      : marketsLength;
 
   return {
-    hasAnyPositions,
+    hasAnyPositions: hasPositions,
     hasError,
     isEmpty,
     showTrendingAbove,

--- a/tests/page-objects/Predict/PredictBalance.ts
+++ b/tests/page-objects/Predict/PredictBalance.ts
@@ -16,10 +16,21 @@ class PredictBalance {
     return Matchers.getElementByID(PredictBalanceSelectorsIDs.WITHDRAW_BUTTON);
   }
 
+  get positionsButton(): Promise<AppiumElement> {
+    return Matchers.getElementByID(PredictBalanceSelectorsIDs.POSITIONS_BUTTON);
+  }
+
   async tapWithdraw(): Promise<void> {
     await Utilities.waitForElementToBeEnabled(this.withdrawButton, 15000);
     await Gestures.waitAndTap(this.withdrawButton, {
       elemDescription: 'Predict Withdraw button',
+    });
+  }
+
+  async tapPositions(): Promise<void> {
+    await Utilities.waitForElementToBeEnabled(this.positionsButton, 15000);
+    await Gestures.waitAndTap(this.positionsButton, {
+      elemDescription: 'Predict Positions button',
     });
   }
 

--- a/tests/page-objects/Predict/PredictMarketList.ts
+++ b/tests/page-objects/Predict/PredictMarketList.ts
@@ -17,7 +17,6 @@ import {
   getPredictFeedSelector,
   getPredictMarketListSelector,
 } from '../../../app/components/UI/Predict/Predict.testIds';
-import { PREDICT_PORTFOLIO_TEST_IDS } from '../../../app/components/UI/Predict/views/PredictHome/components/PredictPortfolio/PredictPortfolio.testIds';
 
 type CategoryTab = 'trending' | 'new' | 'sports' | 'crypto' | 'politics';
 type CategoryTabScrollDirection = 'left' | 'right';
@@ -58,10 +57,6 @@ class PredictMarketList {
 
   get addFundsButton(): Promise<AppiumElement> {
     return Matchers.getElementByText('Add funds');
-  }
-
-  get claimButton(): Promise<AppiumElement> {
-    return Matchers.getElementByID(PREDICT_PORTFOLIO_TEST_IDS.CLAIM_BUTTON);
   }
 
   get balanceCard(): Promise<AppiumElement> {
@@ -268,12 +263,6 @@ class PredictMarketList {
   async tapAddFundsButton(): Promise<void> {
     await Gestures.waitAndTap(this.addFundsButton, {
       elemDescription: 'Predict add funds button',
-    });
-  }
-
-  async tapClaimButton(): Promise<void> {
-    await Gestures.waitAndTap(this.claimButton, {
-      elemDescription: 'Predict claim winnings button',
     });
   }
 

--- a/tests/page-objects/Predict/PredictMarketList.ts
+++ b/tests/page-objects/Predict/PredictMarketList.ts
@@ -17,6 +17,7 @@ import {
   getPredictFeedSelector,
   getPredictMarketListSelector,
 } from '../../../app/components/UI/Predict/Predict.testIds';
+import { PREDICT_PORTFOLIO_TEST_IDS } from '../../../app/components/UI/Predict/views/PredictHome/components/PredictPortfolio/PredictPortfolio.testIds';
 
 type CategoryTab = 'trending' | 'new' | 'sports' | 'crypto' | 'politics';
 type CategoryTabScrollDirection = 'left' | 'right';
@@ -57,6 +58,10 @@ class PredictMarketList {
 
   get addFundsButton(): Promise<AppiumElement> {
     return Matchers.getElementByText('Add funds');
+  }
+
+  get claimButton(): Promise<AppiumElement> {
+    return Matchers.getElementByID(PREDICT_PORTFOLIO_TEST_IDS.CLAIM_BUTTON);
   }
 
   get balanceCard(): Promise<AppiumElement> {
@@ -263,6 +268,12 @@ class PredictMarketList {
   async tapAddFundsButton(): Promise<void> {
     await Gestures.waitAndTap(this.addFundsButton, {
       elemDescription: 'Predict add funds button',
+    });
+  }
+
+  async tapClaimButton(): Promise<void> {
+    await Gestures.waitAndTap(this.claimButton, {
+      elemDescription: 'Predict claim winnings button',
     });
   }
 

--- a/tests/page-objects/Predict/PredictPositions.ts
+++ b/tests/page-objects/Predict/PredictPositions.ts
@@ -1,0 +1,40 @@
+import {
+  Assertions,
+  Gestures,
+  Matchers,
+  type AppiumElement,
+} from '../../framework';
+import { resolveE2EWaitTimeoutMs } from '../../framework/Constants';
+import { PredictPositionsViewSelectorsIDs } from '../../../app/components/UI/Predict/Predict.testIds';
+
+class PredictPositions {
+  get container(): Promise<AppiumElement> {
+    return Matchers.getElementByID(PredictPositionsViewSelectorsIDs.CONTAINER);
+  }
+
+  get claimButton(): Promise<AppiumElement> {
+    return Matchers.getElementByID(PredictPositionsViewSelectorsIDs.CLAIM_CTA);
+  }
+
+  async waitForScreenToDisplay(
+    options: { timeout?: number; description?: string } = {},
+  ): Promise<void> {
+    const {
+      timeout = resolveE2EWaitTimeoutMs(20_000),
+      description = 'Predict Positions screen should be visible',
+    } = options;
+
+    await Assertions.expectElementToBeVisible(this.container, {
+      timeout,
+      description,
+    });
+  }
+
+  async tapClaimButton(): Promise<void> {
+    await Gestures.waitAndTap(this.claimButton, {
+      elemDescription: 'Predict Positions claim winnings button',
+    });
+  }
+}
+
+export default new PredictPositions();

--- a/tests/page-objects/Predict/PredictPositions.ts
+++ b/tests/page-objects/Predict/PredictPositions.ts
@@ -12,6 +12,12 @@ class PredictPositions {
     return Matchers.getElementByID(PredictPositionsViewSelectorsIDs.CONTAINER);
   }
 
+  get backButton(): Promise<AppiumElement> {
+    return Matchers.getElementByID(
+      PredictPositionsViewSelectorsIDs.BACK_BUTTON,
+    );
+  }
+
   get claimButton(): Promise<AppiumElement> {
     return Matchers.getElementByID(PredictPositionsViewSelectorsIDs.CLAIM_CTA);
   }
@@ -33,6 +39,12 @@ class PredictPositions {
   async tapClaimButton(): Promise<void> {
     await Gestures.waitAndTap(this.claimButton, {
       elemDescription: 'Predict Positions claim winnings button',
+    });
+  }
+
+  async tapBackButton(): Promise<void> {
+    await Gestures.waitAndTap(this.backButton, {
+      elemDescription: 'Back button on Predict Positions',
     });
   }
 }

--- a/tests/smoke-appium/predict/predict-claim-positions-section.spec.ts
+++ b/tests/smoke-appium/predict/predict-claim-positions-section.spec.ts
@@ -8,6 +8,8 @@ import PredictClaimPage from '../../page-objects/Predict/PredictClaimPage.js';
 import { predictClaimPositionsAnalyticsExpectations } from '../../helpers/analytics/expectations/predict-claim-positions.analytics.js';
 import WalletActionsBottomSheet from '../../page-objects/wallet/WalletActionsBottomSheet.js';
 import PredictMarketList from '../../page-objects/Predict/PredictMarketList.js';
+import PredictBalance from '../../page-objects/Predict/PredictBalance.js';
+import PredictPositions from '../../page-objects/Predict/PredictPositions.js';
 import {
   loginForPredictTests,
   PredictHelpers,
@@ -22,7 +24,7 @@ import {
 
 appiumTest.describe(SmokePredictions('Claim winnings:'), () => {
   appiumTest(
-    'claim winnings via Predict tab',
+    'claim winnings via Predict Positions',
     async ({ driver: _driver, currentDeviceDetails }) => {
       await withFixtures(
         {
@@ -44,7 +46,9 @@ appiumTest.describe(SmokePredictions('Claim winnings:'), () => {
           await PredictMarketList.waitForScreenToDisplay({
             description: 'Predict market list should be visible',
           });
-          await PredictMarketList.tapClaimButton();
+          await PredictBalance.tapPositions();
+          await PredictPositions.waitForScreenToDisplay();
+          await PredictPositions.tapClaimButton();
 
           await postClaimMocks(mockServer);
 

--- a/tests/smoke-appium/predict/predict-claim-positions-section.spec.ts
+++ b/tests/smoke-appium/predict/predict-claim-positions-section.spec.ts
@@ -10,12 +10,11 @@ import WalletActionsBottomSheet from '../../page-objects/wallet/WalletActionsBot
 import PredictMarketList from '../../page-objects/Predict/PredictMarketList.js';
 import PredictBalance from '../../page-objects/Predict/PredictBalance.js';
 import PredictPositions from '../../page-objects/Predict/PredictPositions.js';
+import ToastModal from '../../page-objects/wallet/ToastModal.js';
 import {
   loginForPredictTests,
   PredictHelpers,
 } from './helpers/predict-helpers.js';
-import { waitForWalletHomePlaywright } from '../../flows/wallet.flow.js';
-import { resolveE2EWaitTimeoutMs } from '../../framework/Constants.js';
 import {
   postClaimMocks,
   predictionMarketFeature,
@@ -58,14 +57,13 @@ appiumTest.describe(SmokePredictions('Claim winnings:'), () => {
 
           await verifyResolvedPositionsRemoved();
 
-          // Claim confirm `goBack` can leave a Predict stack on top after RN v7.
-          // Reach wallet home before Activity so details open on a clean stack.
-          await waitForWalletHomePlaywright(resolveE2EWaitTimeoutMs(20_000));
-
-          await TabBarComponent.tapWallet();
-          await waitForWalletHomePlaywright(resolveE2EWaitTimeoutMs(20_000));
-          await TabBarComponent.tapActions();
-          await WalletActionsBottomSheet.tapPredictButton();
+          // Confirm `goBack` returns to Positions, not wallet home. Claim toast
+          // covers the header back control until it dismisses.
+          await ToastModal.waitForToastToDismiss();
+          await PredictPositions.tapBackButton();
+          await PredictMarketList.waitForScreenToDisplay({
+            description: 'Predict market list should be visible after claim',
+          });
           await Assertions.expectTextDisplayed('$48.16');
         },
       );

--- a/tests/smoke-appium/predict/predict-claim-positions-section.spec.ts
+++ b/tests/smoke-appium/predict/predict-claim-positions-section.spec.ts
@@ -3,11 +3,11 @@ import { SmokePredictions } from '../../tags.js';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
 import Assertions from '../../framework/Assertions.js';
-import WalletView from '../../page-objects/wallet/WalletView.js';
 import TabBarComponent from '../../page-objects/wallet/TabBarComponent.js';
 import PredictClaimPage from '../../page-objects/Predict/PredictClaimPage.js';
 import { predictClaimPositionsAnalyticsExpectations } from '../../helpers/analytics/expectations/predict-claim-positions.analytics.js';
 import WalletActionsBottomSheet from '../../page-objects/wallet/WalletActionsBottomSheet.js';
+import PredictMarketList from '../../page-objects/Predict/PredictMarketList.js';
 import {
   loginForPredictTests,
   PredictHelpers,
@@ -22,7 +22,7 @@ import {
 
 appiumTest.describe(SmokePredictions('Claim winnings:'), () => {
   appiumTest(
-    'claim winnings via predictions section',
+    'claim winnings via Predict tab',
     async ({ driver: _driver, currentDeviceDetails }) => {
       await withFixtures(
         {
@@ -39,7 +39,12 @@ appiumTest.describe(SmokePredictions('Claim winnings:'), () => {
           await PredictHelpers.setPortugalLocation();
           await loginForPredictTests();
 
-          await WalletView.tapClaimButton();
+          await TabBarComponent.tapActions();
+          await WalletActionsBottomSheet.tapPredictButton();
+          await PredictMarketList.waitForScreenToDisplay({
+            description: 'Predict market list should be visible',
+          });
+          await PredictMarketList.tapClaimButton();
 
           await postClaimMocks(mockServer);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->


Product wants claim flows off the wallet homepage. Users should claim from Predict Positions / the Predict tab (`PredictPositionsHeader`, `PredictPortfolioModule`), not from `PredictionsSection`.

This PR removes the Claim CTA from the homepage Predictions section entirely:

- Drops `PredictClaimButton`, `usePredictClaim`, and the claimable-positions query from homepage wiring
- Keeps open position rows and unrealized P&L unchanged
- Treats claimable-only users like users with no open positions (trending markets, no claim CTA)
- Updates unit tests so no claim button or claim-amount CTA appears in any homepage Predictions state
- Retargets the Appium claim-winnings smoke spec from the wallet homepage to the Predict tab portfolio claim button

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Removed the Claim button from the wallet homepage Predictions section

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: [TMCU-1207](https://consensyssoftware.atlassian.net/browse/TMCU-1207)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Homepage Predictions claim CTA removal

  Background:
    Given I am logged into MetaMask Mobile
    And Predict is enabled
    And I am on the Wallet home screen

  Scenario: homepage still shows open positions without a Claim CTA
    Given I have at least one open Predict position
    And I have claimable Predict winnings

    When user scrolls to the Predictions section
    Then I should see my open position rows
    And I should see unrealized P&L
    And I should not see a Claim button or claim-amount CTA

  Scenario: claimable-only users see trending markets instead of a Claim CTA
    Given I have no open Predict positions
    And I have claimable Predict winnings

    When user scrolls to the Predictions section
    Then I should see trending / discovery markets
    And I should not see a Claim button or claim-amount CTA
    And I should not see open position rows

  Scenario: user can still claim from the Predict tab
    Given I have claimable Predict winnings

    When user opens Predict from Wallet Actions
    Then I should see a Claim CTA on the Predict tab
    And tapping Claim should start the existing claim confirmation flow

  Scenario: privacy mode still masks position values
    Given I have open Predict positions
    And privacy mode is enabled

    When user views the Predictions section
    Then monetary values on position rows should be masked
    And I should not see a Claim CTA
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="383" height="295" alt="Screenshot 2026-08-28 at 14 36 38" src="https://github.com/user-attachments/assets/221a91ad-441a-4f73-a89f-13605a3de627" />

<!-- [screenshots/recordings] -->

### **After**
<img width="380" height="222" alt="Screenshot 2026-08-28 at 14 35 11" src="https://github.com/user-attachments/assets/0538cb19-da0e-473f-84ec-b5d8039e3ffd" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TMCU-1207]: https://consensyssoftware.atlassian.net/browse/TMCU-1207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing Predict UX change on the wallet home only; claim flow remains on the Predict tab and is covered by updated unit and smoke tests.
> 
> **Overview**
> Removes the **Claim** CTA from the wallet **Predictions** homepage section so winnings are claimed from the Predict tab (Positions / portfolio), not from `PredictionsSection`.
> 
> **Homepage UI and data:** Drops `PredictClaimButton`, `usePredictClaim`, and the second `usePredictPositionsForHomepage` call with `claimable: true`. Open position rows and unrealized P&L stay as-is. `usePredictPositionsForHomepage` now only loads active positions with live price updates and no longer exposes `totalClaimableValue` or a `claimable` option.
> 
> **Layout logic:** `usePredictionsDefaultSectionModel` no longer treats claimable-only balances as a “positions” layout—users with only claimable winnings see discovery/trending markets like users with no open positions, with no claim button on home.
> 
> **Tests:** Unit tests assert the homepage never shows a claim CTA or fetches claimable positions; claim-only homepage scenarios and privacy-mode claim tests are removed. The Appium smoke flow is retargeted from the wallet homepage claim control to **Predict → Positions → claim**, with new page objects for balance/positions navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b3ee6523f9bd37eb4897dffbdab0c6e997ba105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->