### PR TITLE
fix: sort bridge quotes by cost cp-8.10.0 cp-8.9.1-ota

### DIFF
--- a/.yarn/patches/@metamask-bridge-controller-npm-80.1.0-ea41d41dd2.patch
+++ b/.yarn/patches/@metamask-bridge-controller-npm-80.1.0-ea41d41dd2.patch
@@ -1,0 +1,32 @@
+diff --git a/dist/selectors.cjs b/dist/selectors.cjs
+index 602d01f1015ea2ee0825427f6b1e2d97fcdc7d54..237dbf56d31f295e2b8ae4f8b1040a904150a10c 100644
+--- a/dist/selectors.cjs
++++ b/dist/selectors.cjs
+@@ -267,7 +267,10 @@ const selectSortedBridgeQuotes = createBridgeSelector([
+         case types_js_1.SortOrder.ETA_ASC:
+             return (0, lodash_1.orderBy)(quotesWithMetadata, (quote) => quote.estimatedProcessingTimeInSeconds, 'asc');
+         default:
+-            if (quotesWithMetadata.every((quote) => quote.quote.priceData?.priceImpact?.amount)) {
++            if (quotesWithMetadata.every((quote) => quote.cost?.valueInCurrency)) {
++                return (0, lodash_1.orderBy)(quotesWithMetadata, ({ cost }) => Number(cost?.valueInCurrency), 'asc');
++            }
++            else if (quotesWithMetadata.every((quote) => quote.quote.priceData?.priceImpact?.amount)) {
+                 return (0, lodash_1.orderBy)(quotesWithMetadata, ({ quote: { priceData } }) => Number(priceData?.priceImpact?.amount), 'asc');
+             }
+             else if (quotesWithMetadata.every((quote) => quote.quote.priceData?.priceImpact?.valueInCurrency)) {
+diff --git a/dist/selectors.mjs b/dist/selectors.mjs
+index f5eae8981a946abb3dd67fdc97a2165904ce39d0..6cb6fb5b307b401a4276288e76623c0dfff30eec 100644
+--- a/dist/selectors.mjs
++++ b/dist/selectors.mjs
+@@ -263,7 +263,10 @@ const selectSortedBridgeQuotes = createBridgeSelector([
+         case SortOrder.ETA_ASC:
+             return orderBy(quotesWithMetadata, (quote) => quote.estimatedProcessingTimeInSeconds, 'asc');
+         default:
+-            if (quotesWithMetadata.every((quote) => quote.quote.priceData?.priceImpact?.amount)) {
++            if (quotesWithMetadata.every((quote) => quote.cost?.valueInCurrency)) {
++                return orderBy(quotesWithMetadata, ({ cost }) => Number(cost?.valueInCurrency), 'asc');
++            }
++            else if (quotesWithMetadata.every((quote) => quote.quote.priceData?.priceImpact?.amount)) {
+                 return orderBy(quotesWithMetadata, ({ quote: { priceData } }) => Number(priceData?.priceImpact?.amount), 'asc');
+             }
+             else if (quotesWithMetadata.every((quote) => quote.quote.priceData?.priceImpact?.valueInCurrency)) {

--- a/app/components/UI/Bridge/components/QuoteSelectorView/index.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/index.tsx
@@ -79,16 +79,17 @@ export const QuoteSelectorView = () => {
       (quote) =>
         ({
           formattedTotalCost: formatFiat(
-            quote.cost?.valueInCurrency ? new BigNumber(quote.cost.valueInCurrency):
-            new BigNumber(quote.quote.src.valueInCurrency ?? '0').plus(
-              isGaslessQuote(quote.quote)
-                ? (sumAmounts(quote.quote.feeData?.txFee)?.valueInCurrency ??
-                    '0')
-                : (sumAmounts(
-                    quote.quote.feeData?.network,
-                    quote.quote.feeData?.relayer,
-                  )?.valueInCurrency ?? '0'),
-            ),
+            quote.cost?.valueInCurrency
+              ? new BigNumber(quote.cost.valueInCurrency)
+              : new BigNumber(quote.quote.src.valueInCurrency ?? '0').plus(
+                  isGaslessQuote(quote.quote)
+                    ? (sumAmounts(quote.quote.feeData?.txFee)
+                        ?.valueInCurrency ?? '0')
+                    : (sumAmounts(
+                        quote.quote.feeData?.network,
+                        quote.quote.feeData?.relayer,
+                      )?.valueInCurrency ?? '0'),
+                ),
             currency,
           ),
           receiveAmount:

--- a/app/components/UI/Bridge/components/QuoteSelectorView/index.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/index.tsx
@@ -79,6 +79,7 @@ export const QuoteSelectorView = () => {
       (quote) =>
         ({
           formattedTotalCost: formatFiat(
+            quote.cost?.valueInCurrency ? new BigNumber(quote.cost.valueInCurrency):
             new BigNumber(quote.quote.src.valueInCurrency ?? '0').plus(
               isGaslessQuote(quote.quote)
                 ? (sumAmounts(quote.quote.feeData?.txFee)?.valueInCurrency ??

--- a/package.json
+++ b/package.json
@@ -254,7 +254,8 @@
     "@ledgerhq/context-module/ethers": "^6.16.0",
     "@ledgerhq/device-signer-kit-ethereum/ethers": "^6.16.0",
     "@metamask/assets-controller@npm:^14.0.2": "patch:@metamask/assets-controller@npm%3A14.0.2#~/.yarn/patches/@metamask-assets-controller-npm-14.0.2-3eec54a369.patch",
-    "@metamask/eth-sig-util": "^9.0.0"
+    "@metamask/eth-sig-util": "^9.0.0",
+    "@metamask/bridge-controller@npm:^80.1.0": "patch:@metamask/bridge-controller@npm%3A80.1.0#~/.yarn/patches/@metamask-bridge-controller-npm-80.1.0-ea41d41dd2.patch"
   },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",
@@ -289,7 +290,7 @@
     "@metamask/base-data-service": "^1.0.0",
     "@metamask/bitcoin-wallet-snap": "^1.14.2",
     "@metamask/bitcoin-wallet-standard": "^1.0.0",
-    "@metamask/bridge-controller": "^80.1.0",
+    "@metamask/bridge-controller": "patch:@metamask/bridge-controller@npm%3A80.1.0#~/.yarn/patches/@metamask-bridge-controller-npm-80.1.0-ea41d41dd2.patch",
     "@metamask/bridge-status-controller": "^75.4.0",
     "@metamask/chain-agnostic-permission": "^1.7.0",
     "@metamask/chomp-api-service": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7999,7 +7999,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^80.1.0":
+"@metamask/bridge-controller@npm:80.1.0":
   version: 80.1.0
   resolution: "@metamask/bridge-controller@npm:80.1.0"
   dependencies:
@@ -8029,6 +8029,39 @@ __metadata:
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
   checksum: 10/be595e0853a9bc352e4d9c00665a786706ed7f065433714da24a52183179310ddb72427612860bbc99a09e1693473c204ec171c6a1de5c7b062a60a831bb9d62
+  languageName: node
+  linkType: hard
+
+"@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A80.1.0#~/.yarn/patches/@metamask-bridge-controller-npm-80.1.0-ea41d41dd2.patch":
+  version: 80.1.0
+  resolution: "@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A80.1.0#~/.yarn/patches/@metamask-bridge-controller-npm-80.1.0-ea41d41dd2.patch::version=80.1.0&hash=6c192b"
+  dependencies:
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/constants": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/accounts-controller": "npm:^39.1.1"
+    "@metamask/assets-controller": "npm:^14.0.2"
+    "@metamask/assets-controllers": "npm:^111.1.3"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/gas-fee-controller": "npm:^26.3.2"
+    "@metamask/keyring-api": "npm:^24.0.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/multichain-network-controller": "npm:^3.2.4"
+    "@metamask/network-controller": "npm:^36.0.0"
+    "@metamask/polling-controller": "npm:^16.0.9"
+    "@metamask/profile-sync-controller": "npm:^29.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^6.1.0"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/transaction-controller": "npm:^69.6.1"
+    "@metamask/utils": "npm:^11.11.0"
+    bignumber.js: "npm:^9.1.2"
+    reselect: "npm:^5.1.1"
+    uuid: "npm:^8.3.2"
+  checksum: 10/1db2c5ff2c6f7ecf0f9c24b7ab7e34c536e133ee242c8068ba5d5b341c7ab39bfd5963ccd73058f558f293c4fdf8974309627fe13812719ec1dba319501b069c
   languageName: node
   linkType: hard
 
@@ -35717,7 +35750,7 @@ __metadata:
     "@metamask/base-data-service": "npm:^1.0.0"
     "@metamask/bitcoin-wallet-snap": "npm:^1.14.2"
     "@metamask/bitcoin-wallet-standard": "npm:^1.0.0"
-    "@metamask/bridge-controller": "npm:^80.1.0"
+    "@metamask/bridge-controller": "patch:@metamask/bridge-controller@npm%3A80.1.0#~/.yarn/patches/@metamask-bridge-controller-npm-80.1.0-ea41d41dd2.patch"
     "@metamask/bridge-status-controller": "npm:^75.4.0"
     "@metamask/browser-passworder": "npm:^5.0.0"
     "@metamask/browser-playground": "npm:0.8.1"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Problem: Sub-optimal quotes are ranked higher in the quote list because they get sorted by priceImpact, which doesn't account for network fees.

Solution: Sort by cost and show total cost, which accounts for exchange rate and total fees

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: sort bridge quotes by cost and display cost


## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/35438

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: swap quote sorting

  Scenario: user requests quotes
    Given there are multiple quotes received

    When user opens the quote selector
    Then quotes are sorted by ascending cost
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="603" height="1311" alt="image" src="https://github.com/user-attachments/assets/77b4efc5-f7e1-4dfc-bd18-39882a3d5345" />


<!-- [screenshots/recordings] -->

### **After**

<img width="603" height="1311" alt="Solect Quote" src="https://github.com/user-attachments/assets/94d98ad9-579d-4fed-bff2-df1aa256770c" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bridge quote selection UX and vendored controller sorting logic via a patch; incorrect cost/sort could mis-rank providers but does not change transaction signing.
> 
> **Overview**
> Bridge quote ordering and displayed **total cost** now prefer the controller’s **`quote.cost.valueInCurrency`** when present, instead of inferring cost from source amount plus fees and defaulting sort to price impact.
> 
> A **Yarn patch** on `@metamask/bridge-controller@80.1.0` updates `selectSortedBridgeQuotes` so the default sort uses ascending **cost in currency** when every quote has that field, then keeps the existing price-impact fallbacks. **`QuoteSelectorView`** uses the same `cost` field for `formattedTotalCost`, with the previous fee rollup only as a fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70088c7e803137fcb4804bf0abbb5c628a6b5331. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->