### PR TITLE
chore: proof authentication controller blocks the JS thread for an extended period of time

### DIFF
--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictDiscovery/index.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictDiscovery/index.tsx
@@ -26,6 +26,15 @@ import type { TransactionActiveAbTestEntry } from '../../../../../../../util/tra
 import BtcLiveRow from './BtcLiveRow';
 import ChampionshipRow, { type ChampionshipRowState } from './ChampionshipRow';
 
+/**
+ * TEMP perf-debug switch. CPU profiling showed continuous JS-thread activity
+ * from `BtcLiveRow`'s 1s countdown timer plus its RTDS crypto-price
+ * WebSocket subscription. Flip to true to skip rendering `BtcLiveRow`
+ * entirely and measure its contribution in isolation. Remove this block
+ * before merging.
+ */
+const PERF_DEBUG_SKIP_BTC_LIVE_ROW = true;
+
 export interface HomepagePredictDiscoveryProps {
   title: string;
   onViewAll: (
@@ -109,6 +118,13 @@ const HomepagePredictDiscovery: React.FC<HomepagePredictDiscoveryProps> = ({
     ],
   );
 
+  if (PERF_DEBUG_SKIP_BTC_LIVE_ROW) {
+    // eslint-disable-next-line no-console
+    console.log(
+      '[PERF_DEBUG] skipped rendering BtcLiveRow (no 1s countdown timer, no RTDS crypto-price WebSocket subscription)',
+    );
+  }
+
   const handleViewAll = useCallback(() => {
     onTreatmentCtaClick?.(PREDICT_EMPTY_STATE_CTA_NAMES.EXPLORE_FEATURED);
     onViewAll(transactionActiveAbTests);
@@ -133,7 +149,9 @@ const HomepagePredictDiscovery: React.FC<HomepagePredictDiscoveryProps> = ({
         entryPoint={PredictEventValues.ENTRY_POINT.HOME_SECTION}
       >
         <Box twClassName="px-4">
-          <BtcLiveRow onPress={handleBtcRow} />
+          {!PERF_DEBUG_SKIP_BTC_LIVE_ROW && (
+            <BtcLiveRow onPress={handleBtcRow} />
+          )}
           {eventSlotRows.map((state, index) => (
             <ChampionshipRow
               key={HOMEPAGE_PREDICT_EVENT_SLOTS[index].id}

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -300,6 +300,19 @@ export const useHomeDeepLinkEffects = (opts: {
 };
 
 /**
+ * TEMP perf-debug toggles for manual binary search on wallet-unlock JS-thread spike.
+ * Flip ONE flag at a time (false -> true) re-adding a subtree, re-measure with
+ * Flashlight/Perf Monitor between each flip. Remove this block before merging.
+ */
+const PERF_DEBUG = {
+  walletHeader: true, // does not cause any issues
+  portfolioHeader: true, // does not cause any issues
+  homepage: true, // causes continuous use of JS thread
+  assetPollingProvider: true, // this is not causing any issues
+  perpsAlwaysOnProvider: false, // causes continuous use of JS thread
+};
+
+/**
  * Main view for the wallet
  */
 const Wallet = ({
@@ -1091,85 +1104,93 @@ const Wallet = ({
     [styles],
   );
 
-  return (
-    <ErrorBoundary navigation={navigation} view="Wallet">
-      <PerpsAlwaysOnProvider>
-        <SafeAreaView
-          style={[
-            baseStyles.flexGrow,
-            { backgroundColor: colors.background.default },
-          ]}
-          edges={{ top: 'additive' }}
-          testID={WalletViewSelectorsIDs.WALLET_SAFE_AREA}
-        >
-          {selectedInternalAccount ? (
-            <>
-              <WalletHeader
-                displayName={displayName}
-                navigation={navigation}
-                isMoneyAccountVisible={isMoneyAccountVisible}
-                isNotificationEnabled={isNotificationEnabled}
-                unreadNotificationCount={unreadNotificationCount}
-                handleSearchPress={handleSearchPress}
-                handleActivityPress={handleActivityPress}
-                handleCardPress={handleCardPress}
-                handleHamburgerPress={handleHamburgerPress}
-                touchAreaSlop={touchAreaSlop}
-                headerActionButtonsContainerStyle={
-                  styles.headerActionButtonsContainer
-                }
-                headerAccountPickerStyle={styles.headerAccountPickerStyle}
-              />
-              <View
-                ref={containerViewRef}
-                style={styles.wrapper}
-                testID={WalletViewSelectorsIDs.WALLET_CONTAINER}
-                onLayout={(e) => {
-                  setViewportHeight(e.nativeEvent.layout.height);
-                  containerViewRef.current?.measureInWindow((_x, y) => {
-                    setContainerScreenY(y);
-                  });
+  const walletHomeContent = (
+    <SafeAreaView
+      style={[
+        baseStyles.flexGrow,
+        { backgroundColor: colors.background.default },
+      ]}
+      edges={{ top: 'additive' }}
+      testID={WalletViewSelectorsIDs.WALLET_SAFE_AREA}
+    >
+      {selectedInternalAccount ? (
+        <>
+          {PERF_DEBUG.walletHeader && (
+            <WalletHeader
+              displayName={displayName}
+              navigation={navigation}
+              isMoneyAccountVisible={isMoneyAccountVisible}
+              isNotificationEnabled={isNotificationEnabled}
+              unreadNotificationCount={unreadNotificationCount}
+              handleSearchPress={handleSearchPress}
+              handleActivityPress={handleActivityPress}
+              handleCardPress={handleCardPress}
+              handleHamburgerPress={handleHamburgerPress}
+              touchAreaSlop={touchAreaSlop}
+              headerActionButtonsContainerStyle={
+                styles.headerActionButtonsContainer
+              }
+              headerAccountPickerStyle={styles.headerAccountPickerStyle}
+            />
+          )}
+          <View
+            ref={containerViewRef}
+            style={styles.wrapper}
+            testID={WalletViewSelectorsIDs.WALLET_CONTAINER}
+            onLayout={(e) => {
+              setViewportHeight(e.nativeEvent.layout.height);
+              containerViewRef.current?.measureInWindow((_x, y) => {
+                setContainerScreenY(y);
+              });
+            }}
+          >
+            {PERF_DEBUG.assetPollingProvider && isFocused && (
+              <AssetPollingProvider chainIds={evmChainIds} />
+            )}
+            <HomepageScrollContext.Provider value={homepageScrollContextValue}>
+              <ConditionalScrollView
+                ref={scrollViewRef}
+                isScrollEnabled
+                scrollViewProps={{
+                  testID: WalletViewSelectorsIDs.WALLET_SCROLL_VIEW,
+                  contentContainerStyle: scrollViewContentStyle,
+                  showsVerticalScrollIndicator: false,
+                  onScroll: handleHomepageScroll,
+                  scrollEventThrottle: 16,
+                  refreshControl: (
+                    <RefreshControl
+                      colors={[colors.primary.default]}
+                      tintColor={colors.icon.default}
+                      refreshing={refreshing}
+                      onRefresh={handleRefresh}
+                    />
+                  ),
                 }}
               >
-                {isFocused && <AssetPollingProvider chainIds={evmChainIds} />}
-                <HomepageScrollContext.Provider
-                  value={homepageScrollContextValue}
-                >
-                  <ConditionalScrollView
-                    ref={scrollViewRef}
-                    isScrollEnabled
-                    scrollViewProps={{
-                      testID: WalletViewSelectorsIDs.WALLET_SCROLL_VIEW,
-                      contentContainerStyle: scrollViewContentStyle,
-                      showsVerticalScrollIndicator: false,
-                      onScroll: handleHomepageScroll,
-                      scrollEventThrottle: 16,
-                      refreshControl: (
-                        <RefreshControl
-                          colors={[colors.primary.default]}
-                          tintColor={colors.icon.default}
-                          refreshing={refreshing}
-                          onRefresh={handleRefresh}
-                        />
-                      ),
-                    }}
-                  >
-                    {portfolioHeader}
-                    <Homepage
-                      ref={homepageRef}
-                      balanceBreakdownSectionProps={
-                        balanceBreakdownSectionProps
-                      }
-                    />
-                  </ConditionalScrollView>
-                </HomepageScrollContext.Provider>
-              </View>
-            </>
-          ) : (
-            renderLoader()
-          )}
-        </SafeAreaView>
-      </PerpsAlwaysOnProvider>
+                {PERF_DEBUG.portfolioHeader && portfolioHeader}
+                {PERF_DEBUG.homepage && (
+                  <Homepage
+                    ref={homepageRef}
+                    balanceBreakdownSectionProps={balanceBreakdownSectionProps}
+                  />
+                )}
+              </ConditionalScrollView>
+            </HomepageScrollContext.Provider>
+          </View>
+        </>
+      ) : (
+        renderLoader()
+      )}
+    </SafeAreaView>
+  );
+
+  return (
+    <ErrorBoundary navigation={navigation} view="Wallet">
+      {PERF_DEBUG.perpsAlwaysOnProvider ? (
+        <PerpsAlwaysOnProvider>{walletHomeContent}</PerpsAlwaysOnProvider>
+      ) : (
+        walletHomeContent
+      )}
     </ErrorBoundary>
   );
 };

--- a/app/core/ExtendedMessenger.ts
+++ b/app/core/ExtendedMessenger.ts
@@ -13,26 +13,33 @@ const SUBSCRIPTION_NOT_FOUND_PREFIX = 'Subscription not found for event:';
  * controller untouched. Remove this block before merging.
  */
 export const PERF_DEBUG_UNLOCK_LISTENERS: Record<string, boolean> = {
-  AccountTrackerController: true,
-  AssetsController: true,
-  AuthenticationController: true, //One of the root causes UNBLOCKED
-  BackendWebSocketService: true,
-  CardController: true,
+  AccountTrackerController: true, // Not a problem causer f
+  AssetsController: true, // Not a problem causer f
+  AuthenticationController: false, // Not a problem causer for now
+  BackendWebSocketService: true, // Not a problem causer f
+  CardController: true, // Not a problem causer f
+  // Second picture
+
   ConfigRegistryController: true,
   MoneyAccountUpgradeControllerInitialization: true,
   MultichainAssetsRatesController: true,
   NetworkConnectionBannerController: true,
   NotificationServicesController: true,
+  //Third picture
+
   PermissionControllerInit: true,
   ProfileMetricsController: true,
   RewardsController: true,
   Root: true,
   SnapAccountService: true,
+  //Fourth
+
   SnapControllerInit: true,
   TokenBalancesController: true,
   TokenDetectionController: true,
   TransactionControllerInit: true,
   UserStorageController: true,
+  //fifth
 };
 
 const PERF_DEBUG_EVENT_TYPE = 'KeyringController:unlock';

--- a/app/core/ExtendedMessenger.ts
+++ b/app/core/ExtendedMessenger.ts
@@ -7,6 +7,93 @@ import {
 
 const SUBSCRIPTION_NOT_FOUND_PREFIX = 'Subscription not found for event:';
 
+/**
+ * TEMP perf-debug switches for the wallet-unlock JS-thread spike.
+ * Set a controller to false to stop its unlock listeners while leaving every other
+ * controller untouched. Remove this block before merging.
+ */
+export const PERF_DEBUG_UNLOCK_LISTENERS: Record<string, boolean> = {
+  AccountTrackerController: true,
+  AssetsController: true,
+  AuthenticationController: true, //One of the root causes UNBLOCKED
+  BackendWebSocketService: true,
+  CardController: true,
+  ConfigRegistryController: true,
+  MoneyAccountUpgradeControllerInitialization: true,
+  MultichainAssetsRatesController: true,
+  NetworkConnectionBannerController: true,
+  NotificationServicesController: true,
+  PermissionControllerInit: true,
+  ProfileMetricsController: true,
+  RewardsController: true,
+  Root: true,
+  SnapAccountService: true,
+  SnapControllerInit: true,
+  TokenBalancesController: true,
+  TokenDetectionController: true,
+  TransactionControllerInit: true,
+  UserStorageController: true,
+};
+
+const PERF_DEBUG_EVENT_TYPE = 'KeyringController:unlock';
+const PERF_DEBUG_NAMESPACE_PROBE = 'PERF_DEBUG:namespaceProbe';
+
+type UntypedPublishDelegated = (
+  this: object,
+  eventType: string,
+  ...payload: unknown[]
+) => void;
+type UntypedUnregisterActionHandler = (
+  this: object,
+  actionType: string,
+) => void;
+
+/* eslint-disable @typescript-eslint/no-deprecated -- Temporary perf debugging requires intercepting delegated events. */
+const originalPublishDelegated = Messenger.prototype
+  ._internalPublishDelegated as unknown as UntypedPublishDelegated;
+const originalUnregisterActionHandler = Messenger.prototype
+  .unregisterActionHandler as unknown as UntypedUnregisterActionHandler;
+
+const messengerNamespaces = new WeakMap<object, string>();
+
+const getMessengerNamespace = (messenger: object): string => {
+  const cachedNamespace = messengerNamespaces.get(messenger);
+  if (cachedNamespace) {
+    return cachedNamespace;
+  }
+
+  try {
+    originalUnregisterActionHandler.call(messenger, PERF_DEBUG_NAMESPACE_PROBE);
+  } catch (error) {
+    const namespace =
+      error instanceof Error
+        ? error.message.match(/prefixed by '([^']+):'/u)?.[1]
+        : undefined;
+    if (namespace) {
+      messengerNamespaces.set(messenger, namespace);
+      return namespace;
+    }
+  }
+
+  return 'Unknown';
+};
+
+(Messenger.prototype
+  ._internalPublishDelegated as unknown as UntypedPublishDelegated) =
+  function patchedPublishDelegated(eventType: string, ...payload: unknown[]) {
+    if (eventType === PERF_DEBUG_EVENT_TYPE) {
+      const namespace = getMessengerNamespace(this);
+      if (PERF_DEBUG_UNLOCK_LISTENERS[namespace] === false) {
+        // eslint-disable-next-line no-console
+        console.log(`[PERF_DEBUG] Blocked unlock listeners: ${namespace}`);
+        return;
+      }
+    }
+
+    return originalPublishDelegated.call(this, eventType, ...payload);
+  };
+/* eslint-enable @typescript-eslint/no-deprecated */
+
 export class ExtendedMessenger<
   Namespace extends string,
   Action extends ActionConstraint = never,

--- a/app/util/environment.ts
+++ b/app/util/environment.ts
@@ -26,7 +26,7 @@ export const getE2EMockOAuthEmailForQaMock = (): string | undefined => {
 };
 
 export const getDevAutoUnlockPassword = (): string | undefined => {
-  const password = process.env.DEV_AUTO_UNLOCK_PASSWORD;
+  const password = '';
 
   if (process.env.METAMASK_ENVIRONMENT !== DEV_ENVIRONMENT) {
     return undefined;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
This PR proves that enabling and disabling the authentication controller does cause a big impact in the JS thread. In the following image, the pink line is what happens when the authenticationcontroller is no called by the keyring unlock and the blue line is what happens when it gets called `AuthenticationController: false,`
<img width="1445" height="511" alt="image" src="https://github.com/user-attachments/assets/b79c2107-1d90-4517-8a80-9151584e7886" />

NOTE: I have disabled the `Live BTC` and `perpsAlwaysOnProvider` to reduce noise and proof the point

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Patches global Messenger unlock dispatch and disables dev auto-unlock; if merged accidentally, unlock/auth flows and wallet UI would behave incorrectly in dev.
> 
> **Overview**
> Adds **temporary, merge-blocking instrumentation** to isolate what drives sustained JS-thread work after wallet unlock—not a product fix.
> 
> **Messenger layer:** Patches `Messenger.prototype._internalPublishDelegated` in `ExtendedMessenger.ts` so `KeyringController:unlock` delegated handlers can be skipped per controller namespace via `PERF_DEBUG_UNLOCK_LISTENERS`. **`AuthenticationController` is currently set to `false`**, blocking its unlock listeners while others still run, to compare Perf Monitor traces (as described in the PR).
> 
> **Wallet UI:** Introduces `PERF_DEBUG` flags in `Wallet/index.tsx` to toggle subtrees (`WalletHeader`, portfolio header, `Homepage`, `AssetPollingProvider`, `PerpsAlwaysOnProvider`) one at a time; **`perpsAlwaysOnProvider` is off** in the current config to reduce noise.
> 
> **Predictions homepage:** `PERF_DEBUG_SKIP_BTC_LIVE_ROW = true` skips `BtcLiveRow` (1s countdown + RTDS price WebSocket) in `HomepagePredictDiscovery`.
> 
> **Dev unlock:** `getDevAutoUnlockPassword` in `environment.ts` is forced to an empty password so unlock must be exercised manually during profiling.
> 
> All blocks are labeled **remove before merging**; they alter core messenger behavior and wallet rendering in dev-only ways.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cad0fe8dfa53969d1a65420a16192d04cf12806. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->