### PR TITLE
chore(social): make trader feed cache windows explicit

### DIFF
--- a/app/components/Views/SocialLeaderboard/FeedView/hooks/useTraderFeed.test.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/hooks/useTraderFeed.test.ts
@@ -1,6 +1,10 @@
 import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react-native';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  QueryClient,
+  QueryClientProvider,
+  type QueryObserverOptions,
+} from '@tanstack/react-query';
 import { useTraderFeed } from './useTraderFeed';
 import type { FeedTypeFilter } from '../types';
 import { FEED_CAIP2_CHAINS } from '../feed-constants';
@@ -390,8 +394,9 @@ describe('useTraderFeed', () => {
     await waitFor(() => expect(result.current.items).toHaveLength(1));
 
     const cachedQuery = queryClient.getQueryCache().getAll()[0];
-    expect(cachedQuery?.options.staleTime).toBe(1000 * 60 * 5);
-    expect(cachedQuery?.options.gcTime).toBe(1000 * 60 * 60 * 24);
+    const queryOptions = cachedQuery?.options as QueryObserverOptions;
+    expect(queryOptions.staleTime).toBe(1000 * 60 * 5);
+    expect(queryOptions.gcTime).toBe(1000 * 60 * 60 * 24);
 
     unmount();
     queryClient.clear();

--- a/app/components/Views/SocialLeaderboard/FeedView/hooks/useTraderFeed.test.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/hooks/useTraderFeed.test.ts
@@ -376,6 +376,27 @@ describe('useTraderFeed', () => {
     expect(result.current.hasLoadedItems).toBe(true);
   });
 
+  it('uses a 5 minute staleTime and 24 hour gcTime on the UI query', async () => {
+    mockCall.mockResolvedValue(mockFeedResponse([mockSpotFeedItem()]));
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+    });
+
+    const { result, unmount } = renderHook(
+      () => useTraderFeed({ audience: 'all' }),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+
+    const cachedQuery = queryClient.getQueryCache().getAll()[0];
+    expect(cachedQuery?.options.staleTime).toBe(1000 * 60 * 5);
+    expect(cachedQuery?.options.gcTime).toBe(1000 * 60 * 60 * 24);
+
+    unmount();
+    queryClient.clear();
+  });
+
   it('does not refetch when first-page data is already in the cache', async () => {
     mockCall.mockResolvedValue(mockFeedResponse([mockSpotFeedItem()]));
     const queryClient = new QueryClient({

--- a/app/components/Views/SocialLeaderboard/FeedView/hooks/useTraderFeed.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/hooks/useTraderFeed.ts
@@ -141,6 +141,11 @@ export const useTraderFeed = (
     initialPageParam: undefined as string | undefined,
     enabled: enabled && isUnlocked,
     retry: false,
+    // UI QueryClient owns this snapshot (same windows as ReactQueryService
+    // defaults). SocialService.fetchFeed still uses staleTime: 0, so each
+    // queryFn run is a network fetch.
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 60 * 24,
   });
 
   const pages = query.data?.pages ?? undefined;


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`useTraderFeed` was inheriting the UI QueryClient defaults (`staleTime` 5 min, `gcTime` 24h) from `ReactQueryService`. Those windows are what make `prefetchTraderFeeds` useful: opening Feed within 5 minutes does not refetch.

This PR sets those values explicitly on the infinite query so they are not confused with v4 `cacheTime` or with coordinator-style `staleTime: 0` used by What's Happening / Market Insights. `SocialService.fetchFeed` stays always-fresh (`staleTime: 0`) on each `queryFn` run; the UI client owns the snapshot.

No UX change. What's Happening and Market Insights are intentionally untouched.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: TSA-1033

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Trader feed cache windows

  Background:
    Given I am logged into MetaMask Mobile
    And Social / trader feed is enabled

  Scenario: opening Feed shortly after prefetch does not show a full reload
    Given I have visited a screen that prefetches trader feeds
    And fewer than 5 minutes have passed

    When user opens the trader Feed
    Then the first page is shown from the UI cache without a skeleton refetch

  Scenario: pull-to-refresh still fetches the newest page
    Given I am on the trader Feed with loaded items

    When user pulls to refresh
    Then the first page is refetched from the network
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and explicit query options only; behavior should match prior UI QueryClient defaults with test coverage added.
> 
> **Overview**
> **`useTraderFeed`** now sets **`staleTime` (5 minutes)** and **`gcTime` (24 hours)** directly on its `useInfiniteQuery` instead of relying on the UI `QueryClient` defaults from `ReactQueryService`. Inline comments clarify that the UI client owns the cached snapshot while each `queryFn` run still hits the network via `SocialService.fetchFeed`.
> 
> A new unit test asserts those observer options on the cached query when client defaults are zeroed out, so the windows stay documented and regression-safe. **No intended UX change**—prefetch-to-open behavior within five minutes should match before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1f19ab61a7cf0416050814ca816867c58612c53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->