### PR TITLE
feat(predict-next): add Event About tab (PRED-1234)

### DIFF
--- a/app/components/UI/PredictNext/contracts/v1/marketData.test.ts
+++ b/app/components/UI/PredictNext/contracts/v1/marketData.test.ts
@@ -60,6 +60,18 @@ describe('Predict API canonical response parsers', () => {
     expect(result).toEqual(input);
   });
 
+  it('parses Event description without treating it as rules', () => {
+    const input = createEvent({
+      description: 'Canonical event description.',
+      rules: 'Event resolution rules.',
+    });
+
+    const result = parsePredictEvent(input);
+
+    expect(result.description).toBe('Canonical event description.');
+    expect(result.rules).toBe('Event resolution rules.');
+  });
+
   it('parses market rules and removes raw venue rule fields', () => {
     const input = createEvent({
       settlementSources: [

--- a/app/components/UI/PredictNext/views/PredictEvent/EventAbout.test.tsx
+++ b/app/components/UI/PredictNext/views/PredictEvent/EventAbout.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { EventAbout } from './EventAbout';
+import { EventAboutTestIds } from './EventAbout.testIds';
+
+const CANONICAL_DESCRIPTION = 'This event covers whether the team wins.';
+const EVENT_RULES = 'Resolves from the official league result.';
+const LONG_DESCRIPTION = `${'The event description continues. '.repeat(12).trim()}`;
+
+describe('EventAbout', () => {
+  it('renders only the canonical Event description', () => {
+    render(<EventAbout description={CANONICAL_DESCRIPTION} />);
+
+    expect(screen.getByTestId(EventAboutTestIds.TITLE)).toHaveTextContent(
+      strings('predict.event.description'),
+    );
+    expect(screen.getByTestId(EventAboutTestIds.DESCRIPTION)).toHaveTextContent(
+      CANONICAL_DESCRIPTION,
+    );
+    expect(screen.queryByTestId(EventAboutTestIds.RULES_CARD)).toBeNull();
+    expect(
+      screen.queryByText(strings('predict.rules.market_title')),
+    ).toBeNull();
+  });
+
+  it('renders Event rules in a separate card', () => {
+    render(
+      <EventAbout description={CANONICAL_DESCRIPTION} rules={EVENT_RULES} />,
+    );
+
+    expect(screen.getByTestId(EventAboutTestIds.DESCRIPTION)).toHaveTextContent(
+      CANONICAL_DESCRIPTION,
+    );
+    expect(screen.getByTestId(EventAboutTestIds.RULES_TITLE)).toHaveTextContent(
+      strings('predict.rules.title'),
+    );
+    expect(screen.getByTestId(EventAboutTestIds.RULES)).toHaveTextContent(
+      EVENT_RULES,
+    );
+    expect(
+      screen.getByTestId(EventAboutTestIds.DESCRIPTION_CARD),
+    ).not.toHaveTextContent(EVENT_RULES);
+    expect(
+      screen.getByTestId(EventAboutTestIds.RULES_CARD),
+    ).not.toHaveTextContent(CANONICAL_DESCRIPTION);
+  });
+
+  it('omits the section when description and rules are missing', () => {
+    render(<EventAbout />);
+
+    expect(screen.queryByTestId(EventAboutTestIds.SECTION)).toBeNull();
+  });
+
+  it('omits the section when description and rules are whitespace', () => {
+    render(<EventAbout description="   " rules="   " />);
+
+    expect(screen.queryByTestId(EventAboutTestIds.SECTION)).toBeNull();
+  });
+
+  it('renders a rules card when only Event rules are available', () => {
+    render(<EventAbout rules={EVENT_RULES} />);
+
+    expect(screen.getByTestId(EventAboutTestIds.RULES)).toHaveTextContent(
+      EVENT_RULES,
+    );
+    expect(screen.queryByTestId(EventAboutTestIds.DESCRIPTION_CARD)).toBeNull();
+  });
+
+  it('renders a long description in full', () => {
+    render(<EventAbout description={LONG_DESCRIPTION} />);
+
+    expect(screen.getByTestId(EventAboutTestIds.DESCRIPTION)).toHaveTextContent(
+      LONG_DESCRIPTION,
+    );
+  });
+
+  it('exposes the description heading to assistive technology', () => {
+    render(<EventAbout description={CANONICAL_DESCRIPTION} />);
+
+    expect(screen.getByTestId(EventAboutTestIds.TITLE)).toHaveProp(
+      'accessibilityRole',
+      'header',
+    );
+    expect(
+      screen.getByRole('header', {
+        name: strings('predict.event.description'),
+      }),
+    ).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/PredictNext/views/PredictEvent/EventAbout.testIds.ts
+++ b/app/components/UI/PredictNext/views/PredictEvent/EventAbout.testIds.ts
@@ -1,0 +1,9 @@
+export const EventAboutTestIds = {
+  SECTION: 'predict-next-event-about',
+  TITLE: 'predict-next-event-about-title',
+  DESCRIPTION_CARD: 'predict-next-event-about-description-card',
+  DESCRIPTION: 'predict-next-event-about-description',
+  RULES_CARD: 'predict-next-event-about-rules-card',
+  RULES_TITLE: 'predict-next-event-about-rules-title',
+  RULES: 'predict-next-event-about-rules',
+} as const;

--- a/app/components/UI/PredictNext/views/PredictEvent/EventAbout.tsx
+++ b/app/components/UI/PredictNext/views/PredictEvent/EventAbout.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import {
+  Box,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { EventAboutTestIds } from './EventAbout.testIds';
+
+export interface EventAboutProps {
+  description?: string;
+  rules?: string;
+}
+
+export const EventAbout = ({ description, rules }: EventAboutProps) => {
+  const descriptionText = description?.trim();
+  const rulesText = rules?.trim();
+  if (!descriptionText && !rulesText) {
+    return null;
+  }
+
+  return (
+    <Box testID={EventAboutTestIds.SECTION} twClassName="mt-4 gap-4">
+      {descriptionText ? (
+        <Box testID={EventAboutTestIds.DESCRIPTION_CARD} twClassName="gap-2">
+          <Text
+            testID={EventAboutTestIds.TITLE}
+            accessibilityRole="header"
+            variant={TextVariant.HeadingMd}
+          >
+            {strings('predict.event.description')}
+          </Text>
+          <Text
+            testID={EventAboutTestIds.DESCRIPTION}
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextDefault}
+          >
+            {descriptionText}
+          </Text>
+        </Box>
+      ) : null}
+      {rulesText ? (
+        <Box testID={EventAboutTestIds.RULES_CARD} twClassName="gap-2">
+          <Text
+            testID={EventAboutTestIds.RULES_TITLE}
+            accessibilityRole="header"
+            variant={TextVariant.HeadingMd}
+          >
+            {strings('predict.rules.title')}
+          </Text>
+          <Text
+            testID={EventAboutTestIds.RULES}
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextDefault}
+          >
+            {rulesText}
+          </Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+};

--- a/app/components/UI/PredictNext/views/PredictEvent/EventDetailTabs.test.tsx
+++ b/app/components/UI/PredictNext/views/PredictEvent/EventDetailTabs.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { EVENT_DETAIL_TABS, EventDetailTabs } from './EventDetailTabs';
+import { EventDetailTabsTestIds } from './EventDetailTabs.testIds';
+
+describe('EventDetailTabs', () => {
+  it('renders Outcomes and About without a Positions tab', () => {
+    render(
+      <EventDetailTabs
+        selectedTab={EVENT_DETAIL_TABS.OUTCOMES}
+        tabs={[EVENT_DETAIL_TABS.OUTCOMES, EVENT_DETAIL_TABS.ABOUT]}
+        onSelectTab={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId(EventDetailTabsTestIds.BAR)).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(
+        EventDetailTabsTestIds.tab(EVENT_DETAIL_TABS.OUTCOMES),
+      ),
+    ).toHaveTextContent(strings('predict.tabs.outcomes'));
+    expect(
+      screen.getByTestId(EventDetailTabsTestIds.tab(EVENT_DETAIL_TABS.ABOUT)),
+    ).toHaveTextContent(strings('predict.tabs.about'));
+    expect(screen.queryByText(strings('predict.tabs.positions'))).toBeNull();
+  });
+
+  it('omits the tab bar when only one tab is available', () => {
+    render(
+      <EventDetailTabs
+        selectedTab={EVENT_DETAIL_TABS.OUTCOMES}
+        tabs={[EVENT_DETAIL_TABS.OUTCOMES]}
+        onSelectTab={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId(EventDetailTabsTestIds.BAR)).toBeNull();
+  });
+
+  it('selects the About tab', () => {
+    const onSelectTab = jest.fn();
+
+    render(
+      <EventDetailTabs
+        selectedTab={EVENT_DETAIL_TABS.OUTCOMES}
+        tabs={[EVENT_DETAIL_TABS.OUTCOMES, EVENT_DETAIL_TABS.ABOUT]}
+        onSelectTab={onSelectTab}
+      />,
+    );
+    fireEvent.press(
+      screen.getByTestId(EventDetailTabsTestIds.tab(EVENT_DETAIL_TABS.ABOUT)),
+    );
+
+    expect(onSelectTab).toHaveBeenCalledWith(EVENT_DETAIL_TABS.ABOUT);
+  });
+});

--- a/app/components/UI/PredictNext/views/PredictEvent/EventDetailTabs.testIds.ts
+++ b/app/components/UI/PredictNext/views/PredictEvent/EventDetailTabs.testIds.ts
@@ -1,0 +1,4 @@
+export const EventDetailTabsTestIds = {
+  BAR: 'predict-next-event-tabs',
+  tab: (tabId: string) => `predict-next-event-tab-${tabId}`,
+} as const;

--- a/app/components/UI/PredictNext/views/PredictEvent/EventDetailTabs.tsx
+++ b/app/components/UI/PredictNext/views/PredictEvent/EventDetailTabs.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Pressable } from 'react-native';
+import {
+  Box,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { strings } from '../../../../../../locales/i18n';
+import { EventDetailTabsTestIds } from './EventDetailTabs.testIds';
+
+export const EVENT_DETAIL_TABS = {
+  OUTCOMES: 'outcomes',
+  ABOUT: 'about',
+} as const;
+
+export type EventDetailTab =
+  (typeof EVENT_DETAIL_TABS)[keyof typeof EVENT_DETAIL_TABS];
+
+const TAB_LABELS: Record<EventDetailTab, string> = {
+  [EVENT_DETAIL_TABS.OUTCOMES]: 'predict.tabs.outcomes',
+  [EVENT_DETAIL_TABS.ABOUT]: 'predict.tabs.about',
+};
+
+export interface EventDetailTabsProps {
+  selectedTab: EventDetailTab;
+  tabs: readonly EventDetailTab[];
+  onSelectTab: (tab: EventDetailTab) => void;
+}
+
+export const EventDetailTabs = ({
+  selectedTab,
+  tabs,
+  onSelectTab,
+}: EventDetailTabsProps) => {
+  const tw = useTailwind();
+
+  if (tabs.length < 2) {
+    return null;
+  }
+
+  return (
+    <Box
+      testID={EventDetailTabsTestIds.BAR}
+      twClassName="mt-6 flex-row gap-4 border-b border-muted"
+    >
+      {tabs.map((tab) => {
+        const selected = tab === selectedTab;
+
+        return (
+          <Pressable
+            key={tab}
+            testID={EventDetailTabsTestIds.tab(tab)}
+            accessibilityRole="tab"
+            accessibilityLabel={strings(TAB_LABELS[tab])}
+            accessibilityState={{ selected }}
+            onPress={() => onSelectTab(tab)}
+            style={tw.style(
+              'border-b-2 pb-2',
+              selected ? 'border-icon-default' : 'border-transparent',
+            )}
+          >
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={selected ? FontWeight.Bold : FontWeight.Medium}
+              color={
+                selected ? TextColor.TextDefault : TextColor.TextAlternative
+              }
+            >
+              {strings(TAB_LABELS[tab])}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </Box>
+  );
+};

--- a/app/components/UI/PredictNext/views/PredictEvent/PredictEventScreen.tsx
+++ b/app/components/UI/PredictNext/views/PredictEvent/PredictEventScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ScrollView, StyleSheet } from 'react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   useNavigation,
   useRoute,
@@ -43,11 +42,20 @@ import {
   GameEventHeader,
   StandardEventHeader,
 } from './internal/EventHeaders';
+import { EventAbout } from './EventAbout';
+import {
+  EVENT_DETAIL_TABS,
+  EventDetailTabs,
+  type EventDetailTab,
+} from './EventDetailTabs';
 import RulesBottomSheet from './internal/RulesBottomSheet';
 import { createMarketGroupProjection } from './internal/createMarketGroupProjection';
 import { PredictEventScreenTestIds } from './PredictEventScreen.testIds';
 
 const styles = StyleSheet.create({
+  marketGroup: {
+    flexGrow: 0,
+  },
   marketFilter: {
     height: 'auto',
     minHeight: 32,
@@ -69,26 +77,19 @@ const EventScreenLayout = ({
   children: React.ReactNode;
   footer?: React.ReactNode;
   onBack: () => void;
-}) => {
-  const tw = useTailwind();
-
-  return (
-    <Box
-      testID={PredictEventScreenTestIds.VIEW}
-      twClassName="flex-1 bg-default"
-    >
-      <HeaderStandard
-        includesTopInset
-        onBack={onBack}
-        backButtonProps={{ testID: PredictEventScreenTestIds.BACK }}
-      />
-      <ScrollView contentContainerStyle={tw.style('flex-grow')}>
-        <Box twClassName="flex-1 px-4 pb-8">{children}</Box>
-      </ScrollView>
-      {footer}
-    </Box>
-  );
-};
+}) => (
+  <Box testID={PredictEventScreenTestIds.VIEW} twClassName="flex-1 bg-default">
+    <HeaderStandard
+      includesTopInset
+      onBack={onBack}
+      backButtonProps={{ testID: PredictEventScreenTestIds.BACK }}
+    />
+    <ScrollView>
+      <Box twClassName="px-4 pb-8">{children}</Box>
+    </ScrollView>
+    {footer}
+  </Box>
+);
 
 export const PredictEventScreen = () => {
   const navigation =
@@ -98,6 +99,9 @@ export const PredictEventScreen = () => {
   const query = useEvent(venueId, eventId);
   const [hasBlockingError, setHasBlockingError] = useState(false);
   const [selectedMarketId, setSelectedMarketId] = useState<string>();
+  const [selectedTab, setSelectedTab] = useState<EventDetailTab>(
+    EVENT_DETAIL_TABS.OUTCOMES,
+  );
   const [rulesTarget, setRulesTarget] = useState<RulesTarget>(null);
   const [selectedMarketIds, setSelectedMarketIds] = useState<
     Record<string, PredictMarket['id']>
@@ -146,6 +150,7 @@ export const PredictEventScreen = () => {
   useEffect(() => {
     setSelectedMarketId(undefined);
     setSelectedMarketIds({});
+    setSelectedTab(EVENT_DETAIL_TABS.OUTCOMES);
     setRulesTarget(null);
   }, [eventId]);
   const handleBack = useCallback(
@@ -202,6 +207,14 @@ export const PredictEventScreen = () => {
   if (query.data) {
     const event = query.data;
     const eventRules = event.rules?.trim();
+    const eventDescription = event.description?.trim();
+    const aboutTabs =
+      eventDescription || eventRules
+        ? ([EVENT_DETAIL_TABS.OUTCOMES, EVENT_DETAIL_TABS.ABOUT] as const)
+        : ([EVENT_DETAIL_TABS.OUTCOMES] as const);
+    const isAboutTab =
+      selectedTab === EVENT_DETAIL_TABS.ABOUT &&
+      Boolean(eventDescription || eventRules);
     const firstProjectedMarket =
       marketProjection[0]?.type === 'group'
         ? marketProjection[0].markets[0]
@@ -329,6 +342,7 @@ export const PredictEventScreen = () => {
               value={historyMarket?.id ?? ''}
               onChange={handleMarketSelect}
               variant={FilterButtonVariant.Secondary}
+              style={styles.marketGroup}
               testID={PredictEventScreenTestIds.MARKETS}
             >
               {event.markets.map((market) => (
@@ -348,8 +362,17 @@ export const PredictEventScreen = () => {
               ))}
             </FilterButtonGroup>
           ) : null}
-          {renderMarketHistory()}
-          {marketProjection.length > 0 ? (
+          <Box twClassName="mt-4">{renderMarketHistory()}</Box>
+          <EventDetailTabs
+            selectedTab={
+              isAboutTab ? EVENT_DETAIL_TABS.ABOUT : EVENT_DETAIL_TABS.OUTCOMES
+            }
+            tabs={aboutTabs}
+            onSelectTab={setSelectedTab}
+          />
+          {isAboutTab ? (
+            <EventAbout description={eventDescription} rules={eventRules} />
+          ) : marketProjection.length > 0 ? (
             <Box
               testID={PredictEventScreenTestIds.PREDICT_SECTION}
               twClassName="mt-8 gap-[14px]"

--- a/app/components/UI/PredictNext/views/PredictEvent/PredictEventScreen.view.test.tsx
+++ b/app/components/UI/PredictNext/views/PredictEvent/PredictEventScreen.view.test.tsx
@@ -30,6 +30,9 @@ import type {
 } from '../../types';
 import { PredictHomeTestIds } from '../PredictHome/PredictHome.testIds';
 import { PredictMarketHistoryTestIds } from './internal/PredictMarketHistory.testIds';
+import { EventAboutTestIds } from './EventAbout.testIds';
+import { EVENT_DETAIL_TABS } from './EventDetailTabs';
+import { EventDetailTabsTestIds } from './EventDetailTabs.testIds';
 import { PredictEventScreenTestIds } from './PredictEventScreen.testIds';
 import { RulesBottomSheetTestIds } from './internal/RulesBottomSheet.testIds';
 
@@ -1608,6 +1611,101 @@ describe('PredictEventScreen', () => {
       'market-1',
       'ALL',
     );
+  });
+
+  it('keeps prediction cards on Outcomes and hides Positions', async () => {
+    resolveEvent(
+      createEvent({
+        description: 'Canonical event description.',
+        rules: 'Event resolution rules.',
+      }),
+    );
+    const view = renderPredictEventScreen(routeParams);
+
+    await view.findByTestId(EventDetailTabsTestIds.BAR);
+
+    expect(
+      view.getByTestId(EventDetailTabsTestIds.tab(EVENT_DETAIL_TABS.OUTCOMES)),
+    ).toHaveTextContent('Outcomes');
+    expect(
+      view.getByTestId(EventDetailTabsTestIds.tab(EVENT_DETAIL_TABS.ABOUT)),
+    ).toHaveTextContent('About');
+    expect(view.queryByText('Positions')).not.toBeOnTheScreen();
+    expect(
+      view.getByTestId(PredictEventScreenTestIds.PREDICT_SECTION),
+    ).toBeOnTheScreen();
+    expect(view.queryByTestId(EventAboutTestIds.SECTION)).not.toBeOnTheScreen();
+  });
+
+  it('renders the About tab with description and a separate rules card', async () => {
+    resolveEvent(
+      createEvent({
+        description: 'Canonical event description.',
+        rules: 'Event resolution rules.',
+      }),
+    );
+    const view = renderPredictEventScreen(routeParams);
+
+    fireEvent.press(
+      await view.findByTestId(
+        EventDetailTabsTestIds.tab(EVENT_DETAIL_TABS.ABOUT),
+      ),
+    );
+    const about = await view.findByTestId(EventAboutTestIds.SECTION);
+
+    expect(view.getByTestId(EventAboutTestIds.TITLE)).toHaveTextContent(
+      'Description',
+    );
+    expect(view.getByTestId(EventAboutTestIds.DESCRIPTION)).toHaveTextContent(
+      'Canonical event description.',
+    );
+    expect(view.getByTestId(EventAboutTestIds.RULES_TITLE)).toHaveTextContent(
+      'Rules',
+    );
+    expect(view.getByTestId(EventAboutTestIds.RULES)).toHaveTextContent(
+      'Event resolution rules.',
+    );
+    expect(
+      view.getByTestId(EventAboutTestIds.DESCRIPTION_CARD),
+    ).not.toHaveTextContent('Event resolution rules.');
+    expect(about).not.toHaveTextContent('Market rules');
+    expect(
+      view.getByTestId(PredictEventScreenTestIds.STANDARD_HEADER),
+    ).toBeOnTheScreen();
+    expect(
+      view.getByTestId(PredictMarketHistoryTestIds.VIEW),
+    ).toBeOnTheScreen();
+    expect(
+      view.queryByTestId(PredictEventScreenTestIds.PREDICT_SECTION),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('omits the About tab when description and rules are missing', async () => {
+    resolveEvent(createEvent());
+    const view = renderPredictEventScreen(routeParams);
+
+    await view.findByTestId(PredictEventScreenTestIds.STANDARD_HEADER);
+
+    expect(
+      view.queryByTestId(EventDetailTabsTestIds.BAR),
+    ).not.toBeOnTheScreen();
+    expect(view.queryByTestId(EventAboutTestIds.SECTION)).not.toBeOnTheScreen();
+  });
+
+  it('renders a long Event description on the About tab', async () => {
+    const description = `${'The event description continues. '.repeat(12).trim()}`;
+    resolveEvent(createEvent({ description }));
+    const view = renderPredictEventScreen(routeParams);
+
+    fireEvent.press(
+      await view.findByTestId(
+        EventDetailTabsTestIds.tab(EVENT_DETAIL_TABS.ABOUT),
+      ),
+    );
+
+    expect(
+      await view.findByTestId(EventAboutTestIds.DESCRIPTION),
+    ).toHaveTextContent(description);
   });
 
   it('returns Home when the Event has no originating screen', async () => {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2930,6 +2930,8 @@
       }
     },
     "event": {
+      "about": "About",
+      "description": "Description",
       "loading_accessibility_label": "Loading event",
       "unable_to_load": "Unable to load this event."
     },


### PR DESCRIPTION
<!-- Submit as a draft. UI polish and a real Kalshi Event.description can follow. -->

## **Description**

Adds a first-pass About surface to the PredictNext Kalshi Event screen.

The Event detail page now has Outcomes and About tabs under the header and chart. Outcomes still shows the existing prediction cards. About shows canonical `Event.description` and `Event.rules` as separate cards. Positions stays hidden. The tab bar is omitted when both description and rules are empty.

This does not map Kalshi `rules_primary` / `rules_secondary` into `Event.description`. Live Kalshi Events currently have no description field, so About will not appear on those pages until predict-api sends a real description or event-level rules.

Also stops the Event scroll layout from stretching the market pills when About is shorter than Outcomes.

## **Changelog**

CHANGELOG entry: Added an About tab on Predict Event detail for event description and rules

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-1234

## **Manual testing steps**

```gherkin
Feature: Event About tab

  Scenario: Outcomes stays the default tab
    Given PredictNext is enabled
    And the user opens an Event that has a description or event rules
    Then Outcomes and About tabs are visible
    And prediction cards are shown
    And Positions is not shown

  Scenario: About shows description and rules separately
    Given the same Event
    When the user selects About
    Then the description card shows Event.description
    And the rules card shows Event.rules
    And description is not labeled as Market rules
    And the header and chart stay on screen

  Scenario: no tab bar without description or rules
    Given an Event with no description and no event rules
    Then the tab bar is hidden
    And About is not shown
```

## **Screenshots/Recordings**

N/A — first-pass UI. About is only visible when the API sends `description` or event-level `rules`. Live Kalshi Events currently send neither.

### **Before**

Event detail showed prediction cards only, with no About tab.

### **After**

N/A — attach Event Screen Outcomes / About screenshots before marking ready for review.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.