### PR TITLE
fix: recurring bottom sheet overlays not covering tabs

### DIFF
--- a/app/components/UI/Bridge/components/PriceRangeSheet/PriceRangeSheet.tsx
+++ b/app/components/UI/Bridge/components/PriceRangeSheet/PriceRangeSheet.tsx
@@ -8,7 +8,6 @@ import React, {
 import { Pressable } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import {
-  BottomSheet,
   BottomSheetFooter,
   BottomSheetHeader,
   Box,
@@ -46,6 +45,7 @@ import {
   FIAT_INPUT_DECIMALS,
   FIAT_KEYPAD_CURRENCY,
 } from '../../utils/sourceAmountInputMode';
+import RecurringBottomSheet from '../RecurringBottomSheet';
 import { SwapsKeypad } from '../SwapsKeypad';
 import type { SwapsKeypadRef } from '../SwapsKeypad/types';
 import { PriceRangeSheetSelectorsIDs } from './PriceRangeSheet.testIds';
@@ -329,7 +329,7 @@ const PriceRangeSheet = ({
   }
 
   return (
-    <BottomSheet
+    <RecurringBottomSheet
       ref={sheetRef}
       testID={PriceRangeSheetSelectorsIDs.SHEET}
       onClose={handleSheetClosed}
@@ -513,7 +513,7 @@ const PriceRangeSheet = ({
         onChange={handleKeypadChange}
         onClose={() => setFocusedField(null)}
       />
-    </BottomSheet>
+    </RecurringBottomSheet>
   );
 };
 

--- a/app/components/UI/Bridge/components/RecurringBottomSheet.test.tsx
+++ b/app/components/UI/Bridge/components/RecurringBottomSheet.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
-import RecurringBottomSheet, { BRIDGE_TABS_BAR_HEIGHT } from './RecurringBottomSheet';
+import RecurringBottomSheet, {
+  BRIDGE_TABS_BAR_HEIGHT,
+} from './RecurringBottomSheet';
 
 jest.mock('@metamask/design-system-react-native', () => {
   const ReactModule = jest.requireActual<typeof React>('react');

--- a/app/components/UI/Bridge/components/RecurringBottomSheet.test.tsx
+++ b/app/components/UI/Bridge/components/RecurringBottomSheet.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import RecurringBottomSheet, { BRIDGE_TABS_BAR_HEIGHT } from './RecurringBottomSheet';
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactModule = jest.requireActual<typeof React>('react');
+  const { View } = jest.requireActual<{
+    View: typeof import('react-native').View;
+  }>('react-native');
+
+  return {
+    ...jest.requireActual('@metamask/design-system-react-native'),
+    BottomSheet: ReactModule.forwardRef(function MockBottomSheet(
+      {
+        style,
+        children,
+        ...props
+      }: {
+        style?: unknown;
+        children?: React.ReactNode;
+      },
+      ref: React.Ref<unknown>,
+    ) {
+      return (
+        <View ref={ref} testID="ds-bottom-sheet" style={style} {...props}>
+          {children}
+        </View>
+      );
+    }),
+  };
+});
+
+describe('RecurringBottomSheet', () => {
+  it('pulls the overlay up by the bridge tabs bar height', () => {
+    const { getByTestId } = render(<RecurringBottomSheet />);
+
+    expect(getByTestId('ds-bottom-sheet')).toHaveStyle({
+      top: -BRIDGE_TABS_BAR_HEIGHT,
+      zIndex: 1,
+    });
+  });
+
+  it('keeps caller style after the tabs offset', () => {
+    const { getByTestId } = render(
+      <RecurringBottomSheet style={{ opacity: 0.5 }} />,
+    );
+
+    expect(getByTestId('ds-bottom-sheet')).toHaveStyle({
+      top: -BRIDGE_TABS_BAR_HEIGHT,
+      zIndex: 1,
+      opacity: 0.5,
+    });
+  });
+});

--- a/app/components/UI/Bridge/components/RecurringBottomSheet.test.tsx
+++ b/app/components/UI/Bridge/components/RecurringBottomSheet.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
 import RecurringBottomSheet, {
   BRIDGE_TABS_BAR_HEIGHT,
 } from './RecurringBottomSheet';
@@ -18,13 +19,13 @@ jest.mock('@metamask/design-system-react-native', () => {
         children,
         ...props
       }: {
-        style?: unknown;
+        style?: StyleProp<ViewStyle>;
         children?: React.ReactNode;
       },
-      ref: React.Ref<unknown>,
+      _ref: React.Ref<object>,
     ) {
       return (
-        <View ref={ref} testID="ds-bottom-sheet" style={style} {...props}>
+        <View testID="ds-bottom-sheet" style={style} {...props}>
           {children}
         </View>
       );

--- a/app/components/UI/Bridge/components/RecurringBottomSheet.test.tsx
+++ b/app/components/UI/Bridge/components/RecurringBottomSheet.test.tsx
@@ -5,6 +5,8 @@ import RecurringBottomSheet, {
   BRIDGE_TABS_BAR_HEIGHT,
 } from './RecurringBottomSheet';
 
+const CALLER_STYLE = { opacity: 0.5 };
+
 jest.mock('@metamask/design-system-react-native', () => {
   const ReactModule = jest.requireActual<typeof React>('react');
   const { View } = jest.requireActual<{
@@ -13,23 +15,23 @@ jest.mock('@metamask/design-system-react-native', () => {
 
   return {
     ...jest.requireActual('@metamask/design-system-react-native'),
-    BottomSheet: ReactModule.forwardRef(function MockBottomSheet(
-      {
-        style,
-        children,
-        ...props
-      }: {
-        style?: StyleProp<ViewStyle>;
-        children?: React.ReactNode;
-      },
-      _ref: React.Ref<object>,
-    ) {
-      return (
+    BottomSheet: ReactModule.forwardRef(
+      (
+        {
+          style,
+          children,
+          ...props
+        }: {
+          style?: StyleProp<ViewStyle>;
+          children?: React.ReactNode;
+        },
+        _ref: React.Ref<object>,
+      ) => (
         <View testID="ds-bottom-sheet" style={style} {...props}>
           {children}
         </View>
-      );
-    }),
+      ),
+    ),
   };
 });
 
@@ -45,7 +47,7 @@ describe('RecurringBottomSheet', () => {
 
   it('keeps caller style after the tabs offset', () => {
     const { getByTestId } = render(
-      <RecurringBottomSheet style={{ opacity: 0.5 }} />,
+      <RecurringBottomSheet style={CALLER_STYLE} />,
     );
 
     expect(getByTestId('ds-bottom-sheet')).toHaveStyle({

--- a/app/components/UI/Bridge/components/RecurringBottomSheet.tsx
+++ b/app/components/UI/Bridge/components/RecurringBottomSheet.tsx
@@ -12,17 +12,22 @@ import {
  */
 export const BRIDGE_TABS_BAR_HEIGHT = 40;
 
+const RECURRING_BOTTOM_SHEET_STYLE = {
+  top: -BRIDGE_TABS_BAR_HEIGHT,
+  zIndex: 1,
+};
+
 const RecurringBottomSheet = forwardRef<
   BottomSheetRef,
   ComponentPropsWithoutRef<typeof BottomSheet>
->(function RecurringBottomSheet({ style, ...props }, ref) {
-  return (
-    <BottomSheet
-      {...props}
-      ref={ref}
-      style={[{ top: -BRIDGE_TABS_BAR_HEIGHT, zIndex: 1 }, style]}
-    />
-  );
-});
+>(({ style, ...props }, ref) => (
+  <BottomSheet
+    {...props}
+    ref={ref}
+    style={[RECURRING_BOTTOM_SHEET_STYLE, style]}
+  />
+));
+
+RecurringBottomSheet.displayName = 'RecurringBottomSheet';
 
 export default RecurringBottomSheet;

--- a/app/components/UI/Bridge/components/RecurringBottomSheet.tsx
+++ b/app/components/UI/Bridge/components/RecurringBottomSheet.tsx
@@ -1,0 +1,28 @@
+import React, { forwardRef, type ComponentPropsWithoutRef } from 'react';
+import {
+  BottomSheet,
+  type BottomSheetRef,
+} from '@metamask/design-system-react-native';
+
+/**
+ * TabsBar sits above Recurring tab content in BridgeView. Design-system
+ * BottomSheet is `absolute inset-0` relative to that pane, so the overlay
+ * would stop under Market / Limit / Recurring. Pull it up by the tab bar
+ * height so the dim covers those tabs. Tab layout tests use height 40.
+ */
+export const BRIDGE_TABS_BAR_HEIGHT = 40;
+
+const RecurringBottomSheet = forwardRef<
+  BottomSheetRef,
+  ComponentPropsWithoutRef<typeof BottomSheet>
+>(function RecurringBottomSheet({ style, ...props }, ref) {
+  return (
+    <BottomSheet
+      {...props}
+      ref={ref}
+      style={[{ top: -BRIDGE_TABS_BAR_HEIGHT, zIndex: 1 }, style]}
+    />
+  );
+});
+
+export default RecurringBottomSheet;

--- a/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.tsx
+++ b/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.tsx
@@ -7,7 +7,6 @@ import {
   AvatarTokenSize,
   BadgeWrapper,
   BadgeWrapperPosition,
-  BottomSheet,
   BottomSheetFooter,
   BottomSheetHeader,
   Box,
@@ -50,6 +49,7 @@ import { getNativeSourceToken } from '../../utils/tokenUtils';
 import { getSlippageDisplayValue } from '../SlippageModal/utils';
 import RewardsVipBadge from '../../../Rewards/components/RewardsVipBadge';
 import { RewardsDiscountBadge } from '../../../Rewards/components/RewardsDiscountBadge';
+import RecurringBottomSheet from '../RecurringBottomSheet';
 import { RecurringConfirmOrderSheetSelectorsIDs } from './RecurringConfirmOrderSheet.testIds';
 import type { RecurringConfirmOrderSheetProps } from './RecurringConfirmOrderSheet.types';
 
@@ -243,7 +243,7 @@ const RecurringConfirmOrderSheet = ({
   }
 
   return (
-    <BottomSheet
+    <RecurringBottomSheet
       ref={sheetRef}
       testID={RecurringConfirmOrderSheetSelectorsIDs.SHEET}
       onClose={onClose}
@@ -400,7 +400,7 @@ const RecurringConfirmOrderSheet = ({
           ) : null}
         </Box>
       ) : null}
-    </BottomSheet>
+    </RecurringBottomSheet>
   );
 };
 

--- a/app/components/UI/Bridge/components/RecurringIntervalSheet/RecurringIntervalSheet.tsx
+++ b/app/components/UI/Bridge/components/RecurringIntervalSheet/RecurringIntervalSheet.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
-  BottomSheet,
   BottomSheetFooter,
   BottomSheetHeader,
   Box,
   ListItemSelect,
   type BottomSheetRef,
 } from '@metamask/design-system-react-native';
+import RecurringBottomSheet from '../RecurringBottomSheet';
 import { strings } from '../../../../../../locales/i18n';
 import {
   RECURRING_INTERVAL_UNITS,
@@ -45,7 +45,7 @@ const RecurringIntervalSheet = ({
   }
 
   return (
-    <BottomSheet
+    <RecurringBottomSheet
       ref={sheetRef}
       testID={RecurringIntervalSheetSelectorsIDs.SHEET}
       onClose={onClose}
@@ -77,7 +77,7 @@ const RecurringIntervalSheet = ({
           testID: RecurringIntervalSheetSelectorsIDs.CONFIRM_BUTTON,
         }}
       />
-    </BottomSheet>
+    </RecurringBottomSheet>
   );
 };
 

--- a/app/components/UI/Bridge/components/RecurringRepeatInfoSheet/RecurringRepeatInfoSheet.tsx
+++ b/app/components/UI/Bridge/components/RecurringRepeatInfoSheet/RecurringRepeatInfoSheet.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useRef } from 'react';
 import {
-  BottomSheet,
   BottomSheetHeader,
   Box,
   Text,
@@ -8,6 +7,7 @@ import {
   TextVariant,
   type BottomSheetRef,
 } from '@metamask/design-system-react-native';
+import RecurringBottomSheet from '../RecurringBottomSheet';
 import { strings } from '../../../../../../locales/i18n';
 import { RecurringRepeatInfoSheetSelectorsIDs } from './RecurringRepeatInfoSheet.testIds';
 import type { RecurringRepeatInfoSheetProps } from './RecurringRepeatInfoSheet.types';
@@ -27,7 +27,7 @@ const RecurringRepeatInfoSheet = ({
   }
 
   return (
-    <BottomSheet
+    <RecurringBottomSheet
       ref={sheetRef}
       testID={RecurringRepeatInfoSheetSelectorsIDs.SHEET}
       onClose={onClose}
@@ -50,7 +50,7 @@ const RecurringRepeatInfoSheet = ({
           {strings('bridge.recurring.repeat_info_body')}
         </Text>
       </Box>
-    </BottomSheet>
+    </RecurringBottomSheet>
   );
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Recurring swap sheets (interval, repeat info, price range, confirm order) are inline design-system `BottomSheet`s mounted in the Recurring tab pane. That pane sits below the Market / Limit / Recurring `TabsBar`, and `BottomSheet` is `absolute inset-0` relative to its parent, so the dim overlay stopped under the tabs. Tapping Market or Limit while a sheet was open switched tabs and unmounted the sheet.

Market and Limit already cover those tabs because their sheets go through `Routes.BRIDGE.MODALS.ROOT` (`transparentModal` over the whole Bridge screen). Recurring stays inline.

This PR adds `RecurringBottomSheet`, a thin wrapper that pulls the overlay up by the tab bar height (`top: -40`, `zIndex: 1`) and wires the four Recurring sheets through it. The dialog still docks to the bottom of the screen.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Recurring swap bottom sheet overlays so they cover the Market, Limit, and Recurring tabs

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: Recurring tab overlay stacking follow-up; no linked GitHub or Jira ticket

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Recurring swap bottom sheet overlay covers Market / Limit / Recurring tabs

  Background:
    Given I am logged into MetaMask Mobile
    And the Limit and Recurring swap tabs are enabled
    And I open Swap and switch to the Recurring tab

  Scenario: interval sheet overlay covers the tab bar
    When user taps the Every unit control
    Then the interval bottom sheet opens
    And the dim overlay covers the Market, Limit, and Recurring tabs
    And the sheet still docks to the bottom of the screen

    When user taps the Market tab
    Then the overlay receives the tap and the sheet closes
    And I remain on the Recurring tab

  Scenario: repeat info, price range, and confirm order sheets cover the tab bar
    When user opens each of:
      | Sheet        | How to open                         |
      | Repeat info  | Repeat info icon                    |
      | Price range  | Price range row                     |
      | Confirm      | Preview order (valid quote + schedule) |
    Then the dim overlay covers the Market, Limit, and Recurring tabs
    And tapping a tab dismisses the sheet without switching tabs
```

Automated coverage run on this branch:
- `yarn jest app/components/UI/Bridge/components/RecurringBottomSheet.test.tsx` — passed
- `yarn jest app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.test.tsx` — passed
- `yarn test:view:one -- BridgeRecurringBuyView.view.test.tsx` — 78 passed

Device overlay stacking was not visually verified in this session.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**


https://github.com/user-attachments/assets/0f35414a-da50-4e09-a91f-c0816734b489


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI overlay positioning only; no changes to swap logic, quotes, or persistence.
> 
> **Overview**
> Recurring swap bottom sheets were mounted inline in the Recurring tab pane, so the design-system sheet overlay only dimmed that pane and **did not cover** the Market / Limit / Recurring tab bar. Users could switch tabs while a sheet was open, which dismissed the sheet.
> 
> This PR introduces **`RecurringBottomSheet`**, a thin `BottomSheet` wrapper that offsets the overlay by the tab bar height (`top: -40`, `zIndex: 1`) so the dim layer reaches the tabs while the sheet still docks at the bottom.
> 
> **Price range**, **interval**, **repeat info**, and **confirm order** recurring sheets now use this wrapper instead of `BottomSheet` directly. Unit tests assert the offset styles and that caller `style` props are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e24a3a6d4d083eaa6e5b9a0046dd0cfd9d3f564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->