### PR TITLE
feat(predict-next): align Kalshi Event and Feed chrome with H2 2026

### DIFF
--- a/app/components/UI/PredictNext/events/cards/EventCardGame.test.tsx
+++ b/app/components/UI/PredictNext/events/cards/EventCardGame.test.tsx
@@ -139,7 +139,7 @@ describe('EventCardGame', () => {
     expect(screen.getByText('Arizona Cardinals')).toHaveStyle({ width: 80 });
     expect(
       screen.getByTestId('predict-next-game-matchup-game-event'),
-    ).toHaveStyle({ height: 80, paddingBottom: 16 });
+    ).toHaveStyle({ height: 96, paddingBottom: 16 });
     expect(
       screen.getByTestId('predict-next-game-bar-game-event'),
     ).toBeOnTheScreen();

--- a/app/components/UI/PredictNext/events/cards/EventCardGame.tsx
+++ b/app/components/UI/PredictNext/events/cards/EventCardGame.tsx
@@ -91,7 +91,7 @@ const FeaturedGameCard = ({
           <GameCard.Score selection="home" />
           <GameCard.FeaturedTeam selection="home" />
         </GameCard.Matchup>
-        <EventCard.Body twClassName="pb-2">
+        <EventCard.Body twClassName="pb-4">
           <GameCard.ProbabilityBar />
         </EventCard.Body>
       </GameCard.Navigation>

--- a/app/components/UI/PredictNext/events/cards/PredictEventCard.tsx
+++ b/app/components/UI/PredictNext/events/cards/PredictEventCard.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
 import type { PredictEvent } from '../../types';
 import { getEventGame } from '../game';
-import { EventCardGame } from './EventCardGame';
+import { EventCardGame, type EventCardGameVariant } from './EventCardGame';
 import { EventCardStandard } from './EventCardStandard';
 
 export interface PredictEventCardProps {
   event: PredictEvent;
+  variant?: EventCardGameVariant;
   onPress: () => void;
 }
 
-export const PredictEventCard = ({ event, onPress }: PredictEventCardProps) =>
+export const PredictEventCard = ({
+  event,
+  variant,
+  onPress,
+}: PredictEventCardProps) =>
   getEventGame(event) ? (
-    <EventCardGame event={event} onPress={onPress} />
+    <EventCardGame event={event} variant={variant} onPress={onPress} />
   ) : (
     <EventCardStandard event={event} onPress={onPress} />
   );

--- a/app/components/UI/PredictNext/events/cards/internal/EventCardGameParts.tsx
+++ b/app/components/UI/PredictNext/events/cards/internal/EventCardGameParts.tsx
@@ -119,32 +119,35 @@ const TeamLogo = ({
   const tw = useTailwind();
   const [failed, setFailed] = useState(false);
   const showImage = team.logoUrl && !failed;
-  const sizeClassName = size === 'large' ? 'h-10 w-10' : 'h-8 w-8';
-  const imageSizeClassName = size === 'large' ? 'h-12 w-12' : 'h-9 w-9';
+  const sizeClassName = size === 'large' ? 'h-12 w-12' : 'h-8 w-8';
 
   return (
     <Box
-      twClassName={`${sizeClassName} items-center justify-center overflow-hidden rounded-full bg-muted`}
+      twClassName={`${sizeClassName} items-center justify-center`}
       accessibilityElementsHidden
       importantForAccessibility="no-hide-descendants"
     >
       {showImage ? (
         <ExpoImage
           source={team.logoUrl}
-          style={tw.style(imageSizeClassName)}
+          style={tw.style(sizeClassName)}
           contentFit="contain"
           recyclingKey={team.logoUrl}
           onError={() => setFailed(true)}
           testID={`predict-next-game-logo-${event.id}-${selection}`}
         />
       ) : (
-        <Text
-          variant={TextVariant.BodyXs}
-          fontWeight={FontWeight.Medium}
-          testID={`predict-next-game-logo-fallback-${event.id}-${selection}`}
+        <Box
+          twClassName={`${sizeClassName} items-center justify-center rounded-full bg-muted`}
         >
-          {abbreviation}
-        </Text>
+          <Text
+            variant={TextVariant.BodyXs}
+            fontWeight={FontWeight.Medium}
+            testID={`predict-next-game-logo-fallback-${event.id}-${selection}`}
+          >
+            {abbreviation}
+          </Text>
+        </Box>
       )}
     </Box>
   );
@@ -281,7 +284,7 @@ const Matchup = ({ children }: { children: React.ReactNode }) => {
   const { event } = useGameCard();
   return (
     <Box
-      twClassName="h-20 flex-row items-center justify-between pb-4"
+      twClassName="h-24 flex-row items-center justify-between pb-4"
       testID={`predict-next-game-matchup-${event.id}`}
     >
       {children}

--- a/app/components/UI/PredictNext/views/PredictEvent/PredictEventScreen.tsx
+++ b/app/components/UI/PredictNext/views/PredictEvent/PredictEventScreen.tsx
@@ -15,6 +15,7 @@ import {
   FilterButtonGroup,
   FilterButtonVariant,
   HeaderStandard,
+  IconName,
   Text,
   TextVariant,
 } from '@metamask/design-system-react-native';
@@ -73,16 +74,41 @@ const EventScreenChrome = ({
   children,
   footer,
   onBack,
+  title,
+  onRulesPress,
 }: {
   children: React.ReactNode;
   footer?: React.ReactNode;
   onBack: () => void;
+  title?: string;
+  onRulesPress?: () => void;
 }) => (
   <Box testID={PredictEventScreenTestIds.VIEW} twClassName="flex-1 bg-default">
     <HeaderStandard
       includesTopInset
+      title={title}
+      titleProps={{
+        testID: PredictEventScreenTestIds.TITLE,
+        accessibilityRole: 'header',
+        numberOfLines: 1,
+      }}
       onBack={onBack}
       backButtonProps={{ testID: PredictEventScreenTestIds.BACK }}
+      endButtonIconProps={
+        onRulesPress
+          ? [
+              {
+                iconName: IconName.Question,
+                onPress: onRulesPress,
+                testID: PredictEventScreenTestIds.EVENT_RULES_BUTTON,
+                accessibilityLabel: strings(
+                  'predict.rules.event_accessibility_label',
+                ),
+                accessibilityRole: 'button',
+              },
+            ]
+          : undefined
+      }
     />
     {children}
     {footer}
@@ -92,14 +118,18 @@ const EventScreenChrome = ({
 const EventScreenLayout = ({
   children,
   onBack,
+  title,
+  onRulesPress,
 }: {
   children: React.ReactNode;
   onBack: () => void;
+  title?: string;
+  onRulesPress?: () => void;
 }) => {
   const tw = useTailwind();
 
   return (
-    <EventScreenChrome onBack={onBack}>
+    <EventScreenChrome onBack={onBack} title={title} onRulesPress={onRulesPress}>
       <ScrollView contentContainerStyle={tw.style('flex-grow')}>
         <Box twClassName="flex-1 px-4 pb-8">{children}</Box>
       </ScrollView>
@@ -114,7 +144,6 @@ const EventLoadedHeader = ({
   selectedMarketId,
   showPredictTitle,
   onSelectMarket,
-  onEventRulesPress,
 }: {
   event: PredictEvent;
   winnerQuotes?: WinnerQuotes;
@@ -122,7 +151,6 @@ const EventLoadedHeader = ({
   selectedMarketId?: string;
   showPredictTitle: boolean;
   onSelectMarket: (marketId: string) => void;
-  onEventRulesPress?: () => void;
 }) => {
   const game = getEventGame(event);
 
@@ -171,9 +199,9 @@ const EventLoadedHeader = ({
   return (
     <Box>
       {game ? (
-        <GameEventHeader event={event} onRulesPress={onEventRulesPress} />
+        <GameEventHeader event={event} />
       ) : (
-        <StandardEventHeader event={event} onRulesPress={onEventRulesPress} />
+        <StandardEventHeader event={event} />
       )}
       {event.markets.length > 1 && !winnerQuotes ? (
         <FilterButtonGroup
@@ -199,11 +227,11 @@ const EventLoadedHeader = ({
           ))}
         </FilterButtonGroup>
       ) : null}
-      {renderMarketHistory()}
+      <Box twClassName="mt-4 mb-6">{renderMarketHistory()}</Box>
       {showPredictTitle ? (
         <Box
           testID={PredictEventScreenTestIds.PREDICT_SECTION}
-          twClassName="mt-8 pb-[14px]"
+          twClassName="mt-2 pb-[14px]"
         >
           <Text variant={TextVariant.HeadingMd}>
             {strings('wallet.predict')}
@@ -383,7 +411,9 @@ export const PredictEventScreen = () => {
     return (
       <>
         <EventScreenChrome
+          title={event.title}
           onBack={handleBack}
+          onRulesPress={eventRules ? handleEventRulesPress : undefined}
           footer={
             game && winnerQuotes ? (
               <MarketFooterCard
@@ -411,9 +441,6 @@ export const PredictEventScreen = () => {
                 selectedMarketId={selectedMarketId}
                 showPredictTitle={marketProjection.length > 0}
                 onSelectMarket={handleMarketSelect}
-                onEventRulesPress={
-                  eventRules ? handleEventRulesPress : undefined
-                }
               />
             }
           />
@@ -431,15 +458,8 @@ export const PredictEventScreen = () => {
 
   if (query.isError || hasBlockingError) {
     return (
-      <EventScreenLayout onBack={handleBack}>
+      <EventScreenLayout title={titleSnapshot} onBack={handleBack}>
         <Box twClassName="gap-6">
-          <Text
-            testID={PredictEventScreenTestIds.TITLE}
-            accessibilityRole="header"
-            variant={TextVariant.HeadingLg}
-          >
-            {titleSnapshot}
-          </Text>
           <Box
             testID={PredictEventScreenTestIds.ERROR}
             twClassName="items-start gap-3 py-4"
@@ -466,8 +486,8 @@ export const PredictEventScreen = () => {
   }
 
   return (
-    <EventScreenLayout onBack={handleBack}>
-      <EventLoadingHeader title={titleSnapshot} />
+    <EventScreenLayout title={titleSnapshot} onBack={handleBack}>
+      <EventLoadingHeader />
     </EventScreenLayout>
   );
 };

--- a/app/components/UI/PredictNext/views/PredictEvent/PredictEventScreen.tsx
+++ b/app/components/UI/PredictNext/views/PredictEvent/PredictEventScreen.tsx
@@ -129,7 +129,11 @@ const EventScreenLayout = ({
   const tw = useTailwind();
 
   return (
-    <EventScreenChrome onBack={onBack} title={title} onRulesPress={onRulesPress}>
+    <EventScreenChrome
+      onBack={onBack}
+      title={title}
+      onRulesPress={onRulesPress}
+    >
       <ScrollView contentContainerStyle={tw.style('flex-grow')}>
         <Box twClassName="flex-1 px-4 pb-8">{children}</Box>
       </ScrollView>

--- a/app/components/UI/PredictNext/views/PredictEvent/internal/EventHeaders.tsx
+++ b/app/components/UI/PredictNext/views/PredictEvent/internal/EventHeaders.tsx
@@ -85,27 +85,26 @@ const TeamLogo = ({
   const [imageFailed, setImageFailed] = useState(false);
 
   return (
-    <Box
-      twClassName="h-12 w-12 items-center justify-center overflow-hidden rounded-full bg-muted"
-      accessible={false}
-    >
+    <Box twClassName="h-14 w-14 items-center justify-center" accessible={false}>
       {team.logoUrl && !imageFailed ? (
         <ExpoImage
           testID={PredictEventScreenTestIds.teamLogo(selection)}
           source={team.logoUrl}
           recyclingKey={team.logoUrl}
           contentFit="contain"
-          style={tw.style('h-12 w-12')}
+          style={tw.style('h-14 w-14')}
           onError={() => setImageFailed(true)}
         />
       ) : (
-        <Text
-          testID={PredictEventScreenTestIds.teamLogoFallback(selection)}
-          variant={TextVariant.BodySm}
-          fontWeight={FontWeight.Bold}
-        >
-          {abbreviation}
-        </Text>
+        <Box twClassName="h-14 w-14 items-center justify-center rounded-full bg-muted">
+          <Text
+            testID={PredictEventScreenTestIds.teamLogoFallback(selection)}
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Bold}
+          >
+            {abbreviation}
+          </Text>
+        </Box>
       )}
     </Box>
   );

--- a/app/components/UI/PredictNext/views/PredictEvent/internal/EventHeaders.tsx
+++ b/app/components/UI/PredictNext/views/PredictEvent/internal/EventHeaders.tsx
@@ -3,11 +3,7 @@ import { Image as ExpoImage } from 'expo-image';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
-  ButtonIcon,
-  ButtonIconSize,
   FontWeight,
-  IconColor,
-  IconName,
   Text,
   TextColor,
   TextVariant,
@@ -22,64 +18,35 @@ import {
 import type { PredictEvent, PredictTeam } from '../../../types';
 import { PredictEventScreenTestIds } from '../PredictEventScreen.testIds';
 
-const EventTitle = ({
-  children,
-  onRulesPress,
-}: {
-  children: string;
-  onRulesPress?: () => void;
-}) => (
-  <Box twClassName="flex-row items-center gap-2">
-    <Text
-      testID={PredictEventScreenTestIds.TITLE}
-      accessibilityRole="header"
-      variant={TextVariant.HeadingLg}
-      twClassName="min-w-0 flex-1"
-    >
-      {children}
-    </Text>
-    {onRulesPress ? (
-      <ButtonIcon
-        iconName={IconName.Question}
-        size={ButtonIconSize.Sm}
-        iconProps={{ color: IconColor.IconAlternative }}
-        onPress={onRulesPress}
-        testID={PredictEventScreenTestIds.EVENT_RULES_BUTTON}
-        accessibilityLabel={strings('predict.rules.event_accessibility_label')}
-        accessibilityRole="button"
-      />
-    ) : null}
+export const EventLoadingHeader = () => (
+  <Box
+    testID={PredictEventScreenTestIds.LOADING}
+    accessibilityLabel={strings('predict.event.loading_accessibility_label')}
+    twClassName="gap-3"
+  >
+    <Box twClassName="h-24 rounded-xl bg-muted" />
+    <Box twClassName="h-4 w-2/3 rounded bg-muted" />
   </Box>
 );
 
-export const EventLoadingHeader = ({ title }: { title: string }) => (
-  <Box twClassName="gap-4">
-    <EventTitle>{title}</EventTitle>
-    <Box
-      testID={PredictEventScreenTestIds.LOADING}
-      accessibilityLabel={strings('predict.event.loading_accessibility_label')}
-      twClassName="gap-3"
-    >
-      <Box twClassName="h-24 rounded-xl bg-muted" />
-      <Box twClassName="h-4 w-2/3 rounded bg-muted" />
-    </Box>
-  </Box>
-);
-
-export const StandardEventHeader = ({
-  event,
-  onRulesPress,
-}: {
-  event: PredictEvent;
-  onRulesPress?: () => void;
-}) => {
+export const StandardEventHeader = ({ event }: { event: PredictEvent }) => {
   const tw = useTailwind();
   const [imageFailed, setImageFailed] = useState(false);
+  const showImage = Boolean(event.imageUrl && !imageFailed);
+
+  if (!showImage && !event.subtitle) {
+    return (
+      <Box
+        testID={PredictEventScreenTestIds.STANDARD_HEADER}
+        twClassName="h-0"
+      />
+    );
+  }
 
   return (
     <Box testID={PredictEventScreenTestIds.STANDARD_HEADER} twClassName="gap-3">
       <Box twClassName="flex-row items-start gap-3">
-        {event.imageUrl && !imageFailed ? (
+        {showImage ? (
           <ExpoImage
             testID={PredictEventScreenTestIds.IMAGE}
             source={event.imageUrl}
@@ -90,18 +57,16 @@ export const StandardEventHeader = ({
             accessible={false}
           />
         ) : null}
-        <Box twClassName="min-w-0 flex-1 gap-1">
-          <EventTitle onRulesPress={onRulesPress}>{event.title}</EventTitle>
-          {event.subtitle ? (
-            <Text
-              testID={PredictEventScreenTestIds.SUBTITLE}
-              variant={TextVariant.BodyMd}
-              color={TextColor.TextAlternative}
-            >
-              {event.subtitle}
-            </Text>
-          ) : null}
-        </Box>
+        {event.subtitle ? (
+          <Text
+            testID={PredictEventScreenTestIds.SUBTITLE}
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
+            twClassName="min-w-0 flex-1"
+          >
+            {event.subtitle}
+          </Text>
+        ) : null}
       </Box>
     </Box>
   );
@@ -216,13 +181,7 @@ const GameStatus = ({
   </Box>
 );
 
-export const GameEventHeader = ({
-  event,
-  onRulesPress,
-}: {
-  event: PredictEvent;
-  onRulesPress?: () => void;
-}) => {
+export const GameEventHeader = ({ event }: { event: PredictEvent }) => {
   const game = getEventGame(event);
   if (!game) {
     return null;
@@ -232,7 +191,6 @@ export const GameEventHeader = ({
 
   return (
     <Box testID={PredictEventScreenTestIds.GAME_HEADER} twClassName="gap-6">
-      <EventTitle onRulesPress={onRulesPress}>{event.title}</EventTitle>
       <Box twClassName="flex-row items-start gap-2">
         <GameTeam
           team={presentation.teams.away.team}

--- a/app/components/UI/PredictNext/views/PredictFeedScreen/PredictFeedScreen.tsx
+++ b/app/components/UI/PredictNext/views/PredictFeedScreen/PredictFeedScreen.tsx
@@ -55,7 +55,11 @@ interface FeedEventRowProps {
 const EventSeparator = () => <Box twClassName="h-3" />;
 
 const FeedEventRow = React.memo(({ event, onOpenEvent }: FeedEventRowProps) => (
-  <PredictEventCard event={event} onPress={() => onOpenEvent(event)} />
+  <PredictEventCard
+    event={event}
+    variant="featured"
+    onPress={() => onOpenEvent(event)}
+  />
 ));
 
 const FeedLoading = () => (

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.testIds.ts
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.testIds.ts
@@ -1,5 +1,6 @@
 export const PredictHomeTestIds = {
   HOME: 'predict-next-home',
+  BACK: 'predict-next-home-back',
   SCROLL: 'predict-next-home-scroll',
   section: (feedScreenId: string) =>
     `predict-next-home-section-${feedScreenId}`,

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.tsx
@@ -7,7 +7,12 @@ import {
   useRoute,
 } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
+import {
+  Box,
+  HeaderStandard,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import { usePredictNextMeasurement } from '../../hooks/usePredictNextMeasurement';
 import { useFeed } from '../../hooks/useFeed';
 import {
@@ -92,7 +97,16 @@ export const PredictHome = () => {
   );
 
   return (
-    <Box twClassName="flex-1 pt-12" testID={PredictHomeTestIds.HOME}>
+    <Box twClassName="flex-1 bg-default" testID={PredictHomeTestIds.HOME}>
+      <HeaderStandard
+        includesTopInset
+        {...(navigation.canGoBack()
+          ? {
+              onBack: () => navigation.goBack(),
+              backButtonProps: { testID: PredictHomeTestIds.BACK },
+            }
+          : {})}
+      />
       <ScrollView testID={PredictHomeTestIds.SCROLL}>
         <Box twClassName="gap-6 px-4 pb-8">
           <Text variant={TextVariant.HeadingLg}>Predictions</Text>

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
@@ -68,8 +68,6 @@ describe('PredictHome', () => {
       homeScore: '21',
       awayQuote: 'PAC · 41¢',
       homeQuote: 'STE · 59¢',
-      competition: 'NFL',
-      volume: '$1.5M Vol',
     });
     expectPredictNextGameCard(nflSection, 'nfl-2', {
       away: 'Panthers',
@@ -78,8 +76,6 @@ describe('PredictHome', () => {
       homeScore: '7',
       awayQuote: 'PAN · 36¢',
       homeQuote: 'CAR · 64¢',
-      competition: 'NFL',
-      volume: '$2.5k Vol',
     });
     expect(
       within(nflSection).queryByText('Hidden NFL Game'),
@@ -100,8 +96,6 @@ describe('PredictHome', () => {
       homeScore: '31',
       awayQuote: 'PIT · 47¢',
       homeQuote: 'MIA · 53¢',
-      competition: 'NCAAF',
-      volume: '$500 Vol',
     });
     expectPredictNextGameCard(ncaaSection, 'ncaa-2', {
       away: 'Georgia',
@@ -110,8 +104,6 @@ describe('PredictHome', () => {
       homeScore: '0',
       awayQuote: 'GEO · 55¢',
       homeQuote: 'FLO · 45¢',
-      competition: 'NCAAF',
-      volume: '$900k Vol',
     });
     expect(
       within(ncaaSection).queryByText('Hidden College Game'),

--- a/app/components/UI/PredictNext/views/PredictHome/internal/FeedPreviewSection.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/internal/FeedPreviewSection.tsx
@@ -39,7 +39,12 @@ export const FeedPreviewSection = ({
   const renderEvent = (event: PredictEvent) => {
     const handlePress = () => onOpenEvent(event);
     return (
-      <PredictEventCard key={event.id} event={event} onPress={handlePress} />
+      <PredictEventCard
+        key={event.id}
+        event={event}
+        variant="featured"
+        onPress={handlePress}
+      />
     );
   };
 

--- a/tests/component-view/fixtures/predictNext.ts
+++ b/tests/component-view/fixtures/predictNext.ts
@@ -429,8 +429,8 @@ export const expectPredictNextGameCard = (
     homeScore: string;
     awayQuote: string;
     homeQuote: string;
-    competition: string;
-    volume: string;
+    competition?: string;
+    volume?: string;
   },
 ) => {
   const card = within(section).getByTestId(
@@ -444,6 +444,10 @@ export const expectPredictNextGameCard = (
   expect(scoped.getByText(homeScore)).toBeOnTheScreen();
   expect(scoped.getByText(awayQuote)).toBeOnTheScreen();
   expect(scoped.getByText(homeQuote)).toBeOnTheScreen();
-  expect(scoped.getByText(competition)).toBeOnTheScreen();
-  expect(scoped.getByText(volume)).toBeOnTheScreen();
+  if (competition) {
+    expect(scoped.getByText(competition)).toBeOnTheScreen();
+  }
+  if (volume) {
+    expect(scoped.getByText(volume)).toBeOnTheScreen();
+  }
 };


### PR DESCRIPTION
<!--
Submit as a draft. Attach Home / Feed / Event screenshots vs Figma before
marking ready for review.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Kalshi H2 2026 Figma for Feed and Event pages puts the Event title in the nav bar, not in the body, and uses featured matchup cards on Home and Feed. PredictNext was still showing a large in-body `HeadingLg` under the header, compact stacked game rows on those lists, and a Home screen with no real header.

This PR is first-pass chrome only. It does not change predict-api or market data.

**Event screen**
- `HeaderStandard` now owns the Event title (`event.title` once loaded, `titleSnapshot` while loading or on error).
- The in-body `EventTitle` / `HeadingLg` is gone from `GameEventHeader`, `StandardEventHeader`, loading, and error.
- Event rules stay on the right as `?` (`EVENT_RULES_BUTTON`). Figma’s right icon is share; this PR does not swap that, because existing tests and the rules sheet still use the question button.
- Chart / history is wrapped in `mt-4 mb-6`. The Predict section gap under it is `mt-2` instead of `mt-8`.
- `StandardEventHeader` still mounts a `STANDARD_HEADER` testID when there is no image and no subtitle (`h-0`), so existing view tests keep passing.

**Home and Feed**
- Home uses `HeaderStandard` (back only when `navigation.canGoBack()`). The large **Predictions** heading stays in the body.
- Home preview and Feed rows pass `variant="featured"` into `PredictEventCard`.
- `featured` is not new. `EventCardGame` already had compact vs featured compositions (`4ef4df1947`). Home and Feed never forwarded the prop, so they always rendered compact. This PR only exposes `variant` on `PredictEventCard` and uses featured on those two screens.
- Featured card body padding under the probability bar is `pb-4` so the bar-to-CTA gap matches Figma more closely.
- Featured cards omit the compact competition / volume footer. Home view assertions treat those fields as optional.

**Team logos**
- Home, Feed, and Event scoreboard helmets no longer sit in a circular `overflow-hidden` mask.
- Kalshi already sends full transparent helmets (`Team.logoUrl`). They now render with `contain` as the full icon.
- Circular gray disc + abbreviation remains only as the missing-image fallback.

**Out of scope (follow-up)**
- Event share vs rules `?`
- Home search / filter icons, available balance, Positions / Add funds / Withdraw
- About / Positions tabs (PRED-1234 remains parked at https://github.com/MetaMask/metamask-mobile/pull/35487)
- Featured team abbreviations (`GB` / `PIT` vs full names)
- Mapping Kalshi `rules_primary` / `rules_secondary` into `Event.description`

Figma: Feed and Event heading `21177:26489`, Home `21177:27627`, Event chrome `21177:24707`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Moved Predict Event titles into the navigation bar, showed featured game cards on Home and Feed, and rendered team helmets as full icons

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: Kalshi H2 2026 Feed and Event Figma (no dedicated Jira). Sibling PRED-1234 Event About stays parked at https://github.com/MetaMask/metamask-mobile/pull/35487.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Kalshi Home, Feed, and Event chrome

  Scenario: Event title lives in the nav bar
    Given PredictNext is enabled
    And the user opens a Kalshi Game Event
    Then the nav bar shows the Event title
    And the scoreboard sits under the bar with no second in-body title
    And the right header action is still rules ?

  Scenario: more space under the Event chart
    Given the same Event
    Then there is visible space between the history chart and the Predict heading

  Scenario: Home uses a real header and featured cards
    Given the user opens Predict Home
    Then a HeaderStandard is shown
    And a back button appears only when the stack can go back
    And NFL / NCAAF preview cards use the featured matchup layout
    And those cards do not show the compact competition / volume footer

  Scenario: Feed cards match Home
    Given the user opens an NFL or NCAAF Feed
    Then game rows use the same featured card as Home
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — compared against Figma H2 2026 Home / Event frames on `mm-main`. Attach Home, Feed, and Event screenshots before marking ready for review.

### **Before**

Event title was a large in-body heading. Home and Feed used compact stacked team rows.

### **After**

N/A — attach screenshots of Event title bar + chart spacing, Home featured cards, and Feed featured cards.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to PredictNext headers, card layout, and spacing; no API, auth, or market data logic.
> 
> **Overview**
> Aligns PredictNext **Home**, **Feed**, and **Event** UI with Kalshi H2 2026 Figma: nav chrome, featured game cards, and team helmet presentation.
> 
> **Event** moves the event title into `HeaderStandard` (loaded title or `titleSnapshot` while loading/on error) and keeps event rules on the header **?** action. In-body `HeadingLg` titles are removed from game/standard/loading headers; scoreboard and subtitle/image content stay in the scroll area. Chart/history and **Predict** section spacing is tightened (`mt-4 mb-6` around history, `mt-2` above Predict).
> 
> **Home and Feed** add `HeaderStandard` on Home (back only when the stack can go back). List rows now pass `variant="featured"` through `PredictEventCard` so Home previews and Feed use the featured matchup card (taller matchup row, `pb-4` under the probability bar, no compact competition/volume footer).
> 
> **Team logos** on cards and the event scoreboard drop the circular clipped mask for real logos; images render at larger sizes with `contain`, and the gray circular abbreviation fallback applies only when the image is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4c209c605a460f2689bef7c86aecfd7aa859233. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->