### PR TITLE
fix(token-details): refresh non-EVM activity when a pending tx confirms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed non-EVM token details activity rows that stayed on "Interaction in progress" after the transaction confirmed
+
 ## [8.8.3]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed non-EVM token details activity rows that stayed on "Interaction in progress" after the transaction confirmed
-
 ## [8.8.3]
 
 ### Fixed

--- a/app/components/UI/TokenDetails/hooks/useTokenTransactions.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenTransactions.test.ts
@@ -1076,5 +1076,58 @@ describe('useTokenTransactions', () => {
         'swap-mixed',
       ]);
     });
+
+    it('replaces a pending unknown row when the same non-EVM transaction confirms', async () => {
+      const pendingTx = {
+        id: 'tron-swap-1',
+        chain: SOLANA_CHAIN_ID,
+        type: 'unknown',
+        status: 'unconfirmed',
+        time: 2,
+        from: [createSolanaMovement(SOL_ASSET_ID, 'SOL')],
+        to: [],
+      };
+
+      setupNonEvmMocks([pendingTx]);
+
+      const { result, rerender } = renderHook(() =>
+        useTokenTransactions(
+          solanaAsset({
+            symbol: 'SOL',
+            name: 'Solana',
+            isNative: true,
+            address: SOL_ASSET_ID,
+          }),
+        ),
+      );
+
+      await waitFor(() => {
+        expect(result.current.transactions).toHaveLength(1);
+      });
+
+      expect(result.current.transactions[0]).toMatchObject({
+        id: 'tron-swap-1',
+        type: 'unknown',
+        status: 'unconfirmed',
+      });
+
+      setupNonEvmMocks([
+        {
+          ...pendingTx,
+          type: 'send',
+          status: TX_CONFIRMED,
+          to: [createSolanaMovement(USDC_ASSET_ID, 'USDC')],
+        },
+      ]);
+      rerender({});
+
+      await waitFor(() => {
+        expect(result.current.transactions[0]).toMatchObject({
+          id: 'tron-swap-1',
+          type: 'send',
+          status: TX_CONFIRMED,
+        });
+      });
+    });
   });
 });

--- a/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
@@ -127,11 +127,12 @@ export const getSwapLegTokenIdentifiers = (
   };
 };
 
-// Cache for non-EVM transactions
-// eslint-disable-next-line import-x/no-mutable-exports
-let cachedFilteredTransactions: Transaction[] | null = null;
-// eslint-disable-next-line import-x/no-mutable-exports
-let cacheKey: string | null = null;
+/**
+ * Identity of a non-EVM list so we re-render when the same tx confirms
+ * (count and id stay the same; status/type change).
+ */
+const getNonEvmTransactionFingerprint = (transactions: Transaction[]) =>
+  transactions.map((tx) => `${tx.id}:${tx.status}:${tx.type ?? ''}`).join('|');
 
 /**
  * Hook that handles transaction fetching, filtering, and normalization for a token.
@@ -219,72 +220,51 @@ export const useTokenTransactions = (
       const assetSymbol = asset.symbol?.toLowerCase();
       const isNativeAsset = asset.isNative || asset.isETH;
 
-      const newCacheKey = JSON.stringify({
-        txCount: txs.length,
-        assetAddress,
-        assetSymbol,
-        isNativeAsset,
-        lastTxId: txs[0]?.id,
-      });
+      let filteredTransactions: Transaction[] = txs;
 
-      let filteredTransactions: Transaction[];
-      if (cacheKey === newCacheKey && cachedFilteredTransactions) {
-        filteredTransactions = cachedFilteredTransactions;
-      } else {
-        filteredTransactions = txs;
+      if (isNativeAsset) {
+        const nativeAssetId =
+          AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS[
+            asset.chainId as SupportedCaipChainId
+          ]?.nativeCurrency;
 
-        if (isNativeAsset) {
-          const nativeAssetId =
-            AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS[
-              asset.chainId as SupportedCaipChainId
-            ]?.nativeCurrency;
+        filteredTransactions = txs.filter((tx: Transaction) => {
+          const txData = (tx.from || []).concat(tx.to || []);
 
-          filteredTransactions = txs.filter((tx: Transaction) => {
-            const txData = (tx.from || []).concat(tx.to || []);
+          return txData.some(
+            (participant: { asset?: { type?: string } }) =>
+              participant.asset &&
+              typeof participant.asset === 'object' &&
+              participant.asset.type === nativeAssetId,
+          );
+        });
+      } else if (assetAddress || assetSymbol) {
+        filteredTransactions = txs.filter((tx: Transaction) => {
+          const txData = (tx.from || []).concat(tx.to || []);
 
-            return txData.some(
-              (participant: { asset?: { type?: string } }) =>
-                participant.asset &&
-                typeof participant.asset === 'object' &&
-                participant.asset.type === nativeAssetId,
-            );
-          });
-        } else if (assetAddress || assetSymbol) {
-          filteredTransactions = txs.filter((tx: Transaction) => {
-            const txData = (tx.from || []).concat(tx.to || []);
+          const involvesToken = txData.some(
+            (participant: { asset?: { type?: string; unit?: string } }) => {
+              if (participant.asset && typeof participant.asset === 'object') {
+                const assetType = participant.asset.type || '';
+                const assetUnit = participant.asset.unit || '';
 
-            const involvesToken = txData.some(
-              (participant: { asset?: { type?: string; unit?: string } }) => {
                 if (
-                  participant.asset &&
-                  typeof participant.asset === 'object'
+                  assetAddress &&
+                  assetType.toLowerCase().includes(assetAddress)
                 ) {
-                  const assetType = participant.asset.type || '';
-                  const assetUnit = participant.asset.unit || '';
-
-                  if (
-                    assetAddress &&
-                    assetType.toLowerCase().includes(assetAddress)
-                  ) {
-                    return true;
-                  }
-
-                  if (assetSymbol && assetUnit.toLowerCase() === assetSymbol) {
-                    return true;
-                  }
+                  return true;
                 }
-                return false;
-              },
-            );
 
-            return involvesToken;
-          });
-        }
+                if (assetSymbol && assetUnit.toLowerCase() === assetSymbol) {
+                  return true;
+                }
+              }
+              return false;
+            },
+          );
 
-        // eslint-disable-next-line react-compiler/react-compiler
-        cachedFilteredTransactions = filteredTransactions;
-        // eslint-disable-next-line react-compiler/react-compiler
-        cacheKey = newCacheKey;
+          return involvesToken;
+        });
       }
 
       transactions = [...filteredTransactions].sort(
@@ -608,10 +588,15 @@ export const useTokenTransactions = (
           },
         );
 
+        const didNonEvmTransactionsChange =
+          getNonEvmTransactionFingerprint(txsRef.current) !==
+          getNonEvmTransactionFingerprint(filteredTransactions);
+
         if (
           (txsRef.current.length === 0 && !txState.transactionsUpdated) ||
           txsRef.current.length !== filteredTransactions.length ||
           chainIdRef.current !== chainId ||
+          didNonEvmTransactionsChange ||
           txState.loading
         ) {
           txsRef.current = filteredTransactions;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This pull request addresses an issue where non-EVM token activity rows in the UI would remain stuck on "Interaction in progress" even after the transaction was confirmed. The main fix ensures that when a pending non-EVM transaction is confirmed (with the same id), the UI properly updates the row to reflect the new status and type. Additional improvements include removing a brittle caching mechanism and adding a test to verify the fix.

**Bug Fixes and Behavior Improvements:**

* Fixed an issue where non-EVM token details activity rows would stay on "Interaction in progress" after the transaction was confirmed, ensuring the UI updates correctly when the same transaction id confirms with a new status/type. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R13) [[2]](diffhunk://#diff-4796eaaad3e348f3f03b4ea6c2ccd2c6068878a740cd0716b6d19c243855a093R591-R599)

**Code and Test Improvements:**

* Added a test in `useTokenTransactions.test.ts` to verify that a pending unknown non-EVM transaction row is replaced when the same transaction confirms.
* Removed the previous cache for non-EVM transactions and replaced it with a fingerprinting mechanism that detects changes in status/type, ensuring the UI re-renders appropriately. [[1]](diffhunk://#diff-4796eaaad3e348f3f03b4ea6c2ccd2c6068878a740cd0716b6d19c243855a093L130-R135) [[2]](diffhunk://#diff-4796eaaad3e348f3f03b4ea6c2ccd2c6068878a740cd0716b6d19c243855a093L222-R223) [[3]](diffhunk://#diff-4796eaaad3e348f3f03b4ea6c2ccd2c6068878a740cd0716b6d19c243855a093L284-L289)
* Minor code cleanup for clarity and maintainability in the transaction participant check.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed non-EVM token details activity rows that stayed on "Interaction in progress" after the transaction confirmed

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [[Bug]: Swap issues for Tron network - native to any TRC20 token](https://github.com/MetaMask/metamask-mobile/issues/35299#top)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
1. Build and run the app with a Tron account that has TRX.
2. Open TRX token details and note the current Your Activity list.
3. Swap a small amount of TRX → USDT (same-chain Tron).
4. Stay on TRX token details and wait for on-chain confirmation.
5. Confirm the activity row leaves Interaction in progress and shows a confirmed send (for example Sent TRX). Tap the row and confirm the details sheet also shows confirmed.
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="400" height="450" alt="tron2" src="https://github.com/user-attachments/assets/a7cf980e-18bd-4685-a0d4-2261d7b6297f" />

### **After**

<!-- [screenshots/recordings] -->
<img width="452" height="440" alt="Tron1" src="https://github.com/user-attachments/assets/c0745552-6672-4ea6-90ab-bf8d251df14b" />



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to non-EVM token-details transaction normalization and display; removes caching that could block updates but does not touch auth or payments.
> 
> **Overview**
> Fixes **non-EVM token details** activity that stayed on *Interaction in progress* after the same transaction confirmed (same `id`, updated `status`/`type`).
> 
> In `useTokenTransactions`, the **module-level non-EVM filter cache** is removed so filtered lists are recomputed each time. State updates for non-EVM assets now also run when **`getNonEvmTransactionFingerprint`** (per-tx `id`, `status`, and `type`) changes, not only when list length or chain changes—so confirmed rows replace pending ones in the UI.
> 
> Adds a regression test that a pending `unknown` / `unconfirmed` row updates to a confirmed `send` after a rerender with updated mock data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1187c8b67f408c1795dc6c187f3d95f38b78870. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->