### PR TITLE
fix(perps): show watchlist feedback without waiting on the AUS write

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -1452,6 +1452,21 @@ describe('usePerpsToasts', () => {
         ]);
       });
 
+      it('returns remove error configuration', () => {
+        const { result } = renderHook(() => usePerpsToasts());
+
+        const config = result.current.PerpsToastOptions.watchlist.removeError;
+
+        expect(config).toMatchObject({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Warning,
+          hapticsType: NotificationMoment.Error,
+        });
+        expect(config.labelOptions).toEqual([
+          { label: 'Failed to remove market from watchlist', isBold: true },
+        ]);
+      });
+
       it('returns limit reached configuration', () => {
         const { result } = renderHook(() => usePerpsToasts());
 

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -237,6 +237,7 @@ export interface PerpsToastOptionsConfig {
     added: (symbol: string) => PerpsToastOptions;
     removed: (symbol: string) => PerpsToastOptions;
     addError: PerpsToastOptions;
+    removeError: PerpsToastOptions;
     limitReached: PerpsToastOptions;
   };
 }
@@ -1242,6 +1243,12 @@ const usePerpsToasts = (): {
           ...perpsBaseToastOptions.error,
           labelOptions: getPerpsToastLabels(
             strings('perps.watchlist.add_error'),
+          ),
+        },
+        removeError: {
+          ...perpsBaseToastOptions.error,
+          labelOptions: getPerpsToastLabels(
+            strings('perps.watchlist.remove_error'),
           ),
         },
         limitReached: {

--- a/app/components/UI/Perps/hooks/usePerpsWatchlistActions.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWatchlistActions.test.ts
@@ -72,6 +72,61 @@ describe('usePerpsWatchlistActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetWatchlistMarkets.mockReturnValue(['BTC']);
+    // clearAllMocks leaves return values in place, so reset the persist promise
+    // or a deferred one from the latency cases leaks into later tests.
+    mockToggleWatchlistMarket.mockResolvedValue(undefined);
+  });
+
+  describe('feedback latency', () => {
+    // TAT-3787: the toast and its haptic used to wait on the AUS network write
+    // inside toggleWatchlistMarket, costing 500-1000ms after the press.
+    it('shows the added toast before the persist settles', async () => {
+      mockGetWatchlistMarkets.mockReturnValue(['BTC', 'ETH']);
+      let resolvePersist: () => void = () => undefined;
+      mockToggleWatchlistMarket.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolvePersist = resolve;
+        }),
+      );
+
+      const { result } = renderHook(() => usePerpsWatchlistActions());
+
+      let pending: Promise<void> = Promise.resolve();
+      await act(async () => {
+        pending = result.current.addToWatchlist('ETH');
+      });
+
+      expect(mockShowToast).toHaveBeenCalledWith(mockAdded('ETH'));
+
+      await act(async () => {
+        resolvePersist();
+        await pending;
+      });
+    });
+
+    it('shows the removed toast before the persist settles', async () => {
+      mockGetWatchlistMarkets.mockReturnValue(['ETH']);
+      let resolvePersist: () => void = () => undefined;
+      mockToggleWatchlistMarket.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolvePersist = resolve;
+        }),
+      );
+
+      const { result } = renderHook(() => usePerpsWatchlistActions());
+
+      let pending: Promise<void> = Promise.resolve();
+      await act(async () => {
+        pending = result.current.removeFromWatchlist('BTC');
+      });
+
+      expect(mockShowToast).toHaveBeenCalledWith(mockRemoved('BTC'));
+
+      await act(async () => {
+        resolvePersist();
+        await pending;
+      });
+    });
   });
 
   describe('addToWatchlist', () => {

--- a/app/components/UI/Perps/hooks/usePerpsWatchlistActions.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWatchlistActions.test.ts
@@ -48,6 +48,7 @@ const mockRemoved = jest.fn((symbol: string) => ({
   labelOptions: [{ label: `Removed ${symbol} from watchlist` }],
 }));
 const mockAddError = { variant: 'error', labelOptions: [] };
+const mockRemoveError = { variant: 'error', labelOptions: [] };
 const mockLimitReached = { variant: 'info', labelOptions: [] };
 jest.mock('./usePerpsToasts', () => ({
   __esModule: true,
@@ -58,6 +59,7 @@ jest.mock('./usePerpsToasts', () => ({
         added: mockAdded,
         removed: mockRemoved,
         addError: mockAddError,
+        removeError: mockRemoveError,
         limitReached: mockLimitReached,
       },
     },
@@ -292,7 +294,7 @@ describe('usePerpsWatchlistActions', () => {
       expect(mockShowToast).toHaveBeenCalledWith(mockRemoved('BTC'));
     });
 
-    it('calls Logger.error on failure without showing toast', async () => {
+    it('calls Logger.error and shows the error toast on failure', async () => {
       const testError = new Error('remove fail');
       mockToggleWatchlistMarket.mockImplementationOnce(() => {
         throw testError;
@@ -314,8 +316,10 @@ describe('usePerpsWatchlistActions', () => {
           }),
         }),
       );
-      // No toast on remove failure (intentional — no addError toast for removes)
-      expect(mockShowToast).not.toHaveBeenCalled();
+      // Previously no toast here, which held while the removed toast only fired
+      // after a successful write. It now shows optimistically, so the failure
+      // has to correct it rather than leave it contradicting the reverted star.
+      expect(mockShowToast).toHaveBeenCalledWith(mockRemoveError);
     });
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsWatchlistActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWatchlistActions.ts
@@ -126,6 +126,10 @@ export const usePerpsWatchlistActions = (
             data: { symbol, source },
           },
         });
+
+        // The removed toast has already shown against optimistic state, so it
+        // has to be corrected once the controller reverts the star.
+        showToast(PerpsToastOptions.watchlist.removeError);
       }
     },
     [source, track, showToast, PerpsToastOptions],

--- a/app/components/UI/Perps/hooks/usePerpsWatchlistActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWatchlistActions.ts
@@ -52,7 +52,11 @@ export const usePerpsWatchlistActions = (
           return;
         }
 
-        await controller.toggleWatchlistMarket(symbol);
+        // Not awaited: the controller applies its local update synchronously
+        // and only then persists to AUS. Awaiting the network write delayed the
+        // toast and its haptic by the round-trip. Failures surface through the
+        // rejection handler below, matching useEnableMarketingConsent.
+        const persisted = controller.toggleWatchlistMarket(symbol);
 
         const watchlistAfter = controller.getWatchlistMarkets();
         if (watchlistAfter.includes(symbol)) {
@@ -67,6 +71,8 @@ export const usePerpsWatchlistActions = (
           });
           showToast(PerpsToastOptions.watchlist.added(symbol));
         }
+
+        await persisted;
       } catch (error) {
         Logger.error(ensureError(error, 'usePerpsWatchlistActions.add'), {
           tags: {
@@ -90,7 +96,8 @@ export const usePerpsWatchlistActions = (
     async (symbol: string): Promise<void> => {
       try {
         const controller = Engine.context.PerpsController;
-        await controller.toggleWatchlistMarket(symbol);
+        // Not awaited before the toast — see addToWatchlist.
+        const persisted = controller.toggleWatchlistMarket(symbol);
 
         const watchlistAfter = controller.getWatchlistMarkets();
         if (!watchlistAfter.includes(symbol)) {
@@ -105,6 +112,8 @@ export const usePerpsWatchlistActions = (
           });
           showToast(PerpsToastOptions.watchlist.removed(symbol));
         }
+
+        await persisted;
       } catch (error) {
         Logger.error(ensureError(error, 'usePerpsWatchlistActions.remove'), {
           tags: {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2589,6 +2589,7 @@
       "added": "Added {{symbol}} to watchlist",
       "removed": "Removed {{symbol}} from watchlist",
       "add_error": "Failed to add market to watchlist",
+      "remove_error": "Failed to remove market from watchlist",
       "limit_reached": "Watchlist limit reached ({{limit}} markets max)",
       "filter_badge_label": "Watchlist",
       "suggested": "Suggested"


### PR DESCRIPTION
  ## **Description**

  <!-- mms-check: type=text required=true -->

Pressing the favorite (watchlist) button in Pro mode had a visible 500–1000ms lag before the toast and its haptic appeared.

  The cause: `usePerpsWatchlistActions` awaited `PerpsController.toggleWatchlistMarket()` before showing the toast. That method applies its local state update synchronously, but then persists to `AuthenticatedUserStorageService` — a network write, queued behind `#ausQueue` so it also waits on any in-flight hydration. The user-visible feedback was sitting behind that round-trip for no reason.

  The fix captures the persist promise instead of awaiting it, shows the toast against the already-applied optimistic state, and awaits it at the end so the existing `catch` still handles failures. This matches the convention in `useEnableMarketingConsent`: apply optimistically, give feedback immediately, let the sync settle in the background and revert on failure.

  Behavior on failure is unchanged in substance — the controller reverts its local update and the error toast fires — but the ordering differs: the user now sees the success toast first, then the error, rather than waiting and seeing only the error.

  **AC2 is deliberately not addressed in this PR.** The ticket also asks to halve how long the toast is displayed. That duration is `visibilityDuration = 2750`, a module-level constant in the shared `component-library` Toast with no per-toast
  override. Adding one would mean either retiming every toast in the app, or introducing a per-caller duration knob — and a knob like that invites timing to drift apart across features, which is a design-system decision rather than a Perps one. There's also a reasonable chance 2750ms is simply too long for all confirmatory toasts, and the favorite button just surfaced it because it's high-frequency. Raising that with the design system team separately.

  ## **Changelog**

  <!-- mms-check: type=changelog required=true blocking=true -->

  CHANGELOG entry: Fixed a delay before the confirmation appeared when adding or removing a Perps market from your watchlist

  ## **Related issues**

  <!-- mms-check: type=issue-link required=true -->

  Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3787

  ## **Manual testing steps**

  <!-- mms-check: type=manual-testing required=true -->

  ```gherkin
  Feature: Perps watchlist feedback latency

    Scenario: user favorites a market in Pro mode
      Given the user is on a Perps market screen in Pro mode
      And the market is not in their watchlist

      When the user presses the favorite button
      Then the haptic and "Added to watchlist" toast appear immediately
      And the star fills without waiting on a network response

    Scenario: user unfavorites a market in Pro mode
      Given the user is on a Perps market screen in Pro mode
      And the market is already in their watchlist

      When the user presses the favorite button
      Then the haptic and "Removed from watchlist" toast appear immediately

```

  ## **Screenshots/Recordings**

  <!-- mms-check: type=screenshot required=true -->

  ### **Before**

Loom Video: https://www.loom.com/share/401c41feccd54a59a2eeec630966eda3

  ### **After**

Loom Video: https://www.loom.com/share/3346b8c5bef94562857fae2227813568

  ## **Pre-merge author checklist**

  <!-- mms-check: type=checklist required=true -->

  - [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
  - [x] I've completed the PR template to the best of my ability
  - [x] I've included tests if applicable
  - [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

  #### Performance checks (if applicable)

  - [x] I've tested on Android
    - Ideally on a mid-range device; emulator is acceptable
  - [x] I've tested with a power user scenario
    - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
  - [x] I've instrumented key operations with Sentry traces for production performance metrics
    - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

  For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

  ## **Pre-merge reviewer checklist**

  - [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
  - [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UX change to Perps watchlist toasts and timing; failure paths still log and surface errors, with a new remove-failure toast replacing silent failure.
> 
> **Overview**
> Fixes **500–1000ms delay** before watchlist toasts and haptics by not blocking on `PerpsController.toggleWatchlistMarket()`’s AUS persist. `usePerpsWatchlistActions` now starts the toggle, reads the **optimistic** watchlist, fires analytics and success toasts immediately, then `await`s the persist so failures still hit `catch`.
> 
> On remove failure, users previously got **no** toast; with optimistic “removed” feedback, the PR adds **`watchlist.removeError`** (toast config + `perps.watchlist.remove_error` copy) so a failed persist is corrected after the star reverts.
> 
> Tests cover **toast-before-persist** for add/remove, the new remove-error toast, and mock reset so deferred promises don’t leak between cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2ddee9eb4e200b84315998f1e20f929df593e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->