### PR TITLE
chore: use android for fixture validation and update

### DIFF
--- a/.github/actions/download-e2e-artifact/action.yml
+++ b/.github/actions/download-e2e-artifact/action.yml
@@ -15,20 +15,46 @@ inputs:
   runner-provider:
     description: 'Runner provider or runner label. Namespace download is used when this contains `namespace`.'
     required: true
+  run-id:
+    description: 'Optional workflow run ID to download from. Defaults to the current run.'
+    required: false
+    default: ''
+  github-token:
+    description: 'GitHub token required when downloading from another workflow run.'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
   steps:
-    - name: Download from Namespace
-      if: ${{ contains(inputs.runner-provider, 'namespace') }}
+    - name: Download from Namespace (current run)
+      if: ${{ contains(inputs.runner-provider, 'namespace') && inputs.run-id == '' }}
       uses: namespace-actions/download-artifact@7cbad919e4b0e09f17e9d6311a444ff002992b5b # v2.0.1
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
 
-    - name: Download from GitHub
-      if: ${{ !contains(inputs.runner-provider, 'namespace') }}
+    - name: Download from Namespace (specified run)
+      if: ${{ contains(inputs.runner-provider, 'namespace') && inputs.run-id != '' }}
+      uses: namespace-actions/download-artifact@7cbad919e4b0e09f17e9d6311a444ff002992b5b # v2.0.1
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        run-id: ${{ inputs.run-id }}
+        github-token: ${{ inputs.github-token }}
+
+    - name: Download from GitHub (current run)
+      if: ${{ !contains(inputs.runner-provider, 'namespace') && inputs.run-id == '' }}
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
+
+    - name: Download from GitHub (specified run)
+      if: ${{ !contains(inputs.runner-provider, 'namespace') && inputs.run-id != '' }}
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        run-id: ${{ inputs.run-id }}
+        github-token: ${{ inputs.github-token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1726,6 +1726,7 @@ jobs:
       test-timeout-minutes: 25
       build_type: 'main'
       metamask_environment: 'e2e'
+      appium_retries_override: 0
       # Mirrors build-android-apps' resolution chain so this consumer always matches
       # the builder's artifact store (GitHub on current, Namespace store on namespace).
       runner_provider: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1726,7 +1726,6 @@ jobs:
       test-timeout-minutes: 25
       build_type: 'main'
       metamask_environment: 'e2e'
-      appium_retries_override: 0
       # Mirrors build-android-apps' resolution chain so this consumer always matches
       # the builder's artifact store (GitHub on current, Namespace store on namespace).
       runner_provider: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1592,8 +1592,7 @@ jobs:
       - name: iOS build complete
         run: echo "Dummy step to better visualize the Android and iOS E2E tests in Github workflow graph"
 
-  # Detox iOS E2E smoke workflow removed — tags fully migrated to Appium
-  # (run-appium-smoke-tests-ios.yml).
+
 
   appium-smoke-tests-android:
     name: 'Appium Smoke Tests (Android)'
@@ -1695,16 +1694,18 @@ jobs:
     secrets: inherit
 
   # Fixture validation — ensures committed E2E fixtures match the live app state schema
-  # Runs on iOS only, so on PRs into main it runs only when iOS was requested via
-  # run-appium-ios-tests or skip-smart-e2e-selection. It still runs on PRs into
-  # release/* that build iOS. Moving this to Android would make it unconditional
-  # on PRs again — tracked separately.
+  # Runs on Android only, so on PRs into main it runs only when Android was requested via
+  # run-appium-android-tests or skip-smart-e2e-selection. It still runs on PRs into
+  # release/* that build Android.
   validate-e2e-fixtures:
     name: 'Validate E2E Fixtures'
     if: >-
       ${{
-        needs.ios-tests-ready.result == 'success' &&
-        github.event_name == 'pull_request'
+        !cancelled() &&
+        needs.build-android-apks.result == 'success' &&
+        (needs.prepare-e2e-timings.result == 'success' ||
+          needs.prepare-e2e-timings.result == 'skipped' ||
+          needs.prepare-e2e-timings.result == 'failure')
       }}
     permissions:
       contents: read
@@ -1713,23 +1714,24 @@ jobs:
       # Nested run-appium-e2e-workflow requires these; missing grants → ci startup_failure.
       actions: read
       pull-requests: read
-    needs: [get_requirements, ios-tests-ready, smart-e2e-selection]
+    # Include prepare to avoid a timings race; failure/skipped still run (equal-count fallback).
+    needs: [build-android-apks, smart-e2e-selection, prepare-e2e-timings, get_requirements]
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
       test-suite-name: validate-e2e-fixtures
-      platform: ios
+      platform: android
       test_suite_tag: FixtureValidation
       split_number: 1
       total_splits: 1
       test-timeout-minutes: 25
       build_type: 'main'
       metamask_environment: 'e2e'
-      # Mirrors build-ios-apps' resolution chain so this consumer always matches
+      # Mirrors build-android-apps' resolution chain so this consumer always matches
       # the builder's artifact store (GitHub on current, Namespace store on namespace).
       runner_provider: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-          vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          vars.NAMESPACE_RUNNER_ANDROID || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
         }}
     secrets: inherit
 

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -70,7 +70,7 @@ on:
         description: 'Override for Appium test retries (0 disables retries)'
         required: false
         type: number
-        # No default - only set if explicitly passed
+        # No default - only set if explicitly passed (it will fallback to whatever is defined in the Playwright config)
 
 permissions:
   contents: read

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -66,6 +66,11 @@ on:
         required: false
         type: string
         default: 'default'
+      appium_retries_override:
+        description: 'Override for Appium test retries (0 disables retries)'
+        required: false
+        type: number
+        # No default - only set if explicitly passed
 
 permissions:
   contents: read
@@ -123,7 +128,6 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
           OUTPUT_PATH: ./e2e-timings.json
-
       # On re-run, reuse prior Playwright JSON / shard-status to skip passed specs.
       - name: Download previous Playwright results (on re-run)
         if: ${{ github.run_attempt > 1 }}
@@ -196,6 +200,14 @@ jobs:
           configure-keystores: 'false'
           install-foundry: 'true'
           runner_provider: ${{ inputs.runner_provider }}
+
+      - name: Set APPIUM_RETRIES_OVERRIDE
+        run: |
+          if [[ -n "${{ inputs.appium_retries_override }}" ]]; then
+            export APPIUM_RETRIES_OVERRIDE="${{ inputs.appium_retries_override }}"
+            echo "APPIUM_RETRIES_OVERRIDE set to: ${APPIUM_RETRIES_OVERRIDE}"
+          fi
+        shell: bash
 
       - name: Setup E2E environment (iOS)
         if: ${{ inputs.platform == 'ios' && steps.select-specs.outputs.spec_count != '0' }}

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -537,7 +537,7 @@ jobs:
 
       - name: Upload fixture validation reports
         if: ${{ always() && inputs.test_suite_tag == 'FixtureValidation' && steps.select-specs.outputs.spec_count != '0' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: fixture-validation-results-${{ inputs.test-suite-name }}
           path: |

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -66,11 +66,6 @@ on:
         required: false
         type: string
         default: 'default'
-      appium_retries_override:
-        description: 'Override for Appium test retries (0 disables retries)'
-        required: false
-        type: number
-        # No default - only set if explicitly passed (it will fallback to whatever is defined in the Playwright config)
 
 permissions:
   contents: read
@@ -412,7 +407,6 @@ jobs:
           PLAYWRIGHT_JSON_OUTPUT_FILE: tests/test-reports/playwright-json/playwright-report.json
           APPIUM_RECORD_VIDEO_ON_FAILURE: 'true'
           SKIP_APPIUM_STOP: 'true'
-          APPIUM_RETRIES_OVERRIDE: ${{ inputs.appium_retries_override }}
           ANDROID_APK_PATH: ${{ steps.android-artifacts.outputs.apk-target-path }}/${{ steps.android-artifacts.outputs.apk-file-name }}
           ANDROID_AVD_NAME: appium_smoke_avd
           ANDROID_APPIUM_USE_PACKAGE_ONLY: 'true'
@@ -423,6 +417,8 @@ jobs:
           ANDROID_EMULATOR_NETWORK_READY_CONSECUTIVE_PINGS: '3'
           # Required for Anvil mainnet forks (SmokeStake and other fork-based suites).
           MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
+          # Disable retries for fixture validation — failures must surface immediately. - Otherwise it will fall back to playwright config default
+          APPIUM_RETRIES_OVERRIDE: ${{ inputs.test_suite_tag == 'FixtureValidation' && '0' || '' }}
         run: |
           set -euo pipefail
           read -r -a specs <<< "${SPEC_FILES}"
@@ -453,11 +449,12 @@ jobs:
           SKIP_DEVICE_BOOT: 'true'
           SKIP_APP_REINSTALL: 'true'
           USE_PREBUILT_WDA: 'true'
-          APPIUM_RETRIES_OVERRIDE: ${{ inputs.appium_retries_override }}
           IOS_SIMULATOR_POST_BOOT_SETTLE_MS: '30000'
           IOS_PRE_LAUNCH_SETTLE_MS: '1500'
           # Required for Anvil mainnet forks (SmokeStake and other fork-based suites).
           MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
+          # Disable retries for fixture validation — failures must surface immediately. - Otherwise it will fall back to playwright config default
+          APPIUM_RETRIES_OVERRIDE: ${{ inputs.test_suite_tag == 'FixtureValidation' && '0' || '' }}
         run: |
           set -euo pipefail
           read -r -a specs <<< "${SPEC_FILES}"

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -201,14 +201,6 @@ jobs:
           install-foundry: 'true'
           runner_provider: ${{ inputs.runner_provider }}
 
-      - name: Set APPIUM_RETRIES_OVERRIDE
-        run: |
-          if [[ -n "${{ inputs.appium_retries_override }}" ]]; then
-            export APPIUM_RETRIES_OVERRIDE="${{ inputs.appium_retries_override }}"
-            echo "APPIUM_RETRIES_OVERRIDE set to: ${APPIUM_RETRIES_OVERRIDE}"
-          fi
-        shell: bash
-
       - name: Setup E2E environment (iOS)
         if: ${{ inputs.platform == 'ios' && steps.select-specs.outputs.spec_count != '0' }}
         uses: ./.github/actions/setup-e2e-env
@@ -420,6 +412,7 @@ jobs:
           PLAYWRIGHT_JSON_OUTPUT_FILE: tests/test-reports/playwright-json/playwright-report.json
           APPIUM_RECORD_VIDEO_ON_FAILURE: 'true'
           SKIP_APPIUM_STOP: 'true'
+          APPIUM_RETRIES_OVERRIDE: ${{ inputs.appium_retries_override }}
           ANDROID_APK_PATH: ${{ steps.android-artifacts.outputs.apk-target-path }}/${{ steps.android-artifacts.outputs.apk-file-name }}
           ANDROID_AVD_NAME: appium_smoke_avd
           ANDROID_APPIUM_USE_PACKAGE_ONLY: 'true'
@@ -460,6 +453,7 @@ jobs:
           SKIP_DEVICE_BOOT: 'true'
           SKIP_APP_REINSTALL: 'true'
           USE_PREBUILT_WDA: 'true'
+          APPIUM_RETRIES_OVERRIDE: ${{ inputs.appium_retries_override }}
           IOS_SIMULATOR_POST_BOOT_SETTLE_MS: '30000'
           IOS_PRE_LAUNCH_SETTLE_MS: '1500'
           # Required for Anvil mainnet forks (SmokeStake and other fork-based suites).

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -190,6 +190,18 @@ jobs:
     if: ${{ !cancelled() && needs.prepare.result == 'success' && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
 
     steps:
+      - name: Checkout (Namespace)
+        if: ${{ inputs.runner_provider == 'namespace' }}
+        uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        with:
+          ref: ${{ needs.prepare.outputs.BRANCH }}
+
+      - name: Checkout
+        if: ${{ inputs.runner_provider != 'namespace' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.BRANCH }}
+
       - name: Setup Node for shard selection
         uses: actions/setup-node@v6
         with:
@@ -197,11 +209,12 @@ jobs:
 
       - name: Download frozen qa-stats timings
         id: download-timings
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download-e2e-artifact
         continue-on-error: true
         with:
           name: e2e-timings-${{ github.run_id }}
           path: ./
+          runner-provider: ${{ inputs.runner_provider }}
 
       - name: Fetch qa-stats timings fallback
         if: steps.download-timings.outcome != 'success'
@@ -229,7 +242,7 @@ jobs:
           platform: android
           setup-simulator: 'true'
           android-avd-name: appium_smoke_avd
-          android-tag: ${{ inputs.android-tag }}
+          android-tag: default
           android-api-level: '36'
           android-abi: x86_64
           android-device: pixel_5
@@ -240,44 +253,24 @@ jobs:
       - name: Determine Android artifact paths
         id: android-artifacts
         run: |
-          if [[ "${{ inputs.build_type }}" == "flask" ]]; then
-            {
-              echo "apk-target-path=android/app/build/outputs/apk/flask/release"
-              echo "apk-file-name=app-flask-release.apk"
-            } >> "$GITHUB_OUTPUT"
-          else
-            {
-              echo "apk-target-path=android/app/build/outputs/apk/prod/release"
-              echo "apk-file-name=app-prod-release.apk"
-            } >> "$GITHUB_OUTPUT"
-          fi
+          {
+            echo "apk-target-path=android/app/build/outputs/apk/prod/release"
+            echo "apk-file-name=app-prod-release.apk"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Download Android build artifacts (Namespace)
-        if: ${{ inputs.runner_provider == 'namespace' && steps.select-specs.outputs.spec_count != '0' }}
-        id: download-android-apk-namespace
-        continue-on-error: true
-        uses: namespace-actions/download-artifact@7cbad919e4b0e09f17e9d6311a444ff002992b5b # v2.0.1
+      - name: Download Android build artifacts
+        if: ${{ steps.select-specs.outputs.spec_count != '0' }}
+        uses: ./.github/actions/download-e2e-artifact
         with:
-          name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release.apk
+          name: main-e2e-release.apk
           path: ${{ steps.android-artifacts.outputs.apk-target-path }}
-
-      - name: Download Android build artifacts (fallback)
-        if: ${{ inputs.runner_provider == 'namespace' && steps.select-specs.outputs.spec_count != '0' && steps.download-android-apk-namespace.outcome != 'success' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release.apk
-          path: ${{ steps.android-artifacts.outputs.apk-target-path }}
-
-      - name: Download Android build artifacts (current)
-        if: ${{ inputs.runner_provider != 'namespace' && steps.select-specs.outputs.spec_count != '0' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release.apk
-          path: ${{ steps.android-artifacts.outputs.apk-target-path }}
+          runner-provider: ${{ inputs.runner_provider }}
+          run-id: ${{ needs.prepare.outputs.RUN_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run fixture validation tests
         id: run-tests-android
-        timeout-minutes: ${{ inputs.test-timeout-minutes }}
+        timeout-minutes: 25
         continue-on-error: true
         env:
           SPEC_FILES: ${{ steps.select-specs.outputs.spec_files }}
@@ -304,14 +297,15 @@ jobs:
           yarn playwright test "${specs[@]}" \
             --config tests/playwright.smoke-appium.config.ts \
             --project android-smoke \
-            --grep "${{ inputs.test_suite_tag }}" \
-            --pass-with-no-tests
-
-      - name: Cache updated fixture
-        uses: actions/cache/save@v4
+            --grep FixtureValidation
+      - name: Upload updated fixture
+        uses: ./.github/actions/dual-upload-e2e-artifact
         with:
+          name: fixture-${{ needs.prepare.outputs.COMMIT_SHA }}
           path: tests/framework/fixtures/json/default-fixture.json
-          key: fixture-${{ needs.prepare.outputs.COMMIT_SHA }}
+          if-no-files-found: error
+          retention-days: 1
+          runner-provider: ${{ inputs.runner_provider }}
 
   commit-updated-fixtures:
     name: Commit the updated fixtures
@@ -335,12 +329,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ needs.prepare.outputs.PR_NUMBER }}
 
-      - name: Restore updated fixture
-        uses: actions/cache/restore@v4
+      - name: Download updated fixture
+        uses: ./.github/actions/download-e2e-artifact
         with:
-          path: tests/framework/fixtures/json/default-fixture.json
-          key: fixture-${{ needs.prepare.outputs.COMMIT_SHA }}
-          fail-on-cache-miss: true
+          name: fixture-${{ needs.prepare.outputs.COMMIT_SHA }}
+          path: tests/framework/fixtures/json
+          runner-provider: ${{ inputs.runner_provider }}
 
       - name: Check for fixture changes
         id: fixture-changes

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -314,7 +314,7 @@ jobs:
           PLAYWRIGHT_JSON_OUTPUT_FILE: tests/test-reports/playwright-json/playwright-report.json
           APPIUM_RECORD_VIDEO_ON_FAILURE: 'true'
           SKIP_APPIUM_STOP: 'true'
-          APPIUM_RETRIES_OVERRIDE: ${{ inputs.appium_retries_override }}
+          APPIUM_RETRIES_OVERRIDE: 0
           ANDROID_APK_PATH: ${{ steps.android-artifacts.outputs.apk-target-path }}/${{ steps.android-artifacts.outputs.apk-file-name }}
           ANDROID_AVD_NAME: appium_smoke_avd
           ANDROID_APPIUM_USE_PACKAGE_ONLY: 'true'

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -178,37 +178,169 @@ jobs:
 
   update-fixtures:
     name: Export & update fixtures
-    needs: [is-fork-pull-request, prepare]
-    if: ${{ needs.prepare.result == 'success' && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-android-e2e' || (startsWith(github.base_ref, 'release/') && fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe"]') || fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe", "low-priority"]')) }}
     timeout-minutes: 45
-
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CI: 'true'
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    needs:
+      - prepare
+      - is-fork-pull-request
+    if: ${{ !cancelled() && needs.prepare.result == 'success' && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
 
     steps:
-      - name: Run tests to update fixtures
-        uses: ./.github/workflows/run-appium-e2e-workflow.yml
-        id: run-fixture-validation-test
+      - name: Setup Node for shard selection
+        uses: actions/setup-node@v6
         with:
-          test-suite-name: validate-e2e-fixtures
+          node-version-file: '.nvmrc'
+
+      - name: Download frozen qa-stats timings
+        id: download-timings
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: e2e-timings-${{ github.run_id }}
+          path: ./
+
+      - name: Fetch qa-stats timings fallback
+        if: steps.download-timings.outcome != 'success'
+        run: node .github/scripts/e2e-freeze-timings.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.is-fork-pull-request.outputs.PR_NUMBER }}
+          OUTPUT_PATH: ./e2e-timings.json
+
+      - name: Select specs for fixture validation (timing bin-pack)
+        id: select-specs
+        run: |
+          PLATFORM="android"
+          TEST_SUITE_TAG="FixtureValidation"
+          SPLIT_NUMBER="1"
+          TOTAL_SPLITS="1"
+          BASE_DIR="tests/smoke-appium"
+          E2E_TIMINGS_PATH="./e2e-timings.json"
+
+          if [ -n "${{ github.event.pull_request.number }}" ] && [ "${{ steps.download-timings.outcome }}" == "skipped" ]; then
+            # For PR runs, use changed specs only
+            echo "CHANGED_SPEC_FILES=$(node .github/scripts/e2e-get-changed-specs.mjs)"
+          else
+            # For workflow_dispatch runs, include all fixture validation specs
+            CHANGED_SPEC_FILES=$(node .github/scripts/e2e-split-tags-shards.mjs \
+              --select-specs \
+              --test-suite-tag ${TEST_SUITE_TAG} \
+              --base-dir ${BASE_DIR} \
+              --e2e-timings-path ${E2E_TIMINGS_PATH} \
+              || echo "")
+            echo "CHANGED_SPEC_FILES=${CHANGED_SPEC_FILES}"
+          fi
+
+          readarray -t specs_array <<< "${CHANGED_SPEC_FILES}"
+          SPEC_FILES="${specs_array[*]}"
+          SPEC_COUNT=${#specs_array[@]}
+
+          {
+            echo "spec_count=${SPEC_COUNT}"
+            echo "spec_files=${SPEC_FILES}"
+            echo "changed_spec_files=${CHANGED_SPEC_FILES}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Setup Android AVD & Appium
+        uses: ./.github/actions/setup-e2e-env
+        with:
           platform: android
-          test_suite_tag: FixtureValidation
-          split_number: 1
-          total_splits: 1
-          test-timeout-minutes: 25
-          build_type: 'main'
-          metamask_environment: 'e2e'
-          runner_provider: >-
-            ${{
-              inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-              vars.NAMESPACE_RUNNER_ANDROID || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
-            }}
-          secrets: inherit
+          setup-simulator: 'true'
+          android-avd-name: appium_smoke_avd
+          android-tag: ${{ inputs.android-tag }}
+          android-api-level: '36'
+          android-abi: x86_64
+          android-device: pixel_5
+          configure-keystores: 'false'
+          install-foundry: 'true'
+          runner_provider: ${{ inputs.runner_provider }}
+
+      - name: Determine Android artifact paths
+        id: android-artifacts
+        run: |
+          if [[ "${{ inputs.build_type }}" == "flask" ]]; then
+            {
+              echo "apk-target-path=android/app/build/outputs/apk/flask/release"
+              echo "apk-file-name=app-flask-release.apk"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "apk-target-path=android/app/build/outputs/apk/prod/release"
+              echo "apk-file-name=app-prod-release.apk"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download Android build artifacts (Namespace)
+        if: ${{ inputs.runner_provider == 'namespace' && steps.select-specs.outputs.spec_count != '0' }}
+        id: download-android-apk-namespace
+        continue-on-error: true
+        uses: namespace-actions/download-artifact@7cbad919e4b0e09f17e9d6311a444ff002992b5b # v2.0.1
+        with:
+          name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release.apk
+          path: ${{ steps.android-artifacts.outputs.apk-target-path }}
+
+      - name: Download Android build artifacts (fallback)
+        if: ${{ 
+          inputs.runner_provider == 'namespace' && 
+          steps.select-specs.outputs.spec_count != '0' &&
+          steps.download-android-apk-namespace.outcome != 'success' 
+        }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release.apk
+          path: ${{ steps.android-artifacts.outputs.apk-target-path }}
+
+      - name: Download Android build artifacts (current)
+        if: ${{ inputs.runner_provider != 'namespace' && steps.select-specs.outputs.spec_count != '0' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release.apk
+          path: ${{ steps.android-artifacts.outputs.apk-target-path }}
+
+      - name: Run fixture validation tests
+        id: run-tests-android
+        timeout-minutes: ${{ inputs.test-timeout-minutes }}
+        env:
+          SPEC_FILES: ${{ steps.select-specs.outputs.spec_files }}
+          APPIUM_SMOKE_SUITE_NAME: ${{ inputs.test-suite-name }}
+          APPIUM_SMOKE_JOB_TITLE: Appium ${{ inputs.test-suite-name }} (android)
+          APPIUM_SMOKE_ARTIFACT_NAME: appium-smoke-report-${{ inputs.test-suite-name }}
+          APPIUM_SMOKE_VIDEOS_ARTIFACT_NAME: appium-smoke-videos-${{ inputs.test-suite-name }}
+          PLAYWRIGHT_JSON_OUTPUT_FILE: tests/test-reports/playwright-json/playwright-report.json
+          APPIUM_RECORD_VIDEO_ON_FAILURE: 'true'
+          SKIP_APPIUM_STOP: 'true'
+          APPIUM_RETRIES_OVERRIDE: ${{ inputs.appium_retries_override }}
+          ANDROID_APK_PATH: ${{ steps.android-artifacts.outputs.apk-target-path }}/${{ steps.android-artifacts.outputs.apk-file-name }}
+          ANDROID_AVD_NAME: appium_smoke_avd
+          ANDROID_APPIUM_USE_PACKAGE_ONLY: 'true'
+          ANDROID_BOOT_TIMEOUT_MS: '300000'
+          ANDROID_EMULATOR_CI_CORES: '8'
+          ANDROID_EMULATOR_POST_BOOT_SETTLE_MS: '30000'
+          ANDROID_EMULATOR_NETWORK_READY_TIMEOUT_MS: '90000'
+          ANDROID_EMULATOR_NETWORK_READY_CONSECUTIVE_PINGS: '3'
+          MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          read -r -a specs <<< "${SPEC_FILES}"
+          yarn playwright test "${specs[@]}" \
+            --config tests/playwright.smoke-appium.config.ts \
+            --project android-smoke \
+            --grep "${{ inputs.test_suite_tag }}" \
+            --pass-with-no-tests
 
       - name: Cache updated fixture
         uses: actions/cache/save@v4
+        with:
+          path: tests/framework/fixtures/json/default-fixture.json
+          key: fixture-${{ needs.prepare.outputs.COMMIT_SHA }}
+      - name: Cache updated fixture
+        uses: actions/cache/save@v4
+        if: steps.run-fixture-validation-test.outcome == 'success'
         with:
           path: tests/framework/fixtures/json/default-fixture.json
           key: fixture-${{ needs.prepare.outputs.COMMIT_SHA }}

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -164,12 +164,12 @@ jobs:
           fi
 
           if [ "${RUN_STATUS}" != "completed" ]; then
-            echo "::error title=CI still running::The CI workflow is still in progress (status: ${RUN_STATUS}). Wait for the 'Build iOS Apps' job to complete, then run @metamaskbot update-mobile-fixture again. View CI: ${RUN_URL}"
+            echo "::error title=CI still running::The CI workflow is still in progress (status: ${RUN_STATUS}). Wait for the 'Build Android APKs' job to complete, then run @metamaskbot update-mobile-fixture again. View CI: ${RUN_URL}"
             exit 1
           fi
 
           if [ "${RUN_CONCLUSION}" != "success" ]; then
-            echo "::warning title=CI did not succeed::The CI workflow concluded with '${RUN_CONCLUSION}'. The iOS build artifact may not be available. View CI: ${RUN_URL}"
+            echo "::warning title=CI did not succeed::The CI workflow concluded with '${RUN_CONCLUSION}'. The Android build artifact may not be available. View CI: ${RUN_URL}"
           fi
 
           echo "✅ CI run validated. RUN_ID=${RUN_ID}"
@@ -180,218 +180,32 @@ jobs:
     name: Export & update fixtures
     needs: [is-fork-pull-request, prepare]
     if: ${{ needs.prepare.result == 'success' && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
-    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ios-e2e' || (startsWith(github.base_ref, 'release/') && fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe"]') || fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe", "low-priority"]')) }}
-    timeout-minutes: 60
+    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-android-e2e' || (startsWith(github.base_ref, 'release/') && fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe"]') || fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe", "low-priority"]')) }}
+    timeout-minutes: 45
 
     env:
-      METAMASK_ENVIRONMENT: e2e
-      METAMASK_BUILD_TYPE: main
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PLATFORM: ios
-      GITHUB_CI: 'true'
       CI: 'true'
-      MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
-      RAMP_INTERNAL_BUILD: 'true'
-      MM_SECURITY_ALERTS_API_ENABLED: 'true'
-      MM_NOTIFICATIONS_UI_ENABLED: 'true'
-      FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN: ${{ secrets.FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN }}
-      FEATURES_ANNOUNCEMENTS_SPACE_ID: ${{ secrets.FEATURES_ANNOUNCEMENTS_SPACE_ID }}
-      SEEDLESS_ONBOARDING_ENABLED: 'true'
-      SEGMENT_WRITE_KEY_QA: ${{ secrets.SEGMENT_WRITE_KEY_QA }}
-      SEGMENT_PROXY_URL_QA: ${{ secrets.SEGMENT_PROXY_URL_QA }}
-      SEGMENT_DELETE_API_SOURCE_ID_QA: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_QA }}
-      SEGMENT_REGULATIONS_ENDPOINT_QA: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_QA }}
-      MM_SENTRY_DSN_TEST: ${{ secrets.MM_SENTRY_DSN_TEST }}
-      MM_SENTRY_AUTH_TOKEN: ${{ secrets.MM_SENTRY_AUTH_TOKEN }}
-      GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
-      GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
-      YARN_ENABLE_GLOBAL_CACHE: 'true'
 
     steps:
-      - name: Checkout (Namespace)
-        uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
-        if: ${{ inputs.runner_provider == 'namespace' }}
+      - name: Run tests to update fixtures
+        uses: ./.github/workflows/run-appium-e2e-workflow.yml
+        id: run-fixture-validation-test
         with:
-          ref: ${{ needs.prepare.outputs.BRANCH }}
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        if: ${{ inputs.runner_provider != 'namespace' }}
-        with:
-          ref: ${{ needs.prepare.outputs.BRANCH }}
-
-      - name: Restore .metamask folder (Foundry download cache for install:foundryup)
-        uses: actions/cache@v4
-        with:
-          path: .metamask
-          key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
-
-      - name: Set up E2E environment
-        timeout-minutes: 15
-        uses: ./.github/actions/setup-e2e-env
-        with:
-          platform: ios
-          setup-simulator: 'false'
-          configure-keystores: 'false'
-          install-foundry: 'true'
-          skip-pod-install: 'true'
-          install-applesimutils: 'false'
-          runner_provider: ${{ inputs.runner_provider }}
-
-      - name: Download iOS app artifact from CI (Namespace)
-        if: ${{ inputs.runner_provider == 'namespace' }}
-        id: download-ios-app-namespace
-        continue-on-error: true
-        uses: namespace-actions/download-artifact@7cbad919e4b0e09f17e9d6311a444ff002992b5b # v2.0.1
-        with:
-          name: main-e2e-MetaMask.app
-          path: artifacts/main-e2e-MetaMask.app
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ needs.prepare.outputs.RUN_ID }}
-
-      - name: Clear any partial iOS app before the fallback download
-        if: >-
-          ${{
-            inputs.runner_provider == 'namespace' &&
-            steps.download-ios-app-namespace.outcome != 'success'
-          }}
-        shell: bash
-        run: rm -rf artifacts/main-e2e-MetaMask.app
-
-      - name: Download iOS app artifact from CI (GitHub — build may be on Cirrus)
-        if: >-
-          ${{
-            inputs.runner_provider != 'namespace' ||
-            steps.download-ios-app-namespace.outcome != 'success'
-          }}
-        run: |
-          RUN_ID="${{ needs.prepare.outputs.RUN_ID }}"
-          ARTIFACT_NAME="main-e2e-MetaMask.app"
-          APP_PATH="artifacts/${ARTIFACT_NAME}"
-          echo "Downloading iOS artifact from CI run ${RUN_ID}..."
-
-          # gh run download uses the ListArtifacts API, which includes artifacts from all
-          # attempts of a run — including earlier attempts when only failed jobs were re-run.
-          if ! gh run download "${RUN_ID}" -n "${ARTIFACT_NAME}" -D "${APP_PATH}"; then
-            echo "::error title=iOS artifact not found::The iOS build was skipped in CI run ${RUN_ID} — no iOS-impacting changes were detected, so no artifact was produced.%0A%0AIf you need to force fixture regeneration on an Android-only PR, add the 'run-appium-ios-tests' label (opts into the iOS build), re-run CI, and retry this command. Ignorable-only PRs (docs-only, etc.) must include iOS-impacting app changes — the label alone cannot produce an artifact.%0A%0ACI run: https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}"
-            exit 1
-          fi
-          echo "✅ Downloaded iOS artifact from PR CI run ${RUN_ID}."
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Restore iOS bundle executable permissions
-        env:
-          APP_PATH: artifacts/main-e2e-MetaMask.app
-        run: |
-          BUNDLE_EXEC=$(/usr/libexec/PlistBuddy -c "Print CFBundleExecutable" "$APP_PATH/Info.plist" 2>/dev/null)
-          if [ -z "$BUNDLE_EXEC" ]; then
-            echo "Could not read CFBundleExecutable from Info.plist"
-            exit 1
-          fi
-
-          ACTUAL_PATH=$(find "$APP_PATH" -maxdepth 1 -iname "$BUNDLE_EXEC" -type f | head -1)
-          if [ -z "$ACTUAL_PATH" ]; then
-            echo "Bundle executable not found: $BUNDLE_EXEC"
-            exit 1
-          fi
-
-          if [ "$(basename "$ACTUAL_PATH")" != "$BUNDLE_EXEC" ]; then
-            mv "$ACTUAL_PATH" "$APP_PATH/${BUNDLE_EXEC}_fix"
-            mv "$APP_PATH/${BUNDLE_EXEC}_fix" "$APP_PATH/$BUNDLE_EXEC"
-          fi
-
-          chmod +x "$APP_PATH/$BUNDLE_EXEC"
-
-          if [ -d "$APP_PATH/Frameworks" ]; then
-            find "$APP_PATH/Frameworks" -type d -name "*.framework" | while IFS= read -r fw; do
-              binary="$fw/$(basename "$fw" .framework)"
-              if [ -f "$binary" ]; then
-                chmod +x "$binary"
-              fi
-            done
-            find "$APP_PATH/Frameworks" -type f -name "*.dylib" -exec chmod +x {} \;
-          fi
-          echo "Restored execute permissions on main binary and all framework binaries"
-        shell: bash
-
-      - name: Resolve XCUITest driver version for WDA cache key
-        id: xcuitest-version
-        run: echo "version=$(node scripts/e2e/resolve-xcuitest-driver-version.mjs)" >> "$GITHUB_OUTPUT"
-
-      - name: Get Xcode version for WDA cache key
-        id: xcode-version
-        run: echo "version=$(xcodebuild -version 2>/dev/null | head -1 | tr ' ' '-')" >> "$GITHUB_OUTPUT"
-
-      - name: Restore WDA DerivedData cache
-        uses: actions/cache@v4
-        with:
-          path: ~/appium-wda
-          key: wda-derived-data-xcuitest-${{ steps.xcuitest-version.outputs.version }}-${{ steps.xcode-version.outputs.version }}-${{ runner.os }}
-          restore-keys: |
-            wda-derived-data-xcuitest-${{ steps.xcuitest-version.outputs.version }}-${{ steps.xcode-version.outputs.version }}-
-
-      - name: Check if WDA is prebuilt
-        id: wda-prebuilt
-        run: |
-          WDA_APP=$(find ~/appium-wda/Build/Products -name 'WebDriverAgentRunner-Runner.app' -type d 2>/dev/null | head -1 || true)
-          XCTESTRUN=$(find ~/appium-wda/Build/Products -name '*.xctestrun' 2>/dev/null | head -1 || true)
-          if [ -n "$WDA_APP" ] && [ -n "$XCTESTRUN" ]; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-            echo "WDA prebuilt artifacts found"
-          else
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "WDA cache miss — prepare-ios-appium-runner will prebuild after sim boot"
-          fi
-        shell: bash
-
-      - name: Prepare iOS Appium runner
-        id: prepare-ios-appium
-        timeout-minutes: 30
-        run: node scripts/e2e/prepare-ios-appium-runner.mjs
-        env:
-          IOS_SIMULATOR_NAME: iPhone 16 Pro
-          IOS_APP_PATH: artifacts/main-e2e-MetaMask.app
-          IOS_BUNDLE_ID: io.metamask.MetaMask
-          SKIP_WDA_PREBUILD: ${{ steps.wda-prebuilt.outputs.ready == 'true' && 'true' || 'false' }}
-          IOS_SIMULATOR_POST_BOOT_SETTLE_MS: '30000'
-          IOS_APP_WARM_LAUNCH_SETTLE_MS: '15000'
-
-      - name: Run fixture validation spec (Appium)
-        id: run-fixture-validation
-        # Spec throws after writing an updated fixture when structural changes exist.
-        # Continue so we can cache/commit the written file.
-        continue-on-error: true
-        timeout-minutes: 25
-        run: >-
-          yarn playwright test
-          --config tests/playwright.smoke-appium.config.ts
-          --project ios-smoke
-          --grep FixtureValidation
-          tests/smoke-appium/fixtures/fixture-validation.spec.ts
-        env:
-          HAS_TEST_OVERRIDES: 'true'
-          GITHUB_CI: 'true'
-          CI: 'true'
-          IOS_APP_PATH: artifacts/main-e2e-MetaMask.app
-          IOS_SIMULATOR_NAME: iPhone 16 Pro
-          IOS_SIMULATOR_UDID: ${{ steps.prepare-ios-appium.outputs.ios-simulator-udid }}
-          IOS_WDA_PREINSTALLED: ${{ steps.prepare-ios-appium.outputs.ios-wda-preinstalled }}
-          IOS_WDA_BUNDLE_ID: ${{ steps.prepare-ios-appium.outputs.ios-wda-bundle-id }}
-          SKIP_DEVICE_BOOT: 'true'
-          SKIP_APP_REINSTALL: 'true'
-          USE_PREBUILT_WDA: 'true'
-
-      # Validate before caching so a transient Appium failure cannot poison the
-      # immutable fixture-${COMMIT_SHA} cache with an unchanged file.
-      - name: Fail if validation errored without fixture updates
-        if: steps.run-fixture-validation.outcome == 'failure'
-        run: |
-          if git diff --quiet tests/framework/fixtures/json/default-fixture.json; then
-            echo "::error::Fixture validation failed and no updated fixture was produced."
-            exit 1
-          fi
-          echo "Fixture validation failed as expected after writing structural updates; continuing to commit."
+          test-suite-name: validate-e2e-fixtures
+          platform: android
+          test_suite_tag: FixtureValidation
+          split_number: 1
+          total_splits: 1
+          test-timeout-minutes: 25
+          build_type: 'main'
+          metamask_environment: 'e2e'
+          runner_provider: >-
+            ${{
+              inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
+              vars.NAMESPACE_RUNNER_ANDROID || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+            }}
+          secrets: inherit
 
       - name: Cache updated fixture
         uses: actions/cache/save@v4
@@ -515,7 +329,7 @@ jobs:
         run: |
           passed="${{ needs.check-status.outputs.PASSED }}"
           if [[ $passed != "true" ]]; then
-            body="❌ **E2E fixture update failed.**\n\n**Common causes:**\n- CI workflow is still running — wait for 'Build iOS Apps' to complete\n- CI workflow was skipped — on Android-only PRs add \`run-appium-ios-tests\` (opts into the iOS build) and re-run CI; ignorable-only PRs need iOS-impacting app changes\n- iOS build failed — check the CI workflow for errors\n\n[View logs and retry](${ACTION_RUN_URL})"
+            body="❌ **E2E fixture update failed.**\n\n**Common causes:**\n- CI workflow is still running — wait for 'Build Android APKs' to complete and re-run CI; ignorable-only PRs need Android-impacting app changes\n- Android build failed — check the CI workflow for errors\n\n[View logs and retry](${ACTION_RUN_URL})"
             gh pr comment "${PR_NUMBER}" --body "$body"
           fi
         env:

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -212,38 +212,15 @@ jobs:
           PR_NUMBER: ${{ needs.is-fork-pull-request.outputs.PR_NUMBER }}
           OUTPUT_PATH: ./e2e-timings.json
 
-      - name: Select specs for fixture validation (timing bin-pack)
+      - name: Select specs for fixture validation
         id: select-specs
         run: |
-          PLATFORM="android"
-          TEST_SUITE_TAG="FixtureValidation"
-          SPLIT_NUMBER="1"
-          TOTAL_SPLITS="1"
-          BASE_DIR="tests/smoke-appium"
-          E2E_TIMINGS_PATH="./e2e-timings.json"
-
-          if [ -n "${{ github.event.pull_request.number }}" ] && [ "${{ steps.download-timings.outcome }}" == "skipped" ]; then
-            # For PR runs, use changed specs only
-            echo "CHANGED_SPEC_FILES=$(node .github/scripts/e2e-get-changed-specs.mjs)"
-          else
-            # For workflow_dispatch runs, include all fixture validation specs
-            CHANGED_SPEC_FILES=$(node .github/scripts/e2e-split-tags-shards.mjs \
-              --select-specs \
-              --test-suite-tag ${TEST_SUITE_TAG} \
-              --base-dir ${BASE_DIR} \
-              --e2e-timings-path ${E2E_TIMINGS_PATH} \
-              || echo "")
-            echo "CHANGED_SPEC_FILES=${CHANGED_SPEC_FILES}"
-          fi
-
-          readarray -t specs_array <<< "${CHANGED_SPEC_FILES}"
-          SPEC_FILES="${specs_array[*]}"
-          SPEC_COUNT=${#specs_array[@]}
-
+          # Single fixture validation spec — no sharding/selection needed.
+          SPEC_FILES="tests/smoke-appium/fixtures/fixture-validation.spec.ts"
           {
-            echo "spec_count=${SPEC_COUNT}"
+            echo "spec_count=1"
             echo "spec_files=${SPEC_FILES}"
-            echo "changed_spec_files=${CHANGED_SPEC_FILES}"
+            echo "changed_spec_files=${SPEC_FILES}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Android AVD & Appium
@@ -305,12 +282,13 @@ jobs:
       - name: Run fixture validation tests
         id: run-tests-android
         timeout-minutes: ${{ inputs.test-timeout-minutes }}
+        continue-on-error: true
         env:
           SPEC_FILES: ${{ steps.select-specs.outputs.spec_files }}
-          APPIUM_SMOKE_SUITE_NAME: ${{ inputs.test-suite-name }}
-          APPIUM_SMOKE_JOB_TITLE: Appium ${{ inputs.test-suite-name }} (android)
-          APPIUM_SMOKE_ARTIFACT_NAME: appium-smoke-report-${{ inputs.test-suite-name }}
-          APPIUM_SMOKE_VIDEOS_ARTIFACT_NAME: appium-smoke-videos-${{ inputs.test-suite-name }}
+          APPIUM_SMOKE_SUITE_NAME: update-e2e-fixtures
+          APPIUM_SMOKE_JOB_TITLE: Appium update-e2e-fixtures (android)
+          APPIUM_SMOKE_ARTIFACT_NAME: appium-smoke-report-update-e2e-fixtures
+          APPIUM_SMOKE_VIDEOS_ARTIFACT_NAME: appium-smoke-videos-update-e2e-fixtures
           PLAYWRIGHT_JSON_OUTPUT_FILE: tests/test-reports/playwright-json/playwright-report.json
           APPIUM_RECORD_VIDEO_ON_FAILURE: 'true'
           SKIP_APPIUM_STOP: 'true'
@@ -335,12 +313,6 @@ jobs:
 
       - name: Cache updated fixture
         uses: actions/cache/save@v4
-        with:
-          path: tests/framework/fixtures/json/default-fixture.json
-          key: fixture-${{ needs.prepare.outputs.COMMIT_SHA }}
-      - name: Cache updated fixture
-        uses: actions/cache/save@v4
-        if: steps.run-fixture-validation-test.outcome == 'success'
         with:
           path: tests/framework/fixtures/json/default-fixture.json
           key: fixture-${{ needs.prepare.outputs.COMMIT_SHA }}

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -262,11 +262,7 @@ jobs:
           path: ${{ steps.android-artifacts.outputs.apk-target-path }}
 
       - name: Download Android build artifacts (fallback)
-        if: ${{ 
-          inputs.runner_provider == 'namespace' && 
-          steps.select-specs.outputs.spec_count != '0' &&
-          steps.download-android-apk-namespace.outcome != 'success' 
-        }}
+        if: ${{ inputs.runner_provider == 'namespace' && steps.select-specs.outputs.spec_count != '0' && steps.download-android-apk-namespace.outcome != 'success' }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release.apk

--- a/tests/framework/fixtures/fixture-validation.ts
+++ b/tests/framework/fixtures/fixture-validation.ts
@@ -253,6 +253,7 @@ export function getMobileFixtureIgnoredKeys(): string[] {
     'engine.backgroundState.RemoteFeatureFlagController.rawRemoteFeatureFlags',
     'engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags',
     'engine.backgroundState.RemoteFeatureFlagController.thresholdCache',
+    'engine.backgroundState.RemoteFeatureFlagController.featureFlagThresholdGroups',
     'engine.backgroundState.TokenRatesController.marketData',
     'engine.backgroundState.TokenSearchDiscoveryDataController',
 

--- a/tests/framework/fixtures/json/default-fixture.json
+++ b/tests/framework/fixtures/json/default-fixture.json
@@ -673,8 +673,6 @@
             "stxMigrationCancel": "sentinel on",
             "stxMigrationGetFees": "sentinel on",
             "stxMigrationSubmitTransactions": "sentinel on",
-            "swapsSWAPS4135AbtestNumpadQuickAmounts": "treatment",
-            "swapsSWAPS4242AbtestTokenSelectorBalanceLayout": "treatment",
             "swapsSWAPS4784AbtestCTAButtonColor": "control",
             "swapsSWAPS4825AbtestChainValueOrder": "control",
             "tokenDetailsV2AbTest": "Control is OFF",

--- a/tests/framework/fixtures/json/default-fixture.json
+++ b/tests/framework/fixtures/json/default-fixture.json
@@ -36,19 +36,19 @@
         "steps": [],
         "totalSteps": 0
       },
-      "recurring": {
-        "everyValue": "1",
-        "everyUnit": "hour",
-        "repeatCount": "10"
-      },
       "isDestTokenManuallySet": false,
       "isGasIncluded7702Supported": false,
       "isGasIncludedSTXSendBundleSupported": false,
       "isMaxSourceAmount": false,
       "isSelectingRecipient": false,
       "isSelectingToken": false,
+      "isSlippageUserOverride": false,
       "isSubmittingTx": false,
-      "slippage": "0.5"
+      "recurring": {
+        "everyUnit": "hour",
+        "everyValue": "1",
+        "repeatCount": "10"
+      }
     },
     "browser": {
       "activeTab": 1692550481062,
@@ -65,12 +65,14 @@
       "whitelist": []
     },
     "card": {
+      "cardArrivalAnimationSeen": false,
+      "cardArrivalPreviewRequested": false,
       "geoLocation": "UNKNOWN",
-      "hasViewedCardButton": false,
       "isDaimoDemo": false,
       "onboarding": {
         "consentSetId": null,
         "contactVerificationId": null,
+        "immersveFundingSourceId": null,
         "onboardingId": null
       },
       "pendingMoneyAccountCardLink": null
@@ -147,28 +149,25 @@
         },
         "CardController": {
           "activeProviderId": "baanx",
-          "cardHomeData": {
-            "account": null,
-            "actions": [
-              {
-                "enabled": true,
-                "type": "add_funds"
-              }
-            ],
-            "alerts": [],
-            "availableFundingAssets": [],
-            "card": null,
-            "delegationSettings": null,
-            "fundingAssets": [],
-            "primaryFundingAsset": null
-          },
+          "cardHomeData": null,
+          "cardHomeDataAddress": null,
+          "cardHomeDataFetchedThisSession": false,
           "cardHomeDataStatus": "success",
           "cardholderAccounts": [],
           "isAuthenticated": false,
           "lastUnauthenticatedReason": null,
           "moneyAccountCardLinkInProgress": false,
           "providerData": {},
+          "providerUserId": null,
           "selectedCountry": null
+        },
+        "ClaimsController": {
+          "claims": [],
+          "claimsConfigurations": {
+            "supportedNetworks": ["0x1", "0xe708"],
+            "validSubmissionWindowDays": 21
+          },
+          "drafts": []
         },
         "ClientController": {
           "isUiOpen": false
@@ -207,10 +206,13 @@
           "nonRPCGasFeeApisDisabled": false
         },
         "GeolocationController": {
+          "country": "US",
           "error": null,
           "lastFetchedAt": 1775751316942,
           "location": "UNKNOWN",
-          "status": "idle"
+          "region": "CA",
+          "status": "idle",
+          "timezone": null
         },
         "KeyringController": {
           "keyrings": [
@@ -225,7 +227,9 @@
         "MoneyAccountController": {
           "moneyAccounts": {}
         },
-        "MoneyAccountUpgradeController": {},
+        "MoneyAccountUpgradeController": {
+          "upgradedAccounts": {}
+        },
         "MultichainAssetsController": {
           "accountsAssets": {},
           "assetsMetadata": {}
@@ -317,6 +321,10 @@
           },
           "networksWithTransactionActivity": {},
           "selectedMultichainNetworkChainId": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+        },
+        "NetworkConnectionBannerController": {
+          "networkConnectionBannerNetwork": null,
+          "networkConnectionBannerStatus": "available"
         },
         "NetworkController": {
           "networkConfigurationsByChainId": {
@@ -464,7 +472,7 @@
           "lastCompletedWithdrawalTxHashes": [],
           "lastDepositResult": null,
           "lastDepositTransactionId": null,
-          "lastError": null,
+          "lastError": "CLIENT_NOT_INITIALIZED",
           "lastUpdateTimestamp": 0,
           "lastWithdrawResult": null,
           "marketFilterPreferences": {
@@ -472,6 +480,10 @@
             "optionId": "volume"
           },
           "mode": "lite",
+          "orderBookPreferences": {
+            "currency": "usd",
+            "metric": "total"
+          },
           "perpsBalances": {},
           "proLayoutPreferences": {
             "chartExpanded": false,
@@ -489,11 +501,13 @@
             "mainnet": [],
             "testnet": []
           },
+          "selectedOrderType": "market",
           "selectedPaymentToken": null,
           "tradeConfigurations": {
             "mainnet": {},
             "testnet": {}
           },
+          "visibleCandleCount": 30,
           "watchlistMarkets": {
             "mainnet": [],
             "testnet": []
@@ -641,6 +655,31 @@
           "userRegion": null
         },
         "RemoteFeatureFlagController": {
+          "featureFlagThresholdGroups": {
+            "assetsASSETS3205AbtestAmbientPriceColor": "treatment",
+            "assetsASSETS3380AbtestExploreQuickBuy": "control",
+            "backendWebSocketConnection": "feature is ON",
+            "cardCARD338AbtestAttentionBadge": "control",
+            "confirmationsCONF1775AbtestMoneyAccountDepositPrefill": "control",
+            "coreMCU747AbtestPredictPositionsEmptyState": "treatment",
+            "homeTMCU1103AbtestActionButtonsGrid": "control",
+            "homeTMCU610AbtestWalletHomePostOnboardingSteps": "postOnboardingSteps",
+            "homeTMCU725AbtestHomepagePerpsPillsEmptyState": "treatment",
+            "homeTMCU926AbtestDiscoveryPills": "control",
+            "socialAiTSA531AbtestWhatsHappeningExplore": "control",
+            "socialAiTSA612AbtestQuickBuy": "control",
+            "socialAiTSA901AbtestTopTradersBuyAction": "treatment",
+            "stxMigrationBatchStatus": "sentinel on",
+            "stxMigrationCancel": "sentinel on",
+            "stxMigrationGetFees": "sentinel on",
+            "stxMigrationSubmitTransactions": "sentinel on",
+            "swapsSWAPS4135AbtestNumpadQuickAmounts": "treatment",
+            "swapsSWAPS4242AbtestTokenSelectorBalanceLayout": "treatment",
+            "swapsSWAPS4784AbtestCTAButtonColor": "control",
+            "swapsSWAPS4825AbtestChainValueOrder": "control",
+            "tokenDetailsV2AbTest": "Control is OFF",
+            "trendingTokens": "feature is ON"
+          },
           "localOverrides": {},
           "remoteFeatureFlags": {
             "bitcoinAccounts": {
@@ -665,11 +704,19 @@
             }
           }
         },
+        "ShieldController": {
+          "coverageResults": {},
+          "orderedTransactionHistory": []
+        },
         "SnapController": {},
         "SocialController": {
           "followingAddresses": [],
           "followingProfileIds": [],
           "leaderboardEntries": []
+        },
+        "SubscriptionController": {
+          "subscriptions": [],
+          "trialedProducts": []
         },
         "TokenBalancesController": {
           "tokenBalances": {}
@@ -691,6 +738,7 @@
       }
     },
     "experimentalSettings": {
+      "mmPayDebugEnabled": false,
       "securityAlertsEnabled": true
     },
     "fiatOrders": {
@@ -761,14 +809,12 @@
       "signMessageModalVisible": true
     },
     "moneyBalance": {
-      "lastKnownBalance": null
+      "lastKnownBalance": null,
+      "redeemable": null
     },
     "navigation": {
       "currentBottomNavRoute": "Wallet",
       "currentRoute": "AdvancedSettings"
-    },
-    "networkConnectionBanner": {
-      "visible": false
     },
     "networkOnboarded": {
       "networkOnboardedState": {},
@@ -794,6 +840,7 @@
       "iosGoogleWarningSheetLastDismissedAt": null,
       "onboardingVersion": "7.74.0 (4138)",
       "pendingSocialLoginMarketingConsentBackfill": null,
+      "pushNotificationOsPromptRequested": false,
       "walletHomeOnboardingSkipInitialBalanceWait": false,
       "walletHomeOnboardingSteps": {
         "stepIndex": 0,
@@ -850,10 +897,22 @@
       "candidateSubscriptionId": "pending",
       "currentTier": null,
       "dismissedCampaignOutcomeToasts": {},
+      "firstPredictionOnUsInteraction": {
+        "marketId": null,
+        "offerViewed": false,
+        "orderStatus": null,
+        "outcome": null,
+        "predictAccountAddress": null,
+        "skipped": false,
+        "transactionHash": null
+      },
       "geoLocation": null,
       "hideCurrentAccountNotOptedInBanner": [],
       "hideUnlinkedAccountsBanner": false,
       "isVipReferee": false,
+      "moneyAccountSweepstakesDrawProofs": {},
+      "moneyAccountSweepstakesPrizePools": {},
+      "moneyAccountSweepstakesStats": {},
       "nextTier": null,
       "nextTierPointsNeeded": null,
       "onboardingActiveStep": "INTRO",
@@ -867,6 +926,10 @@
       "optinAllowedForGeoError": false,
       "optinAllowedForGeoLoading": false,
       "pendingDeeplink": null,
+      "pendingMasSeriesOptIn": {
+        "needsRetry": false,
+        "subscriptionId": null
+      },
       "perpsTradingCampaignLeaderboardPositions": {},
       "perpsTradingCampaignLeaderboards": {},
       "perpsTradingCampaignVolumes": {},
@@ -904,7 +967,8 @@
       "vipRefereeDashboardError": false,
       "vipRefereeDashboardLoading": false,
       "vipRefereeSplashAccepted": {},
-      "vipSplashAccepted": {}
+      "vipSplashAccepted": {},
+      "vipTransactions": {}
     },
     "rpcEvents": {
       "signingEvent": {
@@ -949,6 +1013,7 @@
       "hasOnboarded": false,
       "isLive": true
     },
+    "terminalOrderAnalytics": {},
     "user": {
       "ambiguousAddressEntries": {},
       "appInstallEventFired": true,
@@ -965,8 +1030,11 @@
       "moneyEarnBannerDismissedTokens": {},
       "moneyOnboardingSeen": false,
       "multichainAccountsIntroModalSeen": true,
+      "musdConversionAssetDetailCtasSeen": {},
+      "musdConversionEducationSeen": false,
       "onboardingStepperProgress": {},
       "passwordSet": true,
+      "pendingAppInstall": null,
       "protectWalletModalVisible": false,
       "seedphraseBackedUp": true,
       "tokenIndicators": [],

--- a/tests/playwright.smoke-appium.config.ts
+++ b/tests/playwright.smoke-appium.config.ts
@@ -60,11 +60,16 @@ const jsonReportPath = process.env.PLAYWRIGHT_JSON_OUTPUT_FILE?.trim();
 // as part of Appium smoke tag suites.
 const includeApiSpecs = process.env.APPIUM_RUN_API_SPECS === '1';
 
-const appiumRetries = process.env.APPIUM_RETRIES_OVERRIDE
-  ? parseInt(process.env.APPIUM_RETRIES_OVERRIDE, 10)
-  : process.env.CI === 'true'
-    ? 1
-    : 0;
+const isCI = process.env.CI === 'true';
+const appiumRetriesOverride = process.env.APPIUM_RETRIES_OVERRIDE?.trim() ?? '';
+const parsedAppiumRetriesOverride = Number.parseInt(appiumRetriesOverride, 10);
+
+const appiumRetries =
+  appiumRetriesOverride !== '' && !Number.isNaN(parsedAppiumRetriesOverride)
+    ? parsedAppiumRetriesOverride
+    : isCI
+      ? 1
+      : 0;
 
 export default defineConfig({
   testDir: './smoke-appium',

--- a/tests/playwright.smoke-appium.config.ts
+++ b/tests/playwright.smoke-appium.config.ts
@@ -60,13 +60,19 @@ const jsonReportPath = process.env.PLAYWRIGHT_JSON_OUTPUT_FILE?.trim();
 // as part of Appium smoke tag suites.
 const includeApiSpecs = process.env.APPIUM_RUN_API_SPECS === '1';
 
+const appiumRetries = process.env.APPIUM_RETRIES_OVERRIDE
+  ? parseInt(process.env.APPIUM_RETRIES_OVERRIDE, 10)
+  : process.env.CI === 'true'
+    ? 1
+    : 0;
+
 export default defineConfig({
   testDir: './smoke-appium',
   ...(includeApiSpecs ? {} : { testIgnore: ['**/api-specs/**'] as const }),
   fullyParallel: false,
   // Per-test timeout: cold WDA build on CI can take up to 10 min plus test time.
   timeout: 15 * 60 * 1000,
-  retries: process.env.CI === 'true' ? 1 : 0,
+  retries: appiumRetries,
   reporter: [
     ['html', { open: 'never', outputFolder: htmlReportDir }],
     ['junit', { outputFile: junitReportPath }],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without directives are checked for structural presence only.
-->

## **Description**

This PR migrates E2E fixture validation and the `@metamaskbot update-mobile-fixture` bot command from iOS to Android.

### Reason for change
Fixture validation previously required an iOS build artifact and an iOS simulator runner. This made it conditional on iOS being built (gated by `ios-tests-ready`), and added significant complexity (WDA cache, XCUITest driver resolution, bundle permission restoration, etc.). Moving to Android makes fixture validation unconditional on PRs that build Android and simplifies the update workflow.

### Solution
- **`ci.yml`** — `validate-e2e-fixtures` now depends on `build-android-apks` instead of `ios-tests-ready`, runs with `platform: android`, and uses Android namespace runner vars.
- **`update-e2e-fixtures.yml`** — Replaced the iOS-only job (sim prep, WDA cache, `gh run download` for `.app`) with a slimmer Android job: downloads `main-e2e-release.apk` from the validated CI run via the shared download action, runs the `FixtureValidation` Playwright spec with `APPIUM_RETRIES_OVERRIDE: 0`, and passes the updated `default-fixture.json` to the commit job via `dual-upload-e2e-artifact` / `download-e2e-artifact` instead of `actions/cache`.
- **`download-e2e-artifact`** — Added optional `run-id` and `github-token` inputs and split Namespace vs GitHub downloads for current vs specified workflow runs (needed to pull APKs/fixtures from PR CI).
- **`run-appium-e2e-workflow.yml`** — Sets `APPIUM_RETRIES_OVERRIDE` to `0` only when `test_suite_tag` is `FixtureValidation`; other suites are unaffected. Bumped fixture report upload to `upload-artifact@v6`.
- **`playwright.smoke-appium.config.ts`** — Honors `APPIUM_RETRIES_OVERRIDE` env var to override the default retry count.
- **`default-fixture.json`** — Refreshed committed snapshot to match current app state after the Android export path.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/35003

## **Manual testing steps**

N/A — CI workflow changes only.

## **Screenshots/Recordings**

N/A — CI workflow changes only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI and bot-driven fixture commits affect E2E correctness for all PRs; wrong artifact/run-id wiring could skip validation or commit stale fixtures, but changes are scoped to test infra rather than production app code.
> 
> **Overview**
> **E2E fixture validation** and the `@metamaskbot update-mobile-fixture` flow now run on **Android** instead of iOS, so they align with `build-android-apks` rather than iOS sim/WDA setup.
> 
> In **`ci.yml`**, `validate-e2e-fixtures` gates on a successful Android APK build (with the same `prepare-e2e-timings` pattern as other Appium jobs), uses `platform: android`, and Android namespace runner vars. The **`update-e2e-fixtures`** workflow drops the iOS-only path (WDA cache, `.app` download, cache save/restore) in favor of Android AVD/Appium, pulling `main-e2e-release.apk` from the validated PR CI run via **`download-e2e-artifact`**, and passing updated `default-fixture.json` through **`dual-upload-e2e-artifact`** / download instead of `actions/cache`.
> 
> **`download-e2e-artifact`** gains optional `run-id` and `github-token` and branches Namespace vs GitHub downloads for the current run vs a specified run. **`run-appium-e2e-workflow`** sets **`APPIUM_RETRIES_OVERRIDE: 0`** for `FixtureValidation` (also wired in **`playwright.smoke-appium.config.ts`**). Fixture report upload moves to **`upload-artifact@v6`**.
> 
> **`default-fixture.json`** is refreshed for current app state; **`fixture-validation.ts`** ignores `RemoteFeatureFlagController.featureFlagThresholdGroups` as live-fetched data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44ca39816e723fd7ddcd73269a06644dfc485d74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->