### PR TITLE
feat(explore): complete campaign search deeplink support

### DIFF
--- a/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.testIds.ts
+++ b/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.testIds.ts
@@ -8,6 +8,8 @@
 export const ExploreSearchScreenSelectorsIDs = {
   /** FlashList in ExploreSearchResults (testID set directly on the component) */
   SEARCH_RESULTS_LIST: 'trending-search-results-list',
+  /** Clears the interactive search input */
+  SEARCH_CLEAR_BUTTON: 'explore-search-clear-button',
   /** Horizontal ScrollView wrapping all pills */
   PILL_ROW: 'explore-search-pills',
   /** "All" pill */

--- a/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.tsx
+++ b/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.tsx
@@ -31,6 +31,7 @@ import SearchFeedRow, {
 import {
   getExploreSearchResultCount,
   trackExploreSearchEvent,
+  trackExploreSearchOpened,
   useInstrumentedSearchEffect,
   useScrollTracking,
   type SearchFeedPill,
@@ -317,9 +318,19 @@ const ExploreSearchScreen: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState(
     () => route.params?.initialQuery?.trim() ?? '',
   );
+  const routeParams = route.params;
   // Gates the keyboard, which iOS paints dark grey mid-push, and the results
   // subtree, whose mount blocks the JS thread while the screen slides in.
   const isTransitionComplete = useScreenTransitionComplete();
+
+  useEffect(() => {
+    if (!routeParams?.entryPoint) {
+      return;
+    }
+
+    setSearchQuery(routeParams.initialQuery?.trim() ?? '');
+    trackExploreSearchOpened(routeParams.entryPoint);
+  }, [routeParams]);
 
   const handleSearchCancel = useCallback(() => {
     setSearchQuery('');

--- a/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.types.ts
+++ b/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.types.ts
@@ -1,4 +1,8 @@
+import type { SearchEntryPoint } from '../../search/analytics';
+
 export interface ExploreSearchRouteParams {
   /** Prefills the search input (e.g. from a deeplink). */
   initialQuery?: string;
+  /** Attributes Search opens initiated outside its in-app tap handlers. */
+  entryPoint?: SearchEntryPoint;
 }

--- a/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.view.test.tsx
+++ b/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.view.test.tsx
@@ -4,6 +4,7 @@ import { renderExploreSearchScreenWithRoutes } from '../../../../../../tests/com
 import {
   setupTrendingApiFetchMock,
   clearTrendingApiMocks,
+  mockRwaTokensData,
   mockTrendingTokensData,
 } from '../../../../../../tests/component-view/api-mocking/trending';
 import { strings } from '../../../../../../locales/i18n';
@@ -16,6 +17,16 @@ import {
 import { ReactTestInstance } from 'react-test-renderer';
 import { ExploreSearchScreenSelectorsIDs } from './ExploreSearchScreen.testIds';
 import { TrendingViewSelectorsIDs } from '../../TrendingView.testIds';
+import { analytics } from '../../../../../util/analytics/analytics';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
+
+const mockAppleSearchResult = {
+  assetId: 'eip155:1/erc20:0xa11e000000000000000000000000000000000000',
+  name: 'Apple Token',
+  symbol: 'APPLE',
+  decimals: 18,
+  price: '1.00',
+};
 
 /**
  * Prefer userEvent.press for better event simulation; fall back to fireEvent.press
@@ -38,18 +49,73 @@ describeForPlatforms('ExploreSearchScreen - Component Tests', () => {
     clearTrendingApiMocks();
   });
 
-  it('prefills the search input when initialQuery route param is provided', async () => {
-    const { findByTestId, getByDisplayValue } =
+  it('runs search from the deeplink initial query', async () => {
+    clearTrendingApiMocks();
+    setupTrendingApiFetchMock(
+      mockTrendingTokensData,
+      undefined,
+      mockRwaTokensData,
+      [mockAppleSearchResult],
+    );
+    const { findByText, getByDisplayValue } =
       renderExploreSearchScreenWithRoutes({
-        initialParams: { initialQuery: 'ethereum' },
+        initialParams: {
+          initialQuery: 'Apple',
+          entryPoint: 'deeplink',
+        },
       });
 
-    expect(getByDisplayValue('ethereum')).toBeOnTheScreen();
+    expect(getByDisplayValue('Apple')).toBeOnTheScreen();
 
-    const allPill = await findByTestId(
-      ExploreSearchScreenSelectorsIDs.PILL_ALL,
+    expect(await findByText('Apple Token')).toBeOnTheScreen();
+  });
+
+  it('attributes a deeplink search open to the deeplink entry point', async () => {
+    const trackEventSpy = jest.spyOn(analytics, 'trackEvent');
+
+    try {
+      renderExploreSearchScreenWithRoutes({
+        initialParams: {
+          initialQuery: 'Apple',
+          entryPoint: 'deeplink',
+        },
+      });
+
+      await waitFor(() => {
+        expect(trackEventSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: MetaMetricsEvents.EXPLORE_SEARCH_INTERACTED.category,
+            properties: expect.objectContaining({
+              interaction_type: 'opened',
+              search_query: '',
+              entry_point: 'deeplink',
+            }),
+          }),
+        );
+      });
+    } finally {
+      trackEventSpy.mockRestore();
+    }
+  });
+
+  it('allows changing a deeplink initial query', async () => {
+    const { getByDisplayValue, getByTestId } =
+      renderExploreSearchScreenWithRoutes({
+        initialParams: {
+          initialQuery: 'Apple',
+          entryPoint: 'deeplink',
+        },
+      });
+    const searchInput = getByTestId(
+      TrendingViewSelectorsIDs.EXPLORE_VIEW_SEARCH_TEXT_INPUT,
     );
-    expect(allPill).toBeOnTheScreen();
+
+    await actButtonPress(
+      getByTestId(ExploreSearchScreenSelectorsIDs.SEARCH_CLEAR_BUTTON),
+    );
+    await userEvent.type(searchInput, 'Microsoft');
+
+    expect(getByDisplayValue('Microsoft')).toBeOnTheScreen();
   });
 
   it('pill row is visible after typing a search query', async () => {
@@ -167,7 +233,9 @@ describeForPlatforms('ExploreSearchScreen - Component Tests', () => {
     });
 
     // Clear the search query via the clear button
-    const clearButton = getByTestId('explore-search-clear-button');
+    const clearButton = getByTestId(
+      ExploreSearchScreenSelectorsIDs.SEARCH_CLEAR_BUTTON,
+    );
     await actButtonPress(clearButton);
 
     // After clearing, the Crypto pill should remain selected — clearing the

--- a/app/components/Views/TrendingView/search/analytics.test.ts
+++ b/app/components/Views/TrendingView/search/analytics.test.ts
@@ -218,7 +218,7 @@ describe('Explore search analytics', () => {
   });
 
   describe('trackExploreSearchOpened', () => {
-    it.each([['home' as const], ['explore' as const]])(
+    it.each([['home' as const], ['explore' as const], ['deeplink' as const]])(
       'tracks the opened interaction with entry_point %s',
       (entryPoint) => {
         trackExploreSearchOpened(entryPoint);

--- a/app/components/Views/TrendingView/search/analytics.ts
+++ b/app/components/Views/TrendingView/search/analytics.ts
@@ -43,8 +43,8 @@ export type SearchInteractionType =
 /** 'all' = aggregated view; other values are a specific feed pill. */
 export type SearchFeedPill = SearchFeedId | 'all';
 
-/** Surface the user tapped to open search. Only set on `opened`. */
-export type SearchEntryPoint = 'home' | 'explore';
+/** Surface that opened search. Only set on `opened`. */
+export type SearchEntryPoint = 'home' | 'explore' | 'deeplink';
 
 export interface ExploreSearchInteractedProperties {
   interaction_type: SearchInteractionType;
@@ -178,11 +178,12 @@ export const trackExploreSearchEvent = (
 
 /**
  * Fired when the user opens the search screen, so opens can be attributed to
- * the surface they came from. Called from the tap handler rather than on screen
- * mount, so a remount (or a deeplink into search) never duplicates the event.
+ * the surface they came from. In-app entry points call this from their tap
+ * handlers; deeplinks call it when their route params are consumed.
  *
- * `search_query` is sent as an empty string: the schema requires the property
- * and the user has not typed anything yet.
+ * `search_query` is sent as an empty string because the opened-event schema
+ * requires it. A deeplink's prefilled query is reported by the settled
+ * `searched` event.
  */
 export const trackExploreSearchOpened = (
   entryPoint: SearchEntryPoint,

--- a/app/core/DeeplinkManager/handlers/intent/__tests__/handleTrendingUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/intent/__tests__/handleTrendingUrl.test.ts
@@ -1,11 +1,16 @@
 import NavigationService from '../../../../NavigationService';
 import Routes from '../../../../../constants/navigation/Routes';
 import { EXPLORE_TAB_INDEX } from '../../../../../constants/navigation/exploreTabIndices';
-import { handleTrendingUrl } from '../handleTrendingUrl';
+import { executeStartupDeeplinkIntent } from '../../../utils/executeDeeplinkIntent';
+import {
+  createTrendingDeeplinkIntent,
+  handleTrendingUrl,
+} from '../handleTrendingUrl';
 
 jest.mock('../../../../NavigationService', () => ({
   navigation: {
     navigate: jest.fn(),
+    reset: jest.fn(),
   },
 }));
 
@@ -153,35 +158,67 @@ describe('handleTrendingUrl - full-screen views (screen=...)', () => {
     {
       screenParam: 'search',
       expectedRoute: Routes.EXPLORE_SEARCH,
+      expectedParams: { entryPoint: 'deeplink' },
     },
     {
       screenParam: 'search',
-      actionPath: '?screen=search&q=ethereum',
+      actionPath: '?screen=search&q=Apple',
       expectedRoute: Routes.EXPLORE_SEARCH,
-      expectedParams: { initialQuery: 'ethereum' },
+      expectedParams: {
+        initialQuery: 'Apple',
+        entryPoint: 'deeplink',
+      },
     },
     {
       screenParam: 'search',
-      actionPath: '?screen=search&q=%20ethereum%20',
+      actionPath: '?screen=search&q=Apple%20Inc',
       expectedRoute: Routes.EXPLORE_SEARCH,
-      expectedParams: { initialQuery: 'ethereum' },
+      expectedParams: {
+        initialQuery: 'Apple Inc',
+        entryPoint: 'deeplink',
+      },
+    },
+    {
+      screenParam: 'search',
+      actionPath: '?screen=search&q=Apple%20%26%20Caf%C3%A9',
+      expectedRoute: Routes.EXPLORE_SEARCH,
+      expectedParams: {
+        initialQuery: 'Apple & Café',
+        entryPoint: 'deeplink',
+      },
     },
     {
       screenParam: 'search',
       actionPath: '?screen=search&query=bitcoin',
       expectedRoute: Routes.EXPLORE_SEARCH,
-      expectedParams: { initialQuery: 'bitcoin' },
+      expectedParams: {
+        initialQuery: 'bitcoin',
+        entryPoint: 'deeplink',
+      },
     },
     {
       screenParam: 'search',
       actionPath: '?screen=search&q=&query=bitcoin',
       expectedRoute: Routes.EXPLORE_SEARCH,
-      expectedParams: { initialQuery: 'bitcoin' },
+      expectedParams: {
+        initialQuery: 'bitcoin',
+        entryPoint: 'deeplink',
+      },
+    },
+    {
+      screenParam: 'search',
+      actionPath: '?screen=search&q=Apple&query=Microsoft',
+      expectedRoute: Routes.EXPLORE_SEARCH,
+      expectedParams: {
+        initialQuery: 'Apple',
+        entryPoint: 'deeplink',
+      },
     },
     {
       screenParam: 'search',
       actionPath: '?screen=search&q=%20%20',
       expectedRoute: Routes.EXPLORE_SEARCH,
+      expectedParams: { entryPoint: 'deeplink' },
     },
   ])(
     'activates Explore tab then navigates to the full view for screen=$screenParam',
@@ -213,6 +250,51 @@ describe('handleTrendingUrl - full-screen views (screen=...)', () => {
       2,
       Routes.WALLET.RWA_TOKENS_FULL_VIEW,
     );
+  });
+
+  it('preserves the decoded search query in cold-start navigation', async () => {
+    const intent = createTrendingDeeplinkIntent({
+      actionPath: '?screen=search&q=Apple%20Inc',
+    });
+
+    await executeStartupDeeplinkIntent(intent);
+
+    expect(NavigationService.navigation.reset).toHaveBeenCalledWith({
+      routes: [
+        {
+          name: Routes.ONBOARDING.HOME_NAV,
+          state: {
+            routes: [
+              {
+                name: Routes.MAIN_FLOW,
+                state: {
+                  index: 1,
+                  routes: [
+                    {
+                      name: Routes.HOME_TABS,
+                      state: {
+                        index: 1,
+                        routes: [
+                          { name: Routes.WALLET.HOME },
+                          { name: Routes.TRENDING_VIEW },
+                        ],
+                      },
+                    },
+                    {
+                      name: Routes.EXPLORE_SEARCH,
+                      params: {
+                        initialQuery: 'Apple Inc',
+                        entryPoint: 'deeplink',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
   });
 });
 

--- a/app/core/DeeplinkManager/handlers/intent/handleTrendingUrl.schema.ts
+++ b/app/core/DeeplinkManager/handlers/intent/handleTrendingUrl.schema.ts
@@ -128,7 +128,10 @@ const EXPLORE_SCREENS: Record<
         readParam(urlParams, 'q', nonempty(string())) ??
         readParam(urlParams, 'query', nonempty(string()));
 
-      return { ...(query && { initialQuery: query }) };
+      return {
+        ...(query && { initialQuery: query }),
+        entryPoint: 'deeplink',
+      };
     },
   },
 };

--- a/docs/readme/deeplinking.md
+++ b/docs/readme/deeplinking.md
@@ -211,6 +211,52 @@ https://link.metamask.io/{action}?{parameters}
 https://link.metamask.io/buy?chain=1&token=ETH
 ```
 
+### Explore Search Campaign Link
+
+Use this mobile deeplink for campaigns about a real-world name or event that
+can match multiple instrument types:
+
+```
+https://link.metamask.io/trending?screen=search&q=Apple
+```
+
+Contract:
+
+- Minimum MetaMask Mobile version: `8.3.0`.
+- `screen=search` is required. A standalone `q` or `query` parameter opens the
+  default Explore feed instead of Search.
+- `q` is the canonical query parameter. `query` is an alias used only when `q`
+  is missing, empty, or whitespace. If both are non-empty, `q` wins.
+- Values are URL-decoded and trimmed before prefilling the search input. Encode
+  spaces and special characters, for example:
+  `https://link.metamask.io/trending?screen=search&q=Apple%20Inc`.
+- A missing, empty, or whitespace-only query still opens Explore Search with
+  an empty input.
+- The prefilled query runs through the same Explore Search feeds and ranking as
+  a query entered in-app. Feed availability can still vary by app version and
+  feature configuration.
+- Users can clear or edit the query normally.
+- Search-open analytics reports `entry_point: deeplink`; normal deeplink
+  analytics also records the `trending` route and supported UTM parameters.
+- This is a mobile destination. Universal Links on iOS and App Links on Android
+  support `link.metamask.io`; campaign links must also be configured in the
+  Branch LinkHub as described in [Overview](#overview).
+
+For test builds, replace the host:
+
+```
+https://link-test.metamask.io/trending?screen=search&q=Apple
+```
+
+Generate dynamic links with `URLSearchParams` instead of concatenating an
+unescaped query:
+
+```javascript
+const url = new URL('https://link.metamask.io/trending');
+url.searchParams.set('screen', 'search');
+url.searchParams.set('q', campaignQuery);
+```
+
 #### Swap Link (CAIP-19 Format)
 
 ```


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Growth campaigns need one stable mobile destination for events that affect several instrument types. Explore Search already accepted `screen=search` with `q`/`query`, but deeplink opens were not attributed as a Search entry point and an already-mounted Search screen did not consume updated route parameters.

This change:

- attributes Explore Search opens from deeplinks with `entry_point: deeplink`;
- reapplies and runs the prefilled query when deeplink route parameters change;
- preserves empty-query fallback, alias precedence, decoding, and cold-start navigation;
- adds handler and component-view coverage for prefilled results and editable queries; and
- documents the campaign URL contract and its `8.3.0` minimum version.

Canonical campaign URL:

`https://link.metamask.io/trending?screen=search&q=Apple`

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated Explore Search deeplinks to refresh prefilled queries and report deeplink entry attribution

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1321

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Explore Search campaign deeplink

  Background:
    Given MetaMask Mobile 8.3.0 or later is installed
    And I have completed onboarding

  Scenario: open a populated Search deeplink
    Given MetaMask is unlocked

    When I open "https://link-test.metamask.io/trending?screen=search&q=Apple%20Inc"
    Then Explore Search should open
    And the search input should contain "Apple Inc"
    And results should load as if I typed "Apple Inc" in-app

  Scenario: continue the deeplink after unlocking
    Given MetaMask is locked

    When I open "https://link-test.metamask.io/trending?screen=search&q=Apple"
    And I unlock MetaMask
    Then Explore Search should open
    And the search input should contain "Apple"

  Scenario: open Search without a query
    Given MetaMask is unlocked

    When I open "https://link-test.metamask.io/trending?screen=search&q="
    Then Explore Search should open without crashing
    And the search input should be empty

  Scenario: edit a prefilled query
    Given Explore Search was opened with the query "Apple"

    When I clear the query
    And I enter "Microsoft"
    Then the search input should contain "Microsoft"
    And results should load for "Microsoft"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/3abc6b42-30dc-4363-81d9-f84066bc8177


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Explore Search routing, trending deeplink params, and analytics attribution; no auth, payments, or security-sensitive paths.
> 
> **Overview**
> **Finishes Explore Search campaign deeplinks** so `https://link.metamask.io/trending?screen=search&q=…` prefills and runs search like in-app entry, with correct analytics and docs for growth campaigns.
> 
> Trending search deeplinks now always pass **`entryPoint: 'deeplink'`** (with optional **`initialQuery`** from `q` / `query`, same precedence and trimming as before). **Explore Search** watches route params: when `entryPoint` is present it reapplies the prefilled query and fires **`trackExploreSearchOpened`** with `entry_point: deeplink` (prefilled text stays on the separate **`searched`** event). **`SearchEntryPoint`** includes **`deeplink`**.
> 
> Tests cover handler navigation (including cold-start **`reset`**), component behavior (results, attribution, clear/edit), and analytics. **Deeplinking docs** add the campaign URL contract (min version **8.3.0**, param rules, Branch note). A shared **`SEARCH_CLEAR_BUTTON`** test ID is exported for tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9758c1e0298c61598d8bc5d0b64e791217eb953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->