### PR TITLE
feat: design review and improvements to swaps limit orders

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.test.tsx
@@ -7,10 +7,44 @@ import { Hex } from '@metamask/utils';
 import { mockUseBridgeQuoteData } from '../../../_mocks_/useBridgeQuoteData.mock';
 import { useBridgeQuoteData } from '../../../hooks/useBridgeQuoteData';
 import { mockQuoteWithMetadata } from '../../../_mocks_/bridgeQuoteWithMetadata';
-import { createBridgeTestState } from '../../../testUtils';
+import { ethToken1Address } from '../../../_mocks_/initialState';
+import { createBridgeTestState, createMockToken } from '../../../testUtils';
 import type { RootState } from '../../../../../../reducers';
 import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
 import { BridgeLimitOrderFooterView } from './BridgeLimitOrderFooterView';
+
+const pricedDestToken = createMockToken({
+  address: ethToken1Address,
+  symbol: 'TOKEN1',
+});
+const unpricedDestToken = createMockToken({
+  address: '0x00000000000000000000000000000000000000ff',
+  symbol: 'MUSD',
+});
+
+const quoteWithPriceImpact = {
+  ...mockQuoteWithMetadata,
+  quote: {
+    ...mockQuoteWithMetadata.quote,
+    priceData: {
+      ...mockQuoteWithMetadata.quote.priceData,
+      priceImpact: { amount: '0.01' },
+    },
+  },
+};
+
+const quoteWithoutPriceImpact = {
+  ...mockQuoteWithMetadata,
+  quote: {
+    ...mockQuoteWithMetadata.quote,
+    priceData: undefined,
+  },
+};
+
+const mockQuoteDataWithPriceImpact = {
+  ...mockUseBridgeQuoteData,
+  activeQuote: quoteWithPriceImpact,
+};
 
 jest.mock(
   '../../../../../../multichain-accounts/controllers/account-tree-controller',
@@ -69,6 +103,7 @@ function buildActiveQuoteState(
         name: 'Ether',
         symbol: 'ETH',
       },
+      destToken: pricedDestToken,
       ...(overrides.bridgeReducerOverrides ?? {}),
     },
   });
@@ -83,7 +118,7 @@ describe('BridgeLimitOrderFooterView', () => {
     jest.clearAllMocks();
     jest
       .mocked(useBridgeQuoteData as unknown as jest.Mock)
-      .mockImplementation(() => mockUseBridgeQuoteData);
+      .mockImplementation(() => mockQuoteDataWithPriceImpact);
   });
 
   it('renders nothing when loading without an active quote', () => {
@@ -140,5 +175,59 @@ describe('BridgeLimitOrderFooterView', () => {
     expect(
       getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON),
     ).toBeOnTheScreen();
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON).props
+        .accessibilityState?.disabled,
+    ).toBeFalsy();
+  });
+
+  it('disables the confirm button when the quote has no price data', () => {
+    jest
+      .mocked(useBridgeQuoteData as unknown as jest.Mock)
+      .mockImplementation(() => ({
+        ...mockQuoteDataWithPriceImpact,
+        activeQuote: quoteWithoutPriceImpact,
+      }));
+
+    const { getByTestId } = renderFooter(buildActiveQuoteState());
+
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON).props
+        .accessibilityState?.disabled,
+    ).toBe(true);
+  });
+
+  it('disables the confirm button when a selected token has no fiat rate', () => {
+    const { getByTestId } = renderFooter(
+      buildActiveQuoteState({
+        bridgeReducerOverrides: { destToken: unpricedDestToken },
+      }),
+    );
+
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON).props
+        .accessibilityState?.disabled,
+    ).toBe(true);
+  });
+
+  it('keeps the confirm button enabled while the quote is for a previous token pair', () => {
+    jest
+      .mocked(useBridgeQuoteData as unknown as jest.Mock)
+      .mockImplementation(() => ({
+        ...mockQuoteDataWithPriceImpact,
+        isActiveQuoteForCurrentTokenPair: false,
+        activeQuote: quoteWithoutPriceImpact,
+      }));
+
+    const { getByTestId } = renderFooter(
+      buildActiveQuoteState({
+        bridgeReducerOverrides: { destToken: unpricedDestToken },
+      }),
+    );
+
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON).props
+        .accessibilityState?.disabled,
+    ).toBeFalsy();
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.tsx
@@ -7,6 +7,7 @@ import {
   selectBridgeControllerState,
 } from '../../../../../../core/redux/slices/bridge';
 import { useBridgeQuoteDataContext } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import { useHasMissingQuoteAndAssetsPriceData } from '../../../hooks/useHasMissingQuoteAndAssetsPriceData';
 import {
   Box,
   BoxAlignItems,
@@ -21,6 +22,7 @@ export const BridgeLimitOrderFooterView = () => {
   const sourceToken = useSelector(selectSourceToken);
   const { activeQuote, isLoading, needsNewQuote } = useBridgeQuoteDataContext();
   const { quotesLastFetched } = useSelector(selectBridgeControllerState);
+  const isMissingPrice = useHasMissingQuoteAndAssetsPriceData();
 
   const isValidSourceAmount =
     sourceAmount !== undefined && sourceAmount !== '.' && sourceToken?.decimals;
@@ -48,6 +50,7 @@ export const BridgeLimitOrderFooterView = () => {
         onPress={() => 'test'}
         label="test"
         testID={BridgeViewSelectorsIDs.CONFIRM_BUTTON}
+        disabled={isMissingPrice}
       />
     </Box>
   );

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.test.tsx
@@ -10,6 +10,7 @@ import { useBridgeQuoteData } from '../../../hooks/useBridgeQuoteData';
 import { useLimitOrderSwapInputs } from '../../../hooks/useLimitOrderSwapsInput';
 import { useSwapsLimitOrderPriceAdjust } from '../../../hooks/useSwapsLimitOrderPriceAdjust';
 import { useSwapsLimitOrderKeypad } from '../../../hooks/useSwapsLimitOrderKeypad';
+import { useHasMissingQuoteAndAssetsPriceData } from '../../../hooks/useHasMissingQuoteAndAssetsPriceData';
 import { useLatestBalance } from '../../../hooks/useLatestBalance';
 import { LimitOrderExecutionType } from '../../../constants/limitOrders';
 import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
@@ -63,6 +64,10 @@ jest.mock('../../../hooks/useSwapsLimitOrderPriceAdjust', () => ({
 
 jest.mock('../../../hooks/useSwapsLimitOrderKeypad', () => ({
   useSwapsLimitOrderKeypad: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useHasMissingQuoteAndAssetsPriceData', () => ({
+  useHasMissingQuoteAndAssetsPriceData: jest.fn(() => false),
 }));
 
 jest.mock('../../../components/SwapsKeypad', () => {
@@ -303,6 +308,7 @@ describe('BridgeLimitOrderView', () => {
     jest
       .mocked(useSwapsLimitOrderKeypad)
       .mockImplementation(() => buildKeypadMock());
+    jest.mocked(useHasMissingQuoteAndAssetsPriceData).mockReturnValue(false);
   });
 
   it('renders the limit order container and source token input', () => {
@@ -349,6 +355,23 @@ describe('BridgeLimitOrderView', () => {
       getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON_KEYPAD),
     ).toBeOnTheScreen();
     expect(queryByText('25%')).not.toBeOnTheScreen();
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON_KEYPAD).props
+        .accessibilityState?.disabled,
+    ).toBeFalsy();
+  });
+
+  it('disables the keypad confirm button when quote price data is unavailable', () => {
+    mockIsAmountFocused = true;
+    mockSourceAmount = '2';
+    jest.mocked(useHasMissingQuoteAndAssetsPriceData).mockReturnValue(true);
+
+    const { getByTestId } = renderLimitOrderView();
+
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON_KEYPAD).props
+        .accessibilityState?.disabled,
+    ).toBe(true);
   });
 
   it('commits the custom percent and closes the keypad when dismiss runs while custom percent is focused', () => {

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
@@ -36,6 +36,7 @@ import type {
 import { LIMIT_ORDER_BUTTON_PRICE_PRESETS } from '../../../constants/limitOrders';
 import { useSwapsLimitOrderPriceAdjust } from '../../../hooks/useSwapsLimitOrderPriceAdjust';
 import { useSwapsLimitOrderKeypad } from '../../../hooks/useSwapsLimitOrderKeypad';
+import { useHasMissingQuoteAndAssetsPriceData } from '../../../hooks/useHasMissingQuoteAndAssetsPriceData';
 
 interface BridgeLimitOrderViewContentProps {
   latestSourceBalance: ReturnType<typeof useLatestBalance>;
@@ -113,6 +114,7 @@ const BridgeLimitOrderViewContent = ({
   });
 
   const [hasVisibleBanner, setHasVisibleBanner] = useState(false);
+  const isMissingPrice = useHasMissingQuoteAndAssetsPriceData();
 
   const blurLimitAdjustInputs = useCallback(() => {
     limitPriceInputRef.current?.blur();
@@ -286,6 +288,7 @@ const BridgeLimitOrderViewContent = ({
               onPress={() => 'test'}
               label="test"
               testID={BridgeViewSelectorsIDs.CONFIRM_BUTTON_KEYPAD}
+              disabled={isMissingPrice}
             />
           ) : isAmountFocused ? (
             <GaslessQuickPickOptions

--- a/app/components/UI/Bridge/components/LimitOrderPriceAdjustCard/ButtonPricePresetsSection/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderPriceAdjustCard/ButtonPricePresetsSection/index.test.tsx
@@ -52,6 +52,9 @@ describe('ButtonPricePresetsSection', () => {
     expect(
       getByTestId(LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM),
     ).toHaveTextContent(strings('bridge.limit.custom'));
+    expect(
+      getByTestId(LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM_SLOT),
+    ).toBeOnTheScreen();
   });
 
   it('renders positive percent presets for sell orders', () => {
@@ -110,6 +113,9 @@ describe('ButtonPricePresetsSection', () => {
       queryByTestId(LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM),
     ).not.toBeOnTheScreen();
     expect(
+      getByTestId(LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM_SLOT),
+    ).toBeOnTheScreen();
+    expect(
       getByTestId(LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM_INPUT),
     ).toBeOnTheScreen();
 
@@ -119,5 +125,122 @@ describe('ButtonPricePresetsSection', () => {
     );
 
     expect(onCustomInputPress).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      executionType: LimitOrderExecutionType.BUY,
+      expected: '-7%',
+    },
+    {
+      executionType: LimitOrderExecutionType.SELL,
+      expected: '+7%',
+    },
+  ])(
+    'renders $expected in the custom input for $executionType orders',
+    ({ executionType, expected }) => {
+      const { getByTestId } = renderPresetsSection({
+        executionType,
+        isCustomActive: true,
+        customValue: '7',
+      });
+
+      expect(
+        getByTestId(LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM_INPUT),
+      ).toHaveProp('value', expected);
+    },
+  );
+
+  it.each([
+    {
+      executionType: LimitOrderExecutionType.BUY,
+      expected: '-0%',
+    },
+    {
+      executionType: LimitOrderExecutionType.SELL,
+      expected: '+0%',
+    },
+  ])(
+    'renders $expected as the custom input placeholder when empty for $executionType orders',
+    ({ executionType, expected }) => {
+      const { getByTestId } = renderPresetsSection({
+        executionType,
+        isCustomActive: true,
+        customValue: '',
+      });
+
+      expect(
+        getByTestId(LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM_INPUT),
+      ).toHaveProp('value', '');
+      expect(
+        getByTestId(LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM_INPUT),
+      ).toHaveProp('placeholder', expected);
+    },
+  );
+
+  it('offsets custom selection past the sign prefix', () => {
+    const { getByTestId } = renderPresetsSection({
+      isCustomActive: true,
+      customValue: '7',
+      customSelection: { start: 1, end: 1 },
+    });
+
+    expect(
+      getByTestId(LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM_INPUT),
+    ).toHaveProp('selection', { start: 2, end: 2 });
+  });
+
+  it('keeps the caret before the percent postfix when selection moves past it', () => {
+    const onCustomSelectionChange = jest.fn();
+    const { getByTestId } = renderPresetsSection({
+      isCustomActive: true,
+      customValue: '7',
+      onCustomSelectionChange,
+    });
+
+    fireEvent(
+      getByTestId(LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM_INPUT),
+      'selectionChange',
+      {
+        nativeEvent: {
+          selection: { start: 3, end: 3 },
+        },
+      },
+    );
+
+    expect(onCustomSelectionChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nativeEvent: {
+          selection: { start: 1, end: 1 },
+        },
+      }),
+    );
+  });
+
+  it('keeps the caret after the sign prefix when selection moves onto it', () => {
+    const onCustomSelectionChange = jest.fn();
+    const { getByTestId } = renderPresetsSection({
+      isCustomActive: true,
+      customValue: '7',
+      onCustomSelectionChange,
+    });
+
+    fireEvent(
+      getByTestId(LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM_INPUT),
+      'selectionChange',
+      {
+        nativeEvent: {
+          selection: { start: 0, end: 0 },
+        },
+      },
+    );
+
+    expect(onCustomSelectionChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nativeEvent: {
+          selection: { start: 0, end: 0 },
+        },
+      }),
+    );
   });
 });

--- a/app/components/UI/Bridge/components/LimitOrderPriceAdjustCard/ButtonPricePresetsSection/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderPriceAdjustCard/ButtonPricePresetsSection/index.tsx
@@ -1,5 +1,14 @@
-import React, { forwardRef, useImperativeHandle, useRef } from 'react';
-import { TextInput } from 'react-native';
+import React, {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+} from 'react';
+import {
+  Platform,
+  TextInput,
+  type TextInputSelectionChangeEvent,
+} from 'react-native';
 import {
   Box,
   BoxAlignItems,
@@ -8,8 +17,6 @@ import {
   ButtonBaseSize,
   ButtonVariant,
   Input,
-  Text,
-  TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -25,7 +32,11 @@ import {
   LimitOrderPriceAdjustPresetsSelectorsIDs,
 } from './testIds';
 
-const PRESET_ITEM_TW_CLASS_NAME = 'min-w-0 flex-1 shrink';
+const PRESET_SLOT_TW_CLASS_NAME = 'min-w-0 flex-1 shrink basis-0';
+const PRESET_CONTROL_TW_CLASS_NAME = 'w-full px-0';
+const VALUE_FONT_SIZE = 14;
+const VALUE_LINE_HEIGHT = VALUE_FONT_SIZE * 1.25;
+const PERCENT_POSTFIX = '%';
 
 export const ButtonPricePresetsSection = forwardRef<
   ButtonPricePresetsSectionRef,
@@ -49,12 +60,79 @@ export const ButtonPricePresetsSection = forwardRef<
   ) => {
     const tw = useTailwind();
     const inputRef = useRef<TextInput>(null);
+    const valueTextStyle = tw.style({
+      fontSize: VALUE_FONT_SIZE,
+      lineHeight: VALUE_LINE_HEIGHT,
+      height: VALUE_LINE_HEIGHT,
+      paddingVertical: 0,
+      includeFontPadding: false,
+      textAlignVertical: 'center',
+      ...(Platform.OS === 'android' && { paddingTop: 1 }),
+    });
     const percentSign =
       executionType === LimitOrderExecutionType.SELL ? '+' : '-';
+    const formatSignedPercent = (value: string | number) =>
+      `${percentSign}${value}${PERCENT_POSTFIX}`;
     const displayValue =
       customValue && customValue !== '0'
         ? formatAmountWithLocaleSeparators(customValue)
         : customValue;
+    const numericDisplayValue = displayValue ?? '';
+    const hasNumericDisplayValue = numericDisplayValue.length > 0;
+    const signPrefixLength = percentSign.length;
+    const minSelectionIndex = signPrefixLength;
+    const maxSelectionIndex = signPrefixLength + numericDisplayValue.length;
+    const inputValue = hasNumericDisplayValue
+      ? formatSignedPercent(numericDisplayValue)
+      : '';
+    const clampedSelection =
+      customSelection === undefined
+        ? undefined
+        : {
+            start:
+              signPrefixLength +
+              Math.min(
+                Math.max(customSelection.start, 0),
+                numericDisplayValue.length,
+              ),
+            end:
+              signPrefixLength +
+              Math.min(
+                Math.max(customSelection.end, 0),
+                numericDisplayValue.length,
+              ),
+          };
+
+    const handleSelectionChange = useCallback(
+      (event: TextInputSelectionChangeEvent) => {
+        const { start, end } = event.nativeEvent.selection;
+        const nextStart = Math.min(
+          Math.max(start, minSelectionIndex),
+          maxSelectionIndex,
+        );
+        const nextEnd = Math.min(
+          Math.max(end, minSelectionIndex),
+          maxSelectionIndex,
+        );
+
+        onCustomSelectionChange?.({
+          ...event,
+          nativeEvent: {
+            ...event.nativeEvent,
+            selection: {
+              start: nextStart - signPrefixLength,
+              end: nextEnd - signPrefixLength,
+            },
+          },
+        });
+      },
+      [
+        maxSelectionIndex,
+        minSelectionIndex,
+        onCustomSelectionChange,
+        signPrefixLength,
+      ],
+    );
 
     useImperativeHandle(ref, () => ({
       blur: () => inputRef.current?.blur(),
@@ -74,7 +152,7 @@ export const ButtonPricePresetsSection = forwardRef<
           size={ButtonBaseSize.Sm}
           onPress={onMarketPress}
           testID={LimitOrderPriceAdjustPresetsSelectorsIDs.MARKET}
-          twClassName={`${PRESET_ITEM_TW_CLASS_NAME} px-0`}
+          twClassName={`${PRESET_SLOT_TW_CLASS_NAME} ${PRESET_CONTROL_TW_CLASS_NAME}`}
         >
           {strings('bridge.limit.market')}
         </Button>
@@ -85,50 +163,52 @@ export const ButtonPricePresetsSection = forwardRef<
             size={ButtonBaseSize.Sm}
             onPress={() => onPercentPress(percent)}
             testID={getLimitOrderPercentPresetTestId(percent)}
-            twClassName={`${PRESET_ITEM_TW_CLASS_NAME} px-0`}
+            twClassName={`${PRESET_SLOT_TW_CLASS_NAME} ${PRESET_CONTROL_TW_CLASS_NAME}`}
           >
-            {`${percentSign}${percent}%`}
+            {formatSignedPercent(percent)}
           </Button>
         ))}
-        {isCustomActive ? (
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            twClassName={`h-8 overflow-hidden rounded-lg bg-muted px-1 ${PRESET_ITEM_TW_CLASS_NAME}`}
-          >
-            <Input
-              ref={inputRef}
-              testID={LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM_INPUT}
-              value={displayValue}
-              isStateStylesDisabled
-              showSoftInputOnFocus={false}
-              caretHidden={false}
-              autoFocus={false}
-              placeholder="0"
-              textAlign="center"
-              textVariant={TextVariant.BodySm}
-              selection={customSelection}
-              onSelectionChange={onCustomSelectionChange}
-              onPressIn={onCustomInputPress}
-              onFocus={onCustomInputPress}
-              style={tw.style({ includeFontPadding: false })}
-              twClassName="h-full min-w-0 flex-1 border-0 bg-transparent p-0"
-            />
-            <Text variant={TextVariant.BodySm} color={TextColor.TextDefault}>
-              %
-            </Text>
-          </Box>
-        ) : (
-          <Button
-            variant={ButtonVariant.Secondary}
-            size={ButtonBaseSize.Sm}
-            onPress={onCustomPress}
-            testID={LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM}
-            twClassName={`${PRESET_ITEM_TW_CLASS_NAME} px-0`}
-          >
-            {strings('bridge.limit.custom')}
-          </Button>
-        )}
+        <Box
+          testID={LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM_SLOT}
+          twClassName={PRESET_SLOT_TW_CLASS_NAME}
+        >
+          {isCustomActive ? (
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              twClassName="h-8 w-full overflow-hidden rounded-lg bg-muted px-1"
+            >
+              <Input
+                ref={inputRef}
+                testID={LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM_INPUT}
+                value={inputValue}
+                isStateStylesDisabled
+                showSoftInputOnFocus={false}
+                caretHidden={false}
+                autoFocus={false}
+                placeholder={formatSignedPercent(0)}
+                textAlign="center"
+                textVariant={TextVariant.BodySm}
+                selection={clampedSelection}
+                onSelectionChange={handleSelectionChange}
+                onPressIn={onCustomInputPress}
+                onFocus={onCustomInputPress}
+                style={valueTextStyle}
+                twClassName="h-full min-w-0 flex-1 border-0 bg-transparent p-0"
+              />
+            </Box>
+          ) : (
+            <Button
+              variant={ButtonVariant.Secondary}
+              size={ButtonBaseSize.Sm}
+              onPress={onCustomPress}
+              testID={LimitOrderPriceAdjustPresetsSelectorsIDs.CUSTOM}
+              twClassName={PRESET_CONTROL_TW_CLASS_NAME}
+            >
+              {strings('bridge.limit.custom')}
+            </Button>
+          )}
+        </Box>
       </Box>
     );
   },

--- a/app/components/UI/Bridge/components/LimitOrderPriceAdjustCard/ButtonPricePresetsSection/testIds.ts
+++ b/app/components/UI/Bridge/components/LimitOrderPriceAdjustCard/ButtonPricePresetsSection/testIds.ts
@@ -2,6 +2,7 @@ export const LimitOrderPriceAdjustPresetsSelectorsIDs = {
   CONTAINER: 'limit-order-price-adjust-presets',
   MARKET: 'limit-order-price-adjust-market-preset',
   CUSTOM: 'limit-order-price-adjust-custom-preset',
+  CUSTOM_SLOT: 'limit-order-price-adjust-custom-slot',
   CUSTOM_INPUT: 'limit-order-price-adjust-custom-input',
 } as const;
 

--- a/app/components/UI/Bridge/components/LimitOrderPriceAdjustCard/ButtonPricePresetsSection/types.ts
+++ b/app/components/UI/Bridge/components/LimitOrderPriceAdjustCard/ButtonPricePresetsSection/types.ts
@@ -17,11 +17,11 @@ export interface ButtonPricePresetsSectionProps {
    */
   pricePresets: number[];
   /**
-   * When true, the Custom slot is an unsigned percent input.
+   * When true, the Custom slot is a signed percent input matching the presets.
    */
   isCustomActive: boolean;
   /**
-   * Unsigned custom percent shown in the Custom input, e.g. "7".
+   * Unsigned custom percent, e.g. "7". Displayed as "+7%" or "-7%".
    */
   customValue: string;
   /**

--- a/app/components/UI/Bridge/components/LimitOrderPriceAdjustCard/InputSection/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderPriceAdjustCard/InputSection/index.tsx
@@ -147,8 +147,7 @@ export const InputSection = forwardRef<InputSectionRef, InputSectionProps>(
           >
             {inputPrefix ? (
               <Text
-                variant={TextVariant.HeadingLg}
-                fontWeight={FontWeight.Bold}
+                variant={TextVariant.BodyMd}
                 color={TextColor.TextDefault}
                 style={amountTextStyle}
                 twClassName="p-0 leading-none"
@@ -165,7 +164,7 @@ export const InputSection = forwardRef<InputSectionRef, InputSectionProps>(
               caretHidden={false}
               autoFocus={false}
               placeholder="0"
-              textVariant={TextVariant.HeadingLg}
+              textVariant={TextVariant.BodyMd}
               selection={selection}
               onSelectionChange={onSelectionChange}
               onPressIn={onInputPress}
@@ -192,9 +191,7 @@ export const InputSection = forwardRef<InputSectionRef, InputSectionProps>(
                   onAmountTypeTogglePress?.();
                 }}
                 disabled={!onAmountTypeTogglePress}
-                style={tw.style(
-                  'flex-row items-center self-start gap-2 px-1 py-1',
-                )}
+                style={tw.style('flex-row items-center self-start px-1 py-1')}
               >
                 {secondaryValue ? (
                   <Text
@@ -221,7 +218,7 @@ export const InputSection = forwardRef<InputSectionRef, InputSectionProps>(
                 testID={
                   LimitOrderPriceAdjustInputSectionSelectorsIDs.MARKET_COMPARISON
                 }
-                variant={TextVariant.BodyMd}
+                variant={TextVariant.BodySm}
                 color={marketComparisonColor}
                 fontWeight={FontWeight.Medium}
               >

--- a/app/components/UI/Bridge/components/SwapsBanners/banners/MissingQuoteAndAssetsPriceDataBanner.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/banners/MissingQuoteAndAssetsPriceDataBanner.tsx
@@ -4,12 +4,8 @@ import {
   BannerAlertSeverity,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../locales/i18n';
-import { useBridgeQuoteDataContext } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
-import { useTokenFiatRate } from '../../../hooks/useTokenFiatRate';
-import { hasMissingPriceData } from '../../../utils/hasMissingPriceData';
-import { hasMissingTokenFiatRate } from '../../../utils/hasMissingTokenFiatRate';
+import { useHasMissingQuoteAndAssetsPriceData } from '../../../hooks/useHasMissingQuoteAndAssetsPriceData';
 import { SwapsBannersSelectorsIDs } from '../SwapsBanners.testIds';
-import { useSwapsBannersContext } from '../SwapsBannersContext';
 
 /**
  * Tells the user the quote came back without the market price data needed to
@@ -21,27 +17,9 @@ import { useSwapsBannersContext } from '../SwapsBannersContext';
  * a fiat figure to set that order against.
  */
 export const MissingQuoteAndAssetsPriceDataBanner = () => {
-  const { sourceAmount, sourceToken, destToken } = useSwapsBannersContext();
-  const { activeQuote, isActiveQuoteForCurrentTokenPair } =
-    useBridgeQuoteDataContext();
-  const sourceFiatRate = useTokenFiatRate(sourceToken);
-  const destFiatRate = useTokenFiatRate(destToken);
+  const isMissingPrice = useHasMissingQuoteAndAssetsPriceData();
 
-  const hasEnteredAmount = Boolean(sourceAmount) && Number(sourceAmount) > 0;
-  // Rates are only fetched for the selected pair, so waiting for a quote that
-  // matches that pair keeps an in-flight fetch (or a stale quote after a
-  // token-selector change) from being mistaken for a token that has no price.
-  const isMissingPrice =
-    hasMissingPriceData(activeQuote) ||
-    hasMissingTokenFiatRate(sourceToken, sourceFiatRate) ||
-    hasMissingTokenFiatRate(destToken, destFiatRate);
-
-  if (
-    !hasEnteredAmount ||
-    !activeQuote ||
-    !isActiveQuoteForCurrentTokenPair ||
-    !isMissingPrice
-  ) {
+  if (!isMissingPrice) {
     return null;
   }
 

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -128,7 +128,7 @@ const createStyles = ({
     secondaryValueContainer: {
       flexDirection: 'row',
       alignItems: 'center',
-      gap: 8,
+      gap: 1,
       alignSelf: 'flex-start',
       paddingVertical: 4,
       paddingHorizontal: 4,

--- a/app/components/UI/Bridge/hooks/useHasMissingQuoteAndAssetsPriceData/index.ts
+++ b/app/components/UI/Bridge/hooks/useHasMissingQuoteAndAssetsPriceData/index.ts
@@ -1,0 +1,29 @@
+import { useSelector } from 'react-redux';
+import {
+  selectDestToken,
+  selectSourceAmount,
+  selectSourceToken,
+} from '../../../../../core/redux/slices/bridge';
+import { hasMissingQuoteAndAssetsPriceData } from '../../utils/hasMissingQuoteAndAssetsPriceData';
+import { useBridgeQuoteDataContext } from '../useBridgeQuoteData/BridgeQuoteDataContext';
+import { useTokenFiatRate } from '../useTokenFiatRate';
+
+export const useHasMissingQuoteAndAssetsPriceData = () => {
+  const sourceAmount = useSelector(selectSourceAmount);
+  const sourceToken = useSelector(selectSourceToken);
+  const destToken = useSelector(selectDestToken);
+  const { activeQuote, isActiveQuoteForCurrentTokenPair } =
+    useBridgeQuoteDataContext();
+  const sourceFiatRate = useTokenFiatRate(sourceToken);
+  const destFiatRate = useTokenFiatRate(destToken);
+
+  return hasMissingQuoteAndAssetsPriceData({
+    sourceAmount,
+    sourceToken,
+    destToken,
+    sourceFiatRate,
+    destFiatRate,
+    activeQuote,
+    isActiveQuoteForCurrentTokenPair,
+  });
+};

--- a/app/components/UI/Bridge/hooks/useSwapsLimitOrderKeypad/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useSwapsLimitOrderKeypad/index.test.ts
@@ -136,7 +136,7 @@ describe('useSwapsLimitOrderKeypad', () => {
     expect(result.current.keypadProps).toEqual({
       value: '250',
       currency: 'SWAPS_FIAT_INPUT',
-      decimals: 2,
+      decimals: 18,
     });
   });
 
@@ -159,7 +159,8 @@ describe('useSwapsLimitOrderKeypad', () => {
     expect(result.current.keypadProps).toEqual({
       value: '12',
       currency: 'LIMIT_ORDER_CUSTOM_PERCENT',
-      decimals: 2,
+      decimals: 0,
+      periodButtonProps: { isDisabled: true },
     });
   });
 

--- a/app/components/UI/Bridge/hooks/useSwapsLimitOrderKeypad/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapsLimitOrderKeypad/index.ts
@@ -5,7 +5,7 @@ import type { SwapsKeypadRef } from '../../components/SwapsKeypad/types';
 import { useSourceAmountCursor } from '../useSourceAmountCursor';
 import type { useSourceAmountInput } from '../useSourceAmountInput';
 import type { BridgeToken } from '../../types';
-import { FIAT_INPUT_DECIMALS } from '../../utils/sourceAmountInputMode';
+import { LIMIT_ORDER_FIAT_PRICE_DECIMALS } from '../../utils/limitOrders/formatLimitOrderFiatPrice';
 
 export enum LimitOrderKeypadField {
   Amount = 'amount',
@@ -15,7 +15,7 @@ export enum LimitOrderKeypadField {
 
 const FIAT_KEYPAD_CURRENCY = 'SWAPS_FIAT_INPUT';
 const CUSTOM_PERCENT_KEYPAD_CURRENCY = 'LIMIT_ORDER_CUSTOM_PERCENT';
-const CUSTOM_PERCENT_DECIMALS = 2;
+const CUSTOM_PERCENT_DECIMALS = 0;
 
 interface UseLimitOrderKeypadOptions {
   customPercent: string | undefined;
@@ -42,7 +42,7 @@ export const useSwapsLimitOrderKeypad = ({
   );
 
   const limitPriceDecimals = isLimitFiatMode
-    ? FIAT_INPUT_DECIMALS
+    ? LIMIT_ORDER_FIAT_PRICE_DECIMALS
     : (nativeToken?.decimals ?? Infinity);
 
   const {
@@ -133,6 +133,7 @@ export const useSwapsLimitOrderKeypad = ({
         value: customPercent || '0',
         currency: CUSTOM_PERCENT_KEYPAD_CURRENCY,
         decimals: CUSTOM_PERCENT_DECIMALS,
+        periodButtonProps: { isDisabled: true },
       };
     }
 

--- a/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.test.ts
@@ -132,6 +132,15 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
     expect(result.current.isCustomActive).toBe(false);
   });
 
+  it('omits market comparison when market is applied to a sub-dollar dest token', () => {
+    mockFiatRates({ destRate: 0.10298176120674981 });
+
+    const { result } = renderPriceAdjustHook();
+
+    expect(result.current.limitPrice).not.toBe('0.1');
+    expect(result.current.marketComparison).toBeUndefined();
+  });
+
   it('applies negative percent preset in buy mode', () => {
     const { result } = renderPriceAdjustHook({
       destTokenAmount: undefined,
@@ -180,7 +189,27 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
     expect(result.current.isCustomActive).toBe(true);
   });
 
-  it('ignores commitCustomPercent when custom percent is invalid', () => {
+  it('exits custom mode without changing the limit price when custom percent is empty', () => {
+    const { result } = renderPriceAdjustHook({
+      destTokenAmount: undefined,
+    });
+
+    act(() => {
+      result.current.handleLimitPriceChange('3');
+      result.current.handleCustomPress();
+      result.current.handleCustomValueChange('');
+    });
+
+    act(() => {
+      result.current.commitCustomPercent();
+    });
+
+    expect(result.current.limitPrice).toBe('3');
+    expect(result.current.isCustomActive).toBe(false);
+    expect(result.current.customValue).toBe('');
+  });
+
+  it('exits custom mode without changing the limit price when custom percent is zero', () => {
     const { result } = renderPriceAdjustHook({
       destTokenAmount: undefined,
     });
@@ -196,6 +225,8 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
     });
 
     expect(result.current.limitPrice).toBe('3');
+    expect(result.current.isCustomActive).toBe(false);
+    expect(result.current.customValue).toBe('');
   });
 
   it('toggles fiat mode when both token fiat rates are available', () => {

--- a/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.ts
@@ -4,10 +4,11 @@ import { BigNumber } from 'bignumber.js';
 import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
 import { useTokenFiatRate } from '../useTokenFiatRate';
 import type { BridgeToken } from '../../types';
+import { formatTokenInputAmountFromFiat } from '../../utils/sourceAmountInputMode';
 import {
-  formatFiatInputAmount,
-  formatTokenInputAmountFromFiat,
-} from '../../utils/sourceAmountInputMode';
+  formatLimitOrderFiatPrice,
+  formatLimitOrderFiatPriceFromTokenAmount,
+} from '../../utils/limitOrders/formatLimitOrderFiatPrice';
 import { getSwapsLimitOrderPriceFromMarketPercent } from '../../utils/limitOrders/getSwapsLimitOrderPriceFromMarketPercent';
 import { getSwapsLimitOrderPriceMarketComparison } from '../../utils/limitOrders/getSwapsLimitOrderPriceMarketComparison';
 import { getSwapsLimitOrderSecondaryValue } from '../../utils/limitOrders/getSwapsLimitOrderSecondaryValue';
@@ -98,6 +99,7 @@ export const useSwapsLimitOrderPriceAdjust = ({
 
     const magnitude = new BigNumber(customValue ?? '');
     if (!magnitude.isFinite() || magnitude.lte(0)) {
+      dispatch({ type: 'exitCustom' });
       return;
     }
 
@@ -129,7 +131,7 @@ export const useSwapsLimitOrderPriceAdjust = ({
       return;
     }
 
-    const nextLimitPrice = formatFiatInputAmount('1', quotedFiatRate);
+    const nextLimitPrice = formatLimitOrderFiatPrice(quotedFiatRate);
     if (nextLimitPrice === undefined) {
       return;
     }
@@ -167,7 +169,10 @@ export const useSwapsLimitOrderPriceAdjust = ({
               tokenFiatRate: counterFiatRate,
               tokenDecimals: counterToken?.decimals,
             })
-          : formatFiatInputAmount(currentLimitPrice, counterFiatRate),
+          : formatLimitOrderFiatPriceFromTokenAmount(
+              currentLimitPrice,
+              counterFiatRate,
+            ),
     });
   }, [
     canToggleLimitPrice,
@@ -187,12 +192,12 @@ export const useSwapsLimitOrderPriceAdjust = ({
 
   const limitFiat = isLimitFiatMode
     ? limitPrice
-    : formatFiatInputAmount(limitPrice, counterFiatRate);
+    : formatLimitOrderFiatPriceFromTokenAmount(limitPrice, counterFiatRate);
   const marketComparison = getSwapsLimitOrderPriceMarketComparison({
     limitFiat,
     marketFiat: quotedFiatRate,
     executionType,
-    threshold: 3,
+    threshold: 0,
   });
 
   return {

--- a/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.test.ts
+++ b/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.test.ts
@@ -98,6 +98,20 @@ describe('limitOrderPriceAdjustReducer', () => {
     });
   });
 
+  describe('exitCustom', () => {
+    it('clears custom mode without changing the limit price', () => {
+      const result = limitOrderPriceAdjustReducer(modifiedState, {
+        type: 'exitCustom',
+      });
+
+      expect(result).toEqual({
+        ...modifiedState,
+        isCustomActive: false,
+        customValue: undefined,
+      });
+    });
+  });
+
   describe('setCustomValue', () => {
     it('stores the custom percent value', () => {
       const result = limitOrderPriceAdjustReducer(

--- a/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.ts
+++ b/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.ts
@@ -14,6 +14,7 @@ export type LimitOrderPriceAdjustAction =
   | { type: 'applyPreset'; limitPrice?: string }
   | { type: 'seedFromMarket'; limitPrice: string }
   | { type: 'enterCustom' }
+  | { type: 'exitCustom' }
   | { type: 'setCustomValue'; value: string | undefined }
   | {
       type: 'toggleFiatMode';
@@ -67,6 +68,12 @@ export const limitOrderPriceAdjustReducer = (
       return {
         ...state,
         isCustomActive: true,
+      };
+    case 'exitCustom':
+      return {
+        ...state,
+        isCustomActive: false,
+        customValue: undefined,
       };
     case 'setCustomValue':
       return {

--- a/app/components/UI/Bridge/utils/hasMissingQuoteAndAssetsPriceData.test.ts
+++ b/app/components/UI/Bridge/utils/hasMissingQuoteAndAssetsPriceData.test.ts
@@ -1,0 +1,96 @@
+import { createMockToken } from '../testUtils';
+import { hasMissingQuoteAndAssetsPriceData } from './hasMissingQuoteAndAssetsPriceData';
+
+const pricedToken = createMockToken({ symbol: 'ETH' });
+const unpricedToken = createMockToken({ symbol: 'MUSD' });
+
+const quoteWithPriceImpact = {
+  quote: { priceData: { priceImpact: { amount: '0.01' } } },
+};
+const quoteWithoutPriceImpact = { quote: {} };
+
+const pricedPair = {
+  sourceAmount: '1',
+  sourceToken: pricedToken,
+  destToken: pricedToken,
+  sourceFiatRate: 1,
+  destFiatRate: 1,
+  isActiveQuoteForCurrentTokenPair: true,
+};
+
+describe('hasMissingQuoteAndAssetsPriceData', () => {
+  it('returns true when the active quote has no price impact data', () => {
+    const result = hasMissingQuoteAndAssetsPriceData({
+      ...pricedPair,
+      activeQuote: quoteWithoutPriceImpact,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns true when the destination token has no fiat rate', () => {
+    const result = hasMissingQuoteAndAssetsPriceData({
+      ...pricedPair,
+      destToken: unpricedToken,
+      destFiatRate: undefined,
+      activeQuote: quoteWithPriceImpact,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns true when the source token has no fiat rate', () => {
+    const result = hasMissingQuoteAndAssetsPriceData({
+      ...pricedPair,
+      sourceToken: unpricedToken,
+      sourceFiatRate: undefined,
+      activeQuote: quoteWithPriceImpact,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false while no amount has been entered', () => {
+    const result = hasMissingQuoteAndAssetsPriceData({
+      ...pricedPair,
+      sourceAmount: '0',
+      destToken: unpricedToken,
+      destFiatRate: undefined,
+      activeQuote: quoteWithoutPriceImpact,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false until a quote comes back, even when a token has no fiat rate', () => {
+    const result = hasMissingQuoteAndAssetsPriceData({
+      ...pricedPair,
+      destToken: unpricedToken,
+      destFiatRate: undefined,
+      activeQuote: undefined,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false while the active quote is for a previous token pair', () => {
+    const result = hasMissingQuoteAndAssetsPriceData({
+      ...pricedPair,
+      destToken: unpricedToken,
+      destFiatRate: undefined,
+      activeQuote: quoteWithPriceImpact,
+      isActiveQuoteForCurrentTokenPair: false,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when the quote carries price impact data and both tokens are priced', () => {
+    const result = hasMissingQuoteAndAssetsPriceData({
+      ...pricedPair,
+      activeQuote: quoteWithPriceImpact,
+    });
+
+    expect(result).toBe(false);
+  });
+});

--- a/app/components/UI/Bridge/utils/hasMissingQuoteAndAssetsPriceData.ts
+++ b/app/components/UI/Bridge/utils/hasMissingQuoteAndAssetsPriceData.ts
@@ -1,0 +1,44 @@
+import type { DeepPartial, QuoteResponse } from '@metamask/bridge-controller';
+import type { BridgeToken } from '../types';
+import { hasMissingPriceData } from './hasMissingPriceData';
+import { hasMissingTokenFiatRate } from './hasMissingTokenFiatRate';
+
+interface Params {
+  sourceAmount?: string;
+  sourceToken?: BridgeToken;
+  destToken?: BridgeToken;
+  sourceFiatRate?: number;
+  destFiatRate?: number;
+  activeQuote?: DeepPartial<QuoteResponse> | null;
+  isActiveQuoteForCurrentTokenPair?: boolean;
+}
+
+/**
+ * True when a quoted limit/recurring order cannot be priced: the quote is
+ * missing market data, or one of the selected tokens has no fiat rate.
+ *
+ * Hidden until an amount is entered and a quote for the current pair is
+ * available, so an in-flight fetch is not treated as a missing-price warning.
+ */
+export const hasMissingQuoteAndAssetsPriceData = ({
+  sourceAmount,
+  sourceToken,
+  destToken,
+  sourceFiatRate,
+  destFiatRate,
+  activeQuote,
+  isActiveQuoteForCurrentTokenPair,
+}: Params) => {
+  const hasEnteredAmount = Boolean(sourceAmount) && Number(sourceAmount) > 0;
+  const isMissingPrice =
+    hasMissingPriceData(activeQuote) ||
+    hasMissingTokenFiatRate(sourceToken, sourceFiatRate) ||
+    hasMissingTokenFiatRate(destToken, destFiatRate);
+
+  return Boolean(
+    hasEnteredAmount &&
+      activeQuote &&
+      isActiveQuoteForCurrentTokenPair &&
+      isMissingPrice,
+  );
+};

--- a/app/components/UI/Bridge/utils/limitOrders/formatLimitOrderFiatPrice.test.ts
+++ b/app/components/UI/Bridge/utils/limitOrders/formatLimitOrderFiatPrice.test.ts
@@ -1,0 +1,49 @@
+import {
+  LIMIT_ORDER_FIAT_PRICE_DECIMALS,
+  formatLimitOrderFiatPrice,
+  formatLimitOrderFiatPriceFromTokenAmount,
+} from './formatLimitOrderFiatPrice';
+
+describe('formatLimitOrderFiatPrice', () => {
+  it('keeps sub-dollar fiat digits instead of rounding to cents', () => {
+    const result = formatLimitOrderFiatPrice(0.10298176120674981);
+
+    expect(result).toBe('0.10298176');
+  });
+
+  it('trims trailing zeros on whole-dollar amounts', () => {
+    const result = formatLimitOrderFiatPrice(100);
+
+    expect(result).toBe('100');
+  });
+
+  it('returns undefined for non-positive amounts', () => {
+    expect(formatLimitOrderFiatPrice(0)).toBeUndefined();
+    expect(formatLimitOrderFiatPrice(-1)).toBeUndefined();
+    expect(formatLimitOrderFiatPrice(undefined)).toBeUndefined();
+  });
+});
+
+describe('formatLimitOrderFiatPriceFromTokenAmount', () => {
+  it('converts a token amount to a high-precision fiat unit price', () => {
+    const result = formatLimitOrderFiatPriceFromTokenAmount(
+      '0.000042061',
+      2448.4,
+    );
+
+    expect(result).not.toBe('0.1');
+    expect(Number(result)).toBeCloseTo(0.102982, 5);
+  });
+
+  it('returns undefined when the fiat rate is missing', () => {
+    const result = formatLimitOrderFiatPriceFromTokenAmount('1', undefined);
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('LIMIT_ORDER_FIAT_PRICE_DECIMALS', () => {
+  it('allows up to 18 fiat fraction digits', () => {
+    expect(LIMIT_ORDER_FIAT_PRICE_DECIMALS).toBe(18);
+  });
+});

--- a/app/components/UI/Bridge/utils/limitOrders/formatLimitOrderFiatPrice.ts
+++ b/app/components/UI/Bridge/utils/limitOrders/formatLimitOrderFiatPrice.ts
@@ -1,0 +1,61 @@
+import { BigNumber } from 'bignumber.js';
+import { trimTrailingZeros } from '../trimTrailingZeros';
+
+/**
+ * Fiat unit prices for limit orders can be well below $0.01. Rounding them to
+ * two decimal places (currency cents) makes "Market" diverge from the quoted
+ * token's fiat rate by several percent.
+ */
+export const LIMIT_ORDER_FIAT_PRICE_DECIMALS = 18;
+const LIMIT_ORDER_FIAT_PRICE_SIGNIFICANT_DIGITS = 8;
+
+/**
+ * Formats a quoted-token unit price in fiat for the limit-price input.
+ *
+ * Keeps enough significant digits that a market snapshot compares as 0.00%
+ * from the live fiat rate, instead of rounding cheap tokens to cents.
+ *
+ * @param fiatAmount - Positive fiat amount for 1 unit of the quoted token.
+ * @returns Trimmed fiat string, or undefined when the amount is not usable.
+ */
+export const formatLimitOrderFiatPrice = (
+  fiatAmount: BigNumber.Value | undefined,
+): string | undefined => {
+  if (fiatAmount === undefined || fiatAmount === '') {
+    return undefined;
+  }
+
+  const value = new BigNumber(fiatAmount);
+  if (!value.isFinite() || value.lte(0)) {
+    return undefined;
+  }
+
+  const rounded = value
+    .precision(LIMIT_ORDER_FIAT_PRICE_SIGNIFICANT_DIGITS)
+    .decimalPlaces(LIMIT_ORDER_FIAT_PRICE_DECIMALS);
+  if (rounded.lte(0)) {
+    return undefined;
+  }
+
+  return trimTrailingZeros(rounded.toFixed());
+};
+
+/**
+ * Converts a counter-token unit amount into a high-precision fiat unit price.
+ *
+ * @param tokenAmount - Amount of the counter token equal to 1 quoted token.
+ * @param tokenFiatRate - Fiat rate of the counter token.
+ * @returns Trimmed fiat string, or undefined when conversion inputs are missing.
+ */
+export const formatLimitOrderFiatPriceFromTokenAmount = (
+  tokenAmount: string | undefined,
+  tokenFiatRate: number | undefined,
+): string | undefined => {
+  if (!tokenAmount || !tokenFiatRate) {
+    return undefined;
+  }
+
+  return formatLimitOrderFiatPrice(
+    new BigNumber(tokenAmount).multipliedBy(tokenFiatRate),
+  );
+};

--- a/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderPriceFromMarketPercent.test.ts
+++ b/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderPriceFromMarketPercent.test.ts
@@ -1,4 +1,7 @@
+import { BigNumber } from 'bignumber.js';
+import { LimitOrderExecutionType } from '../../constants/limitOrders';
 import { getSwapsLimitOrderPriceFromMarketPercent } from './getSwapsLimitOrderPriceFromMarketPercent';
+import { getSwapsLimitOrderPriceMarketComparison } from './getSwapsLimitOrderPriceMarketComparison';
 
 const tokenModeDefaults = {
   counterFiatRate: 2000,
@@ -81,6 +84,28 @@ describe('getSwapsLimitOrderPriceFromMarketPercent', () => {
 
       expect(result).toBe('95');
     });
+
+    it('keeps sub-dollar market fiat so market compares as zero percent', () => {
+      const marketFiat = 0.10298176120674981;
+
+      const result = getSwapsLimitOrderPriceFromMarketPercent({
+        counterFiatRate: 2448.4,
+        counterTokenDecimals: 18,
+        isLimitFiatMode: true,
+        marketFiat,
+        signedPercent: 0,
+      });
+
+      expect(result).not.toBe('0.1');
+      expect(
+        getSwapsLimitOrderPriceMarketComparison({
+          limitFiat: result,
+          marketFiat,
+          executionType: LimitOrderExecutionType.BUY,
+          threshold: 0,
+        }),
+      ).toBeUndefined();
+    });
   });
 
   describe('token limit price mode', () => {
@@ -109,6 +134,31 @@ describe('getSwapsLimitOrderPriceFromMarketPercent', () => {
       });
 
       expect(result).toBe('0.0475');
+    });
+
+    it('does not round sub-dollar market through two-decimal fiat in token mode', () => {
+      const marketFiat = 0.10298176120674981;
+      const counterFiatRate = 2448.4;
+
+      const result = getSwapsLimitOrderPriceFromMarketPercent({
+        counterFiatRate,
+        counterTokenDecimals: 18,
+        isLimitFiatMode: false,
+        marketFiat,
+        signedPercent: 0,
+      });
+
+      expect(result).not.toBe('0.00004');
+      expect(
+        getSwapsLimitOrderPriceMarketComparison({
+          limitFiat: new BigNumber(result ?? 0)
+            .multipliedBy(counterFiatRate)
+            .toString(),
+          marketFiat,
+          executionType: LimitOrderExecutionType.BUY,
+          threshold: 0,
+        }),
+      ).toBeUndefined();
     });
 
     it('returns undefined when counter fiat rate is unavailable', () => {

--- a/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderPriceFromMarketPercent.ts
+++ b/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderPriceFromMarketPercent.ts
@@ -1,8 +1,6 @@
 import { BigNumber } from 'bignumber.js';
-import {
-  formatFiatInputAmount,
-  formatTokenInputAmountFromFiat,
-} from '../sourceAmountInputMode';
+import { formatTokenInputAmountFromFiat } from '../sourceAmountInputMode';
+import { formatLimitOrderFiatPrice } from './formatLimitOrderFiatPrice';
 
 /**
  * Snapshot of the quoted-token market price after applying a signed percent
@@ -33,10 +31,7 @@ export const getSwapsLimitOrderPriceFromMarketPercent = ({
     return undefined;
   }
 
-  const adjustedFiatAmount = formatFiatInputAmount(
-    '1',
-    adjustedMarketFiat.toNumber(),
-  );
+  const adjustedFiatAmount = formatLimitOrderFiatPrice(adjustedMarketFiat);
 
   if (isLimitFiatMode) {
     return adjustedFiatAmount;

--- a/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderPriceMarketComparison.test.ts
+++ b/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderPriceMarketComparison.test.ts
@@ -47,6 +47,44 @@ describe('getSwapsLimitOrderPriceMarketComparison', () => {
     );
   });
 
+  describe('zero displayed percent', () => {
+    it.each([LimitOrderExecutionType.BUY, LimitOrderExecutionType.SELL])(
+      'returns undefined for %s when limit fiat equals market fiat',
+      (executionType) => {
+        const result = getSwapsLimitOrderPriceMarketComparison({
+          limitFiat: '100',
+          marketFiat: 100,
+          executionType,
+          threshold: 0,
+        });
+
+        expect(result).toBeUndefined();
+      },
+    );
+
+    it('returns undefined for sell when percent above market rounds to zero', () => {
+      const result = getSwapsLimitOrderPriceMarketComparison({
+        limitFiat: '100.001',
+        marketFiat: 100,
+        executionType: LimitOrderExecutionType.SELL,
+        threshold: 0,
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined for buy when percent below market rounds to zero', () => {
+      const result = getSwapsLimitOrderPriceMarketComparison({
+        limitFiat: '99.999',
+        marketFiat: 100,
+        executionType: LimitOrderExecutionType.BUY,
+        threshold: 0,
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe('sell execution type', () => {
     it('returns undefined when limit is within the threshold above market', () => {
       const result = getSwapsLimitOrderPriceMarketComparison({

--- a/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderPriceMarketComparison.ts
+++ b/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderPriceMarketComparison.ts
@@ -12,8 +12,9 @@ interface Params {
 /**
  * Returns the market-comparison label for a quoted-token unit limit price.
  *
- * Buy: shown only when the limit is at least X% below the quoted token's
- * market fiat. Sell: shown only when the limit is more than X% above market.
+ * Hidden when the displayed percent rounds to 0.00. Buy: shown only when the
+ * limit is at least X% below the quoted token's market fiat. Sell: shown only
+ * when the limit is more than X% above market.
  *
  * X = threshold
  */
@@ -39,7 +40,8 @@ export const getSwapsLimitOrderPriceMarketComparison = ({
   }
 
   const percent = limit.minus(market).dividedBy(market).multipliedBy(100);
-  if (!percent.isFinite()) {
+  const displayPercent = percent.abs().toFixed(2);
+  if (!percent.isFinite() || displayPercent === '0.00') {
     return undefined;
   }
 
@@ -50,7 +52,7 @@ export const getSwapsLimitOrderPriceMarketComparison = ({
 
     return {
       label: strings('bridge.limit.from_market_above', {
-        percent: percent.toFixed(2),
+        percent: displayPercent,
       }),
       isNegative: false,
     };
@@ -62,7 +64,7 @@ export const getSwapsLimitOrderPriceMarketComparison = ({
 
   return {
     label: strings('bridge.limit.from_market', {
-      percent: percent.abs().toFixed(2),
+      percent: displayPercent,
     }),
     isNegative: true,
   };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Design review of the swaps limit-order screen found that custom percent did not match the signed preset chips, cheap tokens rounded to cents so "Market" looked several percent off, a 0.00% comparison still rendered, empty custom percent left the keypad in a confusing state, and confirm stayed enabled when quote or token fiat prices were missing.

This PR aligns the limit-order price card with that review: the custom field displays `+N%` / `-N%` like the presets (integer keypad, caret clamped off the sign and percent postfix), market and fiat conversion keep sub-dollar precision so a market snapshot compares as 0.00%, empty or zero custom percent exits without changing the limit price, and both confirm buttons disable when the shared missing-price helper is true. Layout and typography on the price card and token input secondary row are tightened to match the design.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated swaps limit orders so custom percent matches presets, cheap tokens keep market price precision, and confirm is disabled when quote or token prices are missing

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/SWAPS-4998

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Swaps limit-order price card after design review

  Background:
    Given I am logged into MetaMask Mobile
    And swaps limit orders are enabled
    And I am on the Swap screen in Limit order mode

  Scenario: custom percent input matches signed presets
    Given I have selected a priced token pair
    And I have entered a source amount so a quote is available

    When user taps Custom on the price preset row
    Then the custom field should show a signed placeholder ("-0%" for buy, "+0%" for sell)

    When user enters 7 on the keypad
    Then the custom field should display "-7%" for a buy or "+7%" for a sell
    And the decimal button on the keypad should be disabled
    And the caret should stay between the sign and the percent postfix

  Scenario: empty custom percent leaves the current limit price unchanged
    Given I have set a custom limit price
    And I have opened the custom percent field

    When user clears the custom percent and dismisses the keypad
    Then custom mode should close
    And the limit price should remain the previous value

  Scenario: market on a sub-dollar token does not show a false percent-from-market
    Given the destination token has a fiat rate below one dollar
    And I have entered a source amount so a quote is available

    When user taps Market
    Then the limit price should keep sub-cent fiat precision
    And no "from market" comparison label should appear

  Scenario: confirm is disabled when quote or token price data is missing
    Given I have entered a source amount
    And the active quote is for the current token pair

    When the quote has no price data or a selected token has no fiat rate
    Then the missing-price banner should be visible
    And the confirm button should be disabled
    And the keypad confirm button should be disabled when the keypad is open

  Scenario: confirm stays enabled while a stale quote is still showing
    Given I have an active quote for the previous token pair
    And I have changed the destination token to an unpriced token

    When the new quote has not arrived yet
    Then the missing-price banner should stay hidden
    And the confirm button should remain enabled
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes limit-price math, confirm enablement, and missing-price detection for limit orders; incorrect gating could block valid orders or allow unpriced confirms, though behavior is heavily unit-tested.
> 
> **Overview**
> This PR tightens the swaps **limit order** price card and confirm flow after design review.
> 
> **Missing price data** is centralized in `hasMissingQuoteAndAssetsPriceData` / `useHasMissingQuoteAndAssetsPriceData`. The banner, footer confirm, and keypad confirm all use it; confirm disables when quote price impact or token fiat rates are missing, but stays enabled while a stale quote is still shown for the previous pair.
> 
> **Custom percent** now matches preset chips (`-7%` / `+7%`), with caret clamped off the sign and `%`, integer-only keypad (decimal disabled), and a stable custom slot layout. Committing empty or zero custom percent **exits custom mode** without changing the limit price (`exitCustom`).
> 
> **Market / fiat limit prices** stop rounding sub-dollar tokens to cents: new `formatLimitOrderFiatPrice` (up to 18 fraction digits) drives market seeding, presets, and fiat toggles so **Market** aligns with the quote and the “from market” label hides when the displayed percent would be **0.00%** (comparison threshold dropped to 0).
> 
> Minor UI polish on the limit price input row and token secondary row spacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1979a333802136b46f4b63e51b1c0278156bbd6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->