### PR TITLE
fix(ramp): show short quote error messages that never appeared

### DIFF
--- a/app/components/UI/Ramp/components/TruncatedError/TruncatedError.test.tsx
+++ b/app/components/UI/Ramp/components/TruncatedError/TruncatedError.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import { render, fireEvent, act } from '@testing-library/react-native';
 import TruncatedError from './TruncatedError';
 import { createErrorDetailsModalNavDetails } from '../../Views/Modals/ErrorDetailsModal/ErrorDetailsModal';
@@ -82,6 +83,20 @@ describe('TruncatedError', () => {
       triggerFitsMeasurement(getByText, shortError);
 
       expect(getByText(shortError)).toBeOnTheScreen();
+    });
+
+    it('renders visible (not opacity-hidden) before onTextLayout ever fires', () => {
+      // Regression test: onTextLayout is not reliably fired by React Native
+      // for short, single-line text that needs no truncation (unlike longer
+      // text, which reliably triggers a layout pass). Gating visibility on
+      // that event left short error messages permanently invisible.
+      const shortError = 'Minimum buy amount should be more than or equal to 30 USD';
+      const { getByText } = render(<TruncatedError error={shortError} />);
+
+      const textElement = getByText(shortError);
+
+      expect(textElement).toBeOnTheScreen();
+      expect(StyleSheet.flatten(textElement.props.style).opacity).not.toBe(0);
     });
   });
 

--- a/app/components/UI/Ramp/components/TruncatedError/TruncatedError.tsx
+++ b/app/components/UI/Ramp/components/TruncatedError/TruncatedError.tsx
@@ -42,9 +42,6 @@ const styles = StyleSheet.create({
   text: {
     flexShrink: 1,
   },
-  measuring: {
-    opacity: 0,
-  },
 });
 
 const TruncatedError: React.FC<TruncatedErrorProps> = ({
@@ -105,7 +102,7 @@ const TruncatedError: React.FC<TruncatedErrorProps> = ({
         numberOfLines={maxLines}
         ellipsizeMode="tail"
         onTextLayout={handleTextLayout as TextProps['onTextLayout']}
-        style={[styles.text, !hasMeasured && styles.measuring]}
+        style={styles.text}
       >
         {hasMeasured && isTruncated
           ? strings('fiat_on_ramp.encountered_error')


### PR DESCRIPTION
## Summary
`TruncatedError` (used for the inline quote-error summary on the Buy screen) kept the error text at `opacity: 0` until React Native fired `onTextLayout`, used to detect whether the text needed truncating. That event isn't reliably fired for short, single-line text that doesn't need any layout recalculation — only longer text that actually wraps triggers it reliably.

Result: short error messages (e.g. Transak's "Minimum buy amount should be more than or equal to 30 USD") stayed permanently invisible in the inline summary, while longer ones (e.g. Banxa's "We encountered a problem fetching quotes from Banxa (Staging)...") rendered fine. The underlying message was always correct and reached the "Error details" modal (which doesn't depend on this state) — only the inline summary text was affected.

## Fix
Stop gating visibility on the layout event. The text renders immediately; the truncated-fallback string swap (which does need the measurement) still applies once/if `onTextLayout` fires.

## Test plan
- [x] Added a regression test (`renders visible (not opacity-hidden) before onTextLayout ever fires`) — confirmed it fails against the pre-fix code and passes with the fix
- [x] Full existing `TruncatedError.test.tsx` suite passes (13/13)
- [x] `yarn eslint` clean (no new warnings/errors)
- [x] `yarn tsc --noEmit` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change in Ramp error display; truncation and error-details navigation logic are unchanged.
> 
> **Overview**
> **Fixes inline Ramp quote errors that never appeared** when the message was short enough that React Native often skipped `onTextLayout`.
> 
> `TruncatedError` no longer hides the error `Text` at `opacity: 0` until layout measurement. The `measuring` style and `!hasMeasured` style gate are removed so the full error string shows immediately on the Buy quote UI. **Truncation behavior is unchanged**: after `onTextLayout` runs, long text still swaps to the generic `fiat_on_ramp.encountered_error` string.
> 
> Adds a regression test that asserts the error text is on screen and not opacity-hidden when `onTextLayout` never fires.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bef090c5303678f0f110f90aa6e4ca66efe58a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->