### PR TITLE
fix(notifications): stop JS thread from staying pegged after sign-in

### DIFF
--- a/.yarn/patches/@metamask-design-system-react-native-npm-0.42.0-41ac5412c5.patch
+++ b/.yarn/patches/@metamask-design-system-react-native-npm-0.42.0-41ac5412c5.patch
@@ -1,0 +1,130 @@
+diff --git a/dist/components/BadgeWrapper/BadgeWrapper.cjs b/dist/components/BadgeWrapper/BadgeWrapper.cjs
+index 9c7f66c3142a535b861d55277597b1cf8517ab45..64e03817a642aee9f639fbb741a7e70e7f8c27dd 100644
+--- a/dist/components/BadgeWrapper/BadgeWrapper.cjs
++++ b/dist/components/BadgeWrapper/BadgeWrapper.cjs
+@@ -28,23 +28,43 @@ const design_system_shared_1 = require("@metamask/design-system-shared");
+ const design_system_twrnc_preset_1 = require("@metamask/design-system-twrnc-preset");
+ const react_1 = __importStar(require("react"));
+ const react_native_1 = require("react-native");
++// Below this, a measurement is treated as noise rather than a real resize.
++const STABLE_SIZE_THRESHOLD_PX = 1;
++// Tracks a measured element's rounded width/height via `onLayout`.
++//
++// `BadgeWrapper` positions an element based on its own measured size, so
++// applying that position can shift the next measurement by a sub-pixel
++// amount, which can flip-flop forever without this guard. Rounding alone
++// isn't enough to prevent that: two raw values close enough together to be
++// noise can still round to different integers if they straddle a `.5`
++// boundary. Instead this only accepts a new size once it has moved a full
++// pixel away from the last accepted raw measurement (starting from
++// -Infinity, so the first real measurement is always accepted), which
++// absorbs sub-pixel noise regardless of where it falls, while still
++// reacting to genuine size changes.
++const useStableMeasuredSize = () => {
++    const [width, setWidth] = (0, react_1.useState)(0);
++    const [height, setHeight] = (0, react_1.useState)(0);
++    const lastAcceptedRawRef = (0, react_1.useRef)({ width: -Infinity, height: -Infinity });
++    const onLayout = (0, react_1.useCallback)((event) => {
++        const { width: rawWidth, height: rawHeight } = event.nativeEvent.layout;
++        const lastAccepted = lastAcceptedRawRef.current;
++        const hasMoved = Math.abs(rawWidth - lastAccepted.width) >= STABLE_SIZE_THRESHOLD_PX ||
++            Math.abs(rawHeight - lastAccepted.height) >= STABLE_SIZE_THRESHOLD_PX;
++        if (!hasMoved) {
++            return;
++        }
++        lastAcceptedRawRef.current = { width: rawWidth, height: rawHeight };
++        setWidth(Math.round(rawWidth));
++        setHeight(Math.round(rawHeight));
++    }, []);
++    return [width, height, onLayout];
++};
+ const BadgeWrapper = ({ children, childrenContainerProps, badge, badgeContainerProps, position = design_system_shared_1.BadgeWrapperPosition.BottomRight, positionAnchorShape = design_system_shared_1.BadgeWrapperPositionAnchorShape.Circular, positionXOffset = 0, positionYOffset = 0, customPosition, twClassName, style, ...props }) => {
+     const tw = (0, design_system_twrnc_preset_1.useTailwind)();
+-    const [anchorWidth, setAnchorWidth] = (0, react_1.useState)(0);
+-    const [anchorHeight, setAnchorHeight] = (0, react_1.useState)(0);
+-    const [badgeWidth, setbadgeWidth] = (0, react_1.useState)(0);
+-    const [badgeHeight, setbadgeHeight] = (0, react_1.useState)(0);
+-    // Fetching the dimensions of the anchor and bagde element to properly position the badge
+-    const getAnchorSize = (0, react_1.useCallback)((event) => {
+-        const { width, height } = event.nativeEvent.layout;
+-        setAnchorWidth(width);
+-        setAnchorHeight(height);
+-    }, []);
+-    const getBadgeSize = (0, react_1.useCallback)((event) => {
+-        const { width, height } = event.nativeEvent.layout;
+-        setbadgeWidth(width);
+-        setbadgeHeight(height);
+-    }, []);
++    // Fetching the dimensions of the anchor and badge element to properly position the badge
++    const [anchorWidth, anchorHeight, getAnchorSize] = useStableMeasuredSize();
++    const [badgeWidth, badgeHeight, getBadgeSize] = useStableMeasuredSize();
+     const finalPositions = (0, react_1.useMemo)(() => {
+         if (customPosition) {
+             return customPosition;
+diff --git a/dist/components/BadgeWrapper/BadgeWrapper.mjs b/dist/components/BadgeWrapper/BadgeWrapper.mjs
+index dc2fdd5182f5333c58b655cd178a6cd44aee7402..b2a576270bef42a5a971573b596420b858313590 100644
+--- a/dist/components/BadgeWrapper/BadgeWrapper.mjs
++++ b/dist/components/BadgeWrapper/BadgeWrapper.mjs
+@@ -6,26 +6,46 @@ function $importDefault(module) {
+ }
+ import { BadgeWrapperPosition, BadgeWrapperPositionAnchorShape } from "@metamask/design-system-shared";
+ import { useTailwind } from "@metamask/design-system-twrnc-preset";
+-import $React, { useCallback, useState, useMemo } from "react";
++import $React, { useCallback, useState, useMemo, useRef } from "react";
+ const React = $importDefault($React);
+ import { View } from "react-native";
++// Below this, a measurement is treated as noise rather than a real resize.
++const STABLE_SIZE_THRESHOLD_PX = 1;
++// Tracks a measured element's rounded width/height via `onLayout`.
++//
++// `BadgeWrapper` positions an element based on its own measured size, so
++// applying that position can shift the next measurement by a sub-pixel
++// amount, which can flip-flop forever without this guard. Rounding alone
++// isn't enough to prevent that: two raw values close enough together to be
++// noise can still round to different integers if they straddle a `.5`
++// boundary. Instead this only accepts a new size once it has moved a full
++// pixel away from the last accepted raw measurement (starting from
++// -Infinity, so the first real measurement is always accepted), which
++// absorbs sub-pixel noise regardless of where it falls, while still
++// reacting to genuine size changes.
++const useStableMeasuredSize = () => {
++    const [width, setWidth] = useState(0);
++    const [height, setHeight] = useState(0);
++    const lastAcceptedRawRef = useRef({ width: -Infinity, height: -Infinity });
++    const onLayout = useCallback((event) => {
++        const { width: rawWidth, height: rawHeight } = event.nativeEvent.layout;
++        const lastAccepted = lastAcceptedRawRef.current;
++        const hasMoved = Math.abs(rawWidth - lastAccepted.width) >= STABLE_SIZE_THRESHOLD_PX ||
++            Math.abs(rawHeight - lastAccepted.height) >= STABLE_SIZE_THRESHOLD_PX;
++        if (!hasMoved) {
++            return;
++        }
++        lastAcceptedRawRef.current = { width: rawWidth, height: rawHeight };
++        setWidth(Math.round(rawWidth));
++        setHeight(Math.round(rawHeight));
++    }, []);
++    return [width, height, onLayout];
++};
+ export const BadgeWrapper = ({ children, childrenContainerProps, badge, badgeContainerProps, position = BadgeWrapperPosition.BottomRight, positionAnchorShape = BadgeWrapperPositionAnchorShape.Circular, positionXOffset = 0, positionYOffset = 0, customPosition, twClassName, style, ...props }) => {
+     const tw = useTailwind();
+-    const [anchorWidth, setAnchorWidth] = useState(0);
+-    const [anchorHeight, setAnchorHeight] = useState(0);
+-    const [badgeWidth, setbadgeWidth] = useState(0);
+-    const [badgeHeight, setbadgeHeight] = useState(0);
+-    // Fetching the dimensions of the anchor and bagde element to properly position the badge
+-    const getAnchorSize = useCallback((event) => {
+-        const { width, height } = event.nativeEvent.layout;
+-        setAnchorWidth(width);
+-        setAnchorHeight(height);
+-    }, []);
+-    const getBadgeSize = useCallback((event) => {
+-        const { width, height } = event.nativeEvent.layout;
+-        setbadgeWidth(width);
+-        setbadgeHeight(height);
+-    }, []);
++    // Fetching the dimensions of the anchor and badge element to properly position the badge
++    const [anchorWidth, anchorHeight, getAnchorSize] = useStableMeasuredSize();
++    const [badgeWidth, badgeHeight, getBadgeSize] = useStableMeasuredSize();
+     const finalPositions = useMemo(() => {
+         if (customPosition) {
+             return customPosition;

--- a/package.json
+++ b/package.json
@@ -304,7 +304,7 @@
     "@metamask/core-backend": "^9.0.0",
     "@metamask/delegation-controller": "^3.0.2",
     "@metamask/delegation-deployments": "^1.0.0",
-    "@metamask/design-system-react-native": "^0.42.0",
+    "@metamask/design-system-react-native": "patch:@metamask/design-system-react-native@npm%3A0.42.0#~/.yarn/patches/@metamask-design-system-react-native-npm-0.42.0-41ac5412c5.patch",
     "@metamask/design-system-twrnc-preset": "^0.10.0",
     "@metamask/design-tokens": "^10.0.0",
     "@metamask/earn-controller": "^12.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8390,7 +8390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react-native@npm:^0.42.0":
+"@metamask/design-system-react-native@npm:0.42.0":
   version: 0.42.0
   resolution: "@metamask/design-system-react-native@npm:0.42.0"
   dependencies:
@@ -8409,6 +8409,28 @@ __metadata:
     react-native-safe-area-context: ">=5.0.0"
     react-native-worklets: ">=0.7.4"
   checksum: 10/875df28e26b3726266ca26a95a4302a45696fff80bf2c153028bda433666cd2bac376e88245648f33bb400dbe8225a304983a39b5a4ab9f12df3c0580f5b052e
+  languageName: node
+  linkType: hard
+
+"@metamask/design-system-react-native@patch:@metamask/design-system-react-native@npm%3A0.42.0#~/.yarn/patches/@metamask-design-system-react-native-npm-0.42.0-41ac5412c5.patch":
+  version: 0.42.0
+  resolution: "@metamask/design-system-react-native@patch:@metamask/design-system-react-native@npm%3A0.42.0#~/.yarn/patches/@metamask-design-system-react-native-npm-0.42.0-41ac5412c5.patch::version=0.42.0&hash=eed373"
+  dependencies:
+    "@metamask/design-system-shared": "npm:^0.34.0"
+    react-native-jazzicon: "npm:^0.1.2"
+  peerDependencies:
+    "@metamask/design-system-twrnc-preset": ^0.10.0
+    "@metamask/design-tokens": ^10.0.0
+    "@metamask/utils": ^11.11.0
+    expo-image: ">=3.0.0"
+    lodash: ^4.17.21
+    react: ">=18.2.0"
+    react-native: ">=0.76.0"
+    react-native-gesture-handler: ">=2.25.0"
+    react-native-reanimated: ">=4.2.0"
+    react-native-safe-area-context: ">=5.0.0"
+    react-native-worklets: ">=0.7.4"
+  checksum: 10/0f38a5da30c3e0f68f11fd9a56d2ffc40166c0b2d3cc323d37256cdd3a553c0a0df4d3ad5794ff9214927a033ea0cab6f5ef4269074f4d6c0386c19be2cc96e8
   languageName: node
   linkType: hard
 
@@ -35768,7 +35790,7 @@ __metadata:
     "@metamask/core-backend": "npm:^9.0.0"
     "@metamask/delegation-controller": "npm:^3.0.2"
     "@metamask/delegation-deployments": "npm:^1.0.0"
-    "@metamask/design-system-react-native": "npm:^0.42.0"
+    "@metamask/design-system-react-native": "patch:@metamask/design-system-react-native@npm%3A0.42.0#~/.yarn/patches/@metamask-design-system-react-native-npm-0.42.0-41ac5412c5.patch"
     "@metamask/design-system-twrnc-preset": "npm:^0.10.0"
     "@metamask/design-tokens": "npm:^10.0.0"
     "@metamask/device-mcp": "npm:^0.3.0"


### PR DESCRIPTION
## **Description**

After signing in, the JS thread stayed pegged at 90-100% CPU and never settled back down. Tracing it down, a `setState` call was firing dozens of times per second, forever, coming from the wallet notification badge (the red dot on the hamburger menu icon) once the unread notification count went above zero.

The cause is in `BadgeWrapper` from `@metamask/design-system-react-native`. It positions the badge using the badge's own measured width and height. But applying that position changes the badge's layout by a tiny sub-pixel amount, which can flip how the next measurement rounds. That starts a loop: measure, reposition, re-measure at a slightly different size, reposition again, and it never stops once it kicks in.

This is a structural issue in `BadgeWrapper` itself, so it's not only the notification badge. Anywhere in the app that renders a real badge through this component is exposed to the same loop, for example the network badges on token logos in the Earn section.

Patched here with a `yarn patch` so we get the fix now instead of waiting for a new release. The real fix is upstream in MetaMask/metamask-design-system#1471, which rounds the measured size and skips the state update when the rounded value hasn't changed.

## **Changelog**

CHANGELOG entry: Fixed the JS thread staying at high CPU usage after sign-in

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3928

## **Manual testing steps**

```gherkin
Feature: Wallet unlock performance

  Scenario: JS thread settles after sign-in with unread notifications
    Given the user has unread notifications and notifications enabled
    When the user unlocks the wallet and signs in
    Then the notification badge appears on the hamburger menu icon
    And the JS thread CPU usage settles back down shortly after, instead of staying pegged
```

## **Screenshots/Recordings**

### **Before & After**
<img width="12516" height="4308" alt="image" src="https://github.com/user-attachments/assets/a667d68a-f7e9-4983-904e-035b97a498db" />

https://github.com/user-attachments/assets/b13ffcf3-81e2-4682-b633-b4a7fefcdf05



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI layout stabilization in a patched dependency; no auth, data, or payment logic changes.
> 
> **Overview**
> Stops the **post-sign-in JS thread CPU spike** (often 90–100%) caused by an infinite `onLayout` → `setState` loop in **`BadgeWrapper`** from `@metamask/design-system-react-native`. Badge positioning depends on measured badge/anchor size; repositioning shifts layout by sub-pixel amounts, so measurements keep changing and state updates never stop (notification dot on the menu, network badges on token logos, etc.).
> 
> The PR **pins `@metamask/design-system-react-native@0.42.0` through a Yarn patch** instead of waiting on a new package release. The patch adds **`useStableMeasuredSize`**, which rounds dimensions and only updates state when raw width/height move at least **1px** from the last accepted measurement, breaking the flip-flop without ignoring real resizes. **`package.json`** and **`yarn.lock`** point at the patched resolution.
> 
> Upstream equivalent: MetaMask/metamask-design-system#1471.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 488971b6c459ba22ae67557473c348ce6626adae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->