### PR TITLE
ci: move Appium Android onto the android-e2e runner profile

### DIFF
--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -81,11 +81,18 @@ jobs:
     # iOS Appium smoke is not put on low-priority: those runners are often
     # preempted around ~15m wall-clock, which kills the Playwright step before
     # reports/logs upload (and before shards that no longer fail-fast can finish).
+    #
+    # Android moves to `android-e2e`, off the `android-build` profile it used to
+    # share with Gradle. Both are ubuntu-24.04 / 16x32 with the same 90 GB cache
+    # volume, so this is a no-op on shape — the point is to be able to size the
+    # two workloads apart. They are not the same workload: Gradle sits at 100%
+    # CPU-saturated and wants more, while Appium peaks at 57% of 16 vCPU and 37%
+    # of 32 GB and wants less. Right-sizing this profile is a follow-up.
     runs-on: >-
       ${{
         inputs.runner_provider == 'namespace' &&
         (inputs.platform == 'ios' && 'namespace-profile-metamask-ios-e2e' ||
-         'namespace-profile-metamask-android-build') ||
+         'namespace-profile-metamask-android-e2e') ||
         (inputs.platform == 'ios' &&
           fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe"]')) ||
         (startsWith(github.base_ref, 'release/') &&


### PR DESCRIPTION
## **Description**

Moves `Appium Smoke Tests (Android)` off `namespace-profile-metamask-android-build` (16 vCPU / 32 GB) onto `namespace-profile-metamask-android-e2e` (16 vCPU / 32 GB).

**Deliberately a no-op on capacity.** Same shape, same `ubuntu-24.04`, same 90 GB cache volume config, same custom base image. The point is to stop two unrelated workloads sharing one profile, so they can be sized apart. Right-sizing follows separately.

They pull the shape in opposite directions. Namespace instance report, 2026-08-24 → 08-30, `cancelled` excluded:

| job | peak vCPU p50 | peak RAM max | share of profile |
| --- | --- | --- | --- |
| Appium shards (n=22,282) | **9.09 / 16 (57%)** | 11.9 / 32 GB (37%) | **~90% of instance-min** |
| `Build Android E2E APKs` (n=443) | **15.96 / 16 (100%)** | 22.0 / 32 GB | |
| `build (android)` (n=11) | **16.00 / 16 (100%)** | 29.2 / 32 GB (91%) | |

The Gradle jobs are CPU-saturated and right-censored at 16 vCPU, so their real demand is unknown and may be higher. Appium never approaches either limit. While they share a profile neither can move, and Appium is the 90% that makes the profile look busy.

### Profile parity is verified, not assumed

`namespace-profile-metamask-android-e2e` (`ghpf_25jrnjlnf1o90`) builds from the same Dockerfile as `android-build`, so everything `setup-e2e-env` deliberately skips on Namespace is present:

| step skipped on Namespace | provided by the image |
| --- | --- |
| `Setup Java` | Temurin 17, `JAVA_HOME` set |
| `Install required emulator dependencies` | `libpulse0`, `libglu1-mesa`, `libnss3`, `libxss1` |
| `Restore Android system image from cache` | `platforms;android-36`, cmdline-tools, platform-tools, `emulator` on `PATH` |

Plus Node 20.18.0, Yarn 4.10.3, and `chown -R runner:runner $ANDROID_HOME`.

### Expect one temporary regression: a cold cache volume

Namespace keys the bundled cache volume per profile — today's runs report `User Bundled Cache: github-namespace-profile-metamask-android-build-MetaMask-metamask-mobile with 90GB`. Moving profiles starts a **new, empty 90 GB volume**, so the first runs pay a cold `yarn install` (~51s vs ~4s warm), a cold `.metamask` foundryup download and a cold `node_modules`. Current hit rate on the old volume is 96.4%, and the new one should converge to that within a handful of runs. Nothing to action, but the first few runs will look slower and that is expected rather than a defect.

### Not in this PR

- **The 8x16 right-size**, and the emulator core/memory budget that has to move with it. `ANDROID_EMULATOR_CI_CORES` is currently `8`, which on an 8 vCPU box would claim the whole machine, so the shape and those values have to land together.
- **Emulator cold boot**, which is the actual prize here: 171s p50 (p90 175s, max 180s) measured across 24 job logs, ~25% of a 674s job and ~1.0M vCPU-min/week. `EmulatorHelpers.ts` passes `-no-snapshot-save -no-snapshot-load -wipe-data`, so every shard boots cold. Worth its own investigation.
- **The AOSP system image is not baked**, so `sdkmanager` pulls `system-images;android-36;default;x86_64` on 100% of runs (~10s each, ~70k vCPU-min/week). This is a known trade-off documented on the `android-tag` input — the image bakes `google_apis`, which is faster to fetch but ships Play Services and a different browser engine. Fixable in the profile Dockerfile rather than here.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MCWP-736
Refs: MCWP-744

## **Manual testing steps**

N/A for app behaviour — CI runner profile only, no app code changes.

Unlike #35384, **this PR is self-validating**: `appium-smoke-tests-android` runs on `pull_request` whenever `build-android-apks` succeeds, with no label gate, so a green run here exercises the moved jobs directly rather than merely proving nothing else regressed.

**1. Confirm the shards landed on the new profile.**

```bash
gh run view --job <JOB_ID> --log | grep -E 'Machine Type|^Tag:|User Bundled Cache'
```

Expect `Machine Type: 16x32` and `Tag: namespace-profile-metamask-android-e2e`. The `User Bundled Cache` line should name the `android-e2e` volume.

**2. Confirm shape and health afterwards.**

```bash
nsc instance report --start <T0> --repository MetaMask/metamask-mobile \
  --jobname "Appium Smoke Tests (Android)" --out -
```

Expect `profile == namespace-profile-metamask-android-e2e`, `resources_cpu == 16`, `resources_ram_gb == 32`, no exit-137, and a failure rate in line with the 3.8% baseline (4.4% of completed runs). Peak vCPU and RAM should be unchanged from the numbers in the table above — if they are not, the two profiles are not actually identical and that is worth knowing before the 8x16 follow-up.

**3. Confirm the Gradle jobs are unaffected.**

`Build Android APKs / Build Android E2E APKs` should still report `Tag: namespace-profile-metamask-android-build` and remain green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI runner label change only; no app or auth logic, with Gradle jobs still on the build profile.
> 
> **Overview**
> **Namespace Android Appium smoke** jobs in `run-appium-e2e-workflow.yml` now use `namespace-profile-metamask-android-e2e` instead of `namespace-profile-metamask-android-build`, which Gradle APK builds keep using.
> 
> Capacity is unchanged (same 16 vCPU / 32 GB ubuntu-24.04 shape and 90 GB cache volume); the goal is to **decouple profiles** so E2E and build workloads can be right-sized separately. Inline comments document that Gradle runs CPU-saturated while Appium peaks much lower, with profile tuning left for a follow-up.
> 
> Expect a **short-lived cold-cache** effect on the new profile’s bundled volume (slower first runs until `yarn` / `node_modules` / `.metamask` warm up); iOS and non-Namespace runner selection are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d895b6865c84284730e7d6ad7785ea85882b50e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->