### PR TITLE
feat(card): add UK migration bottom sheet UI shell

### DIFF
--- a/app/components/UI/Card/components/UkMigrationBottomSheet/UkMigrationBottomSheet.test.tsx
+++ b/app/components/UI/Card/components/UkMigrationBottomSheet/UkMigrationBottomSheet.test.tsx
@@ -2,9 +2,17 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import UkMigrationBottomSheet from './UkMigrationBottomSheet';
 import { UkMigrationBottomSheetSelectors } from './UkMigrationBottomSheet.testIds';
+import I18n from '../../../../../../locales/i18n';
+import { getIntlDateTimeFormatter } from '../../../../../util/intl';
 
 const mockOnCloseBottomSheet = jest.fn();
 const mockGoBack = jest.fn();
+
+const expectedDeadlineLabel = getIntlDateTimeFormatter(I18n.locale, {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+}).format(new Date(2026, 8, 30));
 
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
@@ -17,11 +25,13 @@ jest.mock('@react-navigation/native', () => {
 });
 
 jest.mock('../../../../../../locales/i18n', () => ({
-  strings: (key: string) => {
+  __esModule: true,
+  default: { locale: 'en-US' },
+  strings: (key: string, vars?: Record<string, string>) => {
     const map: Record<string, string> = {
       'card.uk_migration_bottom_sheet.title': 'Update your MetaMask Card',
       'card.uk_migration_bottom_sheet.description':
-        "We've switched to a new card provider. To keep spending without interruption, complete these steps before Sep 30, 2026.",
+        "We've switched to a new card provider. To keep spending without interruption, complete these steps before {{deadline}}.",
       'card.uk_migration_bottom_sheet.steps.reverify_identity':
         'Re-verify your identity',
       'card.uk_migration_bottom_sheet.steps.get_new_card_number':
@@ -31,7 +41,13 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'card.uk_migration_bottom_sheet.get_started': 'Get started',
       'card.uk_migration_bottom_sheet.remind_me_later': 'Remind me later',
     };
-    return map[key] || key;
+    let value = map[key] || key;
+    if (vars) {
+      Object.entries(vars).forEach(([name, replacement]) => {
+        value = value.replace(`{{${name}}}`, replacement);
+      });
+    }
+    return value;
   },
 }));
 
@@ -65,26 +81,37 @@ describe('UkMigrationBottomSheet', () => {
   });
 
   it('renders title, description, steps, and actions', () => {
-    const { getByTestId, getByText } = render(<UkMigrationBottomSheet />);
+    const { getByTestId } = render(<UkMigrationBottomSheet />);
 
-    expect(getByTestId(UkMigrationBottomSheetSelectors.CONTAINER)).toBeTruthy();
+    expect(
+      getByTestId(UkMigrationBottomSheetSelectors.CONTAINER),
+    ).toBeOnTheScreen();
     expect(
       getByTestId(UkMigrationBottomSheetSelectors.TITLE),
-    ).toHaveTextContent('Update your MetaMask Card');
+    ).toBeOnTheScreen();
     expect(
       getByTestId(UkMigrationBottomSheetSelectors.DESCRIPTION),
     ).toHaveTextContent(
-      "We've switched to a new card provider. To keep spending without interruption, complete these steps before Sep 30, 2026.",
+      `We've switched to a new card provider. To keep spending without interruption, complete these steps before ${expectedDeadlineLabel}.`,
     );
-    expect(getByText('Re-verify your identity')).toBeTruthy();
-    expect(getByText('Get your new card number')).toBeTruthy();
-    expect(getByText('Convert your funds to USDC on Base')).toBeTruthy();
+    expect(
+      getByTestId(UkMigrationBottomSheetSelectors.STEPS),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(UkMigrationBottomSheetSelectors.step(1)),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(UkMigrationBottomSheetSelectors.step(2)),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(UkMigrationBottomSheetSelectors.step(3)),
+    ).toBeOnTheScreen();
     expect(
       getByTestId(UkMigrationBottomSheetSelectors.GET_STARTED_BUTTON),
-    ).toBeTruthy();
+    ).toBeOnTheScreen();
     expect(
       getByTestId(UkMigrationBottomSheetSelectors.REMIND_LATER_BUTTON),
-    ).toBeTruthy();
+    ).toBeOnTheScreen();
   });
 
   it('closes the sheet when Get started is pressed', () => {

--- a/app/components/UI/Card/components/UkMigrationBottomSheet/UkMigrationBottomSheet.test.tsx
+++ b/app/components/UI/Card/components/UkMigrationBottomSheet/UkMigrationBottomSheet.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import UkMigrationBottomSheet from './UkMigrationBottomSheet';
+import { UkMigrationBottomSheetSelectors } from './UkMigrationBottomSheet.testIds';
+
+const mockOnCloseBottomSheet = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actualReactNavigation = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualReactNavigation,
+    useNavigation: () => ({
+      goBack: mockGoBack,
+    }),
+  };
+});
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: (key: string) => {
+    const map: Record<string, string> = {
+      'card.uk_migration_bottom_sheet.title': 'Update your MetaMask Card',
+      'card.uk_migration_bottom_sheet.description':
+        "We've switched to a new card provider. To keep spending without interruption, complete these steps before Sep 30, 2026.",
+      'card.uk_migration_bottom_sheet.steps.reverify_identity':
+        'Re-verify your identity',
+      'card.uk_migration_bottom_sheet.steps.get_new_card_number':
+        'Get your new card number',
+      'card.uk_migration_bottom_sheet.steps.convert_funds_usdc_base':
+        'Convert your funds to USDC on Base',
+      'card.uk_migration_bottom_sheet.get_started': 'Get started',
+      'card.uk_migration_bottom_sheet.remind_me_later': 'Remind me later',
+    };
+    return map[key] || key;
+  },
+}));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+
+  const MockBottomSheet = ReactActual.forwardRef(
+    (
+      { children, testID }: { children: React.ReactNode; testID?: string },
+      ref: React.Ref<{ onCloseBottomSheet: (cb?: () => void) => void }>,
+    ) => {
+      ReactActual.useImperativeHandle(ref, () => ({
+        onCloseBottomSheet: mockOnCloseBottomSheet,
+        onOpenBottomSheet: jest.fn(),
+      }));
+      return ReactActual.createElement(View, { testID }, children);
+    },
+  );
+
+  return {
+    ...actual,
+    BottomSheet: MockBottomSheet,
+  };
+});
+
+describe('UkMigrationBottomSheet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders title, description, steps, and actions', () => {
+    const { getByTestId, getByText } = render(<UkMigrationBottomSheet />);
+
+    expect(getByTestId(UkMigrationBottomSheetSelectors.CONTAINER)).toBeTruthy();
+    expect(
+      getByTestId(UkMigrationBottomSheetSelectors.TITLE),
+    ).toHaveTextContent('Update your MetaMask Card');
+    expect(
+      getByTestId(UkMigrationBottomSheetSelectors.DESCRIPTION),
+    ).toHaveTextContent(
+      "We've switched to a new card provider. To keep spending without interruption, complete these steps before Sep 30, 2026.",
+    );
+    expect(getByText('Re-verify your identity')).toBeTruthy();
+    expect(getByText('Get your new card number')).toBeTruthy();
+    expect(getByText('Convert your funds to USDC on Base')).toBeTruthy();
+    expect(
+      getByTestId(UkMigrationBottomSheetSelectors.GET_STARTED_BUTTON),
+    ).toBeTruthy();
+    expect(
+      getByTestId(UkMigrationBottomSheetSelectors.REMIND_LATER_BUTTON),
+    ).toBeTruthy();
+  });
+
+  it('closes the sheet when Get started is pressed', () => {
+    const { getByTestId } = render(<UkMigrationBottomSheet />);
+
+    fireEvent.press(
+      getByTestId(UkMigrationBottomSheetSelectors.GET_STARTED_BUTTON),
+    );
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the sheet when Remind me later is pressed', () => {
+    const { getByTestId } = render(<UkMigrationBottomSheet />);
+
+    fireEvent.press(
+      getByTestId(UkMigrationBottomSheetSelectors.REMIND_LATER_BUTTON),
+    );
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the sheet when the close button is pressed', () => {
+    const { getByTestId } = render(<UkMigrationBottomSheet />);
+
+    fireEvent.press(getByTestId(UkMigrationBottomSheetSelectors.CLOSE_BUTTON));
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/Card/components/UkMigrationBottomSheet/UkMigrationBottomSheet.testIds.ts
+++ b/app/components/UI/Card/components/UkMigrationBottomSheet/UkMigrationBottomSheet.testIds.ts
@@ -1,0 +1,9 @@
+export const UkMigrationBottomSheetSelectors = {
+  CONTAINER: 'uk-migration-bottom-sheet-container',
+  TITLE: 'uk-migration-bottom-sheet-title',
+  DESCRIPTION: 'uk-migration-bottom-sheet-description',
+  STEPS: 'uk-migration-bottom-sheet-steps',
+  GET_STARTED_BUTTON: 'uk-migration-bottom-sheet-get-started-button',
+  REMIND_LATER_BUTTON: 'uk-migration-bottom-sheet-remind-later-button',
+  CLOSE_BUTTON: 'uk-migration-bottom-sheet-close-button',
+};

--- a/app/components/UI/Card/components/UkMigrationBottomSheet/UkMigrationBottomSheet.testIds.ts
+++ b/app/components/UI/Card/components/UkMigrationBottomSheet/UkMigrationBottomSheet.testIds.ts
@@ -3,6 +3,7 @@ export const UkMigrationBottomSheetSelectors = {
   TITLE: 'uk-migration-bottom-sheet-title',
   DESCRIPTION: 'uk-migration-bottom-sheet-description',
   STEPS: 'uk-migration-bottom-sheet-steps',
+  step: (stepNumber: number) => `uk-migration-bottom-sheet-step-${stepNumber}`,
   GET_STARTED_BUTTON: 'uk-migration-bottom-sheet-get-started-button',
   REMIND_LATER_BUTTON: 'uk-migration-bottom-sheet-remind-later-button',
   CLOSE_BUTTON: 'uk-migration-bottom-sheet-close-button',

--- a/app/components/UI/Card/components/UkMigrationBottomSheet/UkMigrationBottomSheet.tsx
+++ b/app/components/UI/Card/components/UkMigrationBottomSheet/UkMigrationBottomSheet.tsx
@@ -1,0 +1,148 @@
+import React, { useCallback, useMemo, useRef } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
+import {
+  Text,
+  TextVariant,
+  Box,
+  Button,
+  ButtonVariant,
+  ButtonSize,
+  FontWeight,
+  BottomSheet,
+  BottomSheetHeader,
+  type BottomSheetRef,
+} from '@metamask/design-system-react-native';
+import { createNavigationDetails } from '../../../../../util/navigation/navUtils';
+import Routes from '../../../../../constants/navigation/Routes';
+import { strings } from '../../../../../../locales/i18n';
+import { UkMigrationBottomSheetSelectors } from './UkMigrationBottomSheet.testIds';
+
+export const createUkMigrationBottomSheetNavigationDetails =
+  createNavigationDetails(
+    Routes.CARD.MODALS.ID,
+    Routes.CARD.MODALS.UK_MIGRATION,
+  );
+
+const MIGRATION_STEP_KEYS = [
+  'card.uk_migration_bottom_sheet.steps.reverify_identity',
+  'card.uk_migration_bottom_sheet.steps.get_new_card_number',
+  'card.uk_migration_bottom_sheet.steps.convert_funds_usdc_base',
+] as const;
+
+/**
+ * UK Card provider migration prompt.
+ *
+ * Intentionally unreachable from production Card Home until migration
+ * entry points are wired. Registered on the Card modals stack for preview.
+ */
+const UkMigrationBottomSheet = () => {
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const navigation = useNavigation<AppNavigationProp>();
+
+  const handleGoBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const handleClose = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  // Placeholder — will navigate into Immersve onboarding when wired.
+  const handleGetStarted = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  // For now, same as X / dismiss (DF3). Re-entry UX still TBD.
+  const handleRemindLater = handleClose;
+
+  const steps = useMemo(
+    () =>
+      MIGRATION_STEP_KEYS.map((key, index) => ({
+        number: index + 1,
+        label: strings(key),
+      })),
+    [],
+  );
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      goBack={handleGoBack}
+      keyboardAvoidingViewEnabled={false}
+      testID={UkMigrationBottomSheetSelectors.CONTAINER}
+    >
+      <BottomSheetHeader
+        onClose={handleClose}
+        closeButtonProps={{
+          testID: UkMigrationBottomSheetSelectors.CLOSE_BUTTON,
+        }}
+      >
+        <Text
+          variant={TextVariant.HeadingSm}
+          testID={UkMigrationBottomSheetSelectors.TITLE}
+        >
+          {strings('card.uk_migration_bottom_sheet.title')}
+        </Text>
+      </BottomSheetHeader>
+
+      <Box twClassName="px-4 pb-6 gap-6">
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Regular}
+          twClassName="text-alternative"
+          testID={UkMigrationBottomSheetSelectors.DESCRIPTION}
+        >
+          {strings('card.uk_migration_bottom_sheet.description')}
+        </Text>
+
+        <Box twClassName="gap-4" testID={UkMigrationBottomSheetSelectors.STEPS}>
+          {steps.map((step) => (
+            <Box key={step.number} twClassName="flex-row items-center gap-3">
+              <Box twClassName="w-6 h-6 rounded-full bg-icon-default items-center justify-center">
+                <Text
+                  variant={TextVariant.BodySm}
+                  fontWeight={FontWeight.Medium}
+                  twClassName="text-background-default"
+                >
+                  {step.number}
+                </Text>
+              </Box>
+              <Text
+                variant={TextVariant.BodyMd}
+                fontWeight={FontWeight.Medium}
+                twClassName="flex-1"
+              >
+                {step.label}
+              </Text>
+            </Box>
+          ))}
+        </Box>
+
+        <Box twClassName="gap-4">
+          <Button
+            onPress={handleGetStarted}
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Lg}
+            isFullWidth
+            testID={UkMigrationBottomSheetSelectors.GET_STARTED_BUTTON}
+          >
+            {strings('card.uk_migration_bottom_sheet.get_started')}
+          </Button>
+
+          <Button
+            onPress={handleRemindLater}
+            variant={ButtonVariant.Tertiary}
+            size={ButtonSize.Lg}
+            isFullWidth
+            testID={UkMigrationBottomSheetSelectors.REMIND_LATER_BUTTON}
+          >
+            {strings('card.uk_migration_bottom_sheet.remind_me_later')}
+          </Button>
+        </Box>
+      </Box>
+    </BottomSheet>
+  );
+};
+
+export default UkMigrationBottomSheet;

--- a/app/components/UI/Card/components/UkMigrationBottomSheet/UkMigrationBottomSheet.tsx
+++ b/app/components/UI/Card/components/UkMigrationBottomSheet/UkMigrationBottomSheet.tsx
@@ -15,7 +15,8 @@ import {
 } from '@metamask/design-system-react-native';
 import { createNavigationDetails } from '../../../../../util/navigation/navUtils';
 import Routes from '../../../../../constants/navigation/Routes';
-import { strings } from '../../../../../../locales/i18n';
+import I18n, { strings } from '../../../../../../locales/i18n';
+import { getIntlDateTimeFormatter } from '../../../../../util/intl';
 import { UkMigrationBottomSheetSelectors } from './UkMigrationBottomSheet.testIds';
 
 export const createUkMigrationBottomSheetNavigationDetails =
@@ -23,6 +24,19 @@ export const createUkMigrationBottomSheetNavigationDetails =
     Routes.CARD.MODALS.ID,
     Routes.CARD.MODALS.UK_MIGRATION,
   );
+
+/**
+ * Placeholder UK migration cutoff until a remote feature flag supplies it.
+ * Month is 0-indexed (8 = September).
+ */
+const UK_MIGRATION_DEADLINE = new Date(2026, 8, 30);
+
+const formatUkMigrationDeadline = (deadline: Date): string =>
+  getIntlDateTimeFormatter(I18n.locale, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(deadline);
 
 const MIGRATION_STEP_KEYS = [
   'card.uk_migration_bottom_sheet.steps.reverify_identity',
@@ -93,12 +107,18 @@ const UkMigrationBottomSheet = () => {
           twClassName="text-alternative"
           testID={UkMigrationBottomSheetSelectors.DESCRIPTION}
         >
-          {strings('card.uk_migration_bottom_sheet.description')}
+          {strings('card.uk_migration_bottom_sheet.description', {
+            deadline: formatUkMigrationDeadline(UK_MIGRATION_DEADLINE),
+          })}
         </Text>
 
         <Box twClassName="gap-4" testID={UkMigrationBottomSheetSelectors.STEPS}>
           {steps.map((step) => (
-            <Box key={step.number} twClassName="flex-row items-center gap-3">
+            <Box
+              key={step.number}
+              twClassName="flex-row items-center gap-3"
+              testID={UkMigrationBottomSheetSelectors.step(step.number)}
+            >
               <Box twClassName="w-6 h-6 rounded-full bg-icon-default items-center justify-center">
                 <Text
                   variant={TextVariant.BodySm}

--- a/app/components/UI/Card/components/UkMigrationBottomSheet/index.ts
+++ b/app/components/UI/Card/components/UkMigrationBottomSheet/index.ts
@@ -1,0 +1,3 @@
+export { default } from './UkMigrationBottomSheet';
+export { createUkMigrationBottomSheetNavigationDetails } from './UkMigrationBottomSheet';
+export { UkMigrationBottomSheetSelectors } from './UkMigrationBottomSheet.testIds';

--- a/app/components/UI/Card/routes/index.test.tsx
+++ b/app/components/UI/Card/routes/index.test.tsx
@@ -206,6 +206,7 @@ jest.mock('../../../../constants/navigation/Routes', () => ({
       WAITLIST_FORM: 'WaitlistForm',
       FORGOT_PASSWORD: 'ForgotPassword',
       UNLINK_MONEY_ACCOUNT: 'CardUnlinkMoneyAccountSheet',
+      UK_MIGRATION: 'CardUkMigrationModal',
     },
   },
 }));

--- a/app/components/UI/Card/routes/index.tsx
+++ b/app/components/UI/Card/routes/index.tsx
@@ -31,6 +31,7 @@ import WaitlistFormModal from '../components/WaitlistFormModal/WaitlistFormModal
 import ImmersveKYCModal from '../components/ImmersveKYCModal/ImmersveKYCModal';
 import ForgotPasswordModal from '../components/ForgotPasswordModal/ForgotPasswordModal';
 import MoneyUnlinkCardSheet from '../components/MoneyUnlinkCardSheet';
+import UkMigrationBottomSheet from '../components/UkMigrationBottomSheet';
 import OrderCompleted from '../Views/OrderCompleted/OrderCompleted';
 import Cashback from '../Views/Cashback/Cashback';
 import CreditRedeem from '../Views/CreditRedeem/CreditRedeem';
@@ -204,6 +205,10 @@ const CardModalsRoutes = () => (
     <ModalsStack.Screen
       name={Routes.CARD.MODALS.UNLINK_MONEY_ACCOUNT}
       component={MoneyUnlinkCardSheet}
+    />
+    <ModalsStack.Screen
+      name={Routes.CARD.MODALS.UK_MIGRATION}
+      component={UkMigrationBottomSheet}
     />
   </ModalsStack.Navigator>
 );

--- a/app/components/UI/Card/types/navigation.ts
+++ b/app/components/UI/Card/types/navigation.ts
@@ -138,6 +138,7 @@ export type CardModalsNavigationParamList = {
   CardCreditBalanceTooltipModal: CreditBalanceTooltipParams | undefined;
   CardCreditRefundTooltipModal: { isMoneyAccount?: boolean } | undefined;
   CardUnlinkMoneyAccountSheet: MoneyUnlinkCardSheetRouteParams | undefined;
+  CardUkMigrationModal: undefined;
 };
 
 /**

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -592,6 +592,7 @@ const Routes = {
       CREDIT_BALANCE_TOOLTIP: 'CardCreditBalanceTooltipModal',
       CREDIT_REFUND_TOOLTIP: 'CardCreditRefundTooltipModal',
       UNLINK_MONEY_ACCOUNT: 'CardUnlinkMoneyAccountSheet',
+      UK_MIGRATION: 'CardUkMigrationModal',
     },
   },
   SEND: {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9419,6 +9419,17 @@
       "learn_more": "Learn more",
       "got_it": "Got it"
     },
+    "uk_migration_bottom_sheet": {
+      "title": "Update your MetaMask Card",
+      "description": "We've switched to a new card provider. To keep spending without interruption, complete these steps before Sep 30, 2026.",
+      "steps": {
+        "reverify_identity": "Re-verify your identity",
+        "get_new_card_number": "Get your new card number",
+        "convert_funds_usdc_base": "Convert your funds to USDC on Base"
+      },
+      "get_started": "Get started",
+      "remind_me_later": "Remind me later"
+    },
     "daimo_pay_modal": {
       "load_error": "Failed to load payment page. Please try again.",
       "timeout_error": "Payment verification timed out. Please check your transaction status.",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9421,7 +9421,7 @@
     },
     "uk_migration_bottom_sheet": {
       "title": "Update your MetaMask Card",
-      "description": "We've switched to a new card provider. To keep spending without interruption, complete these steps before Sep 30, 2026.",
+      "description": "We've switched to a new card provider. To keep spending without interruption, complete these steps before {{deadline}}.",
       "steps": {
         "reverify_identity": "Re-verify your identity",
         "get_new_card_number": "Get your new card number",


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds a new Card modals-stack bottom sheet (`UkMigrationBottomSheet`) that presents the “Update your MetaMask Card” prompt: title, description, numbered steps, primary **Get started**, and tertiary **Remind me later**.

- Built with MMDS `BottomSheet` / `BottomSheetHeader` and design-system buttons (Primary + Tertiary), matching other Card sheets.
- Registered on `Routes.CARD.MODALS.UK_MIGRATION` with navigation types and English i18n copy.
- Covered by unit tests for render and dismiss actions.
- Not linked from Card Home or other production entry points yet.
- **Get started** and **Remind me later** only dismiss the sheet for now; CTA navigation and persistence will be wired in a follow-up.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: CARD-556

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — sheet is registered but not reachable from production UI yet; covered by unit tests.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**



<img width="300" alt="image" src="https://github.com/user-attachments/assets/58675ffe-8942-475d-8971-b43540182f0c" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9beb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only, modal-stack registration with no production Card Home entry point; dismiss-only CTAs limit user-facing impact until follow-up wiring.
> 
> **Overview**
> Introduces a **UK card provider migration** bottom sheet on the Card modals stack so users can see the “Update your MetaMask Card” flow before production entry points exist.
> 
> The sheet shows localized copy with a **locale-formatted deadline** (hard-coded until a remote flag supplies it), three numbered migration steps, **Get started** / **Remind me later**, and header close—all wired through `Routes.CARD.MODALS.UK_MIGRATION`, navigation types, and new `en.json` strings. **Get started**, **Remind me later**, and close only dismiss the sheet today; Immersve onboarding and remind-later persistence are explicitly deferred.
> 
> Adds test IDs, unit tests for render and dismiss behavior, and exports `createUkMigrationBottomSheetNavigationDetails` for future navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3899aba0d1d8e5f82782b0295e1f75e1db2d8ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->