### PR TITLE
ci: .cjs test files moved to .mjs

### DIFF
--- a/.github/scripts/qa-automation/e2e-ci-orchestration/compute-e2e-platform-flags.mjs
+++ b/.github/scripts/qa-automation/e2e-ci-orchestration/compute-e2e-platform-flags.mjs
@@ -266,7 +266,7 @@ function resolveE2EPlatformRequirements(input) {
   };
 }
 
-module.exports = {
+export {
   computeE2EPlatformFlags,
   applyE2ELabelOverrides,
   resolveRunAppiumIos,

--- a/.github/scripts/qa-automation/e2e-ci-orchestration/compute-e2e-platform-flags.test.ts
+++ b/.github/scripts/qa-automation/e2e-ci-orchestration/compute-e2e-platform-flags.test.ts
@@ -1,8 +1,8 @@
-const {
+import {
   computeE2EPlatformFlags,
   applyE2ELabelOverrides,
   resolveE2EPlatformRequirements,
-} = require('./compute-e2e-platform-flags.cjs');
+} from './compute-e2e-platform-flags.mjs';
 
 describe('computeE2EPlatformFlags', () => {
   const baseInput = {

--- a/.github/scripts/qa-automation/e2e-ci-orchestration/run-compute-e2e-platform-flags.mjs
+++ b/.github/scripts/qa-automation/e2e-ci-orchestration/run-compute-e2e-platform-flags.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 /**
- * GitHub Actions entrypoint for compute-e2e-platform-flags.cjs.
+ * GitHub Actions entrypoint for compute-e2e-platform-flags.mjs.
  */
 
-const fs = require('node:fs');
-const {
+import { appendFileSync } from 'node:fs';
+import {
   resolveE2EPlatformRequirements,
-} = require('./compute-e2e-platform-flags.cjs');
+} from './compute-e2e-platform-flags.mjs';
 
 function readBool(value) {
   return value === 'true';
@@ -134,4 +134,4 @@ const outputLines = [
   'GH_EOF',
 ];
 
-fs.appendFileSync(githubOutputPath, `${outputLines.join('\n')}\n`);
+appendFileSync(githubOutputPath, `${outputLines.join('\n')}\n`);

--- a/.github/scripts/qa-automation/e2e-ci-orchestration/run-compute-e2e-platform-flags.test.ts
+++ b/.github/scripts/qa-automation/e2e-ci-orchestration/run-compute-e2e-platform-flags.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 
 const ENTRYPOINT = path.join(
   __dirname,
-  'run-compute-e2e-platform-flags.cjs',
+  'run-compute-e2e-platform-flags.mjs',
 );
 
 /**

--- a/.github/scripts/qa-automation/performance-tests/browserstack-app-validation.mjs
+++ b/.github/scripts/qa-automation/performance-tests/browserstack-app-validation.mjs
@@ -3,6 +3,8 @@
  * outputs or other local files.
  */
 
+import { appendFileSync } from 'node:fs';
+
 /** BrowserStack app URLs use the bs:// scheme with an opaque app hash. */
 const BROWSERSTACK_APP_URL_PATTERN = /^bs:\/\/[A-Za-z0-9]+$/;
 
@@ -96,10 +98,10 @@ function writeGithubOutputs(path, outputs) {
     }
     lines.push(`${key}=${value}`);
   }
-  require('node:fs').appendFileSync(path, `${lines.join('\n')}\n`);
+  appendFileSync(path, `${lines.join('\n')}\n`);
 }
 
-module.exports = {
+export {
   BROWSERSTACK_APP_URL_PATTERN,
   WITH_SRP_CUSTOM_ID_PATTERN,
   WITHOUT_SRP_CUSTOM_ID_PATTERN,

--- a/.github/scripts/qa-automation/performance-tests/browserstack-app-validation.test.ts
+++ b/.github/scripts/qa-automation/performance-tests/browserstack-app-validation.test.ts
@@ -2,12 +2,12 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-const {
+import {
   assertBrowserStackAppUrl,
   assertBrowserStackCustomId,
   isMainBranchBrowserStackCustomId,
   writeGithubOutputs,
-} = require('./browserstack-app-validation.cjs');
+} from './browserstack-app-validation.mjs';
 
 describe('browserstack-app-validation', () => {
   it('accepts valid BrowserStack app URLs', () => {

--- a/.github/scripts/qa-automation/performance-tests/resolve-main-browserstack-apps.mjs
+++ b/.github/scripts/qa-automation/performance-tests/resolve-main-browserstack-apps.mjs
@@ -9,14 +9,14 @@
  * dual Android upload.
  */
 
-const {
+import {
   MAIN_WITH_SRP_CUSTOM_ID,
   MAIN_WITHOUT_SRP_CUSTOM_ID,
   assertBrowserStackAppUrl,
   assertBrowserStackCustomId,
   isMainBranchBrowserStackCustomId,
   writeGithubOutputs,
-} = require('./browserstack-app-validation.cjs');
+} from './browserstack-app-validation.mjs';
 
 const githubOutputPath = process.env.GITHUB_OUTPUT;
 if (!githubOutputPath) {

--- a/.github/scripts/qa-automation/stats/collect-qa-stats.mjs
+++ b/.github/scripts/qa-automation/stats/collect-qa-stats.mjs
@@ -44,18 +44,16 @@
 import { readFile, writeFile, mkdir, readdir, access } from 'fs/promises';
 import { constants as fsConstants } from 'fs';
 import { execSync } from 'child_process';
-import { createRequire } from 'module';
 import { join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
-const require = createRequire(import.meta.url);
-const {
+import {
   getE2EArtifactDimensions,
   countExecutedTestsFromPlaywrightJson,
   aggregateTimingsFromPlaywrightJson,
   countSkips,
   countDefinedTests,
-} = require('./qa-stats-e2e.cjs');
+} from './qa-stats-e2e.mjs';
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY ?? 'MetaMask/metamask-mobile';

--- a/.github/scripts/qa-automation/stats/qa-stats-e2e.mjs
+++ b/.github/scripts/qa-automation/stats/qa-stats-e2e.mjs
@@ -194,7 +194,7 @@ function countDefinedTests(source) {
   return (source.match(new RegExp(TEST_CALL_SOURCE, 'g')) ?? []).length;
 }
 
-module.exports = {
+export {
   getE2EArtifactDimensions,
   countExecutedTestsFromPlaywrightJson,
   normalizeSpecPath,

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -168,4 +168,4 @@ jobs:
           IOS_COUNT: ${{ steps.filter.outputs.ios_count }}
           ANDROID_OR_IGNORABLE_COUNT: ${{ steps.filter.outputs.android_or_ignorable_count }}
           IOS_OR_IGNORABLE_COUNT: ${{ steps.filter.outputs.ios_or_ignorable_count }}
-        run: node .github/scripts/qa-automation/e2e-ci-orchestration/run-compute-e2e-platform-flags.cjs
+        run: node .github/scripts/qa-automation/e2e-ci-orchestration/run-compute-e2e-platform-flags.mjs

--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/select-tags-hard-rules.test.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/select-tags-hard-rules.test.ts
@@ -78,8 +78,8 @@ describe('checkHardRules', () => {
     '.github/scripts/qa-automation/e2e-sharding/e2e-split-tags-shards.mjs',
     '.github/actions/smart-e2e-selection/e2e-smart-selection.mjs',
     '.github/scripts/qa-automation/stats/e2e-freeze-timings.mjs',
-    '.github/scripts/qa-automation/e2e-ci-orchestration/compute-e2e-platform-flags.cjs',
-    '.github/scripts/qa-automation/e2e-ci-orchestration/run-compute-e2e-platform-flags.cjs',
+    '.github/scripts/qa-automation/e2e-ci-orchestration/compute-e2e-platform-flags.mjs',
+    '.github/scripts/qa-automation/e2e-ci-orchestration/run-compute-e2e-platform-flags.mjs',
   ])('runs all E2E tags when %s changes', (changedFile) => {
     const result = checkHardRules([changedFile], context);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

cjs test files moved to .mjs

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical CJS→ESM refactor of CI helper scripts with test and workflow path updates only; no change to E2E decision logic.
> 
> **Overview**
> Migrates several **QA automation** helpers under `.github/scripts/qa-automation/` from **CommonJS** (`module.exports` / `require`, `.cjs` entrypoints) to **native ESM** (`export` / `import`, `.mjs`).
> 
> **E2E platform flags:** `compute-e2e-platform-flags` and `run-compute-e2e-platform-flags` now use ESM; **`get-requirements.yml`** invokes `run-compute-e2e-platform-flags.mjs` instead of `.cjs`.
> 
> **BrowserStack / performance:** `browserstack-app-validation` and `resolve-main-browserstack-apps` import/export via ESM; `appendFileSync` is a named import where needed.
> 
> **QA stats:** `collect-qa-stats.mjs` drops `createRequire` and imports `qa-stats-e2e.mjs` directly; `qa-stats-e2e` exports its helpers instead of `module.exports`.
> 
> **Tests:** Unit tests and the e2e-ai-analyzer **hard-rules** list are updated to import `.mjs` paths. Behavior is unchanged; this is a module-format alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b70ccdb6cb0732ba124dae08ec7e9b68fadf17d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->