### PR TITLE
perf: lift asset activity selectors out of list rows

### DIFF
--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.test.tsx
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import { useSelector } from 'react-redux';
 import {
   TransactionStatus,
   TransactionType,
@@ -8,18 +7,9 @@ import {
 import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import AssetDetailsActivityListItem from './AssetDetailsActivityListItem';
 import Routes from '../../../constants/navigation/Routes';
-import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
-import { selectSelectedAccountGroupEvmInternalAccount } from '../../../selectors/multichainAccounts/accountTreeController';
-import { selectEvmNetworkConfigurationsByChainId } from '../../../selectors/networkController';
-import { selectAllTokens } from '../../../selectors/tokensController';
-import { selectBridgeHistoryForAccount } from '../../../selectors/bridgeStatusController';
 import type { TransactionWithImportTime } from './AssetDetailsActivityListItem.utils';
 import { resolveActivityListItemTitle } from '../ActivityListItemRow/ActivityListItemRow';
 import { handleUnifiedSwapsTxHistoryItemClick } from '../Bridge/utils/transaction-history';
-
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
-}));
 
 jest.mock('../../../../locales/i18n', () => ({
   strings: (key: string) => key,
@@ -50,8 +40,6 @@ jest.mock('../ActivityListItemRow/ActivityListItemRow', () => ({
   resolveActivityListItemTitle: jest.fn(() => 'Send ETH'),
 }));
 
-const mockUseSelector = jest.mocked(useSelector);
-
 const createNavigation = () =>
   ({
     navigate: jest.fn(),
@@ -76,49 +64,8 @@ const createTransaction = (
 });
 
 describe('AssetDetailsActivityListItem', () => {
-  let bridgeHistory: Record<string, unknown> = {};
-
   beforeEach(() => {
     jest.clearAllMocks();
-    bridgeHistory = {};
-
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectBridgeHistoryForAccount) {
-        return bridgeHistory;
-      }
-
-      if (selector === selectSelectedInternalAccount) {
-        return { metadata: { importTime: 2000 } };
-      }
-
-      if (selector === selectSelectedAccountGroupEvmInternalAccount) {
-        return { address: '0x123' };
-      }
-
-      if (selector === selectEvmNetworkConfigurationsByChainId) {
-        return {
-          '0x1': {
-            nativeCurrency: 'ETH',
-          },
-        };
-      }
-
-      if (selector === selectAllTokens) {
-        return {
-          '0x1': {
-            '0x123': [
-              {
-                address: '0x456',
-                symbol: 'USDC',
-                decimals: 6,
-              },
-            ],
-          },
-        };
-      }
-
-      return undefined;
-    });
   });
 
   it('renders account import marker for transaction import insertion point', () => {
@@ -131,6 +78,7 @@ describe('AssetDetailsActivityListItem', () => {
         index={0}
         assetSymbol="ETH"
         chainId="0x1"
+        accountImportTime={2000}
         navigation={navigation}
         onSpeedUpAction={jest.fn()}
         onCancelAction={jest.fn()}
@@ -148,34 +96,6 @@ describe('AssetDetailsActivityListItem', () => {
   });
 
   it('does not render account import marker when import time is null', () => {
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectBridgeHistoryForAccount) {
-        return bridgeHistory;
-      }
-
-      if (selector === selectSelectedInternalAccount) {
-        return { metadata: { importTime: null } };
-      }
-
-      if (selector === selectSelectedAccountGroupEvmInternalAccount) {
-        return { address: '0x123' };
-      }
-
-      if (selector === selectEvmNetworkConfigurationsByChainId) {
-        return {
-          '0x1': {
-            nativeCurrency: 'ETH',
-          },
-        };
-      }
-
-      if (selector === selectAllTokens) {
-        return {};
-      }
-
-      return undefined;
-    });
-
     const navigation = createNavigation();
     const transaction = createTransaction({ insertImportTime: true });
 
@@ -197,23 +117,12 @@ describe('AssetDetailsActivityListItem', () => {
   });
 
   it('routes a bridge to the redesigned ActivityDetails screen, not the legacy sheet', () => {
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectBridgeHistoryForAccount) return bridgeHistory;
-      if (selector === selectSelectedInternalAccount)
-        return { metadata: { importTime: 2000 } };
-      if (selector === selectSelectedAccountGroupEvmInternalAccount)
-        return { address: '0x123' };
-      if (selector === selectEvmNetworkConfigurationsByChainId)
-        return { '0x1': { nativeCurrency: 'ETH' } };
-      if (selector === selectAllTokens) return {};
-      return undefined;
-    });
     const navigation = createNavigation();
     const transaction = createTransaction({
       id: 'bridge-1',
       type: TransactionType.bridge,
     });
-    bridgeHistory = {
+    const bridgeHistory = {
       'bridge-1': {
         quote: {
           srcChainId: 8453,
@@ -230,6 +139,7 @@ describe('AssetDetailsActivityListItem', () => {
         index={0}
         assetSymbol="USDC"
         chainId="0x2105"
+        bridgeHistory={bridgeHistory as never}
         navigation={navigation}
         onSpeedUpAction={jest.fn()}
         onCancelAction={jest.fn()}
@@ -247,34 +157,6 @@ describe('AssetDetailsActivityListItem', () => {
   });
 
   it('routes to the ActivityDetails screen when the redesign is enabled', () => {
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectBridgeHistoryForAccount) {
-        return bridgeHistory;
-      }
-
-      if (selector === selectSelectedInternalAccount) {
-        return { metadata: { importTime: 2000 } };
-      }
-
-      if (selector === selectSelectedAccountGroupEvmInternalAccount) {
-        return { address: '0x123' };
-      }
-
-      if (selector === selectEvmNetworkConfigurationsByChainId) {
-        return {
-          '0x1': {
-            nativeCurrency: 'ETH',
-          },
-        };
-      }
-
-      if (selector === selectAllTokens) {
-        return {};
-      }
-
-      return undefined;
-    });
-
     const navigation = createNavigation();
     const transaction = createTransaction();
 
@@ -311,6 +193,19 @@ describe('AssetDetailsActivityListItem', () => {
           index={0}
           assetSymbol="ETH"
           chainId="0x1"
+          groupEvmAccountAddress="0x123"
+          networkConfigurations={{ '0x1': { nativeCurrency: 'ETH' } }}
+          allTokens={{
+            '0x1': {
+              '0x123': [
+                {
+                  address: '0x456',
+                  symbol: 'USDC',
+                  decimals: 6,
+                },
+              ],
+            },
+          }}
           navigation={navigation}
           onSpeedUpAction={jest.fn()}
           onCancelAction={jest.fn()}

--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.tsx
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
 import { Box } from '@metamask/design-system-react-native';
-import { useSelector } from 'react-redux';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import Routes from '../../../constants/navigation/Routes';
@@ -10,8 +9,6 @@ import {
   resolveActivityListItemTitle,
 } from '../ActivityListItemRow/ActivityListItemRow';
 import { type ActivityListItem } from '../../../util/activity-adapters';
-import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
-import { selectBridgeHistoryForAccount } from '../../../selectors/bridgeStatusController';
 import { findBridgeHistoryItem } from '../../../util/bridge/findBridgeHistoryItem';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): shared activity-details routing; route-isolation backlog
 import { getActivityDetailsRoute } from '../../Views/ActivityList/getActivityDetailsRoute';
@@ -23,9 +20,21 @@ import {
   mapTransactionToActivityItem,
   type TransactionWithImportTime,
 } from './AssetDetailsActivityListItem.utils';
-import { selectEvmNetworkConfigurationsByChainId } from '../../../selectors/networkController';
-import { selectAllTokens } from '../../../selectors/tokensController';
-import { selectSelectedAccountGroupEvmInternalAccount } from '../../../selectors/multichainAccounts/accountTreeController';
+
+type AssetTokensByChainAndAccount = Record<
+  string,
+  Record<string, { address: string; symbol?: string; decimals?: number }[]>
+>;
+type AssetBridgeHistory = Parameters<
+  typeof findBridgeHistoryItem
+>[0]['bridgeHistory'];
+
+const EMPTY_NETWORK_CONFIGURATIONS: Record<
+  string,
+  { nativeCurrency?: string }
+> = {};
+const EMPTY_ASSET_TOKENS: AssetTokensByChainAndAccount = {};
+const EMPTY_BRIDGE_HISTORY: AssetBridgeHistory = {};
 
 interface AssetDetailsActivityListItemProps {
   transaction: TransactionWithImportTime;
@@ -36,6 +45,11 @@ interface AssetDetailsActivityListItemProps {
   navigation: AppNavigationProp;
   onSpeedUpAction: (open: boolean, tx?: TransactionMeta) => void;
   onCancelAction: (open: boolean, tx?: TransactionMeta) => void;
+  accountImportTime?: number;
+  groupEvmAccountAddress?: string;
+  networkConfigurations?: Record<string, { nativeCurrency?: string }>;
+  allTokens?: AssetTokensByChainAndAccount;
+  bridgeHistory?: AssetBridgeHistory;
 }
 
 export const AssetDetailsActivityListItem = ({
@@ -47,25 +61,12 @@ export const AssetDetailsActivityListItem = ({
   navigation,
   onSpeedUpAction,
   onCancelAction,
+  accountImportTime,
+  groupEvmAccountAddress,
+  networkConfigurations = EMPTY_NETWORK_CONFIGURATIONS,
+  allTokens = EMPTY_ASSET_TOKENS,
+  bridgeHistory = EMPTY_BRIDGE_HISTORY,
 }: AssetDetailsActivityListItemProps) => {
-  // Kept for importTime metadata
-  const selectedInternalAccount = useSelector(selectSelectedInternalAccount);
-  // Used for TokensController lookups (matches useLocalActivityItems)
-  const groupEvmAccount = useSelector(
-    selectSelectedAccountGroupEvmInternalAccount,
-  );
-
-  const networkConfigurations = useSelector(
-    selectEvmNetworkConfigurationsByChainId,
-  );
-  // allTokens: Record<chainId, Record<accountAddress, Token[]>>
-  const allTokens = useSelector(selectAllTokens) as unknown as Record<
-    string,
-    Record<string, { address: string; symbol?: string; decimals?: number }[]>
-  >;
-  const accountImportTime = selectedInternalAccount?.metadata.importTime;
-
-  const bridgeHistory = useSelector(selectBridgeHistoryForAccount);
   // eslint-disable-next-line @typescript-eslint/no-deprecated -- Older persisted bridge history can still be keyed by actionId.
   const { actionId } = tx;
   const bridgeHistoryItem = useMemo(
@@ -90,7 +91,7 @@ export const AssetDetailsActivityListItem = ({
 
     // Token metadata for the tx's target contract, from TokensController —
     // same enrichment as useLocalActivityItems.
-    const accountAddress = groupEvmAccount?.address?.toLowerCase();
+    const accountAddress = groupEvmAccountAddress?.toLowerCase();
     const contractAddress = tx.txParams?.to?.toLowerCase();
     const matchingToken =
       resolvedChainId && accountAddress && contractAddress
@@ -114,7 +115,7 @@ export const AssetDetailsActivityListItem = ({
     assetSymbol,
     bridgeHistoryItem,
     currentChainId,
-    groupEvmAccount?.address,
+    groupEvmAccountAddress,
     networkConfigurations,
     tokenChainId,
     tx,
@@ -122,18 +123,11 @@ export const AssetDetailsActivityListItem = ({
 
   const handlePress = useCallback(
     (item: ActivityListItem) => {
-      const selectedTx =
-        item.raw?.type === 'localTransaction'
-          ? item.raw.data.primaryTransaction
-          : undefined;
-
       const detailsRoute = getActivityDetailsRoute(item);
       if (detailsRoute) {
         navigation.navigate(Routes.ACTIVITY_DETAILS, detailsRoute);
         return;
       }
-
-      if (!selectedTx) return;
 
       const { from, to } = getActivityFromTo(item);
       const value = getActivityValue(item);
@@ -143,15 +137,15 @@ export const AssetDetailsActivityListItem = ({
         screen: Routes.SHEET.TRANSACTION_DETAILS,
         params: getTransactionDetailsParams({
           item,
-          selectedTx,
+          selectedTx: tx,
           actionKey,
           value,
           from,
           to,
           currentChainId,
           tokenChainId,
-          showSpeedUpModal: () => onSpeedUpAction(true, selectedTx),
-          showCancelModal: () => onCancelAction(true, selectedTx),
+          showSpeedUpModal: () => onSpeedUpAction(true, tx),
+          showCancelModal: () => onCancelAction(true, tx),
         }),
       });
     },
@@ -162,6 +156,7 @@ export const AssetDetailsActivityListItem = ({
       onCancelAction,
       onSpeedUpAction,
       tokenChainId,
+      tx,
     ],
   );
 

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -30,19 +30,26 @@ import { isNonEvmChainId } from '../../../core/Multichain/utils';
 import NotificationManager from '../../../core/NotificationManager';
 import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
 import { collectibleContractsSelector } from '../../../reducers/collectibles';
-import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
+import {
+  selectSelectedInternalAccount,
+  selectSelectedInternalAccountFormattedAddress,
+} from '../../../selectors/accountsController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
+import { selectBridgeHistoryForAccount } from '../../../selectors/bridgeStatusController';
 import { selectGasFeeEstimates } from '../../../selectors/confirmTransaction';
 import { selectCurrentCurrency } from '../../../selectors/currencyRateController';
 import { selectGasFeeControllerEstimateType } from '../../../selectors/gasFeeController';
 import {
   selectChainId,
+  selectEvmNetworkConfigurationsByChainId,
   selectNetworkClientId,
   selectNetworkConfigurations,
   selectProviderConfig,
   selectProviderType,
 } from '../../../selectors/networkController';
 import { selectPrimaryCurrency } from '../../../selectors/settings';
+import { selectAllTokens } from '../../../selectors/tokensController';
+import { selectSelectedAccountGroupEvmInternalAccount } from '../../../selectors/multichainAccounts/accountTreeController';
 import { baseStyles, fontStyles } from '../../../styles/common';
 import { isHardwareAccount } from '../../../util/address';
 import Logger from '../../../util/Logger';
@@ -177,6 +184,11 @@ const Transactions = (props) => {
     skipScrollOnClick,
     location,
     hardwareWallet = DEFAULT_HARDWARE_WALLET,
+    accountImportTime,
+    groupEvmAccountAddress,
+    networkConfigurationsByChainId,
+    allTokens,
+    bridgeHistory,
   } = props;
   const theme = useContext(ThemeContext) || mockTheme;
   const { colors } = theme;
@@ -714,6 +726,11 @@ const Transactions = (props) => {
         navigation={navigation}
         onSpeedUpAction={onSpeedUpAction}
         onCancelAction={onCancelAction}
+        accountImportTime={accountImportTime}
+        groupEvmAccountAddress={groupEvmAccountAddress}
+        networkConfigurations={networkConfigurationsByChainId}
+        allTokens={allTokens}
+        bridgeHistory={bridgeHistory}
       />
     ) : null;
   };
@@ -926,6 +943,11 @@ Transactions.propTypes = {
     hideAwaitingConfirmation: PropTypes.func,
     showHardwareWalletError: PropTypes.func,
   }),
+  accountImportTime: PropTypes.number,
+  groupEvmAccountAddress: PropTypes.string,
+  networkConfigurationsByChainId: PropTypes.object,
+  allTokens: PropTypes.object,
+  bridgeHistory: PropTypes.object,
 };
 
 Transactions.defaultProps = {
@@ -948,6 +970,19 @@ const mapStateToProps = (state, ownProps) => {
 
   return {
     accounts: selectAccounts(state),
+    accountImportTime: isAssetDetails
+      ? selectSelectedInternalAccount(state)?.metadata.importTime
+      : undefined,
+    groupEvmAccountAddress: isAssetDetails
+      ? selectSelectedAccountGroupEvmInternalAccount(state)?.address
+      : undefined,
+    networkConfigurationsByChainId: isAssetDetails
+      ? selectEvmNetworkConfigurationsByChainId(state)
+      : undefined,
+    allTokens: isAssetDetails ? selectAllTokens(state) : undefined,
+    bridgeHistory: isAssetDetails
+      ? selectBridgeHistoryForAccount(state)
+      : undefined,
     chainId: isAssetDetails ? ownProps.tokenChainId : selectChainId(state),
     networkClientId: isAssetDetails ? undefined : selectNetworkClientId(state),
     collectibleContracts: collectibleContractsSelector(state),

--- a/app/components/UI/Transactions/index.test.tsx
+++ b/app/components/UI/Transactions/index.test.tsx
@@ -18,10 +18,15 @@ import {
 import { speedUpTransaction } from '../../../util/transaction-controller';
 import {
   selectChainId,
+  selectEvmNetworkConfigurationsByChainId,
   selectNetworkClientId,
   selectProviderConfig,
   selectProviderType,
 } from '../../../selectors/networkController';
+import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
+import { selectBridgeHistoryForAccount } from '../../../selectors/bridgeStatusController';
+import { selectAllTokens } from '../../../selectors/tokensController';
+import { selectSelectedAccountGroupEvmInternalAccount } from '../../../selectors/multichainAccounts/accountTreeController';
 
 const mockGroupActivityListItems = jest.fn();
 const mockMapTransactionToActivityItem = jest.fn();
@@ -277,6 +282,7 @@ jest.mock('../../../component-library/hooks', () => {
 });
 jest.mock('../../../actions/alert', () => ({ showAlert: jest.fn() }));
 jest.mock('../../../selectors/accountsController', () => ({
+  selectSelectedInternalAccount: jest.fn(),
   selectSelectedInternalAccountFormattedAddress: jest.fn(),
 }));
 jest.mock('../../../selectors/accountTrackerController', () => ({
@@ -293,11 +299,24 @@ jest.mock('../../../selectors/gasFeeController', () => ({
 }));
 jest.mock('../../../selectors/networkController', () => ({
   selectChainId: jest.fn(),
+  selectEvmNetworkConfigurationsByChainId: jest.fn(),
   selectNetworkClientId: jest.fn(),
   selectNetworkConfigurations: jest.fn(),
   selectProviderConfig: jest.fn(),
   selectProviderType: jest.fn(),
 }));
+jest.mock('../../../selectors/bridgeStatusController', () => ({
+  selectBridgeHistoryForAccount: jest.fn(),
+}));
+jest.mock('../../../selectors/tokensController', () => ({
+  selectAllTokens: jest.fn(),
+}));
+jest.mock(
+  '../../../selectors/multichainAccounts/accountTreeController',
+  () => ({
+    selectSelectedAccountGroupEvmInternalAccount: jest.fn(),
+  }),
+);
 jest.mock('../../../selectors/settings', () => ({
   selectPrimaryCurrency: jest.fn(),
 }));
@@ -875,6 +894,7 @@ describe('mapStateToProps', () => {
   const mockState = {} as never;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     jest.mocked(selectChainId).mockReturnValue('0x1');
     jest.mocked(selectProviderConfig).mockReturnValue({
       type: 'mainnet',
@@ -913,6 +933,39 @@ describe('mapStateToProps', () => {
       expect(first.providerConfig).toBe(second.providerConfig);
       expect(selectProviderConfig).not.toHaveBeenCalled();
     });
+
+    it('selects asset enrichment data once in the parent', () => {
+      const internalAccount = { metadata: { importTime: 123 } };
+      const groupAccount = { address: '0x123' };
+      const networkConfigurations = { '0x89': { nativeCurrency: 'POL' } };
+      const allTokens = { '0x89': { '0x123': [] } };
+      const bridgeHistory = { bridge: {} };
+      jest
+        .mocked(selectSelectedInternalAccount)
+        .mockReturnValue(internalAccount as never);
+      jest
+        .mocked(selectSelectedAccountGroupEvmInternalAccount)
+        .mockReturnValue(groupAccount as never);
+      jest
+        .mocked(selectEvmNetworkConfigurationsByChainId)
+        .mockReturnValue(networkConfigurations as never);
+      jest.mocked(selectAllTokens).mockReturnValue(allTokens as never);
+      jest
+        .mocked(selectBridgeHistoryForAccount)
+        .mockReturnValue(bridgeHistory as never);
+
+      const result = mapStateToProps(mockState, ownProps);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          accountImportTime: 123,
+          groupEvmAccountAddress: '0x123',
+          networkConfigurationsByChainId: networkConfigurations,
+          allTokens,
+          bridgeHistory,
+        }),
+      );
+    });
   });
 
   describe('when used for the Activity tab (no tokenChainId)', () => {
@@ -932,6 +985,18 @@ describe('mapStateToProps', () => {
 
       expect(result.networkClientId).toBe('mainnet-client');
       expect(result.networkType).toBe('mainnet');
+    });
+
+    it('does not select asset enrichment data', () => {
+      mapStateToProps(mockState, ownProps);
+
+      expect(selectSelectedInternalAccount).not.toHaveBeenCalled();
+      expect(
+        selectSelectedAccountGroupEvmInternalAccount,
+      ).not.toHaveBeenCalled();
+      expect(selectEvmNetworkConfigurationsByChainId).not.toHaveBeenCalled();
+      expect(selectAllTokens).not.toHaveBeenCalled();
+      expect(selectBridgeHistoryForAccount).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Lifts asset-details enrichment selectors from each `AssetDetailsActivityListItem` into the parent `Transactions` connection. Token Details now creates one Redux subscription per enrichment source instead of one per mounted FlashList row, while keeping transaction enrichment lazy at row-render time.

React Compiler cannot remove or consolidate `useSelector` subscriptions across component instances. In a synthetic benchmark with 30 mounted rows and 10,000 unrelated Redux updates, this reduced selector calls from 1,500,000 to 50,000 (96.7%) and elapsed update time from 288 ms to 10 ms (96.4%).

The legacy Activity tab does not select the additional asset enrichment data.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1345

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Token Details activity performance

  Scenario: View and interact with token activity
    Given a wallet has multiple transactions for an EVM token
    And the user opens that token's Token Details screen

    When the activity list is displayed
    Then transaction rows show the expected token, network, and bridge metadata
    And account import-time markers appear in the correct position
    And tapping a transaction opens its Activity Details
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor limited to data plumbing and tests; behavior should match prior row logic, with main risk being missed prop wiring on Token Details lists.
> 
> **Overview**
> **Token Details activity lists** no longer subscribe to Redux inside each `AssetDetailsActivityListItem`. Enrichment data—account import time, group EVM address, network configs, tokens, and bridge history—is read once in the connected `Transactions` parent (only when `tokenChainId` is set) and passed down as props, cutting duplicate `useSelector` work per FlashList row.
> 
> `AssetDetailsActivityListItem` is now a presentational row: it uses those props for token/bridge enrichment and import-time markers, and legacy transaction-details navigation uses the row’s `tx` prop directly instead of pulling the primary transaction from the activity item.
> 
> Tests were updated to pass props instead of mocking `react-redux`, and `mapStateToProps` tests assert enrichment selectors run for Token Details but not for the main Activity tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6abccc49b6390cb3a12f7a5e9905f6a9f0166119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->