### PR TITLE
perf: remove per-row non-EVM transaction lookups

### DIFF
--- a/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.test.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import { useSelector } from 'react-redux';
 import {
   SolScope,
   type Transaction,
@@ -12,12 +11,8 @@ import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import type { ActivityListItem } from '../../../util/activity-adapters';
 import MultichainAssetDetailsActivityListItem from './MultichainAssetDetailsActivityListItem';
 import Routes from '../../../constants/navigation/Routes';
-import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../selectors/multichain/multichain';
 import { handleUnifiedSwapsTxHistoryItemClick } from '../../UI/Bridge/utils/transaction-history';
-
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
-}));
+import { useMultichainTransactionDisplay } from '../../hooks/useMultichainTransactionDisplay';
 
 jest.mock('../../../../locales/i18n', () => ({
   strings: (key: string) => key,
@@ -104,33 +99,43 @@ const createTransaction = (
   ...overrides,
 });
 
-const mockUseSelector = jest.mocked(useSelector);
-
-const mockSelectors = ({ keyringTransactions = [] as Transaction[] } = {}) => {
-  mockUseSelector.mockImplementation((selector) => {
-    if (selector === selectNonEvmTransactionsForSelectedAccountGroup) {
-      return { transactions: keyringTransactions };
-    }
-    return undefined;
-  });
-};
+const mapTransactionToItem = (
+  transaction: TransactionWithImportTime,
+): ActivityListItem =>
+  mapKeyringTransaction({ transaction }) as ActivityListItem;
 
 describe('MultichainAssetDetailsActivityListItem', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSelectors();
+  });
+
+  it('uses the source transaction attached to the activity item', () => {
+    const transaction = createTransaction();
+
+    render(
+      <MultichainAssetDetailsActivityListItem
+        item={mapTransactionToItem(transaction)}
+        transaction={transaction}
+        index={0}
+        chainId={SolScope.Mainnet}
+        navigation={createNavigation()}
+      />,
+    );
+
+    expect(useMultichainTransactionDisplay).toHaveBeenCalledWith(
+      transaction,
+      SolScope.Mainnet,
+    );
   });
 
   it('routes to the ActivityDetails screen', () => {
     const navigation = createNavigation();
     const transaction = createTransaction();
-    mockSelectors({
-      keyringTransactions: [transaction],
-    });
 
     const { getByTestId } = render(
       <MultichainAssetDetailsActivityListItem
-        item={mapKeyringTransaction({ transaction }) as ActivityListItem}
+        item={mapTransactionToItem(transaction)}
+        transaction={transaction}
         index={0}
         chainId={SolScope.Mainnet}
         navigation={navigation}
@@ -154,11 +159,11 @@ describe('MultichainAssetDetailsActivityListItem', () => {
     );
     const navigation = createNavigation();
     const transaction = createTransaction();
-    mockSelectors({ keyringTransactions: [transaction] });
 
     render(
       <MultichainAssetDetailsActivityListItem
-        item={mapKeyringTransaction({ transaction }) as ActivityListItem}
+        item={mapTransactionToItem(transaction)}
+        transaction={transaction}
         index={0}
         chainId={SolScope.Mainnet}
         navigation={navigation}
@@ -171,11 +176,11 @@ describe('MultichainAssetDetailsActivityListItem', () => {
   it('routes import-time rows to ActivityDetails', () => {
     const navigation = createNavigation();
     const transaction = createTransaction({ insertImportTime: true });
-    mockSelectors({ keyringTransactions: [transaction] });
 
     const { getByTestId, queryByTestId } = render(
       <MultichainAssetDetailsActivityListItem
-        item={mapKeyringTransaction({ transaction }) as ActivityListItem}
+        item={mapTransactionToItem(transaction)}
+        transaction={transaction}
         index={0}
         chainId={SolScope.Mainnet}
         navigation={navigation}
@@ -223,13 +228,11 @@ describe('MultichainAssetDetailsActivityListItem', () => {
     it('routes a same-chain swap to the redesigned ActivityDetails screen', () => {
       const navigation = createNavigation();
       const transaction = createTransaction({ type: TransactionType.Swap });
-      mockSelectors({
-        keyringTransactions: [transaction],
-      });
 
       const { getByTestId } = render(
         <MultichainAssetDetailsActivityListItem
-          item={mapKeyringTransaction({ transaction }) as ActivityListItem}
+          item={mapTransactionToItem(transaction)}
+          transaction={transaction}
           bridgeHistoryItem={createBridgeHistoryItem(
             SolScope.Mainnet,
             SolScope.Mainnet,
@@ -252,13 +255,11 @@ describe('MultichainAssetDetailsActivityListItem', () => {
     it('routes a cross-chain bridge to the redesigned ActivityDetails screen', () => {
       const navigation = createNavigation();
       const transaction = createTransaction({ type: TransactionType.Swap });
-      mockSelectors({
-        keyringTransactions: [transaction],
-      });
 
       const { getByTestId } = render(
         <MultichainAssetDetailsActivityListItem
-          item={mapKeyringTransaction({ transaction }) as ActivityListItem}
+          item={mapTransactionToItem(transaction)}
+          transaction={transaction}
           bridgeHistoryItem={createBridgeHistoryItem(
             SolScope.Mainnet,
             'eip155:1',
@@ -283,7 +284,6 @@ describe('MultichainAssetDetailsActivityListItem', () => {
         '../../UI/ActivityListItemRow/ActivityListItemRow',
       );
       const transaction = createTransaction({ type: TransactionType.Swap });
-      mockSelectors({ keyringTransactions: [transaction] });
       const bridgeHistoryItem = createBridgeHistoryItem(
         SolScope.Mainnet,
         SolScope.Mainnet,
@@ -291,7 +291,8 @@ describe('MultichainAssetDetailsActivityListItem', () => {
 
       render(
         <MultichainAssetDetailsActivityListItem
-          item={mapKeyringTransaction({ transaction }) as ActivityListItem}
+          item={mapTransactionToItem(transaction)}
+          transaction={transaction}
           bridgeHistoryItem={bridgeHistoryItem}
           index={0}
           chainId={SolScope.Mainnet}

--- a/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.tsx
@@ -1,12 +1,11 @@
 import React, { useCallback } from 'react';
 import { Box } from '@metamask/design-system-react-native';
-import { useSelector } from 'react-redux';
 import type { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import { SupportedCaipChainId } from '@metamask/multichain-network-controller';
+import type { Transaction } from '@metamask/keyring-api';
 import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import Routes from '../../../constants/navigation/Routes';
 import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
-import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../selectors/multichain/multichain';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { useMultichainTransactionDisplay } from '../../hooks/useMultichainTransactionDisplay';
 import { ActivityListItemRow } from '../../UI/ActivityListItemRow/ActivityListItemRow';
@@ -24,6 +23,7 @@ import {
 
 interface MultichainAssetDetailsActivityListItemProps {
   item: ActivityListItem;
+  transaction?: Transaction;
   chainId: SupportedCaipChainId;
   bridgeHistoryItem?: BridgeHistoryItem;
   navigation: AppNavigationProp;
@@ -33,6 +33,7 @@ interface MultichainAssetDetailsActivityListItemProps {
 
 export const MultichainAssetDetailsActivityListItem = ({
   item,
+  transaction,
   chainId,
   bridgeHistoryItem,
   navigation,
@@ -40,12 +41,6 @@ export const MultichainAssetDetailsActivityListItem = ({
   location,
 }: MultichainAssetDetailsActivityListItemProps) => {
   const { trackEvent, createEventBuilder } = useAnalytics();
-  const keyringState = useSelector(
-    selectNonEvmTransactionsForSelectedAccountGroup,
-  );
-  const transaction = keyringState?.transactions?.find(
-    (keyringTx) => keyringTx.id === item.hash && keyringTx.chain === chainId,
-  );
   const displayData = useMultichainTransactionDisplay(transaction, chainId);
 
   const handlePress = useCallback(() => {

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.test.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.test.tsx
@@ -18,6 +18,7 @@ import { ActivityListItemRow } from '../../UI/ActivityListItemRow/ActivityListIt
 import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
 import { selectBridgeHistoryForAccount } from '../../../selectors/bridgeStatusController';
 import Routes from '../../../constants/navigation/Routes';
+import { useMultichainTransactionDisplay } from '../../hooks/useMultichainTransactionDisplay';
 
 jest.mock('../../../util/analytics/externalLinkTracking', () => ({
   ...jest.requireActual('../../../util/analytics/externalLinkTracking'),
@@ -244,6 +245,10 @@ describe('MultichainTransactionsView', () => {
         }),
       }),
       undefined,
+    );
+    expect(useMultichainTransactionDisplay).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'tx-123' }),
+      SolScope.Mainnet,
     );
     expect(
       jest.mocked(ActivityListItemRow).mock.calls[0][0],
@@ -503,8 +508,8 @@ describe('MultichainTransactionsView', () => {
     expect(ActivityListItemRow).toHaveBeenCalledWith(
       expect.objectContaining({
         item: expect.objectContaining({
+          hash: '0xbase-source-hash',
           type: 'bridge',
-          raw: expect.objectContaining({ type: 'localTransaction' }),
         }),
       }),
       undefined,
@@ -580,7 +585,7 @@ describe('MultichainTransactionsView', () => {
 
     expect(bridgeRows).toHaveLength(1);
     // The surviving row is the arrival (the EVM source tx), not the fill.
-    expect(bridgeRows[0][0].item.raw?.type).toBe('localTransaction');
+    expect(bridgeRows[0][0].item.hash).toBe('0xbase-source-hash');
   });
 
   it('navigates to ActivityDetails when a bridge arrival is tapped', async () => {

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -181,9 +181,14 @@ const MultichainTransactionsView = ({
   const bridgeHistory = useSelector(selectBridgeHistoryForAccount);
   const shouldUseActivityRedesign =
     location === TransactionDetailLocation.AssetDetails;
-  const { bridgeArrivalItems, arrivalDestTxHashes } = useMemo(() => {
+  const {
+    bridgeArrivalItems,
+    arrivalDestTxHashes,
+    bridgeTransactionByActivityItem,
+  } = useMemo(() => {
     const items: ActivityListItem[] = [];
     const destTxHashes = new Set<string>();
+    const sourceTransactions = new WeakMap<ActivityListItem, TransactionMeta>();
 
     for (const tx of bridgeArrivalTransactions ?? []) {
       const bridgeHistoryItem = findBridgeHistoryItem({
@@ -199,67 +204,79 @@ const MultichainTransactionsView = ({
         destTxHashes.add(destTxHash.toLowerCase());
       }
 
-      items.push(
-        mapTransactionToActivityItem({
-          transaction: tx,
-          currentChainId: tx.chainId,
-          bridgeHistoryItem,
-        }),
-      );
+      const activityItem = mapTransactionToActivityItem({
+        transaction: tx,
+        currentChainId: tx.chainId,
+        bridgeHistoryItem,
+      });
+      items.push(activityItem);
+      sourceTransactions.set(activityItem, tx);
     }
 
-    return { bridgeArrivalItems: items, arrivalDestTxHashes: destTxHashes };
+    return {
+      bridgeArrivalItems: items,
+      arrivalDestTxHashes: destTxHashes,
+      bridgeTransactionByActivityItem: sourceTransactions,
+    };
   }, [bridgeArrivalTransactions, bridgeHistory]);
 
-  const activityListData = useMemo(
-    () =>
-      shouldUseActivityRedesign
-        ? groupActivityListItems([
-            ...bridgeArrivalItems,
-            ...visibleMultichainTransactions
-              .filter(
-                (transaction) =>
-                  !arrivalDestTxHashes.has(transaction.id?.toLowerCase()),
-              )
-              .map((transaction) => {
-                const activity = classifyKeyringStakingActivity(
-                  transaction,
-                  mapKeyringTransaction({
-                    transaction: {
-                      ...transaction,
-                      chain: transaction.chain ?? chainId,
-                      fees: transaction.fees ?? [],
-                    },
-                    subjectAddress: address,
-                  }) as ActivityListItem,
-                );
-                const bridgeHistoryItem =
-                  bridgeHistoryItemsBySrcTxHash[transaction.id] ??
-                  bridgeHistoryItemsByDestTxHash[transaction.id];
-                const quote = bridgeHistoryItem?.quote;
+  const { activityListData, transactionByActivityItem } = useMemo(() => {
+    const sourceTransactions = new WeakMap<ActivityListItem, Transaction>();
 
-                if (
-                  quote &&
-                  isCrossChain(quote.srcChainId, quote.destChainId)
-                ) {
-                  return applyBridgeQuote(activity, bridgeHistoryItem, address);
-                }
+    if (!shouldUseActivityRedesign) {
+      return {
+        activityListData: visibleMultichainTransactions,
+        transactionByActivityItem: sourceTransactions,
+      };
+    }
 
-                return activity;
-              }),
-          ])
-        : visibleMultichainTransactions,
-    [
-      address,
-      arrivalDestTxHashes,
-      bridgeArrivalItems,
-      bridgeHistoryItemsByDestTxHash,
-      bridgeHistoryItemsBySrcTxHash,
-      chainId,
-      shouldUseActivityRedesign,
-      visibleMultichainTransactions,
-    ],
-  );
+    const activityItems = visibleMultichainTransactions
+      .filter(
+        (transaction) =>
+          !arrivalDestTxHashes.has(transaction.id?.toLowerCase()),
+      )
+      .map((transaction) => {
+        let activity = classifyKeyringStakingActivity(
+          transaction,
+          mapKeyringTransaction({
+            transaction: {
+              ...transaction,
+              chain: transaction.chain ?? chainId,
+              fees: transaction.fees ?? [],
+            },
+            subjectAddress: address,
+          }) as ActivityListItem,
+        );
+        const bridgeHistoryItem =
+          bridgeHistoryItemsBySrcTxHash[transaction.id] ??
+          bridgeHistoryItemsByDestTxHash[transaction.id];
+        const quote = bridgeHistoryItem?.quote;
+
+        if (quote && isCrossChain(quote.srcChainId, quote.destChainId)) {
+          activity = applyBridgeQuote(activity, bridgeHistoryItem, address);
+        }
+
+        sourceTransactions.set(activity, transaction);
+        return activity;
+      });
+
+    return {
+      activityListData: groupActivityListItems([
+        ...bridgeArrivalItems,
+        ...activityItems,
+      ]),
+      transactionByActivityItem: sourceTransactions,
+    };
+  }, [
+    address,
+    arrivalDestTxHashes,
+    bridgeArrivalItems,
+    bridgeHistoryItemsByDestTxHash,
+    bridgeHistoryItemsBySrcTxHash,
+    chainId,
+    shouldUseActivityRedesign,
+    visibleMultichainTransactions,
+  ]);
 
   const handleBridgeArrivalPress = React.useCallback(
     (item: ActivityListItem) => {
@@ -269,10 +286,7 @@ const MultichainTransactionsView = ({
         return;
       }
 
-      const evmTxMeta =
-        item.raw?.type === 'localTransaction'
-          ? item.raw.data.primaryTransaction
-          : undefined;
+      const evmTxMeta = bridgeTransactionByActivityItem.get(item);
 
       if (!evmTxMeta) {
         return;
@@ -290,7 +304,7 @@ const MultichainTransactionsView = ({
         }),
       });
     },
-    [bridgeHistory, nav],
+    [bridgeHistory, bridgeTransactionByActivityItem, nav],
   );
 
   const [refreshing, setRefreshing] = React.useState(false);
@@ -382,7 +396,7 @@ const MultichainTransactionsView = ({
       return <ActivityListDateHeader timestamp={item.date} />;
     }
 
-    if (item.item.raw?.type === 'localTransaction') {
+    if (bridgeTransactionByActivityItem.has(item.item)) {
       return (
         <Box twClassName="px-4">
           <ActivityListItemRow
@@ -398,6 +412,7 @@ const MultichainTransactionsView = ({
     return (
       <MultichainAssetDetailsActivityListItem
         item={item.item}
+        transaction={transactionByActivityItem.get(item.item)}
         bridgeHistoryItem={
           srcTxHash
             ? (bridgeHistoryItemsBySrcTxHash[srcTxHash] ??


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Removes the per-row Redux subscription and linear transaction lookup from non-EVM Token Details activity rows.
The parent list now associates each generated activity item with its source transaction using memoized `WeakMap`s and passes the transaction directly to the row. This avoids:

- One full-collection Redux subscription per mounted row
- Repeated selector execution across rows
- O(rows × transactions) lookup work when transaction data changes
- Deprecated `ActivityListItem.raw` access

React Compiler memoized the original `.find` for stable inputs, but could not eliminate the per-row subscriptions or repeated scans when the transaction collection changed.

A synthetic 1,000-transaction/30-visible-row benchmark measured approximately 5.4× faster lookup work when associations were rebuilt on every update.


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of data plumbing for activity rows with behavior preserved via tests; incorrect WeakMap pairing could break navigation or display for individual rows.
> 
> **Overview**
> **Non-EVM asset-details activity rows no longer subscribe to Redux or scan the full transaction list on every render.** `MultichainTransactionsView` now builds memoized `WeakMap` associations when it maps keyring transactions (and EVM bridge arrivals) to `ActivityListItem`s, then passes the source `transaction` into `MultichainAssetDetailsActivityListItem`.
> 
> Bridge arrival rows are identified via `bridgeTransactionByActivityItem` instead of deprecated `ActivityListItem.raw` (`localTransaction`), and bridge tap handling resolves `TransactionMeta` from that map rather than `item.raw.data.primaryTransaction`.
> 
> Tests were updated to supply the `transaction` prop directly and assert the display hook receives the attached transaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 834bd60e5efe94df5a6673ea6ade7d0698fabe48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->