### PR TITLE
refactor(digest): own market insights && WH cache in React Query

### DIFF
--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
@@ -304,7 +304,7 @@ describe('useMarketInsights', () => {
     expect(result.current.reportAssetId).toBe('BTC');
   });
 
-  it('reads the controller cache while offline', async () => {
+  it('fetches while offline because networkMode is always', async () => {
     const report = {
       version: '1.0',
       asset: 'eth',
@@ -354,5 +354,59 @@ describe('useMarketInsights', () => {
     expect(result.current.reportAssetId).toBe('ETH');
     expect(result.current.error).toBeNull();
     expect(result.current.isLoading).toBe(false);
+  });
+
+  it('reuses a successful report without refetching on remount', async () => {
+    const report = {
+      version: '1.0',
+      asset: 'eth',
+      generatedAt: '2026-02-17T11:55:00.000Z',
+      headline: 'ETH advances',
+      summary: 'ETF headlines support demand',
+      trends: [],
+      sources: [],
+    };
+    mockFetchMarketInsights.mockResolvedValue(report);
+
+    const first = renderHook(() => useMarketInsights('ETH', true), {
+      wrapper,
+    });
+    await waitFor(() => expect(first.result.current.report).toEqual(report));
+    first.unmount();
+
+    const second = renderHook(() => useMarketInsights('ETH', true), {
+      wrapper,
+    });
+    await waitFor(() => expect(second.result.current.report).toEqual(report));
+
+    expect(mockFetchMarketInsights).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches after a null miss on remount', async () => {
+    const report = {
+      version: '1.0',
+      asset: 'eth',
+      generatedAt: '2026-02-17T11:55:00.000Z',
+      headline: 'ETH advances',
+      summary: 'ETF headlines support demand',
+      trends: [],
+      sources: [],
+    };
+    mockFetchMarketInsights.mockResolvedValueOnce(null);
+
+    const first = renderHook(() => useMarketInsights('ETH', true), {
+      wrapper,
+    });
+    await waitFor(() => expect(first.result.current.isLoading).toBe(false));
+    expect(first.result.current.report).toBeNull();
+    first.unmount();
+
+    mockFetchMarketInsights.mockResolvedValueOnce(report);
+    const second = renderHook(() => useMarketInsights('ETH', true), {
+      wrapper,
+    });
+    await waitFor(() => expect(second.result.current.report).toEqual(report));
+
+    expect(mockFetchMarketInsights).toHaveBeenCalledTimes(2);
   });
 });

--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
@@ -1,7 +1,10 @@
 import { useEffect, useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { MarketInsightsReport } from '@metamask/ai-controllers';
-import { digestQueryCacheTimeOption } from '../../../../constants/digestQuery';
+import {
+  DIGEST_QUERY_GC_TIME_MS,
+  digestQueryStaleTime,
+} from '../../../../constants/digestQuery';
 import Engine from '../../../../core/Engine';
 import { formatRelativeTime } from '../utils/marketInsightsFormatting';
 
@@ -50,8 +53,8 @@ export const useMarketInsights = (
     enabled: isQueryEnabled,
     retry: false,
     networkMode: 'always',
-    staleTime: digestQueryCacheTimeOption,
-    gcTime: digestQueryCacheTimeOption,
+    staleTime: digestQueryStaleTime,
+    gcTime: DIGEST_QUERY_GC_TIME_MS,
   });
 
   useEffect(() => {

--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { MarketInsightsReport } from '@metamask/ai-controllers';
+import { digestQueryCacheTimeOption } from '../../../../constants/digestQuery';
 import Engine from '../../../../core/Engine';
 import { formatRelativeTime } from '../utils/marketInsightsFormatting';
 
@@ -25,8 +26,8 @@ export interface UseMarketInsightsResult {
 /**
  * Hook to fetch market insights for a given asset.
  *
- * This hook reads market insights through AiDigestController, which caches
- * insights per asset identifier and fetches them from the digest service as needed.
+ * Fetches through AiDigestController (passthrough to the digest service).
+ * React Query owns the 10-minute cache; a `null` miss is not cached as a hit.
  *
  * @param assetIdentifier - The asset identifier: either a CAIP-19 ID (e.g. "eip155:1/slip44:60")
  * or a perps market symbol (e.g. "ETH").
@@ -48,13 +49,9 @@ export const useMarketInsights = (
       ),
     enabled: isQueryEnabled,
     retry: false,
-    // The controller can satisfy this request from its persisted cache while
-    // offline. Let it decide whether a network request is necessary.
     networkMode: 'always',
-    // AiDigestController owns the 10-minute cache and intentionally does not
-    // cache empty results. React Query only coordinates active requests here.
-    staleTime: 0,
-    gcTime: 0,
+    staleTime: digestQueryCacheTimeOption,
+    gcTime: digestQueryCacheTimeOption,
   });
 
   useEffect(() => {

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
@@ -531,6 +531,27 @@ describe('useWhatsHappening', () => {
 
       expect(mockFetchFrontPageItem).not.toHaveBeenCalled();
     });
+
+    it('shares the overview query with a carousel observer', async () => {
+      mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
+
+      const { result } = renderHook(
+        () => ({
+          carousel: useWhatsHappening(),
+          detail: useWhatsHappening({ outdatedItemId: mockFrontPage.id }),
+        }),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.carousel.isLoading).toBe(false);
+        expect(result.current.detail.isLoading).toBe(false);
+      });
+
+      expect(mockFetchMarketOverview).toHaveBeenCalledTimes(1);
+      expect(mockFetchFrontPageItem).toHaveBeenCalledTimes(1);
+      expect(result.current.detail.items[0].isOutdated).toBe(true);
+    });
   });
 
   it('shares one in-flight market overview request across same-key mounts', async () => {

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
@@ -5,6 +5,7 @@ import type {
   MarketOverview,
   MarketOverviewFrontPage,
 } from '@metamask/ai-controllers';
+import { digestQueryCacheTimeOption } from '../../../../constants/digestQuery';
 import Engine from '../../../../core/Engine';
 import { selectWhatsHappeningEnabled } from '../../../../selectors/featureFlagController/whatsHappening';
 import Logger from '../../../../util/Logger';
@@ -14,7 +15,9 @@ import type { WhatsHappeningItem } from '../types';
 /** Internal error flag when fetch rejects with a non-Error value (not shown in UI). */
 export const WHATS_HAPPENING_FETCH_FAILED = 'WHATS_HAPPENING_FETCH_FAILED';
 
-const WHATS_HAPPENING_QUERY_KEY = 'whats-happening';
+export const WHATS_HAPPENING_QUERY_KEY = 'whats-happening';
+export const WHATS_HAPPENING_FRONT_PAGE_QUERY_KEY =
+  'whats-happening-front-page';
 
 /**
  * Result interface for useWhatsHappening hook
@@ -73,16 +76,12 @@ const mapFrontPageToItem = (
 /**
  * Fetches the deep-linked "outdated" front-page item, if any.
  *
- * @param outdatedItemId - The front-page item id from the deep link, or `null`.
+ * @param outdatedItemId - The front-page item id from the deep link.
  * @returns The mapped outdated item, or `null` when there is none / on failure.
  */
 const fetchOutdatedItem = async (
-  outdatedItemId: string | null,
+  outdatedItemId: string,
 ): Promise<WhatsHappeningItem | null> => {
-  if (!outdatedItemId) {
-    return null;
-  }
-
   try {
     const frontPage =
       await Engine.context.AiDigestController.fetchFrontPageItem(
@@ -92,6 +91,18 @@ const fetchOutdatedItem = async (
   } catch {
     // Non-fatal: fall back to rendering just the latest market overview items.
     return null;
+  }
+};
+
+const fetchMarketOverview = async (): Promise<MarketOverview | null> => {
+  try {
+    return await Engine.context.AiDigestController.fetchMarketOverview();
+  } catch (err) {
+    Logger.error(ensureError(err, 'useWhatsHappening.fetchMarketOverview'), {
+      tags: { feature: 'WhatsHappening' },
+      extra: { hook: 'useWhatsHappening' },
+    });
+    throw err instanceof Error ? err : new Error(WHATS_HAPPENING_FETCH_FAILED);
   }
 };
 
@@ -145,39 +156,12 @@ const prependOutdatedItem = (
   return [item, ...rest];
 };
 
-const fetchWhatsHappeningItems = async (
-  outdatedItemId: string | null,
-): Promise<WhatsHappeningItem[]> => {
-  try {
-    const data = await Engine.context.AiDigestController.fetchMarketOverview();
-    const baseItems =
-      data === null || data === undefined ? [] : mapTrendsToItems(data);
-
-    // When a deep link supplied an id, prepend that front-page item as the
-    // first card, deduped against the latest feed. It is flagged "Outdated"
-    // only when it is not already in the feed (see prependOutdatedItem).
-    const outdatedItem = await fetchOutdatedItem(outdatedItemId);
-
-    return prependOutdatedItem(outdatedItem, baseItems);
-  } catch (err) {
-    Logger.error(ensureError(err, 'useWhatsHappening.fetchItems'), {
-      tags: { feature: 'WhatsHappening' },
-      extra: { hook: 'useWhatsHappening' },
-    });
-    throw err instanceof Error ? err : new Error(WHATS_HAPPENING_FETCH_FAILED);
-  }
-};
-
 /**
  * Hook to fetch trending "What's Happening" items for the carousel.
  *
- * Calls `AiDigestController.fetchMarketOverview()` (which handles caching
- * internally) and maps the returned `MarketOverviewTrend` entries to
- * `WhatsHappeningItem` shape for the carousel cards. Item count is owned by
- * the Digest API — the client does not slice the response.
- *
- * React Query only coordinates in-flight work. The controller remains the
- * 10-minute cache.
+ * Calls `AiDigestController.fetchMarketOverview()` and maps trends to
+ * `WhatsHappeningItem`. React Query owns the 10-minute overview cache.
+ * A deep-linked front-page item is a separate uncached query.
  *
  * @param options - Hook options (`enabled`, `outdatedItemId`).
  * @returns Object with items, isLoading, error, refresh
@@ -193,22 +177,24 @@ export const useWhatsHappening = (
   const pendingRefreshRef = useRef<(() => void) | null>(null);
   const [isManualRefreshing, setIsManualRefreshing] = useState(false);
 
-  const query = useQuery<WhatsHappeningItem[], Error>({
-    queryKey: [WHATS_HAPPENING_QUERY_KEY, outdatedItemId],
-    queryFn: () => fetchWhatsHappeningItems(outdatedItemId),
+  const overviewQuery = useQuery<MarketOverview | null, Error>({
+    queryKey: [WHATS_HAPPENING_QUERY_KEY],
+    queryFn: fetchMarketOverview,
     enabled: isActive,
     retry: false,
-    // The controller can satisfy this request from its persisted cache while
-    // offline. Let it decide whether a network request is necessary.
     networkMode: 'always',
-    // AiDigestController owns the cache. React Query only coordinates
-    // in-flight requests here.
+    staleTime: digestQueryCacheTimeOption,
+    gcTime: digestQueryCacheTimeOption,
+  });
+
+  const frontPageQuery = useQuery<WhatsHappeningItem | null, Error>({
+    queryKey: [WHATS_HAPPENING_FRONT_PAGE_QUERY_KEY, outdatedItemId],
+    queryFn: () => fetchOutdatedItem(outdatedItemId ?? ''),
+    enabled: isActive && Boolean(outdatedItemId),
+    retry: false,
+    networkMode: 'always',
     staleTime: 0,
     gcTime: 0,
-    // Match the previous hook: fetch on mount / refresh / key change, not on
-    // app resume or reconnect (those would mark every subscriber as fetching).
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
   });
 
   useEffect(() => {
@@ -216,11 +202,14 @@ export const useWhatsHappening = (
     // used by WhatsHappeningSection when a parent already owns the feed.
     if (!isFeatureEnabled) {
       queryClient.removeQueries({
-        queryKey: [WHATS_HAPPENING_QUERY_KEY, outdatedItemId],
+        queryKey: [WHATS_HAPPENING_QUERY_KEY],
         exact: true,
       });
+      queryClient.removeQueries({
+        queryKey: [WHATS_HAPPENING_FRONT_PAGE_QUERY_KEY],
+      });
     }
-  }, [isFeatureEnabled, outdatedItemId, queryClient]);
+  }, [isFeatureEnabled, queryClient]);
 
   useEffect(
     () => () => {
@@ -237,31 +226,53 @@ export const useWhatsHappening = (
 
     return new Promise<void>((resolve) => {
       pendingRefreshRef.current = resolve;
-      queryClient
-        .refetchQueries({
-          queryKey: [WHATS_HAPPENING_QUERY_KEY, outdatedItemId],
+      const refreshes = [
+        queryClient.refetchQueries({
+          queryKey: [WHATS_HAPPENING_QUERY_KEY],
           exact: true,
-        })
-        .finally(() => {
-          if (pendingRefreshRef.current === resolve) {
-            pendingRefreshRef.current();
-            pendingRefreshRef.current = null;
-            setIsManualRefreshing(false);
-          }
-        });
+        }),
+      ];
+      if (outdatedItemId) {
+        refreshes.push(
+          queryClient.refetchQueries({
+            queryKey: [WHATS_HAPPENING_FRONT_PAGE_QUERY_KEY, outdatedItemId],
+            exact: true,
+          }),
+        );
+      }
+      Promise.all(refreshes).finally(() => {
+        if (pendingRefreshRef.current === resolve) {
+          pendingRefreshRef.current();
+          pendingRefreshRef.current = null;
+          setIsManualRefreshing(false);
+        }
+      });
     });
   }, [outdatedItemId, queryClient]);
 
   const error =
-    isActive && query.error
-      ? query.error.message || WHATS_HAPPENING_FETCH_FAILED
+    isActive && overviewQuery.error
+      ? overviewQuery.error.message || WHATS_HAPPENING_FETCH_FAILED
       : null;
 
+  const baseItems =
+    isActive && !error && overviewQuery.data
+      ? mapTrendsToItems(overviewQuery.data)
+      : [];
+  const outdatedItem =
+    outdatedItemId && frontPageQuery.data ? frontPageQuery.data : null;
+  const items = prependOutdatedItem(outdatedItem, baseItems);
+
+  const isFrontPageLoading =
+    Boolean(outdatedItemId) && frontPageQuery.isLoading;
+
   return {
-    items: isActive && !error ? (query.data ?? []) : [],
+    items: isActive && !error ? items : [],
     // isFetching is true for background refetches (new observer, stale mount).
     // Only the initial load and an explicit refresh should show skeletons.
-    isLoading: isActive && (query.isLoading || isManualRefreshing),
+    isLoading:
+      isActive &&
+      (overviewQuery.isLoading || isFrontPageLoading || isManualRefreshing),
     error,
     refresh,
   };

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
@@ -5,7 +5,10 @@ import type {
   MarketOverview,
   MarketOverviewFrontPage,
 } from '@metamask/ai-controllers';
-import { digestQueryCacheTimeOption } from '../../../../constants/digestQuery';
+import {
+  DIGEST_QUERY_GC_TIME_MS,
+  digestQueryStaleTime,
+} from '../../../../constants/digestQuery';
 import Engine from '../../../../core/Engine';
 import { selectWhatsHappeningEnabled } from '../../../../selectors/featureFlagController/whatsHappening';
 import Logger from '../../../../util/Logger';
@@ -183,8 +186,8 @@ export const useWhatsHappening = (
     enabled: isActive,
     retry: false,
     networkMode: 'always',
-    staleTime: digestQueryCacheTimeOption,
-    gcTime: digestQueryCacheTimeOption,
+    staleTime: digestQueryStaleTime,
+    gcTime: DIGEST_QUERY_GC_TIME_MS,
   });
 
   const frontPageQuery = useQuery<WhatsHappeningItem | null, Error>({

--- a/app/constants/digestQuery.test.ts
+++ b/app/constants/digestQuery.test.ts
@@ -1,0 +1,32 @@
+import {
+  DIGEST_QUERY_GC_TIME_MS,
+  DIGEST_QUERY_STALE_TIME_MS,
+  digestQueryCacheTimeMs,
+  digestQueryCacheTimeOption,
+} from './digestQuery';
+
+describe('digestQueryCacheTimeMs', () => {
+  it('uses a 10-minute cache for a successful payload', () => {
+    expect(DIGEST_QUERY_STALE_TIME_MS).toBe(10 * 60 * 1000);
+    expect(DIGEST_QUERY_GC_TIME_MS).toBe(DIGEST_QUERY_STALE_TIME_MS);
+    expect(digestQueryCacheTimeMs({ headline: 'ok' })).toBe(
+      DIGEST_QUERY_STALE_TIME_MS,
+    );
+  });
+
+  it('does not cache a null miss', () => {
+    expect(digestQueryCacheTimeMs(null)).toBe(0);
+    expect(digestQueryCacheTimeMs(undefined)).toBe(0);
+  });
+
+  it('exposes a runtime cache-time function for React Query', () => {
+    const cacheTime = digestQueryCacheTimeOption as unknown as (query: {
+      state: { data: unknown };
+    }) => number;
+
+    expect(cacheTime({ state: { data: { ok: true } } })).toBe(
+      DIGEST_QUERY_STALE_TIME_MS,
+    );
+    expect(cacheTime({ state: { data: null } })).toBe(0);
+  });
+});

--- a/app/constants/digestQuery.test.ts
+++ b/app/constants/digestQuery.test.ts
@@ -1,32 +1,20 @@
 import {
   DIGEST_QUERY_GC_TIME_MS,
   DIGEST_QUERY_STALE_TIME_MS,
-  digestQueryCacheTimeMs,
-  digestQueryCacheTimeOption,
+  digestQueryStaleTime,
 } from './digestQuery';
 
-describe('digestQueryCacheTimeMs', () => {
-  it('uses a 10-minute cache for a successful payload', () => {
+describe('digestQueryStaleTime', () => {
+  it('uses a 10-minute stale time for a successful payload', () => {
     expect(DIGEST_QUERY_STALE_TIME_MS).toBe(10 * 60 * 1000);
     expect(DIGEST_QUERY_GC_TIME_MS).toBe(DIGEST_QUERY_STALE_TIME_MS);
-    expect(digestQueryCacheTimeMs({ headline: 'ok' })).toBe(
+    expect(digestQueryStaleTime({ state: { data: { headline: 'ok' } } })).toBe(
       DIGEST_QUERY_STALE_TIME_MS,
     );
   });
 
-  it('does not cache a null miss', () => {
-    expect(digestQueryCacheTimeMs(null)).toBe(0);
-    expect(digestQueryCacheTimeMs(undefined)).toBe(0);
-  });
-
-  it('exposes a runtime cache-time function for React Query', () => {
-    const cacheTime = digestQueryCacheTimeOption as unknown as (query: {
-      state: { data: unknown };
-    }) => number;
-
-    expect(cacheTime({ state: { data: { ok: true } } })).toBe(
-      DIGEST_QUERY_STALE_TIME_MS,
-    );
-    expect(cacheTime({ state: { data: null } })).toBe(0);
+  it('marks a null miss as immediately stale', () => {
+    expect(digestQueryStaleTime({ state: { data: null } })).toBe(0);
+    expect(digestQueryStaleTime({ state: { data: undefined } })).toBe(0);
   });
 });

--- a/app/constants/digestQuery.ts
+++ b/app/constants/digestQuery.ts
@@ -6,19 +6,14 @@ export const DIGEST_QUERY_STALE_TIME_MS = 10 * 60 * 1000;
 export const DIGEST_QUERY_GC_TIME_MS = DIGEST_QUERY_STALE_TIME_MS;
 
 /**
- * 10-minute cache for a successful digest payload; 0 so a 404/`null` miss
- * does not block a later fetch.
+ * Dynamic `staleTime` so a successful digest payload stays fresh for 10
+ * minutes, while a `null` 404 miss is immediately stale and retried on remount.
  *
- * @param data - Cached query data.
- * @returns Cache duration in milliseconds.
+ * `gcTime` stays a constant: unused queries are collected after 10 minutes.
+ *
+ * @param query - React Query cache entry.
+ * @returns Stale time in milliseconds.
  */
-export const digestQueryCacheTimeMs = (data: unknown): number =>
-  data ? DIGEST_QUERY_STALE_TIME_MS : 0;
-
-/**
- * React Query `staleTime` / `gcTime` option. This app's installed types only
- * allow a number; the runtime accepts a function (TanStack Query 5.80+).
- */
-export const digestQueryCacheTimeOption = ((query: {
+export const digestQueryStaleTime = (query: {
   state: { data: unknown };
-}) => digestQueryCacheTimeMs(query.state.data)) as unknown as number;
+}): number => (query.state.data == null ? 0 : DIGEST_QUERY_STALE_TIME_MS);

--- a/app/constants/digestQuery.ts
+++ b/app/constants/digestQuery.ts
@@ -1,0 +1,24 @@
+/**
+ * Digest query freshness. React Query owns this; AiDigestController is a
+ * passthrough and does not cache.
+ */
+export const DIGEST_QUERY_STALE_TIME_MS = 10 * 60 * 1000;
+export const DIGEST_QUERY_GC_TIME_MS = DIGEST_QUERY_STALE_TIME_MS;
+
+/**
+ * 10-minute cache for a successful digest payload; 0 so a 404/`null` miss
+ * does not block a later fetch.
+ *
+ * @param data - Cached query data.
+ * @returns Cache duration in milliseconds.
+ */
+export const digestQueryCacheTimeMs = (data: unknown): number =>
+  data ? DIGEST_QUERY_STALE_TIME_MS : 0;
+
+/**
+ * React Query `staleTime` / `gcTime` option. This app's installed types only
+ * allow a number; the runtime accepts a function (TanStack Query 5.80+).
+ */
+export const digestQueryCacheTimeOption = ((query: {
+  state: { data: unknown };
+}) => digestQueryCacheTimeMs(query.state.data)) as unknown as number;

--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -1234,6 +1234,7 @@ describe('Engine', () => {
             'state' in controller &&
             Boolean(controller.state) &&
             (!isEmpty(controller.state) ||
+              controllerName === 'AiDigestController' ||
               controllerName === 'ComplianceController' ||
               controllerName === 'DelegationController'),
         )

--- a/app/core/Engine/controllers/ai-digest-controller-init.test.ts
+++ b/app/core/Engine/controllers/ai-digest-controller-init.test.ts
@@ -49,7 +49,6 @@ describe('aiDigestControllerInit', () => {
 
     expect(jest.mocked(AiDigestController)).toHaveBeenCalledWith({
       messenger: expect.any(Object),
-      state: undefined,
       digestService: expect.any(AiDigestService),
     });
   });

--- a/app/core/Engine/controllers/ai-digest-controller-init.ts
+++ b/app/core/Engine/controllers/ai-digest-controller-init.ts
@@ -9,22 +9,23 @@ import AppConstants from '../../AppConstants';
 /**
  * Initialize the AiDigestController.
  *
+ * Digest freshness is owned by React Query. Do not rehydrate leftover
+ * `marketInsights` / `marketOverview` snapshots from older controller versions.
+ *
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.
- * @param request.persistedState - The persisted state to hydrate from.
  * @returns The initialized controller.
  */
 export const aiDigestControllerInit: MessengerClientInitFunction<
   AiDigestController,
   AiDigestControllerMessenger
-> = ({ controllerMessenger, persistedState }) => {
+> = ({ controllerMessenger }) => {
   const digestService = new AiDigestService({
     baseUrl: AppConstants.DIGEST_API_URL,
   });
 
   const controller = new AiDigestController({
     messenger: controllerMessenger,
-    state: persistedState.AiDigestController,
     digestService,
   });
 

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -914,10 +914,7 @@
     "otp": null,
     "error": null
   },
-  "AiDigestController": {
-    "marketInsights": {},
-    "marketOverview": null
-  },
+  "AiDigestController": {},
   "RampsController": {
     "userRegion": null,
     "countries": {

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -914,7 +914,10 @@
     "otp": null,
     "error": null
   },
-  "AiDigestController": {},
+  "AiDigestController": {
+    "marketInsights": {},
+    "marketOverview": null
+  },
   "RampsController": {
     "userRegion": null,
     "countries": {

--- a/package.json
+++ b/package.json
@@ -279,7 +279,7 @@
     "@metamask/account-tree-controller": "^8.0.0",
     "@metamask/accounts-controller": "^39.1.0",
     "@metamask/address-book-controller": "^7.1.2",
-    "@metamask/ai-controllers": "^0.8.0",
+    "@metamask/ai-controllers": "^1.0.0",
     "@metamask/analytics-controller": "^2.0.0",
     "@metamask/app-metadata-controller": "^2.0.0",
     "@metamask/approval-controller": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7690,15 +7690,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ai-controllers@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "@metamask/ai-controllers@npm:0.8.0"
+"@metamask/ai-controllers@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@metamask/ai-controllers@npm:1.0.0"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/messenger": "npm:^2.0.0"
-    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.11.0"
-  checksum: 10/a3afa17519d91d72b8c4cf4d85540d59c02b11a95e8dd55799448e49f89cd577a63c72016f9b88e8430173327f5d4f55743b897e3760940b07806f04815de5f2
+  checksum: 10/6fd030c6519be8845f9056b21acf78d08031df4c91aff3d81a2b66bbeb58148344a13dea4b4c9c0e240d0f5702f1b8cba68d82e8e2ff4de0d4a1dd1458df97ae
   languageName: node
   linkType: hard
 
@@ -35738,7 +35738,7 @@ __metadata:
     "@metamask/account-tree-controller": "npm:^8.0.0"
     "@metamask/accounts-controller": "npm:^39.1.0"
     "@metamask/address-book-controller": "npm:^7.1.2"
-    "@metamask/ai-controllers": "npm:^0.8.0"
+    "@metamask/ai-controllers": "npm:^1.0.0"
     "@metamask/analytics-controller": "npm:^2.0.0"
     "@metamask/app-metadata-controller": "npm:^2.0.0"
     "@metamask/approval-controller": "npm:^9.0.0"


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

What's Happening and Market Insights were coordinating in-flight work with React Query (`staleTime: 0` / `gcTime: 0`) while `AiDigestController` still owned a 10-minute persisted TTL. That double ownership is hard to debug.

This PR moves freshness to React Query: 10-minute `staleTime`/`gcTime` on a successful overview or insights payload, `0` on a `null` miss so a 404 does not block a later hit. What's Happening splits into a shared overview query plus an uncached front-page query for deep links. The controller is no longer rehydrated from leftover `marketInsights` / `marketOverview` persist.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/TSA-1055

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Digest cache owned by React Query

  Background:
    Given What's Happening and Market Insights are enabled
    And the app is using the matching AiDigestController passthrough from Core

  Scenario: user sees What's Happening on Explore without extra overview fetches
    Given I am logged into MetaMask Mobile
    And I open the Explore Trending Now tab

    When the What's Happening carousel loads
    Then I see the latest market overview cards
    And opening Perps home reuses the same overview without a second network call while it is fresh

  Scenario: user opens a What's Happening deep link
    Given I have a front-page item id that is no longer in the latest overview

    When I open the What's Happening detail deep link
    Then that item appears first and is flagged outdated
    And the latest overview cards still load
    And the overview request is shared with the carousel if it is already in memory

  Scenario: user opens Market Insights for an asset with no digest
    Given I am on an asset that returns no insights (404)

    When I leave and return to that asset
    Then the app retries the fetch instead of treating the miss as a 10-minute empty cache

  Scenario: user returns after ten minutes
    Given I loaded What's Happening or Market Insights
    And more than ten minutes have passed in the background

    When I bring the app to the foreground
    Then the digest data refreshes
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes digest data loading and caching across Explore/Perps/Whats Happening and drops persisted digest snapshots, which can affect offline behavior and duplicate-fetch assumptions until verified in manual scenarios.
> 
> **Overview**
> **Digest freshness moves from `AiDigestController` persistence to React Query**, with shared `digestQuery` helpers: successful payloads stay fresh for **10 minutes**, while **`null` misses stay immediately stale** so 404s retry on remount instead of blocking later hits.
> 
> **Market Insights** (`useMarketInsights`) adopts those stale/gc settings and documents the controller as a passthrough; tests cover offline fetch with `networkMode: 'always'`, remount reuse without refetch, and remount refetch after a null miss.
> 
> **What's Happening** splits into a **shared overview query** (one key for carousel and observers) plus a **separate uncached front-page query** when a deep-link id is set; refresh refetches both when needed. A test confirms carousel + detail share a single overview fetch.
> 
> **Engine init** stops rehydrating `marketInsights` / `marketOverview` from persisted `AiDigestController` state; background state fixtures use an empty controller object. **`@metamask/ai-controllers` is bumped to ^1.0.0** to align with the passthrough controller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74d55791d28552489eb139d989b02f630813b8ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->