### PR TITLE
feat(predict): rotate homepage slots to NFL, BTC, and EPL cp-8.10.0

### DIFF
--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -73,6 +73,13 @@ const HOMEPAGE_DISCOVERY_MARKET_BASE = {
   ],
 };
 
+const HOMEPAGE_DISCOVERY_NFL_MARKET = {
+  ...HOMEPAGE_DISCOVERY_MARKET_BASE,
+  id: '202857',
+  title: 'Pro Football: 2027 Champion',
+  slug: 'pro-football-2027-champion-20260729185915366',
+};
+
 const HOMEPAGE_DISCOVERY_EPL_MARKET = {
   ...HOMEPAGE_DISCOVERY_MARKET_BASE,
   id: '659518',
@@ -80,17 +87,10 @@ const HOMEPAGE_DISCOVERY_EPL_MARKET = {
   slug: 'epl-2027-champion-20260701200428749',
 };
 
-const HOMEPAGE_DISCOVERY_NBA_MARKET = {
-  ...HOMEPAGE_DISCOVERY_MARKET_BASE,
-  id: '478277',
-  title: 'NBA: 2027 Champion',
-  slug: 'nba-2027-champion',
-};
-
 const homepageMarketSlotsMock = () =>
   homepageMarketSlotsResultMock([
+    HOMEPAGE_DISCOVERY_NFL_MARKET,
     HOMEPAGE_DISCOVERY_EPL_MARKET,
-    HOMEPAGE_DISCOVERY_NBA_MARKET,
   ]);
 
 const mockUseABTest = jest.fn(
@@ -657,8 +657,10 @@ describe('PredictionsSection', () => {
       );
 
       await waitFor(() => {
+        expect(
+          screen.getByText('Pro Football: 2027 Champion'),
+        ).toBeOnTheScreen();
         expect(screen.getByText('EPL: 2027 Champion')).toBeOnTheScreen();
-        expect(screen.getByText('NBA: 2027 Champion')).toBeOnTheScreen();
       });
     });
 
@@ -675,7 +677,10 @@ describe('PredictionsSection', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByTestId('homepage-predict-discovery-market-slot-2'),
+          screen.getByTestId('homepage-predict-discovery-market-slot-1'),
+        ).toBeOnTheScreen();
+        expect(
+          screen.getByTestId('homepage-predict-discovery-btc-row'),
         ).toBeOnTheScreen();
         expect(
           screen.getByTestId('homepage-predict-discovery-market-slot-3'),
@@ -683,17 +688,48 @@ describe('PredictionsSection', () => {
       });
       expect(
         within(
-          screen.getByTestId('homepage-predict-discovery-market-slot-2'),
-        ).getByText('EPL: 2027 Champion'),
+          screen.getByTestId('homepage-predict-discovery-market-slot-1'),
+        ).getByText('Pro Football: 2027 Champion'),
       ).toBeOnTheScreen();
       expect(
         within(
           screen.getByTestId('homepage-predict-discovery-market-slot-3'),
-        ).getByText('NBA: 2027 Champion'),
+        ).getByText('EPL: 2027 Champion'),
       ).toBeOnTheScreen();
     });
 
-    it('navigates to the EPL market details from slot 2', async () => {
+    it('navigates to the NFL market details from slot 1', async () => {
+      mockUsePredictMarketsForHomepage.mockReturnValue({
+        markets: noPositionsTrendingMarkets,
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+      renderWithProvider(
+        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Pro Football: 2027 Champion'),
+        ).toBeOnTheScreen();
+      });
+
+      fireEvent.press(screen.getByText('Pro Football: 2027 Champion'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: '202857',
+          entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
+          title: 'Pro Football: 2027 Champion',
+          image: undefined,
+          transactionActiveAbTests: predictEmptyStateTreatmentActiveAbTests,
+        },
+      });
+    });
+
+    it('navigates to the EPL market details from slot 3', async () => {
       mockUsePredictMarketsForHomepage.mockReturnValue({
         markets: noPositionsTrendingMarkets,
         isLoading: false,
@@ -749,7 +785,7 @@ describe('PredictionsSection', () => {
       });
     });
 
-    it('tracks the NBA slot click as a sports CTA', async () => {
+    it('tracks the NFL slot click as a sports CTA', async () => {
       mockUsePredictMarketsForHomepage.mockReturnValue({
         markets: noPositionsTrendingMarkets,
         isLoading: false,
@@ -761,12 +797,14 @@ describe('PredictionsSection', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText('NBA: 2027 Champion')).toBeOnTheScreen();
+        expect(
+          screen.getByText('Pro Football: 2027 Champion'),
+        ).toBeOnTheScreen();
       });
 
       mockTrackEvent.mockClear();
 
-      fireEvent.press(screen.getByText('NBA: 2027 Champion'));
+      fireEvent.press(screen.getByText('Pro Football: 2027 Champion'));
 
       expect(mockTrackEvent).toHaveBeenCalledTimes(1);
       expect(mockTrackEvent).toHaveBeenCalledWith({
@@ -796,7 +834,10 @@ describe('PredictionsSection', () => {
 
       expect(screen.getByText('Predictions')).toBeOnTheScreen();
       expect(
-        screen.getByTestId('homepage-predict-discovery-market-slot-2'),
+        screen.getByTestId('homepage-predict-discovery-market-slot-1'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('homepage-predict-discovery-btc-row'),
       ).toBeOnTheScreen();
       expect(
         screen.getByTestId('homepage-predict-discovery-market-slot-3'),
@@ -830,7 +871,7 @@ describe('PredictionsSection', () => {
         refetch: jest.fn(),
       });
       mockUseHomepagePredictMarketSlots.mockReturnValue(
-        homepageMarketSlotsResultMock([HOMEPAGE_DISCOVERY_EPL_MARKET]),
+        homepageMarketSlotsResultMock([HOMEPAGE_DISCOVERY_NFL_MARKET]),
       );
 
       renderWithProvider(
@@ -839,8 +880,8 @@ describe('PredictionsSection', () => {
 
       expect(
         within(
-          screen.getByTestId('homepage-predict-discovery-market-slot-2'),
-        ).getByText('EPL: 2027 Champion'),
+          screen.getByTestId('homepage-predict-discovery-market-slot-1'),
+        ).getByText('Pro Football: 2027 Champion'),
       ).toBeOnTheScreen();
       expect(
         within(
@@ -1134,8 +1175,10 @@ describe('PredictionsSection', () => {
       await waitFor(() => {
         expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
       });
+      expect(
+        screen.queryByText('Pro Football: 2027 Champion'),
+      ).not.toBeOnTheScreen();
       expect(screen.queryByText('EPL: 2027 Champion')).not.toBeOnTheScreen();
-      expect(screen.queryByText('NBA: 2027 Champion')).not.toBeOnTheScreen();
     });
 
     it('does not render active position rows in claimable-only state', async () => {

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictDiscovery/index.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictDiscovery/index.test.tsx
@@ -164,7 +164,7 @@ describe('HomepagePredictDiscovery', () => {
             detailsTitle: undefined,
           },
           transactionActiveAbTests,
-          testID: 'homepage-predict-discovery-market-slot-2',
+          testID: 'homepage-predict-discovery-market-slot-1',
         }),
         expect.objectContaining({
           state: {
@@ -176,6 +176,16 @@ describe('HomepagePredictDiscovery', () => {
           testID: 'homepage-predict-discovery-market-slot-3',
         }),
       ]);
+    });
+
+    it('renders the BTC series between the configured championship slots', () => {
+      renderComponent();
+
+      expect(getChampionshipRowProps().map(({ testID }) => testID)).toEqual([
+        'homepage-predict-discovery-market-slot-1',
+        'homepage-predict-discovery-market-slot-3',
+      ]);
+      expect(mockBtcLiveRow).toHaveBeenCalledTimes(1);
     });
 
     it('rejects a market whose slug does not match its configured slot', () => {

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictDiscovery/index.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictDiscovery/index.tsx
@@ -17,7 +17,9 @@ import {
 import { usePredictNavigation } from '../../../../../../UI/Predict/hooks/usePredictNavigation';
 import {
   HOMEPAGE_PREDICT_EVENT_SLOTS,
+  HOMEPAGE_PREDICT_MARKET_SLOTS,
   HOMEPAGE_PREDICT_SERIES_SLOT,
+  isHomepagePredictEventSlot,
 } from '../../constants/homepagePredictMarketSlots';
 import type { PredictMarket } from '../../../../../../UI/Predict/types';
 import type { UseHomepagePredictMarketSlotsResult } from '../../hooks/useHomepagePredictMarketSlots';
@@ -50,19 +52,23 @@ const HomepagePredictDiscovery: React.FC<HomepagePredictDiscoveryProps> = ({
 }) => {
   const navigation = useNavigation();
   const { navigateToMarketDetails } = usePredictNavigation();
-  const eventSlotRows = useMemo<ChampionshipRowState[]>(
-    () =>
-      HOMEPAGE_PREDICT_EVENT_SLOTS.map(({ id, slug }) => {
-        const market = marketSlots.marketData.find(
-          (candidate) => candidate.id === id && candidate.slug === slug,
+  const eventSlotStateById = useMemo(() => {
+    const states = new Map<string, ChampionshipRowState>();
+    for (const { id, slug } of HOMEPAGE_PREDICT_EVENT_SLOTS) {
+      const market = marketSlots.marketData.find(
+        (candidate) => candidate.id === id && candidate.slug === slug,
+      );
+      if (market) {
+        states.set(id, { kind: 'market', market, detailsTitle: undefined });
+      } else {
+        states.set(
+          id,
+          marketSlots.isFetching ? { kind: 'loading' } : { kind: 'empty' },
         );
-        if (market) {
-          return { kind: 'market', market, detailsTitle: undefined };
-        }
-        return marketSlots.isFetching ? { kind: 'loading' } : { kind: 'empty' };
-      }),
-    [marketSlots.isFetching, marketSlots.marketData],
-  );
+      }
+    }
+    return states;
+  }, [marketSlots.isFetching, marketSlots.marketData]);
 
   const handleBtcRow = useCallback(
     (
@@ -133,16 +139,20 @@ const HomepagePredictDiscovery: React.FC<HomepagePredictDiscoveryProps> = ({
         entryPoint={PredictEventValues.ENTRY_POINT.HOME_SECTION}
       >
         <Box twClassName="px-4">
-          <BtcLiveRow onPress={handleBtcRow} />
-          {eventSlotRows.map((state, index) => (
-            <ChampionshipRow
-              key={HOMEPAGE_PREDICT_EVENT_SLOTS[index].id}
-              state={state}
-              onPress={handleChampionshipRowPress}
-              transactionActiveAbTests={transactionActiveAbTests}
-              testID={`homepage-predict-discovery-market-slot-${index + 2}`}
-            />
-          ))}
+          {HOMEPAGE_PREDICT_MARKET_SLOTS.map((slot, index) => {
+            if (!isHomepagePredictEventSlot(slot)) {
+              return <BtcLiveRow key={slot.series.id} onPress={handleBtcRow} />;
+            }
+            return (
+              <ChampionshipRow
+                key={slot.id}
+                state={eventSlotStateById.get(slot.id) ?? { kind: 'empty' }}
+                onPress={handleChampionshipRowPress}
+                transactionActiveAbTests={transactionActiveAbTests}
+                testID={`homepage-predict-discovery-market-slot-${index + 1}`}
+              />
+            );
+          })}
         </Box>
       </PredictEntryPointProvider>
     </>

--- a/app/components/Views/Homepage/Sections/Predictions/constants/homepagePredictMarketSlots.test.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/constants/homepagePredictMarketSlots.test.ts
@@ -1,13 +1,19 @@
 import {
   HOMEPAGE_PREDICT_EVENT_QUERY,
+  HOMEPAGE_PREDICT_EVENT_SLOTS,
   HOMEPAGE_PREDICT_MARKET_SLOTS,
 } from './homepagePredictMarketSlots';
 
 describe('homepagePredictMarketSlots', () => {
-  it('defines the August 3–16 slots in display order', () => {
+  it('defines the August 31–September 13 slots in display order', () => {
     const slots = HOMEPAGE_PREDICT_MARKET_SLOTS;
 
     expect(slots).toEqual([
+      {
+        type: 'event',
+        id: '202857',
+        slug: 'pro-football-2027-champion-20260729185915366',
+      },
       {
         type: 'series',
         series: {
@@ -22,10 +28,22 @@ describe('homepagePredictMarketSlots', () => {
         id: '659518',
         slug: 'epl-2027-champion-20260701200428749',
       },
+    ]);
+  });
+
+  it('derives event-backed slots without the BTC series', () => {
+    const eventSlots = HOMEPAGE_PREDICT_EVENT_SLOTS;
+
+    expect(eventSlots).toEqual([
       {
         type: 'event',
-        id: '478277',
-        slug: 'nba-2027-champion',
+        id: '202857',
+        slug: 'pro-football-2027-champion-20260729185915366',
+      },
+      {
+        type: 'event',
+        id: '659518',
+        slug: 'epl-2027-champion-20260701200428749',
       },
     ]);
   });
@@ -34,7 +52,7 @@ describe('homepagePredictMarketSlots', () => {
     const query = HOMEPAGE_PREDICT_EVENT_QUERY;
 
     expect(query).toBe(
-      'active=true&archived=false&closed=false&id=659518&id=478277',
+      'active=true&archived=false&closed=false&id=202857&id=659518',
     );
   });
 });

--- a/app/components/Views/Homepage/Sections/Predictions/constants/homepagePredictMarketSlots.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/constants/homepagePredictMarketSlots.ts
@@ -16,10 +16,6 @@ export type HomepagePredictMarketSlot =
   | HomepagePredictSeriesSlot
   | HomepagePredictEventSlot;
 
-export const isHomepagePredictEventSlot = (
-  slot: HomepagePredictMarketSlot,
-): slot is HomepagePredictEventSlot => slot.type === 'event';
-
 export const HOMEPAGE_PREDICT_SERIES_SLOT = {
   type: 'series',
   series: BTC_UP_OR_DOWN_5M_SERIES,
@@ -54,6 +50,14 @@ export const HOMEPAGE_PREDICT_MARKET_SLOTS = [
     slug: 'epl-2027-champion-20260701200428749',
   },
 ] as const satisfies readonly HomepagePredictMarketSlot[];
+
+type HomepagePredictConfiguredSlot =
+  (typeof HOMEPAGE_PREDICT_MARKET_SLOTS)[number];
+
+export const isHomepagePredictEventSlot = (
+  slot: HomepagePredictConfiguredSlot,
+): slot is Extract<HomepagePredictConfiguredSlot, { type: 'event' }> =>
+  slot.type === 'event';
 
 export const HOMEPAGE_PREDICT_EVENT_SLOTS =
   HOMEPAGE_PREDICT_MARKET_SLOTS.filter(isHomepagePredictEventSlot);

--- a/app/components/Views/Homepage/Sections/Predictions/constants/homepagePredictMarketSlots.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/constants/homepagePredictMarketSlots.ts
@@ -16,34 +16,47 @@ export type HomepagePredictMarketSlot =
   | HomepagePredictSeriesSlot
   | HomepagePredictEventSlot;
 
-/**
- * Predict homepage market slots for August 3–16, 2026.
- *
- * Polymarket represents the championship selections as events containing one
- * market per team, so their IDs are queried through the Gamma events endpoint.
- */
-export const HOMEPAGE_PREDICT_EVENT_SLOTS = [
-  {
-    type: 'event',
-    id: '659518',
-    slug: 'epl-2027-champion-20260701200428749',
-  },
-  {
-    type: 'event',
-    id: '478277',
-    slug: 'nba-2027-champion',
-  },
-] as const satisfies readonly HomepagePredictEventSlot[];
+export const isHomepagePredictEventSlot = (
+  slot: HomepagePredictMarketSlot,
+): slot is HomepagePredictEventSlot => slot.type === 'event';
 
 export const HOMEPAGE_PREDICT_SERIES_SLOT = {
   type: 'series',
   series: BTC_UP_OR_DOWN_5M_SERIES,
 } as const satisfies HomepagePredictSeriesSlot;
 
+/**
+ * Predict homepage market slots for August 31–September 13, 2026.
+ *
+ * Slot 1 is Polymarket NFL Champion 2027. Kalshi NFL Week 1 was the Sep 1
+ * gate candidate; homepage discovery is Polymarket Gamma-only and Kalshi is
+ * not enabled, so Slot 1 stays on this event.
+ *
+ * Slot 3 stays EPL Champion 2027. US Open Men's Winner (id 139236) is live
+ * but resolves around Sep 7, which would leave Slot 3 empty for the rest of
+ * this window.
+ *
+ * Polymarket championships are events with one market per team; IDs are
+ * queried through the Gamma events endpoint. Event 202857's live slug is
+ * `pro-football-2027-champion-20260729185915366` (not the calendar alias
+ * `big-game-champion-2027`).
+ */
 export const HOMEPAGE_PREDICT_MARKET_SLOTS = [
+  {
+    type: 'event',
+    id: '202857',
+    slug: 'pro-football-2027-champion-20260729185915366',
+  },
   HOMEPAGE_PREDICT_SERIES_SLOT,
-  ...HOMEPAGE_PREDICT_EVENT_SLOTS,
+  {
+    type: 'event',
+    id: '659518',
+    slug: 'epl-2027-champion-20260701200428749',
+  },
 ] as const satisfies readonly HomepagePredictMarketSlot[];
+
+export const HOMEPAGE_PREDICT_EVENT_SLOTS =
+  HOMEPAGE_PREDICT_MARKET_SLOTS.filter(isHomepagePredictEventSlot);
 
 export const HOMEPAGE_PREDICT_EVENT_QUERY = [
   'active=true',

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictMarketSlots.test.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictMarketSlots.test.ts
@@ -26,16 +26,20 @@ const createMarket = (
 
 describe('orderHomepagePredictEventMarkets', () => {
   it('returns configured events in slot order', () => {
-    const nba = createMarket('478277', 'nba-2027-champion', 'NBA');
+    const nfl = createMarket(
+      '202857',
+      'pro-football-2027-champion-20260729185915366',
+      'NFL',
+    );
     const epl = createMarket(
       '659518',
       'epl-2027-champion-20260701200428749',
       'EPL',
     );
 
-    const result = orderHomepagePredictEventMarkets([nba, epl]);
+    const result = orderHomepagePredictEventMarkets([epl, nfl]);
 
-    expect(result).toEqual([epl, nba]);
+    expect(result).toEqual([nfl, epl]);
   });
 
   it('excludes an event when its slug does not match config', () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Rotates the wallet homepage Predict discovery slots for the Aug 31–Sep 13 window. NFL Week 1 is Sep 9, so NFL takes Slot 1 and BTC drops to Slot 2.

Final lineup:

| Slot | Market | ID / series | Slug |
| --- | --- | --- | --- |
| 1 | NFL Champion 2027 (Polymarket) | 202857 | `pro-football-2027-champion-20260729185915366` |
| 2 | BTC Up/Down 5m | series 10684 | `btc-up-or-down-5m` |
| 3 | EPL Champion 2027 | 659518 | `epl-2027-champion-20260701200428749` |

Sep 1 Kalshi gate: Slot 1 stays on Polymarket NFL Champion 2027. Homepage discovery is Gamma-only and Kalshi is not enabled (`venues.kalshi.enabled` defaults false), so Kalshi NFL Week 1 cannot render in this surface.

US Open Men's Winner (`139236` / `2026-mens-us-open-winner-tennis`) is live but resolves around Sep 7, which would leave Slot 3 empty for the rest of the window. Keep EPL.

Gamma event 202857's live slug is `pro-football-2027-champion-20260729185915366`, not the calendar alias `big-game-champion-2027`. Slot matching requires both id and slug, so the live slug is required.

`HomepagePredictDiscovery` now renders from `HOMEPAGE_PREDICT_MARKET_SLOTS` instead of hardcoding BTC as row 1, so later calendar rotations only need a config change.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated Predict homepage featured markets to NFL Champion 2027, BTC Up/Down 5m, and EPL Champion 2027

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: [TMCU-1146](https://consensyssoftware.atlassian.net/browse/TMCU-1146)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Homepage Predict market slots for Aug 31–Sep 13

  Background:
    Given I am logged into MetaMask Mobile
    And Predict is enabled
    And I have no open Predict positions
    And the Predictions empty-state experiment is in treatment
    And I am on the Wallet home screen

  Scenario: discovery shows NFL, BTC, then EPL
    When user scrolls to the Predictions section

    Then Slot 1 should show Pro Football: 2027 Champion
    And Slot 2 should show the live BTC Up/Down 5m row
    And Slot 3 should show EPL: 2027 Champion
    And I should not see NBA: 2027 Champion

  Scenario: NFL slot opens market details
    When user taps Slot 1

    Then I should land on Predict market details for event 202857
    And the title should be Pro Football: 2027 Champion

  Scenario: BTC slot opens the current 5m window
    When user taps Slot 2

    Then I should land on the current BTC Up/Down 5m market
    And the row should show a live countdown

  Scenario: EPL slot opens market details
    When user taps Slot 3

    Then I should land on Predict market details for event 659518
    And the title should be EPL: 2027 Champion

  Scenario: same lineup on both platforms
    Given I repeat the discovery scenario on iOS and Android

    Then the same three markets should render in the same order
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="385" height="281" alt="Screenshot 2026-08-28 at 14 53 57" src="https://github.com/user-attachments/assets/58d626e9-830b-45af-b464-164545f73f54" />

<!-- [screenshots/recordings] -->

### **After**
<img width="382" height="286" alt="Screenshot 2026-08-28 at 14 52 24" src="https://github.com/user-attachments/assets/e40a3515-daa8-4741-85d0-edfb1c9adc77" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TMCU-1146]: https://consensyssoftware.atlassian.net/browse/TMCU-1146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Calendar/config and UI ordering changes on the Predict homepage empty-state discovery surface, with no auth or payment impact and broad test coverage.
> 
> **Overview**
> Updates the **Aug 31–Sep 13** Predict homepage discovery lineup to **NFL Champion 2027** (slot 1), **BTC Up/Down 5m** (slot 2), and **EPL Champion 2027** (slot 3), replacing **NBA** and refreshing Gamma event ids/slugs (including NFL `202857` with the live `pro-football-2027-champion-*` slug).
> 
> **`HOMEPAGE_PREDICT_MARKET_SLOTS`** is now the single ordered config (event → series → event); event-only slots and the events query are **derived** via `isHomepagePredictEventSlot` / `HOMEPAGE_PREDICT_EVENT_SLOTS`.
> 
> **`HomepagePredictDiscovery`** walks that list so BTC renders **between** the two championship rows instead of always on top; championship `testID`s follow slot index (`market-slot-1` / `market-slot-3`) with an explicit BTC row test id in integration tests.
> 
> Tests and hooks specs are aligned with the new order, navigation, sports CTA analytics, and unavailable-slot behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e65f3b72054497c0fe99ef50a62a084bfdb43eee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->