### PR TITLE
fix: suppress Sentry noise from marketing consent backfill without OAuth token

### DIFF
--- a/app/store/sagas/backfillSocialLoginMarketingConsent.test.ts
+++ b/app/store/sagas/backfillSocialLoginMarketingConsent.test.ts
@@ -207,6 +207,7 @@ describe('backfillSocialLoginMarketingConsent', () => {
     await expectSaga(backfillSocialLoginMarketingConsentSaga)
       .withState(state)
       .dispatch(loginAction)
+      .not.put(setPendingSocialLoginMarketingConsentBackfill(null))
       .run();
 
     expect(mockedGetMarketingOptInStatus).not.toHaveBeenCalled();
@@ -235,6 +236,7 @@ describe('backfillSocialLoginMarketingConsent', () => {
     await expectSaga(backfillSocialLoginMarketingConsentSaga)
       .withState(state)
       .dispatch(loginAction)
+      .not.put(setPendingSocialLoginMarketingConsentBackfill(null))
       .run();
 
     expect(mockedLoggerError).not.toHaveBeenCalled();

--- a/app/store/sagas/backfillSocialLoginMarketingConsent.test.ts
+++ b/app/store/sagas/backfillSocialLoginMarketingConsent.test.ts
@@ -66,9 +66,7 @@ describe('backfillSocialLoginMarketingConsent', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedGetMarketingOptInStatus.mockResolvedValue({ is_opt_in: false });
-    if (Engine.context.SeedlessOnboardingController?.getAccessToken) {
-      getMockedGetAccessToken().mockResolvedValue('mock-access-token');
-    }
+    getMockedGetAccessToken().mockResolvedValue('mock-access-token');
   });
 
   it('does nothing when no pending backfill marker exists', async () => {

--- a/app/store/sagas/backfillSocialLoginMarketingConsent.test.ts
+++ b/app/store/sagas/backfillSocialLoginMarketingConsent.test.ts
@@ -8,6 +8,7 @@ import { UserActionType } from '../../actions/user';
 import OAuthService from '../../core/OAuthService/OAuthService';
 import Logger from '../../util/Logger';
 import { UserProfileProperty } from '../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
+import Engine from '../../core/Engine';
 
 jest.mock('../../core/Analytics', () => ({
   __esModule: true,
@@ -38,6 +39,17 @@ jest.mock('../../core/OAuthService/OAuthService', () => ({
   },
 }));
 
+jest.mock('../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      SeedlessOnboardingController: {
+        getAccessToken: jest.fn().mockResolvedValue('mock-access-token'),
+      },
+    },
+  },
+}));
+
 const loginAction = { type: UserActionType.LOGIN };
 
 describe('backfillSocialLoginMarketingConsent', () => {
@@ -46,11 +58,15 @@ describe('backfillSocialLoginMarketingConsent', () => {
   const mockedGetMarketingOptInStatus = jest.mocked(
     OAuthService.getMarketingOptInStatus,
   );
+  const mockedGetAccessToken = jest.mocked(
+    Engine.context.SeedlessOnboardingController.getAccessToken,
+  );
   const mockedLoggerError = jest.mocked(Logger.error);
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockedGetMarketingOptInStatus.mockResolvedValue({ is_opt_in: false });
+    mockedGetAccessToken.mockResolvedValue('mock-access-token');
   });
 
   it('does nothing when no pending backfill marker exists', async () => {
@@ -173,9 +189,62 @@ describe('backfillSocialLoginMarketingConsent', () => {
     );
   });
 
-  it('clears the marker when getMarketingOptInStatus rejects', async () => {
+  it('keeps the marker when OAuth access token is unavailable', async () => {
+    mockedGetAccessToken.mockResolvedValueOnce(undefined);
+
+    const state = {
+      ...initialRootState,
+      security: {
+        ...initialRootState.security,
+        dataCollectionForMarketing: false,
+      },
+      onboarding: {
+        ...initialRootState.onboarding,
+        pendingSocialLoginMarketingConsentBackfill: 'google',
+      },
+    };
+
+    await expectSaga(backfillSocialLoginMarketingConsentSaga)
+      .withState(state)
+      .dispatch(loginAction)
+      .run();
+
+    expect(mockedGetMarketingOptInStatus).not.toHaveBeenCalled();
+    expect(mockedLoggerError).not.toHaveBeenCalled();
+    expect(mockedIdentify).not.toHaveBeenCalled();
+    expect(mockedTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it('keeps the marker when getMarketingOptInStatus rejects with no access token', async () => {
     mockedGetMarketingOptInStatus.mockRejectedValueOnce(
-      new Error('no access token'),
+      new Error('No access token found. User must be authenticated.'),
+    );
+
+    const state = {
+      ...initialRootState,
+      security: {
+        ...initialRootState.security,
+        dataCollectionForMarketing: false,
+      },
+      onboarding: {
+        ...initialRootState.onboarding,
+        pendingSocialLoginMarketingConsentBackfill: 'google',
+      },
+    };
+
+    await expectSaga(backfillSocialLoginMarketingConsentSaga)
+      .withState(state)
+      .dispatch(loginAction)
+      .run();
+
+    expect(mockedLoggerError).not.toHaveBeenCalled();
+    expect(mockedIdentify).not.toHaveBeenCalled();
+    expect(mockedTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it('clears the marker when getMarketingOptInStatus rejects with an unexpected error', async () => {
+    mockedGetMarketingOptInStatus.mockRejectedValueOnce(
+      new Error('marketing opt-in request failed'),
     );
 
     const state = {

--- a/app/store/sagas/backfillSocialLoginMarketingConsent.test.ts
+++ b/app/store/sagas/backfillSocialLoginMarketingConsent.test.ts
@@ -58,15 +58,17 @@ describe('backfillSocialLoginMarketingConsent', () => {
   const mockedGetMarketingOptInStatus = jest.mocked(
     OAuthService.getMarketingOptInStatus,
   );
-  const mockedGetAccessToken = jest.mocked(
-    Engine.context.SeedlessOnboardingController.getAccessToken,
-  );
   const mockedLoggerError = jest.mocked(Logger.error);
+
+  const getMockedGetAccessToken = () =>
+    jest.mocked(Engine.context.SeedlessOnboardingController.getAccessToken);
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockedGetMarketingOptInStatus.mockResolvedValue({ is_opt_in: false });
-    mockedGetAccessToken.mockResolvedValue('mock-access-token');
+    if (Engine.context.SeedlessOnboardingController?.getAccessToken) {
+      getMockedGetAccessToken().mockResolvedValue('mock-access-token');
+    }
   });
 
   it('does nothing when no pending backfill marker exists', async () => {
@@ -190,7 +192,7 @@ describe('backfillSocialLoginMarketingConsent', () => {
   });
 
   it('keeps the marker when OAuth access token is unavailable', async () => {
-    mockedGetAccessToken.mockResolvedValueOnce(undefined);
+    getMockedGetAccessToken().mockResolvedValueOnce(undefined);
 
     const state = {
       ...initialRootState,
@@ -216,6 +218,40 @@ describe('backfillSocialLoginMarketingConsent', () => {
     expect(mockedTrackEvent).not.toHaveBeenCalled();
   });
 
+  it('keeps the marker when SeedlessOnboardingController is missing', async () => {
+    const originalController = Engine.context.SeedlessOnboardingController;
+    // Simulate Engine.context without SeedlessOnboardingController.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Engine.context as any).SeedlessOnboardingController = undefined;
+
+    const state = {
+      ...initialRootState,
+      security: {
+        ...initialRootState.security,
+        dataCollectionForMarketing: false,
+      },
+      onboarding: {
+        ...initialRootState.onboarding,
+        pendingSocialLoginMarketingConsentBackfill: 'google',
+      },
+    };
+
+    try {
+      await expectSaga(backfillSocialLoginMarketingConsentSaga)
+        .withState(state)
+        .dispatch(loginAction)
+        .not.put(setPendingSocialLoginMarketingConsentBackfill(null))
+        .run();
+
+      expect(mockedGetMarketingOptInStatus).not.toHaveBeenCalled();
+      expect(mockedLoggerError).not.toHaveBeenCalled();
+      expect(mockedIdentify).not.toHaveBeenCalled();
+      expect(mockedTrackEvent).not.toHaveBeenCalled();
+    } finally {
+      Engine.context.SeedlessOnboardingController = originalController;
+    }
+  });
+
   it('keeps the marker when getMarketingOptInStatus rejects with no access token', async () => {
     mockedGetMarketingOptInStatus.mockRejectedValueOnce(
       new Error('No access token found. User must be authenticated.'),
@@ -239,6 +275,9 @@ describe('backfillSocialLoginMarketingConsent', () => {
       .not.put(setPendingSocialLoginMarketingConsentBackfill(null))
       .run();
 
+    // Pre-check passed (token present); API was called and failed with the
+    // known no-access-token message — catch path preserves the marker.
+    expect(mockedGetMarketingOptInStatus).toHaveBeenCalledTimes(1);
     expect(mockedLoggerError).not.toHaveBeenCalled();
     expect(mockedIdentify).not.toHaveBeenCalled();
     expect(mockedTrackEvent).not.toHaveBeenCalled();

--- a/app/store/sagas/backfillSocialLoginMarketingConsent.ts
+++ b/app/store/sagas/backfillSocialLoginMarketingConsent.ts
@@ -11,6 +11,12 @@ import { selectPendingSocialLoginMarketingConsentBackfill } from '../../selector
 import { UserActionType } from '../../actions/user';
 import OAuthService from '../../core/OAuthService/OAuthService';
 import { setDataCollectionForMarketing } from '../../actions/security';
+import Engine from '../../core/Engine';
+import { containsErrorMessage } from '../../util/errorHandling';
+import { ensureError } from '../../util/errorUtils';
+
+const OAUTH_ACCESS_TOKEN_UNAVAILABLE_MESSAGE =
+  'No access token found. User must be authenticated.';
 
 export function* backfillSocialLoginMarketingConsentSaga() {
   yield take(UserActionType.LOGIN);
@@ -30,6 +36,15 @@ export function* backfillSocialLoginMarketingConsentSaga() {
 
   try {
     if (marketingConsent !== true) {
+      const accessToken: string | undefined = yield call([
+        Engine.context.SeedlessOnboardingController,
+        Engine.context.SeedlessOnboardingController.getAccessToken,
+      ]);
+
+      if (!accessToken) {
+        return;
+      }
+
       const marketingOptIn: Awaited<
         ReturnType<typeof OAuthService.getMarketingOptInStatus>
       > = yield call([OAuthService, OAuthService.getMarketingOptInStatus]);
@@ -59,8 +74,14 @@ export function* backfillSocialLoginMarketingConsentSaga() {
     yield put(setDataCollectionForMarketing(resolvedMarketingConsent));
     yield put(setPendingSocialLoginMarketingConsentBackfill(null));
   } catch (error) {
+    const err = ensureError(error);
+
+    if (containsErrorMessage(err, OAUTH_ACCESS_TOKEN_UNAVAILABLE_MESSAGE)) {
+      return;
+    }
+
     Logger.error(
-      error as Error,
+      err,
       'Failed to backfill social login marketing consent analytics',
     );
     if (fetchedMarketingConsent) {

--- a/app/store/sagas/backfillSocialLoginMarketingConsent.ts
+++ b/app/store/sagas/backfillSocialLoginMarketingConsent.ts
@@ -15,6 +15,13 @@ import Engine from '../../core/Engine';
 import { containsErrorMessage } from '../../util/errorHandling';
 import { ensureError } from '../../util/errorUtils';
 
+/**
+ * Message thrown by OAuthService.getValidAccessToken() when
+ * SeedlessOnboardingController.getAccessToken() returns nothing.
+ * OAuthService throws a plain Error (no error code/class), so the catch path
+ * must match this message string — keep in sync with
+ * app/core/OAuthService/OAuthService.ts.
+ */
 const OAUTH_ACCESS_TOKEN_UNAVAILABLE_MESSAGE =
   'No access token found. User must be authenticated.';
 
@@ -36,11 +43,20 @@ export function* backfillSocialLoginMarketingConsentSaga() {
 
   try {
     if (marketingConsent !== true) {
+      const controller = Engine?.context?.SeedlessOnboardingController;
+      if (!controller || typeof controller.getAccessToken !== 'function') {
+        // No controller/token available at unlock — preserve marker so we can retry later.
+        return;
+      }
+
       const accessToken: string | undefined = yield call([
-        Engine.context.SeedlessOnboardingController,
-        Engine.context.SeedlessOnboardingController.getAccessToken,
+        controller,
+        controller.getAccessToken,
       ]);
 
+      // If no OAuth access token is available (expected during unlock), return
+      // silently and preserve the pending backfill marker so the backfill can
+      // retry on a subsequent login — this avoids reporting expected Sentry noise.
       if (!accessToken) {
         return;
       }
@@ -76,6 +92,10 @@ export function* backfillSocialLoginMarketingConsentSaga() {
   } catch (error) {
     const err = ensureError(error);
 
+    // Safety net for races where the pre-check saw a token but
+    // getMarketingOptInStatus still threw OAuthService's plain Error.
+    // String match is required because OAuthService does not expose a typed
+    // error code for this case (see getValidAccessToken).
     if (containsErrorMessage(err, OAUTH_ACCESS_TOKEN_UNAVAILABLE_MESSAGE)) {
       return;
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Social-login users with a pending marketing-consent backfill marker trigger backfillSocialLoginMarketingConsentSaga on LOGIN. When Redux dataCollectionForMarketing is not true, the saga calls OAuthService.getMarketingOptInStatus(), which throws if SeedlessOnboardingController.getAccessToken() returns nothing.

That case is expected at unlock when the OAuth session is not ready yet. The saga already caught the error, but it still called Logger.error (reporting to Sentry as [METAMASK-MOBILE-5RWT](https://metamask.sentry.io/issues/METAMASK-MOBILE-5RWT)) and cleared the backfill marker, so analytics backfill never retried on a later login.

This PR:

* Checks for an OAuth access token before calling the marketing opt-in API
* Skips the backfill silently when no token is available (no Sentry noise)
* Preserves the backfill marker so the saga can retry on a future login
* Still logs to Sentry and clears the marker for unexpected failures
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TO-1018

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Social login marketing consent backfill without OAuth token

 Scenario: Unlock does not report Sentry error when OAuth token is unavailable
    Given a social login user with pendingSocialLoginMarketingConsentBackfill set
    And dataCollectionForMarketing is false in Redux
    And SeedlessOnboardingController.getAccessToken returns no token at login
    When the user unlocks the wallet and LOGIN is dispatched
    Then getMarketingOptInStatus is not called
    And no error is logged to Sentry for missing OAuth token
    And pendingSocialLoginMarketingConsentBackfill remains set for a later retry

  Scenario: Backfill completes when OAuth token is available
    Given a social login user with pendingSocialLoginMarketingConsentBackfill set
    And dataCollectionForMarketing is false in Redux
    And a valid OAuth access token is available at login
    When the user unlocks the wallet and LOGIN is dispatched
    Then marketing consent is backfilled from the auth service
    And analytics identify/track events are sent
    And pendingSocialLoginMarketingConsentBackfill is cleared
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A 
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
