### PR TITLE
feat: display position liquidation distance in pro mode

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -532,6 +532,7 @@ export const PerpsProMarketViewSelectorsIDs = {
   POSITION_EDIT_TPSL: 'perps-pro-market-position-edit-tpsl',
   POSITION_EDIT_MARGIN: 'perps-pro-market-position-edit-margin',
   POSITION_PNL_TEXT: 'perps-pro-market-position-pnl-text',
+  POSITION_LIQ_PRICE: 'perps-pro-market-position-liq-price',
   POSITION_ROW: 'perps-pro-market-position-row',
   ORDERS_LIST: 'perps-pro-market-orders-list',
   ORDERS_SUMMARY: 'perps-pro-market-orders-summary',

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionCard.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionCard.test.tsx
@@ -80,6 +80,55 @@ describe('PerpsProPositionCard', () => {
     expect(screen.getByText('$3,000')).toBeOnTheScreen();
   });
 
+  it('appends the liquidation distance in parentheses to the liquidation price', () => {
+    // Mark 4350 / 1.5 = 2900, liq 2500 → (2900 - 2500) / 2900 = 13.79%
+    render(<PerpsProPositionCard position={position} />);
+
+    expect(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.POSITION_LIQ_PRICE),
+    ).toBeOnTheScreen();
+    expect(screen.getByText('$2,500 (13.79%)')).toBeOnTheScreen();
+  });
+
+  it('measures the liquidation distance against the live mark price', () => {
+    // Mark moves to 5000 / 1.5 = 3333.33, liq 2500 → 25.00%
+    render(
+      <PerpsProPositionCard
+        position={{ ...position, positionValue: '5000' }}
+      />,
+    );
+
+    expect(screen.getByText('$2,500 (25.00%)')).toBeOnTheScreen();
+  });
+
+  it('reports the distance as a positive value for a short position', () => {
+    // Short: mark 4350 / 1.5 = 2900, liq 3200 → |2900 - 3200| / 2900 = 10.34%
+    render(
+      <PerpsProPositionCard
+        position={{ ...position, size: '-1.5', liquidationPrice: '3200' }}
+      />,
+    );
+
+    expect(screen.getByText('$3,200 (10.34%)')).toBeOnTheScreen();
+  });
+
+  it('renders the fallback when the position has no liquidation price', () => {
+    render(
+      <PerpsProPositionCard
+        position={{ ...position, liquidationPrice: null }}
+      />,
+    );
+
+    expect(screen.getByText('$---')).toBeOnTheScreen();
+  });
+
+  it('renders the liquidation price without a distance when size is zero', () => {
+    // No size means no derivable mark price, so no distance can be shown.
+    render(<PerpsProPositionCard position={{ ...position, size: '0' }} />);
+
+    expect(screen.getByText('$2,500')).toBeOnTheScreen();
+  });
+
   it('renders TP/SL edit control when handler is provided', () => {
     const onEditTpSl = jest.fn();
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionCard.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionCard.tsx
@@ -32,6 +32,7 @@ import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../../locales/i18n';
 import { selectPrivacyMode } from '../../../../../../selectors/preferencesController';
 import PerpsTokenLogo from '../../../components/PerpsTokenLogo';
+import { LIQUIDATION_DISTANCE_DECIMALS } from '../../../constants/perpsConfig';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 import {
   formatPercentage,
@@ -75,6 +76,8 @@ interface KeyValueItemProps {
   valuePressTestID?: string;
   valuePressAccessibilityLabel?: string;
   showEditIcon?: boolean;
+  /** Test ID for the value row, so agentic recipes can read the rendered value. */
+  valueTestID?: string;
 }
 
 const KeyValueItem = ({
@@ -88,6 +91,7 @@ const KeyValueItem = ({
   valuePressTestID,
   valuePressAccessibilityLabel,
   showEditIcon = false,
+  valueTestID,
 }: KeyValueItemProps) => {
   const valueContent = (
     <>
@@ -137,6 +141,7 @@ const KeyValueItem = ({
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Center}
           twClassName="gap-1"
+          testID={valueTestID}
         >
           {valueContent}
         </Box>
@@ -199,11 +204,27 @@ const PerpsProPositionCard = ({
   const entryPriceDisplay = formatPerpsFiat(position.entryPrice, {
     ranges: PRICE_RANGES_UNIVERSAL,
   });
+  // How far the live mark price sits from liquidation. Same formula and
+  // precision as the Lite card, so both modes report the same percentage for
+  // the same position.
+  const liqPriceNum =
+    position.liquidationPrice != null
+      ? parseFloat(String(position.liquidationPrice))
+      : NaN;
+  const canShowDistance =
+    liqPriceNum > 0 && Number.isFinite(markPriceNum) && markPriceNum > 0;
+  const liquidationDistanceSuffix = canShowDistance
+    ? ` (${(
+        (Math.abs(markPriceNum - liqPriceNum) / markPriceNum) *
+        100
+      ).toFixed(LIQUIDATION_DISTANCE_DECIMALS)}%)`
+    : '';
+
   const liqPriceDisplay =
     position.liquidationPrice != null
-      ? formatPerpsFiat(position.liquidationPrice, {
+      ? `${formatPerpsFiat(position.liquidationPrice, {
           ranges: PRICE_RANGES_UNIVERSAL,
-        })
+        })}${liquidationDistanceSuffix}`
       : PERPS_CONSTANTS.FallbackPriceDisplay;
   const marginDisplay = formatPerpsFiat(position.marginUsed, {
     ranges: PRICE_RANGES_MINIMAL_VIEW,
@@ -371,6 +392,7 @@ const PerpsProPositionCard = ({
                 label={strings('perps.pro_positions_panel.card.liq_price')}
                 value={liqPriceDisplay}
                 isHidden={privacyMode}
+                valueTestID={PerpsProMarketViewSelectorsIDs.POSITION_LIQ_PRICE}
               />
             </Box>
             <Box twClassName="flex-1 min-w-0 gap-3">


### PR DESCRIPTION
## **Description**

In Pro mode the position card showed the liquidation price on its own, while Lite mode showed the liquidation distance alongside it. This adds that distance to the Pro card, so the "Liq. price" field now reads `$1,622.3 (31.82%)`.

The percentage is measured from the live mark price the card already derives, using the same formula and 2-decimal precision as the Lite card, so both modes report the same distance for the same position. When there is no liquidation price, or no derivable mark price, the field keeps its previous rendering.

## **Changelog**

CHANGELOG entry: Added the liquidation distance next to the liquidation price on position cards in Perps Pro mode

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3890

## **Manual testing steps**

```gherkin
Feature: Liquidation distance on the Pro position card

  Scenario: user reads the liquidation distance in Pro mode
    Given the user holds an open perps position
    And the user is on that market's detail screen in Pro mode

    When user opens the Positions tab and scrolls to the position card
    Then the "Liq. price" field reads the liquidation price followed by the
      distance to it in parentheses, for example "$1,622.3 (31.82%)"
    And that percentage matches the distance between the card's own
      "Mark price" and the liquidation price
```

## **Screenshots/Recordings**

Pro position card 'Liq. price' before and after the change, same market and viewport.

<table>
<tr><td colspan="2"><strong>Pro position card: Liq. price gains the liquidation distance in parentheses — Before reads '$1,622.4'; after reads '$1,622.3 (31.82%)' against a mark price of $2,379.3 shown in the row above it.</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/features/35461/before-ac1-pro-liq-price-no-distance.png?sha=68a3845bfe8ed622" alt="before" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/features/35461/after-ac1-pro-liq-price-with-distance.png?sha=317f4b2362ac2799" alt="after" width="320" /></td>
</tr>
</table>

## **Validation Recipe**

<details><summary>recipe.json (11 steps — opens an open position in Pro mode and asserts the Liq. price field against live controller state)</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "Pro position card shows liquidation distance beside liquidation price",
  "description": "Proves AC1: in Pro mode the position card's 'Liq. price' field renders '<liquidation price> (<liquidation distance>%)'. The assertion recomputes the expected distance from live PerpsController state, so it hardcodes no price and no percentage and stays portable across markets and prices.",
  "paramsSchema": {
    "type": "object",
    "additionalProperties": false,
    "properties": {
      "network": {
        "type": "string",
        "enum": [
          "testnet",
          "mainnet"
        ],
        "default": "testnet",
        "description": "Perps network used for the proof."
      },
      "market": {
        "type": "string",
        "default": "ETH",
        "description": "Perps market whose position card is asserted."
      },
      "notional": {
        "type": "number",
        "default": 12,
        "description": "Small testnet notional used to converge one open position."
      },
      "leverage": {
        "type": "number",
        "default": 3,
        "description": "Leverage used to converge one open position."
      }
    }
  },
  "workflow": {
    "entry": "prepare-pro-position",
    "nodes": {
      "prepare-pro-position": {
        "action": "metamask.perps.start_state",
        "profile": "open_position_testnet",
        "market": "{{params.market}}",
        "network": "{{params.network}}",
        "page": "market_details",
        "side": "long",
        "positions": {
          "state": "open",
          "notional": "{{params.notional}}",
          "leverage": "{{params.leverage}}"
        },
        "orders": {
          "state": "none"
        },
        "intent": "Unlock the fixture wallet and converge one open {{params.market}} position, then open its market-detail screen",
        "next": "reset-scroll-position"
      },
      "reset-scroll-position": {
        "action": "ui.scroll",
        "test_id": "perps-pro-market-scroll-view",
        "delta_y": 0,
        "intent": "Return the market view to the top so the Lite/Pro mode control a trader taps is on screen",
        "next": "ensure-pro-mode"
      },
      "ensure-pro-mode": {
        "action": "metamask.perps.ensure_mode",
        "mode": "pro",
        "intent": "Reach Pro mode through the visible market-detail mode control, since AC1 is Pro-only",
        "next": "open-positions-tab"
      },
      "open-positions-tab": {
        "action": "ui.press",
        "test_id": "perps-pro-market-positions-panel-tab-positions",
        "intent": "Select the Positions tab of the Pro positions panel",
        "next": "reveal-position-card"
      },
      "reveal-position-card": {
        "action": "ui.scroll",
        "test_id": "perps-pro-market-scroll-view",
        "delta_y": 1400,
        "intent": "Bring the open position's summary card into the viewport, where a trader reads its Liq. price",
        "next": "await-position-card-visible"
      },
      "await-position-card-visible": {
        "action": "ui.wait_for",
        "test_id": "perps-pro-market-position-close",
        "expected": "visible",
        "timeout_ms": 20000,
        "intent": "Confirm the Pro position card carrying the Liq. price field is measurably on screen before asserting and capturing it",
        "next": "await-liq-price-mounted"
      },
      "await-liq-price-mounted": {
        "action": "ui.wait_for",
        "test_id": "perps-pro-market-position-liq-price",
        "expected": "present",
        "timeout_ms": 20000,
        "intent": "Confirm the Liq. price value node itself is rendered in the card",
        "next": "assert-liquidation-distance"
      },
      "assert-liquidation-distance": {
        "action": "command",
        "timeout_ms": 120000,
        "intent": "Recompute the expected '<liq price> (<distance>%)' string from live PerpsController state and assert the Pro card rendered exactly that",
        "next": "assert-liquidation-distance-passed"
      },
      "assert-liquidation-distance-passed": {
        "action": "assert_output",
        "source": "assert-liquidation-distance",
        "stream": "stdout",
        "contains": "AC1 PASS",
        "intent": "Fail the recipe unless the portable liquidation-distance assertion reported a pass",
        "next": "capture-liq-price-with-distance"
      },
      "capture-liq-price-with-distance": {
        "action": "ui.screenshot",
        "label": "AC1: Pro position card 'Liq. price' shows the price followed by the liquidation distance in parentheses",
        "intent": "Record what a trader sees: the Liq. price reading as a price followed by its distance in parentheses",
        "next": "done"
      },
      "done": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}
```
</details>

The recipe hardcodes no price and no percentage. `assert-liquidation-distance` reads `PerpsController.getPositions()`, derives the mark price, recomputes the distance with the component's formula, and requires the rendered text to match `"<liquidation price> (<distance>%)"` with the distance inside the range two live samples bracket and the price half equal to the liquidation price. `market`, `network`, `notional` and `leverage` are recipe parameters.

**Negative control.** With the parenthetical append removed, the assertion fails:

```
AC1 FAIL: rendered "$1,622.3" is not "<liquidation price> (<liquidation distance>%)"
exit=1
```

## **Validation Logs**

Command:
```bash
  --adapter mobile \
  --target /Users/deeeed/dev/metamask/metamask-mobile-3 \
  --slot macpro-mm-3 --json
```

<details><summary>Full output (11/11 passed)</summary>

```
[PASS] prepare-pro-position               metamask.perps.start_state         14006ms
[PASS] reset-scroll-position              ui.scroll                          653ms
[PASS] ensure-pro-mode                    metamask.perps.ensure_mode         323ms
[PASS] open-positions-tab                 ui.press                           693ms
[PASS] reveal-position-card               ui.scroll                          482ms
[PASS] await-position-card-visible        ui.wait_for                        722ms
[PASS] await-liq-price-mounted            ui.wait_for                        701ms
[PASS] assert-liquidation-distance        command                            592ms
        AC1 PASS: Pro position card liq. price renders "$1,622.3 (31.82%)" — liquidation 1622.3219287715, mark 2379.6 → 2379.6, rendered distance 31.82% inside live range [31.32%, 32.32%] recomputed from PerpsController state
[PASS] assert-liquidation-distance-passed assert_output                      30ms
[PASS] capture-liq-price-with-distance    ui.screenshot                      593ms
[PASS] done                               end                                0ms

Result: pass — 11/11 nodes passed in 19183ms
```
</details>

Unit tests: `yarn jest app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionCard.test.tsx --no-coverage` → 18/18 passed, including the liquidation-distance format, the live mark-price basis, a short position, a missing liquidation price, and a zero-size position. `PerpsProPositionsPanel` and `PerpsProMarketView` suites pass unchanged (78 tests). Scoped coverage on the changed file: 92% statements, 92% lines.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Validated on iOS only; this is a string-formatting change in an already-rendered field with no platform-specific behavior.
- [x] I've tested with a power user scenario
  - The field renders per position card and adds no new data source or subscription.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Not applicable: no new operation, network call, or async work is introduced.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting on an existing Perps Pro UI field; no auth, trading, or new data subscriptions.
> 
> **Overview**
> Pro mode position cards now show **liquidation distance** next to the liquidation price on the **Liq. price** row (e.g. `$2,500 (13.79%)`), matching Lite mode behavior.
> 
> The percentage uses the card’s derived **mark price** (`positionValue / |size|`), `|mark − liq| / mark × 100`, and **`LIQUIDATION_DISTANCE_DECIMALS`** so Pro and Lite stay aligned. Short positions use the absolute gap; missing liquidation price still shows the existing fallback; zero size shows price only with no distance suffix.
> 
> **`KeyValueItem`** gains optional **`valueTestID`**, wired to new **`POSITION_LIQ_PRICE`** for E2E/recipes. Unit tests cover long/short, live mark updates, null liq price, and zero size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f451d3406335034f3648576cbe203b7ae06a3585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->