### PR TITLE
feat: social trading prototype (feature-flagged, mock data only)

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -171,6 +171,8 @@ import { withUnmountOnTabBlur } from '../../Views/UnmountOnBlur/UnmountOnTabBlur
 ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
 import SampleFeature from '../../../features/SampleFeature/components/views/SampleFeature';
 ///: END:ONLY_INCLUDE_IF
+import SocialTradingScreenStack from '../../../features/SocialTrading/routes';
+import { selectSocialTradingPrototypeEnabled } from '../../../features/SocialTrading/selectors/socialTradingPrototypeEnabled';
 import WalletRecovery from '../../Views/WalletRecovery';
 import CardRoutes from '../../UI/Card/routes';
 import { Send } from '../../Views/confirmations/components/send';
@@ -1016,6 +1018,10 @@ const MainNavigator = () => {
   const isSocialLeaderboardEnabled = useSelector(
     selectSocialLeaderboardEnabled,
   );
+  // Get feature flag state for conditional Social Trading prototype registration
+  const isSocialTradingPrototypeEnabled = useSelector(
+    selectSocialTradingPrototypeEnabled,
+  );
 
   return (
     <NativeStack.Navigator
@@ -1517,6 +1523,13 @@ const MainNavigator = () => {
       {
         ///: END:ONLY_INCLUDE_IF
       }
+      {isSocialTradingPrototypeEnabled && (
+        <NativeStack.Screen
+          name={Routes.SOCIAL_TRADING.ROOT}
+          component={SocialTradingScreenStack}
+          options={{ headerShown: false, ...slideFromRightNativeOptions }}
+        />
+      )}
       <NativeStack.Screen
         name={Routes.CARD.ROOT}
         component={CardRoutes}

--- a/app/constants/featureFlags.ts
+++ b/app/constants/featureFlags.ts
@@ -20,6 +20,7 @@ export enum FeatureFlagNames {
   addDeviceSyncEnabled = 'addDeviceSyncEnabled',
   hapticsKillSwitch = 'hapticsKillSwitch',
   ledgerDmk = 'ledgerDmk',
+  socialTradingPrototypeEnabled = 'socialTradingPrototypeEnabled',
 }
 
 /** Minimum expected app version required for QR add-device account sync. Will update if extends */
@@ -46,4 +47,5 @@ export const DEFAULT_FEATURE_FLAG_VALUES: Partial<
     minimumVersion: null,
   },
   [FeatureFlagNames.telegramLoginEnabled]: false,
+  [FeatureFlagNames.socialTradingPrototypeEnabled]: false,
 };

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -542,6 +542,11 @@ const Routes = {
   ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
   SAMPLE_FEATURE: 'SampleFeature',
   ///: END:ONLY_INCLUDE_IF
+  SOCIAL_TRADING: {
+    ROOT: 'SocialTrading',
+    HOME: 'SocialTradingHome',
+    TRADER_PROFILE: 'SocialTradingTraderProfile',
+  },
   CARD: {
     ROOT: 'CardScreens',
     HOME: 'CardHome',

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -1121,6 +1121,11 @@ export type RootStackParamList = {
   SampleFeature: undefined;
   ///: END:ONLY_INCLUDE_IF
 
+  // Social trading prototype (feature-flagged, mock data only)
+  SocialTrading: undefined;
+  SocialTradingHome: undefined;
+  SocialTradingTraderProfile: { traderId: string };
+
   // Card routes
   CardScreens: NavigatorScreenParams<CardRootParamList> | undefined;
   CardHome: CardScreensStackParamList['CardHome'];

--- a/app/features/SocialTrading/README.md
+++ b/app/features/SocialTrading/README.md
@@ -1,0 +1,70 @@
+# Social Trading (prototype)
+
+A feature-flagged, mock-data-only prototype of a social/copy-trading
+experience: a trade feed, a trader leaderboard, trader profiles, and a
+simulated "copy trade" flow with a local simulated portfolio.
+
+> **Prototype disclaimer**
+>
+> Everything in this feature is simulated. All traders, trades, prices, and
+> returns are fictional fixtures in `data/mockData.ts`. "Copying" a trade
+> only records a local in-memory position — no transaction is created,
+> nothing is signed, and no funds move. The UI shows a persistent banner
+> and per-flow notices stating this.
+
+## Enabling it
+
+The feature is **disabled by default** and has no user-visible entry point.
+
+- Remote flag: `socialTradingPrototypeEnabled` (default `false`, see
+  `app/constants/featureFlags.ts` and
+  `selectors/socialTradingPrototypeEnabled/`).
+- Local override: set `MM_SOCIAL_TRADING_PROTOTYPE_ENABLED=true` in `.js.env`,
+  or toggle the flag in the developer Feature Flag Override screen.
+- Navigate to `Routes.SOCIAL_TRADING.ROOT` (`SocialTrading`), e.g. from a dev
+  entry point or programmatically. The screen is only registered on the main
+  stack while the flag is enabled.
+
+## Structure
+
+```
+SocialTrading/
+├── analytics/events.ts          # Feature-local MetaMetrics events
+├── components/
+│   ├── TradeCard/               # One simulated trade in a feed
+│   ├── CopyTradeSheet/          # Simulated copy confirmation bottom sheet
+│   └── views/
+│       ├── SocialTradingView/         # Root: banner + feed/leaders/portfolio tabs
+│       ├── SocialTradingFeed/
+│       ├── SocialTradingLeaderboard/
+│       ├── SocialTradingPortfolio/
+│       └── SocialTraderProfile/       # Pushed screen (traderId param)
+├── context/SocialTradingContext.tsx   # In-memory simulated state (see below)
+├── data/mockData.ts                   # Mock fixtures + formatters (data boundary)
+├── routes/index.tsx                   # Feature-local native stack
+└── selectors/socialTradingPrototypeEnabled/
+```
+
+## State choice
+
+Per the feature development guidelines, feature state normally belongs in
+Redux or a controller. This prototype intentionally keeps its simulated
+state (follows, likes, simulated positions) in a feature-local React
+context mounted at the stack root:
+
+- The state is throwaway simulation data with no cross-feature consumers
+  and no persistence requirement; it should die with the flow.
+- It keeps the prototype's footprint outside `app/features/SocialTrading`
+  to a minimum (routes, flag, strings, navigator registration only).
+
+`data/mockData.ts` and `context/SocialTradingContext.tsx` are the seams to
+replace when graduating to real services: swap the fixtures for an API
+adapter and move state into a Redux slice or controller without touching
+the views.
+
+## Graduation checklist (out of scope for the prototype)
+
+- Real trader/trade data source and pagination
+- Real copy execution path (confirmations, signing, risk disclosures)
+- Persisted state (Redux slice or controller) and E2E tests
+- Compliance/legal review of copy-trading UX and copy

--- a/app/features/SocialTrading/analytics/events.ts
+++ b/app/features/SocialTrading/analytics/events.ts
@@ -1,0 +1,23 @@
+import {
+  generateOpt,
+  EVENT_NAME as ANALYTICS_EVENT_NAME,
+} from '../../../core/Analytics/MetaMetrics.events';
+
+// Feature-specific event names (match EVENT_NAME style: SCREAMING_SNAKE_CASE
+// keys, Initial Case string values with spaces)
+export enum EVENT_NAME {
+  TRADER_FOLLOW_TOGGLED = 'Social Trading Trader Follow Toggled',
+  TRADE_LIKE_TOGGLED = 'Social Trading Trade Like Toggled',
+  TRADE_COPY_SIMULATED = 'Social Trading Trade Copy Simulated',
+  POSITION_CLOSE_SIMULATED = 'Social Trading Position Close Simulated',
+}
+
+const createEvent = (name: EVENT_NAME) =>
+  generateOpt(name as unknown as ANALYTICS_EVENT_NAME);
+
+export const SOCIAL_TRADING_EVENTS = {
+  TRADER_FOLLOW_TOGGLED: createEvent(EVENT_NAME.TRADER_FOLLOW_TOGGLED),
+  TRADE_LIKE_TOGGLED: createEvent(EVENT_NAME.TRADE_LIKE_TOGGLED),
+  TRADE_COPY_SIMULATED: createEvent(EVENT_NAME.TRADE_COPY_SIMULATED),
+  POSITION_CLOSE_SIMULATED: createEvent(EVENT_NAME.POSITION_CLOSE_SIMULATED),
+};

--- a/app/features/SocialTrading/components/CopyTradeSheet/CopyTradeSheet.tsx
+++ b/app/features/SocialTrading/components/CopyTradeSheet/CopyTradeSheet.tsx
@@ -1,0 +1,267 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Pressable } from 'react-native';
+import {
+  AvatarToken,
+  AvatarTokenSize,
+  BottomSheet,
+  BottomSheetFooter,
+  BottomSheetHeader,
+  type BottomSheetRef,
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  ButtonsAlignment,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Tag,
+  TagSeverity,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+
+import { strings } from '../../../../../locales/i18n';
+import { useAnalytics } from '../../../../components/hooks/useAnalytics/useAnalytics';
+import { SOCIAL_TRADING_EVENTS } from '../../analytics/events';
+import { useSocialTrading } from '../../context/SocialTradingContext';
+import { formatUsd, getTrader, Trade } from '../../data/mockData';
+
+const PRESET_AMOUNTS_USD = [50, 100, 250, 500];
+const DONE_DISMISS_DELAY_MS = 1100;
+
+interface CopyTradeSheetProps {
+  trade: Trade;
+  onClose: () => void;
+}
+
+/**
+ * Simulated copy-trade sheet. Confirming records a local mock position via
+ * SocialTradingContext. No transaction is created, nothing is signed, and
+ * no funds move.
+ */
+export function CopyTradeSheet({ trade, onClose }: CopyTradeSheetProps) {
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const { copyTrade } = useSocialTrading();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const [amount, setAmount] = useState<number>(100);
+  const [done, setDone] = useState<boolean>(false);
+  const dismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const trader = getTrader(trade.traderId);
+  const isBuy = trade.side === 'buy';
+
+  useEffect(
+    () => () => {
+      if (dismissTimer.current) clearTimeout(dismissTimer.current);
+    },
+    [],
+  );
+
+  const handleConfirm = () => {
+    copyTrade(trade, amount);
+    trackEvent(
+      createEventBuilder(SOCIAL_TRADING_EVENTS.TRADE_COPY_SIMULATED)
+        .addProperties({
+          trade_id: trade.id,
+          trader_id: trade.traderId,
+          token_symbol: trade.tokenSymbol,
+          amount_usd: amount,
+          simulated: true,
+        })
+        .build(),
+    );
+    setDone(true);
+    dismissTimer.current = setTimeout(() => {
+      sheetRef.current?.onCloseBottomSheet(onClose);
+    }, DONE_DISMISS_DELAY_MS);
+  };
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      onClose={onClose}
+      testID="social-trading-copy-trade-sheet"
+    >
+      {done ? (
+        <Box
+          alignItems={BoxAlignItems.Center}
+          paddingVertical={8}
+          paddingHorizontal={4}
+          gap={3}
+        >
+          <Box
+            backgroundColor={BoxBackgroundColor.SuccessMuted}
+            twClassName="rounded-full"
+            padding={4}
+          >
+            <Icon
+              name={IconName.Confirmation}
+              size={IconSize.Xl}
+              color={IconColor.SuccessDefault}
+            />
+          </Box>
+          <Text variant={TextVariant.HeadingMd}>
+            {strings('social_trading.sheet.done_title')}
+          </Text>
+          <Text
+            variant={TextVariant.BodySm}
+            color={TextColor.TextAlternative}
+            twClassName="text-center"
+          >
+            {strings('social_trading.sheet.done_description', {
+              amount: formatUsd(amount),
+              trader: trader?.name ?? strings('social_trading.sheet.a_trader'),
+              symbol: trade.tokenSymbol,
+            })}
+          </Text>
+        </Box>
+      ) : (
+        <>
+          <BottomSheetHeader
+            onClose={() => sheetRef.current?.onCloseBottomSheet(onClose)}
+          >
+            {strings('social_trading.sheet.title')}
+          </BottomSheetHeader>
+          <Box paddingHorizontal={4} paddingBottom={2} gap={4}>
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              justifyContent={BoxJustifyContent.Between}
+              backgroundColor={BoxBackgroundColor.BackgroundMuted}
+              twClassName="rounded-xl"
+              padding={3}
+            >
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                gap={3}
+              >
+                <AvatarToken
+                  name={trade.tokenName}
+                  fallbackText={trade.tokenSymbol.slice(0, 1)}
+                  size={AvatarTokenSize.Md}
+                />
+                <Box>
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    fontWeight={FontWeight.Medium}
+                  >
+                    {trade.tokenSymbol} · {formatUsd(trade.price)}
+                  </Text>
+                  <Text
+                    variant={TextVariant.BodyXs}
+                    color={TextColor.TextAlternative}
+                  >
+                    {strings('social_trading.sheet.by_trader', {
+                      name:
+                        trader?.name ??
+                        strings('social_trading.sheet.a_trader'),
+                      handle: trader?.handle ?? '',
+                    })}
+                  </Text>
+                </Box>
+              </Box>
+              <Tag severity={isBuy ? TagSeverity.Success : TagSeverity.Danger}>
+                {isBuy
+                  ? strings('social_trading.trade.buy')
+                  : strings('social_trading.trade.sell')}
+              </Tag>
+            </Box>
+
+            <Box gap={2}>
+              <Text
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                color={TextColor.TextAlternative}
+              >
+                {strings('social_trading.sheet.amount_label')}
+              </Text>
+              <Box flexDirection={BoxFlexDirection.Row} gap={2}>
+                {PRESET_AMOUNTS_USD.map((preset) => {
+                  const active = amount === preset;
+                  return (
+                    <Pressable
+                      key={preset}
+                      onPress={() => setAmount(preset)}
+                      accessibilityRole="button"
+                      accessibilityLabel={`$${preset}`}
+                      accessibilityState={{ selected: active }}
+                      style={{ flex: 1 }}
+                      testID={`social-trading-copy-amount-${preset}`}
+                    >
+                      <Box
+                        backgroundColor={
+                          active
+                            ? BoxBackgroundColor.PrimaryMuted
+                            : BoxBackgroundColor.BackgroundMuted
+                        }
+                        twClassName={
+                          active
+                            ? 'rounded-xl border border-primary-default'
+                            : 'rounded-xl'
+                        }
+                        alignItems={BoxAlignItems.Center}
+                        paddingVertical={3}
+                      >
+                        <Text
+                          variant={TextVariant.BodyMd}
+                          fontWeight={FontWeight.Medium}
+                          color={
+                            active
+                              ? TextColor.PrimaryDefault
+                              : TextColor.TextDefault
+                          }
+                        >
+                          ${preset}
+                        </Text>
+                      </Box>
+                    </Pressable>
+                  );
+                })}
+              </Box>
+            </Box>
+
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              justifyContent={BoxJustifyContent.Between}
+            >
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
+                {strings('social_trading.sheet.est_entry')}
+              </Text>
+              <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+                {strings('social_trading.sheet.est_entry_value', {
+                  price: formatUsd(trade.price),
+                  symbol: trade.tokenSymbol,
+                })}
+              </Text>
+            </Box>
+
+            <Text variant={TextVariant.BodyXs} color={TextColor.TextMuted}>
+              {strings('social_trading.sheet.simulation_notice')}
+            </Text>
+          </Box>
+          <BottomSheetFooter
+            buttonsAlignment={ButtonsAlignment.Vertical}
+            twClassName="px-4 pb-4"
+            primaryButtonProps={{
+              children: strings('social_trading.sheet.confirm', {
+                amount: `$${amount}`,
+              }),
+              onPress: handleConfirm,
+              testID: 'social-trading-confirm-copy-trade',
+            }}
+          />
+        </>
+      )}
+    </BottomSheet>
+  );
+}
+
+export default CopyTradeSheet;

--- a/app/features/SocialTrading/components/TradeCard/TradeCard.tsx
+++ b/app/features/SocialTrading/components/TradeCard/TradeCard.tsx
@@ -1,0 +1,285 @@
+import React from 'react';
+import { Pressable } from 'react-native';
+import {
+  AvatarAccount,
+  AvatarAccountSize,
+  AvatarToken,
+  AvatarTokenSize,
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Tag,
+  TagSeverity,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+
+import { strings } from '../../../../../locales/i18n';
+import { useAnalytics } from '../../../../components/hooks/useAnalytics/useAnalytics';
+import { SOCIAL_TRADING_EVENTS } from '../../analytics/events';
+import { useSocialTrading } from '../../context/SocialTradingContext';
+import {
+  formatCount,
+  formatMinutesAgo,
+  formatPct,
+  formatUsd,
+  getTrader,
+  Trade,
+} from '../../data/mockData';
+
+interface TradeCardProps {
+  trade: Trade;
+  onCopy: (trade: Trade) => void;
+  onPressTrader?: (traderId: string) => void;
+}
+
+/**
+ * Renders a single simulated trade in the Social Trading prototype feed.
+ * All values shown are mock data; the copy action only opens the simulated
+ * copy sheet.
+ */
+export function TradeCard({ trade, onCopy, onPressTrader }: TradeCardProps) {
+  const { isLiked, toggleLike } = useSocialTrading();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const trader = getTrader(trade.traderId);
+  if (!trader) return null;
+
+  const liked = isLiked(trade.id);
+  const isBuy = trade.side === 'buy';
+  const pnlPositive = trade.pnlPct > 0;
+  const pnlFlat = trade.pnlPct === 0;
+
+  const handleLike = () => {
+    toggleLike(trade.id);
+    trackEvent(
+      createEventBuilder(SOCIAL_TRADING_EVENTS.TRADE_LIKE_TOGGLED)
+        .addProperties({ trade_id: trade.id, liked: !liked })
+        .build(),
+    );
+  };
+
+  return (
+    <Box
+      backgroundColor={BoxBackgroundColor.BackgroundSection}
+      twClassName="rounded-2xl"
+      padding={4}
+      gap={3}
+    >
+      {/* Trader row */}
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+      >
+        <Pressable
+          onPress={() => onPressTrader?.(trader.id)}
+          disabled={!onPressTrader}
+          accessibilityRole="button"
+          accessibilityLabel={trader.name}
+          testID={`social-trading-trade-${trade.id}-trader`}
+        >
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            gap={3}
+          >
+            <AvatarAccount
+              address={trader.address}
+              size={AvatarAccountSize.Md}
+            />
+            <Box>
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                gap={1}
+              >
+                <Text
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                >
+                  {trader.name}
+                </Text>
+                {trader.verified ? (
+                  <Icon
+                    name={IconName.VerifiedFilled}
+                    size={IconSize.Sm}
+                    color={IconColor.PrimaryDefault}
+                  />
+                ) : null}
+              </Box>
+              <Text
+                variant={TextVariant.BodyXs}
+                color={TextColor.TextAlternative}
+              >
+                {trader.handle} ·{' '}
+                {strings('social_trading.trade.time_ago', {
+                  time: formatMinutesAgo(trade.minutesAgo),
+                })}
+              </Text>
+            </Box>
+          </Box>
+        </Pressable>
+        <Tag severity={isBuy ? TagSeverity.Success : TagSeverity.Danger}>
+          {isBuy
+            ? strings('social_trading.trade.buy')
+            : strings('social_trading.trade.sell')}
+        </Tag>
+      </Box>
+
+      {/* Asset row */}
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+        backgroundColor={BoxBackgroundColor.BackgroundMuted}
+        twClassName="rounded-xl"
+        padding={3}
+      >
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={3}
+        >
+          <AvatarToken
+            name={trade.tokenName}
+            fallbackText={trade.tokenSymbol.slice(0, 1)}
+            size={AvatarTokenSize.Md}
+          />
+          <Box>
+            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+              {trade.tokenSymbol}
+            </Text>
+            <Text
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextAlternative}
+            >
+              {formatUsd(trade.price)}
+            </Text>
+          </Box>
+        </Box>
+        <Box alignItems={BoxAlignItems.End}>
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+            {formatUsd(trade.amountUsd)}
+          </Text>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            gap={1}
+          >
+            {!pnlFlat ? (
+              <Icon
+                name={pnlPositive ? IconName.TrendUp : IconName.TrendDown}
+                size={IconSize.Xs}
+                color={
+                  pnlPositive
+                    ? IconColor.SuccessDefault
+                    : IconColor.ErrorDefault
+                }
+              />
+            ) : null}
+            <Text
+              variant={TextVariant.BodyXs}
+              fontWeight={FontWeight.Medium}
+              color={
+                pnlFlat
+                  ? TextColor.TextAlternative
+                  : pnlPositive
+                    ? TextColor.SuccessDefault
+                    : TextColor.ErrorDefault
+              }
+            >
+              {formatPct(trade.pnlPct)}
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+
+      {trade.note ? (
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+          {trade.note}
+        </Text>
+      ) : null}
+
+      {/* Actions */}
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+      >
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={5}
+        >
+          <Pressable
+            onPress={handleLike}
+            accessibilityRole="button"
+            accessibilityLabel={strings('social_trading.trade.like')}
+            testID={`social-trading-trade-${trade.id}-like`}
+            hitSlop={8}
+          >
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              gap={1}
+            >
+              <Icon
+                name={liked ? IconName.HeartFilled : IconName.Heart}
+                size={IconSize.Sm}
+                color={
+                  liked ? IconColor.ErrorDefault : IconColor.IconAlternative
+                }
+              />
+              <Text
+                variant={TextVariant.BodyXs}
+                color={TextColor.TextAlternative}
+              >
+                {formatCount(trade.likes + (liked ? 1 : 0))}
+              </Text>
+            </Box>
+          </Pressable>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            gap={1}
+          >
+            <Icon
+              name={IconName.Copy}
+              size={IconSize.Sm}
+              color={IconColor.IconAlternative}
+            />
+            <Text
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextAlternative}
+            >
+              {strings('social_trading.trade.copied_count', {
+                count: formatCount(trade.copies),
+              })}
+            </Text>
+          </Box>
+        </Box>
+        <Button
+          variant={ButtonVariant.Secondary}
+          size={ButtonSize.Sm}
+          onPress={() => onCopy(trade)}
+          testID={`social-trading-trade-${trade.id}-copy`}
+        >
+          {strings('social_trading.trade.copy_trade')}
+        </Button>
+      </Box>
+    </Box>
+  );
+}
+
+export default TradeCard;

--- a/app/features/SocialTrading/components/views/SocialTraderProfile/SocialTraderProfile.tsx
+++ b/app/features/SocialTrading/components/views/SocialTraderProfile/SocialTraderProfile.tsx
@@ -1,0 +1,293 @@
+import React, { useState } from 'react';
+import { ScrollView, View } from 'react-native';
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import {
+  AvatarAccount,
+  AvatarAccountSize,
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+
+import { strings } from '../../../../../../locales/i18n';
+import { useTheme } from '../../../../../util/theme';
+import { useAnalytics } from '../../../../../components/hooks/useAnalytics/useAnalytics';
+import { SOCIAL_TRADING_EVENTS } from '../../../analytics/events';
+import CopyTradeSheet from '../../CopyTradeSheet/CopyTradeSheet';
+import TradeCard from '../../TradeCard/TradeCard';
+import { useSocialTrading } from '../../../context/SocialTradingContext';
+import {
+  formatCount,
+  formatPct,
+  formatUsd,
+  getTrader,
+  Trade,
+  tradesByTrader,
+} from '../../../data/mockData';
+
+export interface SocialTraderProfileParams {
+  traderId: string;
+}
+
+type SocialTraderProfileRouteProp = RouteProp<
+  { SocialTradingTraderProfile: SocialTraderProfileParams },
+  'SocialTradingTraderProfile'
+>;
+
+/**
+ * Profile screen for a mock trader: stats, simulated performance bars, and
+ * recent simulated trades.
+ */
+export function SocialTraderProfile() {
+  const navigation = useNavigation();
+  const route = useRoute<SocialTraderProfileRouteProp>();
+  const { colors } = useTheme();
+  const { isFollowing, toggleFollow } = useSocialTrading();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const [copyTarget, setCopyTarget] = useState<Trade | null>(null);
+
+  const trader = getTrader(route.params?.traderId ?? '');
+
+  if (!trader) {
+    return (
+      <Box
+        twClassName="flex-1"
+        backgroundColor={BoxBackgroundColor.BackgroundDefault}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
+        gap={3}
+      >
+        <Text variant={TextVariant.BodyMd}>
+          {strings('social_trading.profile.not_found')}
+        </Text>
+        <Button
+          variant={ButtonVariant.Secondary}
+          size={ButtonSize.Sm}
+          onPress={() => navigation.goBack()}
+        >
+          {strings('social_trading.profile.go_back')}
+        </Button>
+      </Box>
+    );
+  }
+
+  const following = isFollowing(trader.id);
+  const trades = tradesByTrader(trader.id).sort(
+    (a, b) => a.minutesAgo - b.minutesAgo,
+  );
+
+  const handleFollow = () => {
+    toggleFollow(trader.id);
+    trackEvent(
+      createEventBuilder(SOCIAL_TRADING_EVENTS.TRADER_FOLLOW_TOGGLED)
+        .addProperties({
+          trader_id: trader.id,
+          following: !following,
+          source: 'profile',
+        })
+        .build(),
+    );
+  };
+
+  const stats = [
+    {
+      label: strings('social_trading.profile.stat_pnl_30d'),
+      value: formatPct(trader.pnl30d),
+      positive: trader.pnl30d >= 0,
+    },
+    {
+      label: strings('social_trading.profile.stat_win_rate'),
+      value: `${trader.winRate}%`,
+    },
+    {
+      label: strings('social_trading.profile.stat_copiers'),
+      value: formatCount(trader.copiers),
+    },
+    {
+      label: strings('social_trading.profile.stat_aum'),
+      value: formatUsd(trader.aumUsd),
+    },
+  ];
+
+  return (
+    <Box
+      twClassName="flex-1"
+      backgroundColor={BoxBackgroundColor.BackgroundDefault}
+    >
+      <ScrollView
+        testID="social-trading-profile-scroll"
+        contentContainerStyle={{
+          paddingHorizontal: 16,
+          paddingBottom: 24,
+          paddingTop: 12,
+          gap: 16,
+        }}
+      >
+        {/* Identity */}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Between}
+        >
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            gap={3}
+          >
+            <AvatarAccount
+              address={trader.address}
+              size={AvatarAccountSize.Xl}
+            />
+            <Box>
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                gap={1}
+              >
+                <Text variant={TextVariant.HeadingMd}>{trader.name}</Text>
+                {trader.verified ? (
+                  <Icon
+                    name={IconName.VerifiedFilled}
+                    size={IconSize.Md}
+                    color={IconColor.PrimaryDefault}
+                  />
+                ) : null}
+              </Box>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
+                {trader.handle} ·{' '}
+                {strings('social_trading.profile.followers', {
+                  count: formatCount(trader.followers),
+                })}
+              </Text>
+            </Box>
+          </Box>
+          <Button
+            variant={following ? ButtonVariant.Tertiary : ButtonVariant.Primary}
+            size={ButtonSize.Sm}
+            onPress={handleFollow}
+            testID="social-trading-trader-follow"
+          >
+            {following
+              ? strings('social_trading.leaderboard.following')
+              : strings('social_trading.leaderboard.follow')}
+          </Button>
+        </Box>
+
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+          {trader.bio}
+        </Text>
+
+        {/* Stats */}
+        <Box flexDirection={BoxFlexDirection.Row} gap={2}>
+          {stats.map((stat) => (
+            <Box
+              key={stat.label}
+              backgroundColor={BoxBackgroundColor.BackgroundSection}
+              twClassName="rounded-xl flex-1"
+              alignItems={BoxAlignItems.Center}
+              paddingVertical={3}
+              gap={1}
+            >
+              <Text
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                color={
+                  stat.positive === undefined
+                    ? TextColor.TextDefault
+                    : stat.positive
+                      ? TextColor.SuccessDefault
+                      : TextColor.ErrorDefault
+                }
+              >
+                {stat.value}
+              </Text>
+              <Text variant={TextVariant.BodyXs} color={TextColor.TextMuted}>
+                {stat.label}
+              </Text>
+            </Box>
+          ))}
+        </Box>
+
+        {/* Performance bars */}
+        <Box
+          backgroundColor={BoxBackgroundColor.BackgroundSection}
+          twClassName="rounded-2xl"
+          padding={4}
+          gap={3}
+        >
+          <Text variant={TextVariant.HeadingSm}>
+            {strings('social_trading.profile.performance_title')}
+          </Text>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.End}
+            gap={2}
+            twClassName="h-24"
+          >
+            {trader.perf.map((v, i) => (
+              <View
+                // eslint-disable-next-line react/no-array-index-key
+                key={i}
+                style={{
+                  flex: 1,
+                  height: `${Math.max(8, v * 100)}%`,
+                  borderRadius: 4,
+                  backgroundColor:
+                    i === trader.perf.length - 1
+                      ? colors.success.default
+                      : colors.success.muted,
+                }}
+              />
+            ))}
+          </Box>
+          <Text variant={TextVariant.BodyXs} color={TextColor.TextMuted}>
+            {strings('social_trading.profile.performance_caption')}
+          </Text>
+        </Box>
+
+        {/* Recent trades */}
+        <Box gap={3}>
+          <Text variant={TextVariant.HeadingSm}>
+            {strings('social_trading.profile.recent_trades')}
+          </Text>
+          {trades.length === 0 ? (
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
+              {strings('social_trading.profile.no_trades')}
+            </Text>
+          ) : (
+            trades.map((trade) => (
+              <TradeCard key={trade.id} trade={trade} onCopy={setCopyTarget} />
+            ))
+          )}
+        </Box>
+      </ScrollView>
+      {copyTarget ? (
+        <CopyTradeSheet
+          trade={copyTarget}
+          onClose={() => setCopyTarget(null)}
+        />
+      ) : null}
+    </Box>
+  );
+}
+
+export default SocialTraderProfile;

--- a/app/features/SocialTrading/components/views/SocialTradingFeed/SocialTradingFeed.tsx
+++ b/app/features/SocialTrading/components/views/SocialTradingFeed/SocialTradingFeed.tsx
@@ -1,0 +1,159 @@
+import React, { useMemo, useState } from 'react';
+import { FlatList, Pressable, ScrollView } from 'react-native';
+import {
+  AvatarAccount,
+  AvatarAccountSize,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  ButtonFilter,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+
+import { strings } from '../../../../../../locales/i18n';
+import CopyTradeSheet from '../../CopyTradeSheet/CopyTradeSheet';
+import TradeCard from '../../TradeCard/TradeCard';
+import { useSocialTrading } from '../../../context/SocialTradingContext';
+import {
+  formatPct,
+  MOCK_TRADERS,
+  MOCK_TRADES,
+  Trade,
+} from '../../../data/mockData';
+
+type FeedFilter = 'all' | 'following';
+
+interface SocialTradingFeedProps {
+  onPressTrader: (traderId: string) => void;
+}
+
+/**
+ * Feed of simulated trades with a top-traders strip and filter chips.
+ */
+export function SocialTradingFeed({ onPressTrader }: SocialTradingFeedProps) {
+  const { followedIds } = useSocialTrading();
+  const [filter, setFilter] = useState<FeedFilter>('all');
+  const [copyTarget, setCopyTarget] = useState<Trade | null>(null);
+
+  const trades = useMemo(() => {
+    const sorted = [...MOCK_TRADES].sort((a, b) => a.minutesAgo - b.minutesAgo);
+    if (filter === 'following') {
+      return sorted.filter((t) => followedIds.includes(t.traderId));
+    }
+    return sorted;
+  }, [filter, followedIds]);
+
+  return (
+    <>
+      <FlatList
+        data={trades}
+        keyExtractor={(item) => item.id}
+        testID="social-trading-feed-list"
+        contentContainerStyle={{
+          paddingHorizontal: 16,
+          paddingBottom: 24,
+          paddingTop: 12,
+          gap: 12,
+        }}
+        ListHeaderComponent={
+          <Box gap={4} marginBottom={2}>
+            {/* Top traders strip */}
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={{ gap: 16 }}
+            >
+              {MOCK_TRADERS.map((trader) => (
+                <Pressable
+                  key={trader.id}
+                  onPress={() => onPressTrader(trader.id)}
+                  accessibilityRole="button"
+                  accessibilityLabel={trader.name}
+                  testID={`social-trading-story-${trader.id}`}
+                >
+                  <Box
+                    alignItems={BoxAlignItems.Center}
+                    gap={1}
+                    twClassName="w-16"
+                  >
+                    <AvatarAccount
+                      address={trader.address}
+                      size={AvatarAccountSize.Lg}
+                    />
+                    <Text
+                      variant={TextVariant.BodyXs}
+                      numberOfLines={1}
+                      color={TextColor.TextAlternative}
+                    >
+                      {trader.name.split(' ')[0]}
+                    </Text>
+                    <Text
+                      variant={TextVariant.BodyXs}
+                      fontWeight={FontWeight.Medium}
+                      color={
+                        trader.pnl30d >= 0
+                          ? TextColor.SuccessDefault
+                          : TextColor.ErrorDefault
+                      }
+                    >
+                      {formatPct(trader.pnl30d)}
+                    </Text>
+                  </Box>
+                </Pressable>
+              ))}
+            </ScrollView>
+            {/* Filter chips */}
+            <Box flexDirection={BoxFlexDirection.Row} gap={2}>
+              <ButtonFilter
+                isActive={filter === 'all'}
+                onPress={() => setFilter('all')}
+                testID="social-trading-filter-all"
+              >
+                {strings('social_trading.feed.all_trades')}
+              </ButtonFilter>
+              <ButtonFilter
+                isActive={filter === 'following'}
+                onPress={() => setFilter('following')}
+                testID="social-trading-filter-following"
+              >
+                {strings('social_trading.feed.following')}
+              </ButtonFilter>
+            </Box>
+          </Box>
+        }
+        ListEmptyComponent={
+          <Box alignItems={BoxAlignItems.Center} paddingVertical={12} gap={2}>
+            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+              {strings('social_trading.feed.empty_title')}
+            </Text>
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+              twClassName="text-center"
+            >
+              {strings('social_trading.feed.empty_description')}
+            </Text>
+          </Box>
+        }
+        renderItem={({ item }) => (
+          <TradeCard
+            trade={item}
+            onCopy={setCopyTarget}
+            onPressTrader={onPressTrader}
+          />
+        )}
+      />
+      {copyTarget ? (
+        <CopyTradeSheet
+          trade={copyTarget}
+          onClose={() => setCopyTarget(null)}
+        />
+      ) : null}
+    </>
+  );
+}
+
+export default SocialTradingFeed;

--- a/app/features/SocialTrading/components/views/SocialTradingLeaderboard/SocialTradingLeaderboard.tsx
+++ b/app/features/SocialTrading/components/views/SocialTradingLeaderboard/SocialTradingLeaderboard.tsx
@@ -1,0 +1,208 @@
+import React, { useMemo, useState } from 'react';
+import { FlatList, Pressable } from 'react-native';
+import {
+  AvatarAccount,
+  AvatarAccountSize,
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  FilterButton,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  SegmentedControl,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+
+import { strings } from '../../../../../../locales/i18n';
+import { useAnalytics } from '../../../../../components/hooks/useAnalytics/useAnalytics';
+import { SOCIAL_TRADING_EVENTS } from '../../../analytics/events';
+import { useSocialTrading } from '../../../context/SocialTradingContext';
+import {
+  formatCount,
+  formatPct,
+  MOCK_TRADERS,
+} from '../../../data/mockData';
+
+/**
+ * Fictional multipliers used to fake different time ranges from the single
+ * mocked 30d PnL figure. Prototype-only.
+ */
+const RANGE_MULTIPLIER: Record<string, number> = {
+  '7d': 0.35,
+  '30d': 1,
+  '90d': 2.4,
+};
+
+interface SocialTradingLeaderboardProps {
+  onPressTrader: (traderId: string) => void;
+}
+
+/**
+ * Ranked list of mock traders with a follow toggle.
+ */
+export function SocialTradingLeaderboard({
+  onPressTrader,
+}: SocialTradingLeaderboardProps) {
+  const { isFollowing, toggleFollow } = useSocialTrading();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const [range, setRange] = useState<string>('30d');
+
+  const ranked = useMemo(() => {
+    const mult = RANGE_MULTIPLIER[range] ?? 1;
+    return [...MOCK_TRADERS]
+      .map((t) => ({ ...t, rangePnl: t.pnl30d * mult }))
+      .sort((a, b) => b.rangePnl - a.rangePnl);
+  }, [range]);
+
+  const handleFollow = (traderId: string, following: boolean) => {
+    toggleFollow(traderId);
+    trackEvent(
+      createEventBuilder(SOCIAL_TRADING_EVENTS.TRADER_FOLLOW_TOGGLED)
+        .addProperties({
+          trader_id: traderId,
+          following: !following,
+          source: 'leaderboard',
+        })
+        .build(),
+    );
+  };
+
+  return (
+    <FlatList
+      data={ranked}
+      keyExtractor={(item) => item.id}
+      testID="social-trading-leaderboard-list"
+      contentContainerStyle={{
+        paddingHorizontal: 16,
+        paddingBottom: 24,
+        paddingTop: 12,
+        gap: 8,
+      }}
+      ListHeaderComponent={
+        <Box gap={4} marginBottom={2}>
+          <SegmentedControl value={range} onChange={setRange}>
+            <FilterButton value="7d">
+              {strings('social_trading.leaderboard.range_7d')}
+            </FilterButton>
+            <FilterButton value="30d">
+              {strings('social_trading.leaderboard.range_30d')}
+            </FilterButton>
+            <FilterButton value="90d">
+              {strings('social_trading.leaderboard.range_90d')}
+            </FilterButton>
+          </SegmentedControl>
+        </Box>
+      }
+      renderItem={({ item, index }) => {
+        const following = isFollowing(item.id);
+        return (
+          <Pressable
+            onPress={() => onPressTrader(item.id)}
+            accessibilityRole="button"
+            accessibilityLabel={item.name}
+            testID={`social-trading-leader-${item.id}`}
+          >
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              justifyContent={BoxJustifyContent.Between}
+              backgroundColor={BoxBackgroundColor.BackgroundSection}
+              twClassName="rounded-2xl"
+              padding={3}
+            >
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                gap={3}
+                twClassName="flex-1"
+              >
+                <Text
+                  variant={TextVariant.BodySm}
+                  fontWeight={FontWeight.Bold}
+                  color={
+                    index < 3 ? TextColor.PrimaryDefault : TextColor.TextMuted
+                  }
+                  twClassName="w-5 text-center"
+                >
+                  {index + 1}
+                </Text>
+                <AvatarAccount
+                  address={item.address}
+                  size={AvatarAccountSize.Md}
+                />
+                <Box twClassName="flex-1">
+                  <Box
+                    flexDirection={BoxFlexDirection.Row}
+                    alignItems={BoxAlignItems.Center}
+                    gap={1}
+                  >
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      fontWeight={FontWeight.Medium}
+                      numberOfLines={1}
+                    >
+                      {item.name}
+                    </Text>
+                    {item.verified ? (
+                      <Icon
+                        name={IconName.VerifiedFilled}
+                        size={IconSize.Sm}
+                        color={IconColor.PrimaryDefault}
+                      />
+                    ) : null}
+                  </Box>
+                  <Text
+                    variant={TextVariant.BodyXs}
+                    color={TextColor.TextAlternative}
+                  >
+                    {strings('social_trading.leaderboard.stats', {
+                      winRate: item.winRate,
+                      copiers: formatCount(item.copiers),
+                    })}
+                  </Text>
+                </Box>
+              </Box>
+              <Box alignItems={BoxAlignItems.End} gap={1}>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                  color={
+                    item.rangePnl >= 0
+                      ? TextColor.SuccessDefault
+                      : TextColor.ErrorDefault
+                  }
+                >
+                  {formatPct(item.rangePnl)}
+                </Text>
+                <Button
+                  variant={
+                    following ? ButtonVariant.Tertiary : ButtonVariant.Secondary
+                  }
+                  size={ButtonSize.Sm}
+                  onPress={() => handleFollow(item.id, following)}
+                  testID={`social-trading-follow-${item.id}`}
+                >
+                  {following
+                    ? strings('social_trading.leaderboard.following')
+                    : strings('social_trading.leaderboard.follow')}
+                </Button>
+              </Box>
+            </Box>
+          </Pressable>
+        );
+      }}
+    />
+  );
+}
+
+export default SocialTradingLeaderboard;

--- a/app/features/SocialTrading/components/views/SocialTradingPortfolio/SocialTradingPortfolio.tsx
+++ b/app/features/SocialTrading/components/views/SocialTradingPortfolio/SocialTradingPortfolio.tsx
@@ -1,0 +1,317 @@
+import React, { useMemo } from 'react';
+import { Pressable, ScrollView } from 'react-native';
+import {
+  AvatarAccount,
+  AvatarAccountSize,
+  AvatarToken,
+  AvatarTokenSize,
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  ButtonIcon,
+  ButtonIconSize,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Tag,
+  TagSeverity,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+
+import { strings } from '../../../../../../locales/i18n';
+import { useAnalytics } from '../../../../../components/hooks/useAnalytics/useAnalytics';
+import { SOCIAL_TRADING_EVENTS } from '../../../analytics/events';
+import { useSocialTrading } from '../../../context/SocialTradingContext';
+import { formatPct, formatUsd, getTrader } from '../../../data/mockData';
+
+interface SocialTradingPortfolioProps {
+  onPressTrader: (traderId: string) => void;
+}
+
+/**
+ * Summary of simulated copied positions and followed traders. All values
+ * are mock data; closing a position only removes it from local state.
+ */
+export function SocialTradingPortfolio({
+  onPressTrader,
+}: SocialTradingPortfolioProps) {
+  const { positions, followedIds, closePosition } = useSocialTrading();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+
+  const { totalValue, totalPnlUsd, totalPnlPct } = useMemo(() => {
+    const invested = positions.reduce((sum, p) => sum + p.amountUsd, 0);
+    const pnl = positions.reduce(
+      (sum, p) => sum + (p.amountUsd * p.pnlPct) / 100,
+      0,
+    );
+    return {
+      totalValue: invested + pnl,
+      totalPnlUsd: pnl,
+      totalPnlPct: invested > 0 ? (pnl / invested) * 100 : 0,
+    };
+  }, [positions]);
+
+  const followedTraders = followedIds
+    .map((id) => getTrader(id))
+    .filter((t): t is NonNullable<typeof t> => !!t);
+
+  const handleClose = (positionId: string) => {
+    closePosition(positionId);
+    trackEvent(
+      createEventBuilder(SOCIAL_TRADING_EVENTS.POSITION_CLOSE_SIMULATED)
+        .addProperties({ position_id: positionId, simulated: true })
+        .build(),
+    );
+  };
+
+  return (
+    <ScrollView
+      testID="social-trading-portfolio-scroll"
+      contentContainerStyle={{
+        paddingHorizontal: 16,
+        paddingBottom: 24,
+        paddingTop: 12,
+        gap: 16,
+      }}
+    >
+      {/* Summary card */}
+      <Box
+        backgroundColor={BoxBackgroundColor.BackgroundSection}
+        twClassName="rounded-2xl"
+        padding={5}
+        gap={2}
+      >
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+          {strings('social_trading.portfolio.value_label')}
+        </Text>
+        <Text variant={TextVariant.DisplayMd}>{formatUsd(totalValue)}</Text>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={2}
+        >
+          <Tag
+            severity={
+              totalPnlUsd > 0
+                ? TagSeverity.Success
+                : totalPnlUsd < 0
+                  ? TagSeverity.Danger
+                  : TagSeverity.Neutral
+            }
+            startIconName={
+              totalPnlUsd > 0
+                ? IconName.TrendUp
+                : totalPnlUsd < 0
+                  ? IconName.TrendDown
+                  : undefined
+            }
+          >
+            {`${formatUsd(totalPnlUsd)} (${formatPct(totalPnlPct)})`}
+          </Tag>
+          <Text variant={TextVariant.BodyXs} color={TextColor.TextMuted}>
+            {strings('social_trading.portfolio.open_following', {
+              open: positions.length,
+              following: followedTraders.length,
+            })}
+          </Text>
+        </Box>
+      </Box>
+
+      {/* Positions */}
+      <Box gap={3}>
+        <Text variant={TextVariant.HeadingSm}>
+          {strings('social_trading.portfolio.positions_title')}
+        </Text>
+        {positions.length === 0 ? (
+          <Box
+            alignItems={BoxAlignItems.Center}
+            backgroundColor={BoxBackgroundColor.BackgroundSection}
+            twClassName="rounded-2xl"
+            paddingVertical={8}
+            paddingHorizontal={4}
+            gap={2}
+          >
+            <Icon
+              name={IconName.Copy}
+              size={IconSize.Xl}
+              color={IconColor.IconMuted}
+            />
+            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+              {strings('social_trading.portfolio.empty_title')}
+            </Text>
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+              twClassName="text-center"
+            >
+              {strings('social_trading.portfolio.empty_description')}
+            </Text>
+          </Box>
+        ) : (
+          positions.map((pos) => {
+            const trader = getTrader(pos.traderId);
+            const pnlUsd = (pos.amountUsd * pos.pnlPct) / 100;
+            return (
+              <Box
+                key={pos.id}
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                justifyContent={BoxJustifyContent.Between}
+                backgroundColor={BoxBackgroundColor.BackgroundSection}
+                twClassName="rounded-2xl"
+                padding={3}
+              >
+                <Box
+                  flexDirection={BoxFlexDirection.Row}
+                  alignItems={BoxAlignItems.Center}
+                  gap={3}
+                  twClassName="flex-1"
+                >
+                  <AvatarToken
+                    name={pos.tokenName}
+                    fallbackText={pos.tokenSymbol.slice(0, 1)}
+                    size={AvatarTokenSize.Md}
+                  />
+                  <Box twClassName="flex-1">
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      fontWeight={FontWeight.Medium}
+                    >
+                      {pos.tokenSymbol}{' '}
+                      {pos.side === 'buy'
+                        ? strings('social_trading.portfolio.long')
+                        : strings('social_trading.portfolio.short')}
+                    </Text>
+                    <Text
+                      variant={TextVariant.BodyXs}
+                      color={TextColor.TextAlternative}
+                      numberOfLines={1}
+                    >
+                      {strings('social_trading.portfolio.copying', {
+                        name:
+                          trader?.name ??
+                          strings('social_trading.sheet.a_trader'),
+                        amount: formatUsd(pos.amountUsd),
+                      })}
+                    </Text>
+                  </Box>
+                </Box>
+                <Box
+                  flexDirection={BoxFlexDirection.Row}
+                  alignItems={BoxAlignItems.Center}
+                  gap={2}
+                >
+                  <Box alignItems={BoxAlignItems.End}>
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      fontWeight={FontWeight.Medium}
+                      color={
+                        pos.pnlPct > 0
+                          ? TextColor.SuccessDefault
+                          : pos.pnlPct < 0
+                            ? TextColor.ErrorDefault
+                            : TextColor.TextDefault
+                      }
+                    >
+                      {formatPct(pos.pnlPct)}
+                    </Text>
+                    <Text
+                      variant={TextVariant.BodyXs}
+                      color={TextColor.TextAlternative}
+                    >
+                      {formatUsd(pnlUsd)}
+                    </Text>
+                  </Box>
+                  <ButtonIcon
+                    iconName={IconName.Close}
+                    size={ButtonIconSize.Sm}
+                    onPress={() => handleClose(pos.id)}
+                    accessibilityLabel={strings(
+                      'social_trading.portfolio.close_position',
+                    )}
+                    testID={`social-trading-close-${pos.id}`}
+                  />
+                </Box>
+              </Box>
+            );
+          })
+        )}
+      </Box>
+
+      {/* Following */}
+      <Box gap={3}>
+        <Text variant={TextVariant.HeadingSm}>
+          {strings('social_trading.portfolio.following_title')}
+        </Text>
+        {followedTraders.length === 0 ? (
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {strings('social_trading.portfolio.following_empty')}
+          </Text>
+        ) : (
+          followedTraders.map((trader) => (
+            <Pressable
+              key={trader.id}
+              onPress={() => onPressTrader(trader.id)}
+              accessibilityRole="button"
+              accessibilityLabel={trader.name}
+              testID={`social-trading-following-${trader.id}`}
+            >
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                justifyContent={BoxJustifyContent.Between}
+                backgroundColor={BoxBackgroundColor.BackgroundSection}
+                twClassName="rounded-2xl"
+                padding={3}
+              >
+                <Box
+                  flexDirection={BoxFlexDirection.Row}
+                  alignItems={BoxAlignItems.Center}
+                  gap={3}
+                >
+                  <AvatarAccount
+                    address={trader.address}
+                    size={AvatarAccountSize.Md}
+                  />
+                  <Box>
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      fontWeight={FontWeight.Medium}
+                    >
+                      {trader.name}
+                    </Text>
+                    <Text
+                      variant={TextVariant.BodyXs}
+                      color={TextColor.TextAlternative}
+                    >
+                      {trader.handle}
+                    </Text>
+                  </Box>
+                </Box>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                  color={
+                    trader.pnl30d >= 0
+                      ? TextColor.SuccessDefault
+                      : TextColor.ErrorDefault
+                  }
+                >
+                  {formatPct(trader.pnl30d)}
+                </Text>
+              </Box>
+            </Pressable>
+          ))
+        )}
+      </Box>
+    </ScrollView>
+  );
+}
+
+export default SocialTradingPortfolio;

--- a/app/features/SocialTrading/components/views/SocialTradingView/SocialTradingView.tsx
+++ b/app/features/SocialTrading/components/views/SocialTradingView/SocialTradingView.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import {
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  ButtonFilter,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+
+import { strings } from '../../../../../../locales/i18n';
+import Routes from '../../../../../constants/navigation/Routes';
+import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
+import { SocialTradingFeed } from '../SocialTradingFeed/SocialTradingFeed';
+import { SocialTradingLeaderboard } from '../SocialTradingLeaderboard/SocialTradingLeaderboard';
+import { SocialTradingPortfolio } from '../SocialTradingPortfolio/SocialTradingPortfolio';
+
+type SocialTradingTab = 'feed' | 'leaderboard' | 'portfolio';
+
+/**
+ * Root view of the Social Trading prototype. Hosts the feed, leaderboard,
+ * and simulated portfolio behind local tab state, with a persistent
+ * prototype/mock-data disclosure banner.
+ */
+export function SocialTradingView() {
+  const navigation = useNavigation<AppNavigationProp>();
+  const [tab, setTab] = useState<SocialTradingTab>('feed');
+
+  const onPressTrader = (traderId: string) => {
+    navigation.navigate(Routes.SOCIAL_TRADING.TRADER_PROFILE, { traderId });
+  };
+
+  return (
+    <Box
+      twClassName="flex-1"
+      backgroundColor={BoxBackgroundColor.BackgroundDefault}
+      testID="social-trading-view"
+    >
+      {/* Prototype disclosure */}
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        backgroundColor={BoxBackgroundColor.WarningMuted}
+        paddingHorizontal={4}
+        paddingVertical={2}
+        gap={2}
+      >
+        <Icon
+          name={IconName.Warning}
+          size={IconSize.Sm}
+          color={IconColor.WarningDefault}
+        />
+        <Text
+          variant={TextVariant.BodyXs}
+          color={TextColor.TextAlternative}
+          twClassName="flex-1"
+        >
+          {strings('social_trading.prototype_banner')}
+        </Text>
+      </Box>
+
+      {/* Tabs */}
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        gap={2}
+        paddingHorizontal={4}
+        paddingVertical={3}
+      >
+        <ButtonFilter
+          isActive={tab === 'feed'}
+          onPress={() => setTab('feed')}
+          testID="social-trading-tab-feed"
+        >
+          {strings('social_trading.tabs.feed')}
+        </ButtonFilter>
+        <ButtonFilter
+          isActive={tab === 'leaderboard'}
+          onPress={() => setTab('leaderboard')}
+          testID="social-trading-tab-leaderboard"
+        >
+          {strings('social_trading.tabs.leaderboard')}
+        </ButtonFilter>
+        <ButtonFilter
+          isActive={tab === 'portfolio'}
+          onPress={() => setTab('portfolio')}
+          testID="social-trading-tab-portfolio"
+        >
+          {strings('social_trading.tabs.portfolio')}
+        </ButtonFilter>
+      </Box>
+
+      {tab === 'feed' ? (
+        <SocialTradingFeed onPressTrader={onPressTrader} />
+      ) : null}
+      {tab === 'leaderboard' ? (
+        <SocialTradingLeaderboard onPressTrader={onPressTrader} />
+      ) : null}
+      {tab === 'portfolio' ? (
+        <SocialTradingPortfolio onPressTrader={onPressTrader} />
+      ) : null}
+    </Box>
+  );
+}
+
+export default SocialTradingView;

--- a/app/features/SocialTrading/context/SocialTradingContext.test.tsx
+++ b/app/features/SocialTrading/context/SocialTradingContext.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { act, renderHook } from '@testing-library/react-native';
+
+import {
+  SocialTradingProvider,
+  useSocialTrading,
+} from './SocialTradingContext';
+import { MOCK_TRADES } from '../data/mockData';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <SocialTradingProvider>{children}</SocialTradingProvider>
+);
+
+describe('SocialTradingContext', () => {
+  it('throws when used outside the provider', () => {
+    expect(() => renderHook(() => useSocialTrading())).toThrow(
+      'useSocialTrading must be used within SocialTradingProvider',
+    );
+  });
+
+  it('toggles following a trader', () => {
+    const { result } = renderHook(() => useSocialTrading(), { wrapper });
+
+    expect(result.current.isFollowing('t2')).toBe(false);
+    act(() => result.current.toggleFollow('t2'));
+    expect(result.current.isFollowing('t2')).toBe(true);
+    act(() => result.current.toggleFollow('t2'));
+    expect(result.current.isFollowing('t2')).toBe(false);
+  });
+
+  it('toggles liking a trade', () => {
+    const { result } = renderHook(() => useSocialTrading(), { wrapper });
+
+    expect(result.current.isLiked('tr1')).toBe(false);
+    act(() => result.current.toggleLike('tr1'));
+    expect(result.current.isLiked('tr1')).toBe(true);
+    act(() => result.current.toggleLike('tr1'));
+    expect(result.current.isLiked('tr1')).toBe(false);
+  });
+
+  it('creates a simulated position when copying a trade', () => {
+    const { result } = renderHook(() => useSocialTrading(), { wrapper });
+    const trade = MOCK_TRADES[0];
+
+    act(() => result.current.copyTrade(trade, 250));
+
+    expect(result.current.positions).toHaveLength(1);
+    const position = result.current.positions[0];
+    expect(position).toMatchObject({
+      tradeId: trade.id,
+      traderId: trade.traderId,
+      tokenSymbol: trade.tokenSymbol,
+      side: trade.side,
+      amountUsd: 250,
+      entryPrice: trade.price,
+    });
+  });
+
+  it('removes a simulated position when closed', () => {
+    const { result } = renderHook(() => useSocialTrading(), { wrapper });
+
+    act(() => result.current.copyTrade(MOCK_TRADES[0], 100));
+    const positionId = result.current.positions[0].id;
+
+    act(() => result.current.closePosition(positionId));
+    expect(result.current.positions).toHaveLength(0);
+  });
+});

--- a/app/features/SocialTrading/context/SocialTradingContext.tsx
+++ b/app/features/SocialTrading/context/SocialTradingContext.tsx
@@ -1,0 +1,147 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+import { Trade, TradeSide } from '../data/mockData';
+
+/**
+ * A simulated copied position. Created locally when the user "copies" a
+ * mock trade. No funds move and nothing is signed.
+ */
+export interface SimulatedPosition {
+  id: string;
+  tradeId: string;
+  traderId: string;
+  tokenSymbol: string;
+  tokenName: string;
+  side: TradeSide;
+  amountUsd: number;
+  entryPrice: number;
+  pnlPct: number;
+  createdAt: number;
+}
+
+export interface SocialTradingState {
+  followedIds: string[];
+  likedTradeIds: string[];
+  positions: SimulatedPosition[];
+  toggleFollow: (traderId: string) => void;
+  isFollowing: (traderId: string) => boolean;
+  toggleLike: (tradeId: string) => void;
+  isLiked: (tradeId: string) => boolean;
+  copyTrade: (trade: Trade, amountUsd: number) => void;
+  closePosition: (positionId: string) => void;
+}
+
+const SocialTradingContext = createContext<SocialTradingState | null>(null);
+
+const DEFAULT_FOLLOWED_IDS = ['t1', 't4'];
+
+/**
+ * Feature-local, in-memory state for the Social Trading prototype.
+ *
+ * Deliberately not persisted and not in Redux/controllers: the state is
+ * throwaway simulation data scoped to the prototype flow. When the feature
+ * graduates, this provider is the seam to replace with real services
+ * (Redux slice or controller per the feature development guidelines).
+ */
+export function SocialTradingProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [followedIds, setFollowedIds] =
+    useState<string[]>(DEFAULT_FOLLOWED_IDS);
+  const [likedTradeIds, setLikedTradeIds] = useState<string[]>([]);
+  const [positions, setPositions] = useState<SimulatedPosition[]>([]);
+
+  const toggleFollow = useCallback((traderId: string) => {
+    setFollowedIds((ids) =>
+      ids.includes(traderId)
+        ? ids.filter((id) => id !== traderId)
+        : [...ids, traderId],
+    );
+  }, []);
+
+  const toggleLike = useCallback((tradeId: string) => {
+    setLikedTradeIds((ids) =>
+      ids.includes(tradeId)
+        ? ids.filter((id) => id !== tradeId)
+        : [...ids, tradeId],
+    );
+  }, []);
+
+  const copyTrade = useCallback((trade: Trade, amountUsd: number) => {
+    const position: SimulatedPosition = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+      tradeId: trade.id,
+      traderId: trade.traderId,
+      tokenSymbol: trade.tokenSymbol,
+      tokenName: trade.tokenName,
+      side: trade.side,
+      amountUsd,
+      entryPrice: trade.price,
+      pnlPct: trade.pnlPct,
+      createdAt: Date.now(),
+    };
+    setPositions((p) => [position, ...p]);
+  }, []);
+
+  const closePosition = useCallback((positionId: string) => {
+    setPositions((p) => p.filter((pos) => pos.id !== positionId));
+  }, []);
+
+  const isFollowing = useCallback(
+    (traderId: string) => followedIds.includes(traderId),
+    [followedIds],
+  );
+  const isLiked = useCallback(
+    (tradeId: string) => likedTradeIds.includes(tradeId),
+    [likedTradeIds],
+  );
+
+  const value = useMemo<SocialTradingState>(
+    () => ({
+      followedIds,
+      likedTradeIds,
+      positions,
+      toggleFollow,
+      isFollowing,
+      toggleLike,
+      isLiked,
+      copyTrade,
+      closePosition,
+    }),
+    [
+      followedIds,
+      likedTradeIds,
+      positions,
+      toggleFollow,
+      isFollowing,
+      toggleLike,
+      isLiked,
+      copyTrade,
+      closePosition,
+    ],
+  );
+
+  return (
+    <SocialTradingContext.Provider value={value}>
+      {children}
+    </SocialTradingContext.Provider>
+  );
+}
+
+export function useSocialTrading(): SocialTradingState {
+  const ctx = useContext(SocialTradingContext);
+  if (!ctx) {
+    throw new Error(
+      'useSocialTrading must be used within SocialTradingProvider',
+    );
+  }
+  return ctx;
+}

--- a/app/features/SocialTrading/data/mockData.ts
+++ b/app/features/SocialTrading/data/mockData.ts
@@ -1,0 +1,280 @@
+/**
+ * Mock data for the Social Trading prototype.
+ *
+ * All traders, trades, prices, and returns in this file are fictional and
+ * exist only to exercise the prototype UI. Nothing here reflects real
+ * accounts, real market data, or real performance.
+ *
+ * This module acts as the single data boundary for the feature. When the
+ * prototype graduates to real services, replace these exports with an
+ * adapter backed by the production API while keeping the same types.
+ */
+
+export type TradeSide = 'buy' | 'sell';
+
+export interface Trader {
+  id: string;
+  name: string;
+  handle: string;
+  address: string;
+  verified: boolean;
+  /** Win rate, 0-100 */
+  winRate: number;
+  /** 30-day PnL, percent */
+  pnl30d: number;
+  followers: number;
+  copiers: number;
+  aumUsd: number;
+  bio: string;
+  /** Normalized 0-1 sparkline points */
+  perf: number[];
+}
+
+export interface Trade {
+  id: string;
+  traderId: string;
+  side: TradeSide;
+  tokenSymbol: string;
+  tokenName: string;
+  amountUsd: number;
+  price: number;
+  minutesAgo: number;
+  /** Simulated live PnL of the position, percent */
+  pnlPct: number;
+  note?: string;
+  likes: number;
+  copies: number;
+}
+
+export const MOCK_TRADERS: Trader[] = [
+  {
+    id: 't1',
+    name: 'Nova Chen',
+    handle: '@novatrades',
+    address: '0x9Cbf7c41B7787F6c621115010D3B044029FE2Ce8',
+    verified: true,
+    winRate: 78,
+    pnl30d: 42.6,
+    followers: 18400,
+    copiers: 2310,
+    aumUsd: 1240000,
+    bio: 'Momentum on majors, tight stops. I only post trades I actually take.',
+    perf: [0.2, 0.35, 0.3, 0.5, 0.45, 0.62, 0.58, 0.8, 0.75, 0.92],
+  },
+  {
+    id: 't2',
+    name: 'Marcus Vale',
+    handle: '@valemacro',
+    address: '0x1f4E7Db8514Ec4E99467a8d2ee3a63094a904e7A',
+    verified: true,
+    winRate: 64,
+    pnl30d: 18.9,
+    followers: 9200,
+    copiers: 1150,
+    aumUsd: 620000,
+    bio: 'Macro swing trader. ETH maxi with a rotation habit.',
+    perf: [0.4, 0.42, 0.38, 0.5, 0.55, 0.5, 0.6, 0.58, 0.66, 0.7],
+  },
+  {
+    id: 't3',
+    name: 'Ivy Ramos',
+    handle: '@ivy_onchain',
+    address: '0x8a3B7c9d2E4f5A6b8C9d0E1f2A3b4C5d6E7f8A9b',
+    verified: false,
+    winRate: 71,
+    pnl30d: 27.3,
+    followers: 6100,
+    copiers: 840,
+    aumUsd: 310000,
+    bio: 'DeFi native. Farming narratives before they trend.',
+    perf: [0.3, 0.28, 0.45, 0.4, 0.52, 0.6, 0.55, 0.68, 0.72, 0.78],
+  },
+  {
+    id: 't4',
+    name: 'Kenji Sato',
+    handle: '@kenji_scalps',
+    address: '0x5D2a8E7f3C1b9A0d4E6f8C2a1B3d5E7f9A0c2E4d',
+    verified: true,
+    winRate: 82,
+    pnl30d: 12.4,
+    followers: 22700,
+    copiers: 3480,
+    aumUsd: 2100000,
+    bio: 'High win-rate scalper. Small gains, compounded daily.',
+    perf: [0.5, 0.52, 0.54, 0.53, 0.58, 0.6, 0.62, 0.61, 0.66, 0.68],
+  },
+  {
+    id: 't5',
+    name: 'Sofia Andersson',
+    handle: '@sofia_alpha',
+    address: '0x3C6e9F1a4B7d0E2f5A8c1D4e7F0a3B6c9D2e5F8a',
+    verified: false,
+    winRate: 58,
+    pnl30d: 64.1,
+    followers: 4400,
+    copiers: 620,
+    aumUsd: 180000,
+    bio: 'Asymmetric bets on small caps. High risk, sized accordingly.',
+    perf: [0.15, 0.3, 0.22, 0.5, 0.42, 0.35, 0.7, 0.62, 0.85, 0.95],
+  },
+  {
+    id: 't6',
+    name: 'Dmitri Volkov',
+    handle: '@volkov_waves',
+    address: '0x7B0d3F6a9C2e5B8d1F4a7C0e3B6d9F2a5C8e1B4d',
+    verified: true,
+    winRate: 69,
+    pnl30d: 21.7,
+    followers: 12800,
+    copiers: 1930,
+    aumUsd: 890000,
+    bio: 'Elliott waves and liquidity zones. Patience pays.',
+    perf: [0.35, 0.4, 0.44, 0.42, 0.5, 0.56, 0.52, 0.6, 0.64, 0.7],
+  },
+];
+
+export const MOCK_TRADES: Trade[] = [
+  {
+    id: 'tr1',
+    traderId: 't1',
+    side: 'buy',
+    tokenSymbol: 'ETH',
+    tokenName: 'Ethereum',
+    amountUsd: 24500,
+    price: 3841.2,
+    minutesAgo: 4,
+    pnlPct: 2.4,
+    note: 'Reclaimed the range low with volume. Targeting 4k, stop under 3.7k.',
+    likes: 214,
+    copies: 96,
+  },
+  {
+    id: 'tr2',
+    traderId: 't4',
+    side: 'sell',
+    tokenSymbol: 'SOL',
+    tokenName: 'Solana',
+    amountUsd: 8900,
+    price: 212.55,
+    minutesAgo: 12,
+    pnlPct: 6.8,
+    note: 'Taking profit into resistance. Will rebuy the retest.',
+    likes: 158,
+    copies: 61,
+  },
+  {
+    id: 'tr3',
+    traderId: 't5',
+    side: 'buy',
+    tokenSymbol: 'ARB',
+    tokenName: 'Arbitrum',
+    amountUsd: 3200,
+    price: 1.18,
+    minutesAgo: 26,
+    pnlPct: 11.2,
+    note: 'Narrative rotation into L2s starting. Small cap sized bet.',
+    likes: 342,
+    copies: 187,
+  },
+  {
+    id: 'tr4',
+    traderId: 't2',
+    side: 'buy',
+    tokenSymbol: 'LINK',
+    tokenName: 'Chainlink',
+    amountUsd: 15600,
+    price: 22.4,
+    minutesAgo: 47,
+    pnlPct: -1.3,
+    note: 'Accumulating under 23. This one is a multi-week hold.',
+    likes: 97,
+    copies: 44,
+  },
+  {
+    id: 'tr5',
+    traderId: 't3',
+    side: 'buy',
+    tokenSymbol: 'AAVE',
+    tokenName: 'Aave',
+    amountUsd: 5400,
+    price: 301.7,
+    minutesAgo: 73,
+    pnlPct: 3.9,
+    note: 'Fee switch chatter picking up. DeFi blue chips first.',
+    likes: 126,
+    copies: 58,
+  },
+  {
+    id: 'tr6',
+    traderId: 't6',
+    side: 'sell',
+    tokenSymbol: 'BTC',
+    tokenName: 'Bitcoin',
+    amountUsd: 40200,
+    price: 97210.0,
+    minutesAgo: 95,
+    pnlPct: 4.1,
+    note: 'Wave 5 exhaustion at the weekly level. De-risking half.',
+    likes: 289,
+    copies: 132,
+  },
+  {
+    id: 'tr7',
+    traderId: 't1',
+    side: 'buy',
+    tokenSymbol: 'OP',
+    tokenName: 'Optimism',
+    amountUsd: 7800,
+    price: 2.86,
+    minutesAgo: 140,
+    pnlPct: -2.7,
+    note: 'Early entry, wide stop. L2 basket play with ARB.',
+    likes: 84,
+    copies: 39,
+  },
+  {
+    id: 'tr8',
+    traderId: 't4',
+    side: 'buy',
+    tokenSymbol: 'USDC',
+    tokenName: 'USD Coin',
+    amountUsd: 52000,
+    price: 1.0,
+    minutesAgo: 210,
+    pnlPct: 0,
+    note: 'Rotating to stables into the weekend. Flat is a position.',
+    likes: 63,
+    copies: 21,
+  },
+];
+
+export function getTrader(id: string): Trader | undefined {
+  return MOCK_TRADERS.find((t) => t.id === id);
+}
+
+export function tradesByTrader(traderId: string): Trade[] {
+  return MOCK_TRADES.filter((t) => t.traderId === traderId);
+}
+
+export function formatUsd(n: number): string {
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (abs >= 10_000) return `$${(n / 1_000).toFixed(1)}K`;
+  return `$${n.toLocaleString('en-US', { maximumFractionDigits: 2 })}`;
+}
+
+export function formatCount(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
+  return `${n}`;
+}
+
+export function formatMinutesAgo(minutes: number): string {
+  if (minutes < 60) return `${minutes}m`;
+  if (minutes < 1440) return `${Math.floor(minutes / 60)}h`;
+  return `${Math.floor(minutes / 1440)}d`;
+}
+
+export function formatPct(p: number): string {
+  const sign = p > 0 ? '+' : '';
+  return `${sign}${p.toFixed(1)}%`;
+}

--- a/app/features/SocialTrading/routes/index.tsx
+++ b/app/features/SocialTrading/routes/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import { strings } from '../../../../locales/i18n';
+import Routes from '../../../constants/navigation/Routes';
+import { SocialTradingProvider } from '../context/SocialTradingContext';
+import SocialTradingView from '../components/views/SocialTradingView/SocialTradingView';
+import SocialTraderProfile from '../components/views/SocialTraderProfile/SocialTraderProfile';
+
+const Stack = createNativeStackNavigator();
+
+/**
+ * Feature-local stack for the Social Trading prototype. The provider is
+ * mounted here so simulated state lives and dies with the flow.
+ */
+export function SocialTradingScreenStack() {
+  return (
+    <SocialTradingProvider>
+      <Stack.Navigator>
+        <Stack.Screen
+          name={Routes.SOCIAL_TRADING.HOME}
+          component={SocialTradingView}
+          options={{ title: strings('social_trading.title') }}
+        />
+        <Stack.Screen
+          name={Routes.SOCIAL_TRADING.TRADER_PROFILE}
+          component={SocialTraderProfile}
+          options={{ title: strings('social_trading.profile.title') }}
+        />
+      </Stack.Navigator>
+    </SocialTradingProvider>
+  );
+}
+
+export default SocialTradingScreenStack;

--- a/app/features/SocialTrading/selectors/socialTradingPrototypeEnabled/index.test.ts
+++ b/app/features/SocialTrading/selectors/socialTradingPrototypeEnabled/index.test.ts
@@ -1,0 +1,73 @@
+import {
+  selectSocialTradingPrototypeEnabled,
+  FEATURE_FLAG_NAME,
+  DEFAULT_SOCIAL_TRADING_PROTOTYPE_ENABLED,
+} from './index';
+
+interface TestState {
+  engine: {
+    backgroundState: {
+      RemoteFeatureFlagController: {
+        remoteFeatureFlags: Record<string, unknown>;
+        cacheTimestamp: number;
+      };
+    };
+  };
+}
+
+const buildState = (remoteFeatureFlags: Record<string, unknown>): TestState => ({
+  engine: {
+    backgroundState: {
+      RemoteFeatureFlagController: {
+        remoteFeatureFlags,
+        cacheTimestamp: 0,
+      },
+    },
+  },
+});
+
+describe('selectSocialTradingPrototypeEnabled', () => {
+  const originalEnv = process.env.MM_SOCIAL_TRADING_PROTOTYPE_ENABLED;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.MM_SOCIAL_TRADING_PROTOTYPE_ENABLED;
+    } else {
+      process.env.MM_SOCIAL_TRADING_PROTOTYPE_ENABLED = originalEnv;
+    }
+  });
+
+  it('defaults to disabled when the remote flag is absent', () => {
+    delete process.env.MM_SOCIAL_TRADING_PROTOTYPE_ENABLED;
+    expect(DEFAULT_SOCIAL_TRADING_PROTOTYPE_ENABLED).toBe(false);
+    expect(
+      selectSocialTradingPrototypeEnabled(
+        buildState({}) as unknown as Parameters<
+          typeof selectSocialTradingPrototypeEnabled
+        >[0],
+      ),
+    ).toBe(false);
+  });
+
+  it('returns the remote flag value when present', () => {
+    delete process.env.MM_SOCIAL_TRADING_PROTOTYPE_ENABLED;
+    expect(
+      selectSocialTradingPrototypeEnabled(
+        buildState({ [FEATURE_FLAG_NAME]: true }) as unknown as Parameters<
+          typeof selectSocialTradingPrototypeEnabled
+        >[0],
+      ),
+    ).toBe(true);
+  });
+
+  it('lets the env var override the remote flag in development', () => {
+    process.env.MM_SOCIAL_TRADING_PROTOTYPE_ENABLED = 'true';
+    expect(
+      selectSocialTradingPrototypeEnabled(
+        buildState({ [FEATURE_FLAG_NAME]: false }) as unknown as Parameters<
+          typeof selectSocialTradingPrototypeEnabled
+        >[0],
+      ),
+    ).toBe(true);
+  });
+});

--- a/app/features/SocialTrading/selectors/socialTradingPrototypeEnabled/index.ts
+++ b/app/features/SocialTrading/selectors/socialTradingPrototypeEnabled/index.ts
@@ -1,0 +1,27 @@
+import { createSelector } from 'reselect';
+import { hasProperty } from '@metamask/utils';
+
+import { selectRemoteFeatureFlags } from '../../../../selectors/featureFlagController';
+import { getFeatureFlagValue } from '../../../../selectors/featureFlagController/env';
+
+/**
+ * The Social Trading prototype is disabled by default. Enable it locally
+ * with the MM_SOCIAL_TRADING_PROTOTYPE_ENABLED env var or via the feature
+ * flag override developer screen.
+ */
+export const DEFAULT_SOCIAL_TRADING_PROTOTYPE_ENABLED = false;
+export const FEATURE_FLAG_NAME = 'socialTradingPrototypeEnabled';
+
+export const selectSocialTradingPrototypeEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const remoteValue = hasProperty(remoteFeatureFlags, FEATURE_FLAG_NAME)
+      ? (remoteFeatureFlags[FEATURE_FLAG_NAME] as boolean)
+      : DEFAULT_SOCIAL_TRADING_PROTOTYPE_ENABLED;
+
+    return getFeatureFlagValue(
+      process.env.MM_SOCIAL_TRADING_PROTOTYPE_ENABLED,
+      remoteValue,
+    );
+  },
+);

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1353,6 +1353,76 @@
       "edit_quick_amounts_sell_below_max": "Sell amount should be below 100%"
     }
   },
+  "social_trading": {
+    "title": "Social trading",
+    "prototype_banner": "Prototype preview. All traders, trades, and returns are simulated. Copying a trade doesn't move real funds.",
+    "tabs": {
+      "feed": "Feed",
+      "leaderboard": "Leaders",
+      "portfolio": "Portfolio"
+    },
+    "feed": {
+      "all_trades": "All trades",
+      "following": "Following",
+      "empty_title": "No trades yet",
+      "empty_description": "Follow traders in the Leaders tab to see their trades here."
+    },
+    "trade": {
+      "buy": "Buy",
+      "sell": "Sell",
+      "like": "Like trade",
+      "time_ago": "{{time}} ago",
+      "copied_count": "{{count}} copied",
+      "copy_trade": "Copy trade"
+    },
+    "sheet": {
+      "title": "Copy trade",
+      "a_trader": "this trader",
+      "by_trader": "By {{name}} {{handle}}",
+      "amount_label": "Amount to copy",
+      "est_entry": "Est. entry",
+      "est_entry_value": "{{price}} per {{symbol}}",
+      "simulation_notice": "This is a simulation. No transaction is created and no funds move.",
+      "confirm": "Copy for {{amount}} (simulated)",
+      "done_title": "Trade copied",
+      "done_description": "{{amount}} mirroring {{trader}}'s {{symbol}} trade was added to your simulated portfolio."
+    },
+    "leaderboard": {
+      "range_7d": "7D",
+      "range_30d": "30D",
+      "range_90d": "90D",
+      "stats": "{{winRate}}% win rate · {{copiers}} copiers",
+      "follow": "Follow",
+      "following": "Following"
+    },
+    "portfolio": {
+      "value_label": "Simulated copied positions value",
+      "open_following": "{{open}} open · {{following}} following",
+      "positions_title": "Copied positions",
+      "empty_title": "Nothing copied yet",
+      "empty_description": "Copy a trade from the feed and it will show up here with simulated performance.",
+      "long": "long",
+      "short": "short",
+      "copying": "Copying {{name}} · {{amount}} in",
+      "close_position": "Close position",
+      "following_title": "Traders you follow",
+      "following_empty": "You aren't following anyone yet. Find traders in the Leaders tab."
+    },
+    "profile": {
+      "title": "Trader",
+      "not_found": "Trader not found",
+      "go_back": "Go back",
+      "followers": "{{count}} followers",
+      "stat_pnl_30d": "30D PnL",
+      "stat_win_rate": "Win rate",
+      "stat_copiers": "Copiers",
+      "stat_aum": "AUM",
+      "performance_title": "Performance",
+      "performance_caption": "Last 10 weeks, relative returns (simulated)",
+      "recent_trades": "Recent trades",
+      "no_trades": "No public trades in the last 24 hours."
+    }
+  },
   "perps": {
     "basic_functionality_disabled_title": "Perps is not available",
     "title": "Perps",


### PR DESCRIPTION
Testing Replit to Code

## What

Adds a **feature-flagged, mock-data-only prototype** of a social/copy-trading experience under app/features/SocialTrading:

- Simulated trade feed with a top-traders strip and All/Following filters
- Trader leaderboard with 7D/30D/90D ranges and follow toggle
- Trader profile (stats, simulated performance bars, recent trades)
- Simulated copy-trade bottom sheet with preset amounts
- Local simulated portfolio (copied positions + followed traders)

## Safety boundaries

- **Disabled by default.** The remote flag socialTradingPrototypeEnabled defaults to false; the flow is only registered on the main stack while the flag is enabled, and there is no user-visible entry point otherwise.
- **Everything is simulated.** All traders, trades, prices, and returns are fictional fixtures in data/mockData.ts. Copying a trade records an in-memory position only — no transaction, no signing, no approvals, no movement of funds.
- The UI shows a persistent prototype banner plus an in-sheet simulation notice.

## How to try it

1. Set MM_SOCIAL_TRADING_PROTOTYPE_ENABLED=true in .js.env (or toggle socialTradingPrototypeEnabled in the Feature Flag Override dev screen).
2. Navigate to Routes.SOCIAL_TRADING.ROOT ("SocialTrading"), e.g. from a dev entry point.

## Implementation notes

- Follows the SampleFeature conventions: feature-local analytics events, remote-flag selector with env override, localized strings, and design-system components from @metamask/design-system-react-native.
- Simulated state intentionally lives in a feature-local React context mounted at the stack root (throwaway prototype state; see the feature README for the graduation seams to Redux/controller + real services).
- Shared-file footprint kept minimal: MainNavigator registration, Routes, navigation param types, featureFlags default, en.json strings.

## Validation

- Focused Jest tests added for the flag selector (default-off, remote value, env override) and the simulated state context (follow/like/copy/close).
- Authored in a sparse environment without node_modules, so yarn lint:tsc / yarn jest were not run locally — please rely on CI. A source-level review verified import paths, i18n key coverage, and design-system component usage.

## For maintainers

- To get this into TestFlight for internal review, run the existing iOS internal-build pipeline on this branch (no signing/release config was touched).

Draft PR — prototype for internal evaluation only, not intended to ship as-is.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prototype is off by default, has no production entry point, and performs no transactions or fund movement—only mock UI and local state when explicitly enabled.
> 
> **Overview**
> Introduces a **feature-flagged Social Trading prototype** under `app/features/SocialTrading`, wired into the main stack only when `socialTradingPrototypeEnabled` is on (default **off**, with `MM_SOCIAL_TRADING_PROTOTYPE_ENABLED` env override).
> 
> The flow is a self-contained native stack with a **feed** (mock trades, top-traders strip, All/Following filters), **leaderboard** (7D/30D/90D, follow), **simulated portfolio** (copied positions + followed traders), **trader profile**, and a **copy-trade bottom sheet** with preset USD amounts. All data comes from `mockData.ts`; follow/like/copy/close state lives in feature-local **React context** (in-memory only). UI copy and banners state clearly that nothing is signed or moves funds.
> 
> Shared touchpoints are minimal: `MainNavigator` screen registration, `Routes` / navigation param types, `featureFlags` default, `en.json` strings, plus feature-local analytics and Jest coverage for the flag selector and context behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75e2ea51d1938f53ca3df53797e3f5e40a038982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->