### PR TITLE
fix(token-details): leave Asset before opening block explorer

### DIFF
--- a/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.test.tsx
+++ b/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.test.tsx
@@ -483,16 +483,17 @@ describe('MoreTokenActionsMenu', () => {
 
       await userEvent.press(getByTestId('more-actions-view-explorer'));
 
-      await Promise.resolve();
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('Webview', {
+          screen: 'SimpleWebview',
+          params: {
+            url: 'https://etherscan.io/token/0x123',
+            title: 'Etherscan',
+          },
+        });
+      });
 
       expect(mockNavigate).toHaveBeenCalledWith('WalletView');
-      expect(mockNavigate).toHaveBeenCalledWith('Webview', {
-        screen: 'SimpleWebview',
-        params: {
-          url: 'https://etherscan.io/token/0x123',
-          title: 'Etherscan',
-        },
-      });
       expect(jest.mocked(trackBlockExplorerLinkClicked)).toHaveBeenCalledWith(
         expect.any(Function),
         expect.any(Function),
@@ -519,12 +520,13 @@ describe('MoreTokenActionsMenu', () => {
 
       await userEvent.press(getByTestId('more-actions-view-explorer'));
 
-      await Promise.resolve();
+      await waitFor(() => {
+        expect(mockInAppBrowserOpen).toHaveBeenCalledWith(
+          'https://etherscan.io/token/0x123',
+        );
+      });
 
       expect(mockNavigate).toHaveBeenCalledWith('WalletView');
-      expect(mockInAppBrowserOpen).toHaveBeenCalledWith(
-        'https://etherscan.io/token/0x123',
-      );
     });
 
     it('uses block explorer base URL for native currency when View on block explorer is pressed', async () => {
@@ -741,9 +743,9 @@ describe('MoreTokenActionsMenu', () => {
       await userEvent.press(getByTestId('more-actions-deactivate-asset'));
 
       await waitFor(() => {
-        expect(mockDeactivateAsset).toHaveBeenCalled();
         expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
       });
+      expect(mockDeactivateAsset).toHaveBeenCalled();
       expect(NotificationManager.showSimpleNotification).not.toHaveBeenCalled();
     });
 

--- a/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.test.tsx
+++ b/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.test.tsx
@@ -468,7 +468,7 @@ describe('MoreTokenActionsMenu', () => {
       expect(onReceive).toHaveBeenCalled();
     });
 
-    it('navigates to Webview when View on block explorer is pressed and InAppBrowser is not available', async () => {
+    it('leaves Token Details then navigates to Webview when InAppBrowser is unavailable', async () => {
       mockInAppBrowserIsAvailable.mockResolvedValue(false);
       updateRouteParams({
         hasPerpsMarket: false,
@@ -485,6 +485,7 @@ describe('MoreTokenActionsMenu', () => {
 
       await Promise.resolve();
 
+      expect(mockNavigate).toHaveBeenCalledWith('WalletView');
       expect(mockNavigate).toHaveBeenCalledWith('Webview', {
         screen: 'SimpleWebview',
         params: {
@@ -502,7 +503,7 @@ describe('MoreTokenActionsMenu', () => {
       );
     });
 
-    it('opens InAppBrowser when View on block explorer is pressed and InAppBrowser is available', async () => {
+    it('leaves Token Details then opens InAppBrowser when available', async () => {
       mockInAppBrowserIsAvailable.mockResolvedValue(true);
       mockInAppBrowserOpen.mockResolvedValue(undefined);
       updateRouteParams({
@@ -520,6 +521,7 @@ describe('MoreTokenActionsMenu', () => {
 
       await Promise.resolve();
 
+      expect(mockNavigate).toHaveBeenCalledWith('WalletView');
       expect(mockInAppBrowserOpen).toHaveBeenCalledWith(
         'https://etherscan.io/token/0x123',
       );

--- a/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx
+++ b/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx
@@ -103,14 +103,24 @@ const MoreTokenActionsMenu = () => {
   const goToBrowserUrl = useCallback(
     (url: string, title: string) => {
       closeBottomSheetAndNavigate(async () => {
-        if (await InAppBrowser.isAvailable()) {
-          await InAppBrowser.open(url);
-        } else {
-          navigation.navigate('Webview', {
-            screen: 'SimpleWebview',
-            params: { url, title },
-          });
+        navigation.navigate('WalletView');
+
+        try {
+          if (await InAppBrowser.isAvailable()) {
+            await InAppBrowser.open(url);
+            return;
+          }
+        } catch (error) {
+          Logger.error(
+            error as Error,
+            'MoreTokenActionsMenu: Failed to open InAppBrowser',
+          );
         }
+
+        navigation.navigate(Routes.WEBVIEW.MAIN, {
+          screen: Routes.WEBVIEW.SIMPLE,
+          params: { url, title },
+        });
       });
     },
     [closeBottomSheetAndNavigate, navigation],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Opening "View on block explorer" from Token Details more-actions could fail with `Another InAppBrowser is already being presented` because `closeBottomSheetAndNavigate` dismissed the sheet and presented InAppBrowser/Webview while Token Details (`Asset`) was still on the stack.

This change closes the actions sheet, navigates to `WalletView` to leave Token Details, then opens InAppBrowser (or falls back to the in-app Webview).

## **Changelog**

CHANGELOG entry: Fixed a bug that prevented opening the block explorer from Token Details

## **Related issues**

Fixes: ASSETS-3871

## **Manual testing steps**

```gherkin
Feature: Token Details block explorer

  Scenario: user opens block explorer from more actions
    Given the user is on Token Details for an ERC-20 on Ethereum
    And the more-actions bottom sheet is open

    When the user taps View on block explorer
    Then Token Details is dismissed
    And the block explorer opens without an InAppBrowser presentation error

  Scenario: user opens block explorer for native currency
    Given the user is on Token Details for native ETH
    And the more-actions bottom sheet is open

    When the user taps View on block explorer
    Then the explorer base URL opens successfully
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/ef9a0e4b-2950-4dd0-90c7-f694c90d3cae



### **After**

<!-- [screenshots/recordings] -->



https://github.com/user-attachments/assets/43f99110-d382-499f-bc34-21fdaf19fb52


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized navigation-order fix for one menu action with error logging; no auth or payment changes.
> 
> **Overview**
> Fixes **View on block explorer** from Token Details more-actions failing with an InAppBrowser “already being presented” error by changing when navigation and the browser open.
> 
> **`goToBrowserUrl`** now navigates to **`WalletView`** right after the sheet closes, so Token Details is off the stack before **InAppBrowser** or the in-app webview is shown. InAppBrowser open is wrapped in **try/catch** with **`Logger.error`** on failure; if InAppBrowser isn’t available or errors, the flow falls back to **`Routes.WEBVIEW`** instead of hardcoded route names.
> 
> Tests assert **`WalletView`** is navigated for both webview and InAppBrowser paths, use **`waitFor`** for async behavior, and lightly reorder deactivate-success expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fec20f12656ff609e30edbb00460ea62f503d0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->