### PR TITLE
chore: remove redundant component

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -57,7 +57,7 @@ import ManualBackupStep1 from '../../Views/ManualBackupStep1';
 import ManualBackupStep2 from '../../Views/ManualBackupStep2';
 import ManualBackupStep3 from '../../Views/ManualBackupStep3';
 import ContactForm from '../../Views/Settings/Contacts/ContactForm';
-import ActivityView from '../../Views/ActivityView';
+import ActivityScreen from '../../Views/ActivityScreen';
 import { selectRewardsSubscriptionId } from '../../../selectors/rewards';
 import { selectIsRewardsVersionBlocked } from '../../../reducers/rewards/selectors';
 import useRewardsVersionGuard from '../../UI/Rewards/hooks/useRewardsVersionGuard';
@@ -296,7 +296,7 @@ const TransactionsHome = () => {
     >
       <NativeStack.Screen
         name={Routes.TRANSACTIONS_VIEW}
-        component={ActivityView}
+        component={ActivityScreen}
       />
       <NativeStack.Screen
         name={Routes.RAMP.ORDER_DETAILS}

--- a/app/components/UI/Perps/routes/index.tsx
+++ b/app/components/UI/Perps/routes/index.tsx
@@ -40,7 +40,7 @@ import PerpsSelectOrderTypeView from '../Views/PerpsSelectOrderTypeView';
 import PerpsOrderDetailsView from '../Views/PerpsOrderDetailsView';
 import PerpsOrderBookView from '../Views/PerpsOrderBookView';
 import PerpsHeroCardView from '../Views/PerpsHeroCardView';
-import ActivityView from '../../../Views/ActivityView';
+import ActivityScreen from '../../../Views/ActivityScreen';
 import PerpsStreamBridge from '../components/PerpsStreamBridge';
 import { HIP3DebugView } from '../Debug';
 import PerpsCrossMarginWarningBottomSheet from '../components/PerpsCrossMarginWarningBottomSheet';
@@ -419,7 +419,7 @@ const PerpsScreenStack = () => {
               />
               <Stack.Screen
                 name={Routes.PERPS.ACTIVITY}
-                component={ActivityView}
+                component={ActivityScreen}
                 options={{
                   title: strings('activity_view.title'),
                   headerShown: false,

--- a/app/components/Views/ActivityView/ActivitiesView.testIds.ts
+++ b/app/components/Views/ActivityView/ActivitiesView.testIds.ts
@@ -37,7 +37,3 @@ export const ActivitiesViewSelectorsText = {
   LENDING_DEPOSIT: enContent.transactions.tx_review_lending_deposit,
   LENDING_WITHDRAWAL: enContent.transactions.tx_review_lending_withdraw,
 };
-
-export const sentMessageTokenIDs = {
-  eth: ActivitiesViewSelectorsText.SENT_TOKENS_MESSAGE_TEXT(enContent.unit.eth),
-};

--- a/app/components/Views/ActivityView/index.js
+++ b/app/components/Views/ActivityView/index.js
@@ -1,7 +1,0 @@
-import React from 'react';
-// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import ActivityScreen from '../ActivityScreen/ActivityScreen';
-
-const ActivityView = () => <ActivityScreen />;
-
-export default ActivityView;

--- a/tests/component-view/renderers/activity.ts
+++ b/tests/component-view/renderers/activity.ts
@@ -8,7 +8,6 @@ import type { RootState } from '../../../app/reducers';
 import Routes from '../../../app/constants/navigation/Routes';
 import ActivityScreen from '../../../app/components/Views/ActivityScreen/ActivityScreen';
 import ActivityList from '../../../app/components/Views/ActivityList';
-import ActivityView from '../../../app/components/Views/ActivityView';
 import ActivityDetails from '../../../app/components/Views/ActivityDetails';
 import ActivityTypeFilterSheet from '../../../app/components/Views/ActivityScreen/components/ActivityTypeFilterSheet';
 import PerpsActivityFilterSheet from '../../../app/components/Views/ActivityScreen/components/PerpsActivityFilterSheet';
@@ -93,28 +92,11 @@ interface RenderActivityListViewWithRoutesOptions
   extraRoutes: { name: string; Component?: React.ComponentType<object> }[];
 }
 
-interface RenderActivityViewOptions {
-  overrides?: DeepPartial<RootState>;
-}
-
-interface RenderActivityViewWithRoutesOptions
-  extends RenderActivityViewOptions {
-  extraRoutes: { name: string; Component?: React.ComponentType<object> }[];
-}
-
 interface RenderActivityDetailsViewOptions {
   overrides?: DeepPartial<RootState>;
   state?: DeepPartial<RootState>;
   params: ActivityDetailsParams;
   extraRoutes?: { name: string; Component?: React.ComponentType<object> }[];
-}
-
-function ActivityViewWithProviders() {
-  return React.createElement(
-    HardwareWalletProvider,
-    null,
-    React.createElement(ActivityView as unknown as React.ComponentType),
-  );
 }
 
 function ActivityScreenWithProviders() {
@@ -269,35 +251,6 @@ export function renderActivityListViewWithRoutes(
 
   return renderScreenWithRoutes(
     ActivityListWithProviders,
-    { name: Routes.TRANSACTIONS_VIEW },
-    options.extraRoutes,
-    { state },
-  );
-}
-
-export function renderActivityView(
-  options: RenderActivityViewOptions = {},
-): ReturnType<typeof renderComponentViewScreen> {
-  const state = buildActivityState({
-    overrides: options.overrides,
-  });
-
-  return renderComponentViewScreen(
-    ActivityViewWithProviders,
-    { name: Routes.TRANSACTIONS_VIEW },
-    { state },
-  );
-}
-
-export function renderActivityViewWithRoutes(
-  options: RenderActivityViewWithRoutesOptions,
-): ReturnType<typeof renderScreenWithRoutes> {
-  const state = buildActivityState({
-    overrides: options.overrides,
-  });
-
-  return renderScreenWithRoutes(
-    ActivityViewWithProviders,
     { name: Routes.TRANSACTIONS_VIEW },
     options.extraRoutes,
     { state },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Remove redundant legacy ActivityView component (pass-through to newer ActivityScreen). No user facing changes

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal navigation and test wiring only; no behavior or user-facing UI changes.
> 
> **Overview**
> Removes the **`ActivityView`** pass-through component that only rendered **`ActivityScreen`**, and registers **`ActivityScreen`** directly on the main transactions stack (`Routes.TRANSACTIONS_VIEW`) and the Perps activity route (`Routes.PERPS.ACTIVITY`).
> 
> Component-view test helpers **`renderActivityView`** / **`renderActivityViewWithRoutes`** are dropped in favor of the existing **`ActivityScreen`** render paths. **`sentMessageTokenIDs`** is removed from **`ActivitiesView.testIds.ts`** as unused test-id exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 431f6b0e59b26563ee6293e06e8cc8aa5fa015d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->