### PR TITLE
chore: use design-system BadgeWrapper, Tag, ButtonIcon and Text in TokenList

### DIFF
--- a/app/components/UI/Tokens/TokenList/ScamWarningModal/ScamWarningModal.tsx
+++ b/app/components/UI/Tokens/TokenList/ScamWarningModal/ScamWarningModal.tsx
@@ -5,11 +5,11 @@ import Box from '../../../Ramp/Aggregator/components/Box';
 import { StyleSheet, View } from 'react-native';
 import SheetHeader from '../../../../../component-library/components/Sheet/SheetHeader';
 import { strings } from '../../../../../../locales/i18n';
-import Text from '../../../../../component-library/components/Texts/Text';
 import {
   Button,
   ButtonVariant,
   ButtonSize,
+  Text,
 } from '@metamask/design-system-react-native';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
 import { useSelector } from 'react-redux';

--- a/app/components/UI/Tokens/TokenList/TokenListItem/ScamWarningIcon/ScamWarningIcon.test.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/ScamWarningIcon/ScamWarningIcon.test.tsx
@@ -3,8 +3,7 @@ import useIsOriginalNativeTokenSymbol from '../../../../../hooks/useIsOriginalNa
 import { TokenI } from '../../../types';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { ScamWarningIcon } from './ScamWarningIcon';
-import ButtonIcon from '../../../../../../component-library/components/Buttons/ButtonIcon';
-import { IconName } from '../../../../../../component-library/components/Icons/Icon';
+import { ButtonIcon, IconName } from '@metamask/design-system-react-native';
 
 // Mock dependencies
 jest.mock('react-redux', () => ({

--- a/app/components/UI/Tokens/TokenList/TokenListItem/ScamWarningIcon/ScamWarningIcon.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/ScamWarningIcon/ScamWarningIcon.tsx
@@ -3,13 +3,12 @@ import { TokenI } from '../../../types';
 import useIsOriginalNativeTokenSymbol from '../../../../../hooks/useIsOriginalNativeTokenSymbol/useIsOriginalNativeTokenSymbol';
 import { useSelector } from 'react-redux';
 import { selectProviderConfig } from '../../../../../../selectors/networkController';
-import ButtonIcon, {
-  ButtonIconSizes,
-} from '../../../../../../component-library/components/Buttons/ButtonIcon';
 import {
+  ButtonIcon,
+  ButtonIconSize,
   IconColor,
   IconName,
-} from '../../../../../../component-library/components/Icons/Icon';
+} from '@metamask/design-system-react-native';
 
 interface ScamWarningIconProps {
   asset: TokenI & { chainId: string };
@@ -36,8 +35,8 @@ export const ScamWarningIcon = ({
         onPressIn={() => {
           setShowScamWarningModal(asset.chainId);
         }}
-        iconColor={IconColor.Error}
-        size={ButtonIconSizes.Lg}
+        iconProps={{ color: IconColor.ErrorDefault }}
+        size={ButtonIconSize.Lg}
       />
     );
   }

--- a/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.tsx
@@ -5,12 +5,6 @@ import type { AppNavigationProp } from '../../../../../core/NavigationService/ty
 import React, { useCallback, useMemo } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import { useSelector } from 'react-redux';
-import Badge, {
-  BadgeVariant,
-} from '../../../../../component-library/components/Badges/Badge';
-import BadgeWrapper, {
-  BadgePosition,
-} from '../../../../../component-library/components/Badges/BadgeWrapper';
 import { RootState } from '../../../../../reducers';
 import { isTestNet } from '../../../../../util/networks';
 import { useTheme } from '../../../../../util/theme';
@@ -23,7 +17,6 @@ import { FlashListAssetKey } from '../TokenList';
 import { selectStablecoinLendingEnabledFlag } from '../../../Earn/selectors/featureFlags';
 import { useTokenPricePercentageChange } from '../../hooks/useTokenPricePercentageChange';
 import { selectAsset } from '../../../../../selectors/assets/assets-list';
-import Tag from '../../../../../component-library/components/Tags/Tag';
 import { NetworkBadgeSource } from '../../../AssetOverview/Balance/Balance';
 import AssetLogo from '../../../Assets/components/AssetLogo/AssetLogo';
 import { ACCOUNT_TYPE_LABELS } from '../../../../../constants/account-type-labels';
@@ -71,6 +64,9 @@ import {
   SECONDARY_BALANCE_TEST_ID,
 } from '../../../AssetElement/index.constants';
 import {
+  BadgeNetwork,
+  BadgeWrapper,
+  BadgeWrapperPosition,
   Box,
   BoxAlignItems,
   BoxFlexDirection,
@@ -78,6 +74,7 @@ import {
   FontWeight,
   SensitiveText,
   SensitiveTextLength,
+  Tag,
   Text,
   TextColor,
   TextVariant,
@@ -521,6 +518,23 @@ export const TokenListItem = React.memo(
       );
     }
 
+    const assetLogoWithNetworkBadge = (
+      <BadgeWrapper
+        style={styles.badge}
+        position={BadgeWrapperPosition.BottomRight}
+        badge={
+          networkBadgeSource && (
+            <BadgeNetwork
+              src={networkBadgeSource}
+              twClassName="h-5 w-5 rounded-1"
+            />
+          )
+        }
+      >
+        <AssetLogo asset={asset} />
+      </BadgeWrapper>
+    );
+
     // Money Hub compact mUSD layout: name vertically centered, fiat over
     // native on the right, no price/24h-change row.
     if (hideSecondaryPriceRow && isMusdAsset) {
@@ -530,20 +544,7 @@ export const TokenListItem = React.memo(
           style={styles.itemWrapper}
           testID={getAssetTestId(asset.symbol)}
         >
-          <BadgeWrapper
-            style={styles.badge}
-            badgePosition={BadgePosition.BottomRight}
-            badgeElement={
-              networkBadgeSource && (
-                <Badge
-                  variant={BadgeVariant.Network}
-                  imageSource={networkBadgeSource}
-                />
-              )
-            }
-          >
-            <AssetLogo asset={asset} />
-          </BadgeWrapper>
+          {assetLogoWithNetworkBadge}
           <Box
             flexDirection={BoxFlexDirection.Row}
             alignItems={BoxAlignItems.Center}
@@ -600,20 +601,7 @@ export const TokenListItem = React.memo(
         testID={getAssetTestId(asset.symbol)}
       >
         {/* Column: 1 - Token logo */}
-        <BadgeWrapper
-          style={styles.badge}
-          badgePosition={BadgePosition.BottomRight}
-          badgeElement={
-            networkBadgeSource && (
-              <Badge
-                variant={BadgeVariant.Network}
-                imageSource={networkBadgeSource}
-              />
-            )
-          }
-        >
-          <AssetLogo asset={asset} />
-        </BadgeWrapper>
+        {assetLogoWithNetworkBadge}
 
         {/* Column 2*/}
         <Box twClassName="flex-1 ml-5">
@@ -640,7 +628,7 @@ export const TokenListItem = React.memo(
                   {asset.name || asset.symbol}
                 </Text>
                 {label && (
-                  <Tag label={label} testID={ACCOUNT_TYPE_LABEL_TEST_ID} />
+                  <Tag testID={ACCOUNT_TYPE_LABEL_TEST_ID}>{label}</Tag>
                 )}
                 {shouldResolveCaipForSecurityBadge &&
                   caipAssetIdForSecurity && (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

> [!IMPORTANT]
> **Blocked** until [MetaMask/metamask-design-system#1471](https://github.com/MetaMask/metamask-design-system/pull/1471) is merged and published, and `@metamask/design-system-react-native` is bumped to a version that includes it (targeting [v63.0.0](https://github.com/MetaMask/metamask-design-system/releases)). That PR fixes a `BadgeWrapper` bug this PR's `BadgeNetwork` usage would otherwise be affected by.

## **Description**

Migrates `TokenListItem`, its `ScamWarningIcon`, and `ScamWarningModal` from `component-library` to their `@metamask/design-system-react-native` equivalents:

- `Badge`/`BadgeWrapper` (network badge on the token/asset logo) → `BadgeWrapper` + `BadgeNetwork`, sized/positioned to match the pattern already used in Earn's `EarnAssetIcon`.
- `Tag` → `Tag`
- `ButtonIcon` → `ButtonIcon`
- `Text` → `Text`

This is a visual-parity refactor, no behavior change intended.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3930

## **Manual testing steps**

```gherkin
Feature: Token list network badge

  Scenario: user views their token list
    Given the user has tokens on multiple networks
    When user opens the wallet home screen
    Then each token's network badge renders at the same size and position as before, with no visible regression
```

## **Screenshots/Recordings**

### **Before**

<!-- N/A, no visual change intended -->

### **After**

<!-- N/A, no visual change intended -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import and component-API swap on wallet token list UI only; no logic or data-flow changes intended.
> 
> **Overview**
> **Migrates token list scam-warning and row UI** from `component-library` to `@metamask/design-system-react-native`, intended as visual parity with no behavior change.
> 
> `TokenListItem` now uses design-system `BadgeWrapper` + `BadgeNetwork` (with `twClassName` sizing) for the network badge on the asset logo, shared via a new `assetLogoWithNetworkBadge` fragment for both standard and mUSD layouts. Account-type labels use design-system `Tag` with **children** instead of a `label` prop.
> 
> `ScamWarningIcon` and `ScamWarningModal` switch to design-system `ButtonIcon` / `Text`; the danger icon uses `ButtonIconSize.Lg`, `iconProps.color: IconColor.ErrorDefault`, and the test mocks the design-system `ButtonIcon` import.
> 
> **Note:** PR description states this is blocked until a design-system `BadgeWrapper` fix ships in `@metamask/design-system-react-native` v63+.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 620fb05aeb75ea91e1cfc48f63cbadd9cb9a718e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->