### PR TITLE
feat(social): include BSC and Robinhood in follow trading queries

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
@@ -268,7 +268,7 @@ describe('TopTradersSection', () => {
 
     expect(mockUseTopTraders).toHaveBeenCalledWith(
       expect.objectContaining({
-        chains: ['base', 'solana', 'ethereum', 'robinhood'],
+        chains: ['base', 'solana', 'ethereum', 'bsc', 'robinhood'],
         sort: 'pnl',
         timeframe: '7d',
         limit: 50,
@@ -425,7 +425,7 @@ describe('TopTradersSection', () => {
 
     expect(mockUseTopTraders).toHaveBeenCalledWith(
       expect.objectContaining({
-        chains: ['base', 'solana', 'ethereum', 'robinhood'],
+        chains: ['base', 'solana', 'ethereum', 'bsc', 'robinhood'],
       }),
     );
   });

--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
@@ -268,7 +268,7 @@ describe('TopTradersSection', () => {
 
     expect(mockUseTopTraders).toHaveBeenCalledWith(
       expect.objectContaining({
-        chains: ['base', 'solana', 'ethereum'],
+        chains: ['base', 'solana', 'ethereum', 'robinhood'],
         sort: 'pnl',
         timeframe: '7d',
         limit: 50,
@@ -425,7 +425,7 @@ describe('TopTradersSection', () => {
 
     expect(mockUseTopTraders).toHaveBeenCalledWith(
       expect.objectContaining({
-        chains: ['base', 'solana', 'ethereum'],
+        chains: ['base', 'solana', 'ethereum', 'robinhood'],
       }),
     );
   });

--- a/app/components/Views/SocialLeaderboard/FeedView/feed-constants.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/feed-constants.ts
@@ -9,6 +9,7 @@ import type { CaipChainId } from '@metamask/utils';
 export const FEED_CAIP2_CHAINS: readonly CaipChainId[] = [
   'eip155:8453', // base
   'eip155:1', // ethereum
+  'eip155:4663', // robinhood
   'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', // solana mainnet
   'eip155:999', // hyperliquid
 ];

--- a/app/components/Views/SocialLeaderboard/FeedView/feed-constants.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/feed-constants.ts
@@ -9,6 +9,7 @@ import type { CaipChainId } from '@metamask/utils';
 export const FEED_CAIP2_CHAINS: readonly CaipChainId[] = [
   'eip155:8453', // base
   'eip155:1', // ethereum
+  'eip155:56', // bsc
   'eip155:4663', // robinhood
   'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', // solana mainnet
   'eip155:999', // hyperliquid

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -266,13 +266,20 @@ const expectLatestQueryEnabledStates = (expected: Record<TabKey, boolean>) => {
   expect(latestCalls).toEqual([
     [
       expect.objectContaining({
-        chains: ['base', 'solana', 'ethereum', 'robinhood', 'hyperliquid'],
+        chains: [
+          'base',
+          'solana',
+          'ethereum',
+          'bsc',
+          'robinhood',
+          'hyperliquid',
+        ],
         enabled: expected.all,
       }),
     ],
     [
       expect.objectContaining({
-        chains: ['base', 'solana', 'ethereum', 'robinhood'],
+        chains: ['base', 'solana', 'ethereum', 'bsc', 'robinhood'],
         enabled: expected.tokens,
       }),
     ],
@@ -700,14 +707,14 @@ describe('TopTradersView', () => {
     expect(mockUseTopTradersHook).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        chains: ['base', 'solana', 'ethereum', 'robinhood'],
+        chains: ['base', 'solana', 'ethereum', 'bsc', 'robinhood'],
         enabled: true,
       }),
     );
     expect(mockUseTopTradersHook).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        chains: ['base', 'solana', 'ethereum', 'robinhood'],
+        chains: ['base', 'solana', 'ethereum', 'bsc', 'robinhood'],
         enabled: false,
       }),
     );

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -266,13 +266,13 @@ const expectLatestQueryEnabledStates = (expected: Record<TabKey, boolean>) => {
   expect(latestCalls).toEqual([
     [
       expect.objectContaining({
-        chains: ['base', 'solana', 'ethereum', 'hyperliquid'],
+        chains: ['base', 'solana', 'ethereum', 'robinhood', 'hyperliquid'],
         enabled: expected.all,
       }),
     ],
     [
       expect.objectContaining({
-        chains: ['base', 'solana', 'ethereum'],
+        chains: ['base', 'solana', 'ethereum', 'robinhood'],
         enabled: expected.tokens,
       }),
     ],
@@ -700,14 +700,14 @@ describe('TopTradersView', () => {
     expect(mockUseTopTradersHook).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        chains: ['base', 'solana', 'ethereum'],
+        chains: ['base', 'solana', 'ethereum', 'robinhood'],
         enabled: true,
       }),
     );
     expect(mockUseTopTradersHook).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        chains: ['base', 'solana', 'ethereum'],
+        chains: ['base', 'solana', 'ethereum', 'robinhood'],
         enabled: false,
       }),
     );

--- a/app/components/Views/shared/top-traders-constants.ts
+++ b/app/components/Views/shared/top-traders-constants.ts
@@ -8,6 +8,7 @@ export const SPOT_CHAINS: string[] = [
   'base',
   'solana',
   'ethereum',
+  'bsc',
   'robinhood',
 ];
 

--- a/app/components/Views/shared/top-traders-constants.ts
+++ b/app/components/Views/shared/top-traders-constants.ts
@@ -4,7 +4,12 @@
 // homepage carousel).
 // ALL_CHAINS: combined spot + perps rankings (TopTradersView "All" tab).
 // PERP_CHAINS: perps-only rankings (TopTradersView "Perps" tab).
-export const SPOT_CHAINS: string[] = ['base', 'solana', 'ethereum'];
+export const SPOT_CHAINS: string[] = [
+  'base',
+  'solana',
+  'ethereum',
+  'robinhood',
+];
 
 export const ALL_CHAINS: string[] = [...SPOT_CHAINS, 'hyperliquid'];
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The social API now accepts `bsc` and `robinhood` on public trading surfaces (`SupportedChainEnum` / `SUPPORTED_CAIP2_CHAIN_IDS`). Follow Trading still requested only Base, Ethereum, Solana, and Hyperliquid, so those traders and feed items never arrived even when the API had them.

This PR adds `bsc` and `robinhood` to `SPOT_CHAINS` (leaderboard All/Tokens, onboarding, homepage carousel) and `eip155:56` / `eip155:4663` to `FEED_CAIP2_CHAINS`. Mapping, badges, and Buy CTA already handle both chains via `chainMapping.ts`; no UI chrome changes.

<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-28 at 17 28 25" src="https://github.com/user-attachments/assets/549eac7b-a284-48fd-bfec-9004f230d4a2" />


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: NA

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: BSC and Robinhood Chain in Follow Trading

  Background:
    Given I am logged into MetaMask Mobile
    And Follow Trading / Social Leaderboard is enabled
    And the social API environment includes bsc and robinhood in SupportedChainEnum

  Scenario: leaderboard includes BSC and Robinhood traders
    Given I open Follow Trading
    And I am on the Leaderboard tab

    When I view the All and Tokens type filters
    Then traders with BSC or Robinhood activity can appear in the ranked list
    And the request includes chains containing bsc and robinhood

  Scenario: feed includes BSC and Robinhood spot trades
    Given I open Follow Trading
    And I am on the Feed tab

    When the feed loads
    Then BSC and Robinhood spot items can appear with the correct network badge
    And tapping a spot item opens position detail with Buy still functioning

  Scenario: homepage carousel uses the expanded spot chain set
    Given I am on the Wallet home screen
    And the Top Traders section is visible

    When the carousel loads
    Then the request includes bsc and robinhood among spot chains
```

Note: if a given API environment has no BSC or Robinhood rows yet, the UI will look unchanged. Confirm via request query params (`chains=bsc`, `chains=robinhood` / `eip155:56`, `eip155:4663`) rather than requiring a row on screen.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no visual chrome change; only which chains are requested.

### **After**

N/A — no visual chrome change; BSC and Robinhood rows appear only when the API returns them.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope-limited constant and test updates that widen query parameters; no auth or payment logic, with behavior unchanged until the API returns BSC/Robinhood data.
> 
> **Overview**
> **Expands Follow Trading API chain filters** so BSC and Robinhood spot activity can appear in leaderboard rankings, the trader feed, and the home Top Traders carousel—aligned with the social API’s supported chain set.
> 
> `SPOT_CHAINS` now includes `bsc` and `robinhood`, which flows into **Tokens** / spot-only leaderboard queries, the homepage carousel, and onboarding when perps are off; `ALL_CHAINS` picks them up automatically for the **All** tab. `FEED_CAIP2_CHAINS` adds `eip155:56` and `eip155:4663` so feed fetches request the same networks. **Tests** were updated to assert the wider `chains` arguments—no new UI or mapping work in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e936789f21f628044e905de4d564d1040d5a3ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->