### PR TITLE
fix(token-details): show Tron same-chain swaps on token activity

### DIFF
--- a/app/components/UI/TokenDetails/hooks/useTokenTransactions.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenTransactions.test.ts
@@ -950,14 +950,17 @@ describe('useTokenTransactions', () => {
   });
 
   describe('non-EVM asset filtering', () => {
-    const setupNonEvmMocks = (transactions: unknown[]) => {
+    const setupNonEvmMocks = (
+      transactions: unknown[],
+      bridgeHistory: Record<string, unknown> = {},
+    ) => {
       jest.mocked(isNonEvmChainId).mockReturnValue(true);
       jest
         .mocked(formatChainIdToCaip)
         .mockImplementation((chainId: unknown) => chainId as never);
       mockUseSelector.mockImplementation((selector) => {
         if (selector === selectTransactions) return [];
-        if (selector === selectBridgeHistoryForAccount) return {};
+        if (selector === selectBridgeHistoryForAccount) return bridgeHistory;
         if (selector === selectTokens) return [];
         if (selector === selectSelectedInternalAccount) {
           return { address: SOLANA_ADDRESS, metadata: { importTime: 0 } };
@@ -996,6 +999,26 @@ describe('useTokenTransactions', () => {
       time: 1,
       from: [createSolanaMovement(USDC_ASSET_ID, 'USDC')],
       to: [createSolanaMovement(USDC_ASSET_ID, 'USDC')],
+    });
+
+    const createSameChainSwapHistory = (id: string) => ({
+      [id]: {
+        status: { status: 'COMPLETE', srcChain: { txHash: id } },
+        quote: {
+          srcChainId: SOLANA_CHAIN_ID,
+          destChainId: SOLANA_CHAIN_ID,
+          srcTokenAmount: '1000000000',
+          destTokenAmount: '1000000',
+          srcAsset: {
+            assetId: SOL_ASSET_ID,
+            symbol: 'SOL',
+          },
+          destAsset: {
+            assetId: USDC_ASSET_ID,
+            symbol: 'USDC',
+          },
+        },
+      },
     });
 
     const solanaAsset = (overrides: Partial<TokenI>) =>
@@ -1048,6 +1071,43 @@ describe('useTokenTransactions', () => {
 
       expect(result.current.transactions.map((tx) => tx.id)).toEqual([
         'swap-token-page',
+      ]);
+    });
+
+    it('includes a same-chain swap on the destination token page using its bridge quote', async () => {
+      const transactionId = 'native-only-swap';
+      setupNonEvmMocks(
+        [
+          {
+            id: transactionId,
+            chain: SOLANA_CHAIN_ID,
+            status: TX_CONFIRMED,
+            type: 'send',
+            time: 2,
+            from: [createSolanaMovement(SOL_ASSET_ID, 'SOL')],
+            to: [],
+          },
+        ],
+        createSameChainSwapHistory(transactionId),
+      );
+
+      const { result } = renderHook(() =>
+        useTokenTransactions(
+          solanaAsset({
+            symbol: 'USDC',
+            name: 'USD Coin',
+            isNative: false,
+            address: USDC_ASSET_ID,
+          }),
+        ),
+      );
+
+      await waitFor(() => {
+        expect(result.current.transactionsUpdated).toBe(true);
+      });
+
+      expect(result.current.transactions.map((tx) => tx.id)).toEqual([
+        transactionId,
       ]);
     });
 

--- a/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
@@ -111,6 +111,8 @@ export const getSwapLegTokenIdentifiers = (
 
   return {
     addresses: normalize([
+      quote?.srcAsset?.assetId,
+      quote?.destAsset?.assetId,
       quote?.srcAsset?.address,
       quote?.destAsset?.address,
       tx.sourceTokenAddress,
@@ -219,6 +221,31 @@ export const useTokenTransactions = (
       const assetAddress = asset.address?.toLowerCase();
       const assetSymbol = asset.symbol?.toLowerCase();
       const isNativeAsset = asset.isNative || asset.isETH;
+      // Tron same-chain swaps often record only the
+      // native TRX send movement on the keyring transaction. Use the persisted
+      // quote to recover the received token so the swap also appears on that
+      // token's details page.
+      const quoteIncludesAsset = (tx: Transaction) => {
+        const bridgeHistoryItem = findBridgeHistoryItem({
+          bridgeHistory,
+          transactionMetaId: tx.id,
+          transactionHash: tx.id,
+        });
+        const { addresses, symbols } = getSwapLegTokenIdentifiers(
+          tx,
+          bridgeHistoryItem,
+        );
+
+        if (assetAddress && addresses.length > 0) {
+          return addresses.some(
+            (identifier) =>
+              identifier.includes(assetAddress) ||
+              assetAddress.includes(identifier),
+          );
+        }
+
+        return Boolean(assetSymbol && symbols.includes(assetSymbol));
+      };
 
       let filteredTransactions: Transaction[] = txs;
 
@@ -231,11 +258,13 @@ export const useTokenTransactions = (
         filteredTransactions = txs.filter((tx: Transaction) => {
           const txData = (tx.from || []).concat(tx.to || []);
 
-          return txData.some(
-            (participant: { asset?: { type?: string } }) =>
-              participant.asset &&
-              typeof participant.asset === 'object' &&
-              participant.asset.type === nativeAssetId,
+          return (
+            txData.some(
+              (participant: { asset?: { type?: string } }) =>
+                participant.asset &&
+                typeof participant.asset === 'object' &&
+                participant.asset.type === nativeAssetId,
+            ) || quoteIncludesAsset(tx)
           );
         });
       } else if (assetAddress || assetSymbol) {
@@ -263,7 +292,7 @@ export const useTokenTransactions = (
             },
           );
 
-          return involvesToken;
+          return involvesToken || quoteIncludesAsset(tx);
         });
       }
 
@@ -281,6 +310,7 @@ export const useTokenTransactions = (
     asset.symbol,
     asset.isNative,
     asset.isETH,
+    bridgeHistory,
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     nonEvmTransactionsData,
     ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/ActivityDetails/templates/SwapDetails.test.tsx
+++ b/app/components/Views/ActivityDetails/templates/SwapDetails.test.tsx
@@ -233,6 +233,38 @@ describe('SwapDetails', () => {
     );
   });
 
+  it('does not mark quote-backed atomic amounts as human-readable on non-EVM swaps', () => {
+    const solAssetId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501';
+
+    render(
+      <SwapDetails
+        item={
+          {
+            ...makeItem('swap', {
+              sourceToken: {
+                direction: 'out',
+                amount: '1000000000',
+                assetId: solAssetId,
+                decimals: 9,
+                symbol: 'SOL',
+              },
+            }),
+            chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          } as never
+        }
+      />,
+    );
+
+    expect(capturedSentToken).toEqual(
+      expect.objectContaining({
+        amount: '1000000000',
+        decimals: 9,
+        symbol: 'SOL',
+      }),
+    );
+    expect(capturedSentToken?.amountIsHumanReadable).toBeUndefined();
+  });
+
   describe('call-to-action', () => {
     it('renders "Lend again" instead of "Swap again" for a lending deposit', () => {
       arrangeLendAgain(true);

--- a/app/components/Views/ActivityDetails/templates/SwapDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/SwapDetails.tsx
@@ -83,14 +83,16 @@ export function SwapDetails({ item }: { item: SwapDetailsItem }) {
   );
   // Keep API decimals for Swap again, but keyring amounts are already
   // human-readable so display/fiat must not run formatUnits on them.
-  const amountIsHumanReadable = isNonEvmChainId(item.chainId);
+  // Quote-backed same-chain swaps already carry atomic amounts + decimals,
+  // so those must stay convertible.
+  const isNonEvm = isNonEvmChainId(item.chainId);
   const sourceToken = markAmountHumanReadable(
     enrichTokenFromApi(rawSourceToken, tokenData),
-    amountIsHumanReadable,
+    isNonEvm && rawSourceToken?.decimals == null,
   );
   const destinationToken = markAmountHumanReadable(
     enrichTokenFromApi(rawDestinationToken, tokenData),
-    amountIsHumanReadable,
+    isNonEvm && rawDestinationToken?.decimals == null,
   );
   const totalToken = sourceToken?.amount ? sourceToken : destinationToken;
   const handleDoItAgain = useActivityDetailsDoItAgain({

--- a/app/components/Views/ActivityList/helpers/apply-bridge-quote.test.ts
+++ b/app/components/Views/ActivityList/helpers/apply-bridge-quote.test.ts
@@ -113,14 +113,26 @@ describe('applyBridgeQuote', () => {
     });
   });
 
-  it('leaves same-chain swaps with bridge history on the regular keyring mapping', () => {
+  it('enriches a same-chain send as a swap without overriding keyring status', () => {
     const item = applyBridgeQuote(
       mapKeyringTransaction({
-        transaction: makeKeyringTx({ type: TransactionType.Swap }),
+        transaction: makeKeyringTx(),
       }) as ActivityListItem,
-      makeBridgeHistory({ destChainId: solanaChainId }),
+      makeBridgeHistory({
+        destChainId: solanaChainId,
+        bridgeStatus: StatusTypes.PENDING,
+      }),
+      'from-address',
     );
 
-    expect(item).toMatchObject({ type: 'swap', status: 'success' });
+    expect(item).toMatchObject({
+      type: 'swap',
+      status: 'success',
+      data: {
+        from: 'from-address',
+        sourceToken: { symbol: 'SOL', direction: 'out' },
+        destinationToken: { symbol: 'ETH', direction: 'in' },
+      },
+    });
   });
 });

--- a/app/components/Views/ActivityList/helpers/apply-bridge-quote.ts
+++ b/app/components/Views/ActivityList/helpers/apply-bridge-quote.ts
@@ -42,13 +42,19 @@ export function applyBridgeQuote(
 
   const isBridge = isCrossChain(quote.srcChainId, quote.destChainId);
   const fees = 'fees' in activity.data ? activity.data.fees : undefined;
-  const bridgeStatus =
-    activity.status === 'failed'
-      ? 'failed'
-      : getBridgeActivityStatus(bridgeHistory);
   // A same-chain swap is settled as soon as its keyring transaction confirms,
-  // so only bridges take their status from the bridge history.
-  const status = isBridge ? bridgeStatus : undefined;
+  // so only bridges read status and destination amount from the bridge history.
+  let status;
+  let destinationAmount = quote.destTokenAmount;
+
+  if (isBridge) {
+    status =
+      activity.status === 'failed'
+        ? 'failed'
+        : getBridgeActivityStatus(bridgeHistory);
+    destinationAmount =
+      bridgeHistory.status.destChain?.amount ?? destinationAmount;
+  }
 
   return {
     ...activity,
@@ -64,7 +70,7 @@ export function applyBridgeQuote(
         symbol: quote.srcAsset.symbol,
       },
       destinationToken: {
-        amount: bridgeHistory.status.destChain?.amount ?? quote.destTokenAmount,
+        amount: destinationAmount,
         assetId: quote.destAsset.assetId,
         decimals: quote.destAsset.decimals,
         direction: 'in',

--- a/app/components/Views/ActivityList/helpers/apply-bridge-quote.ts
+++ b/app/components/Views/ActivityList/helpers/apply-bridge-quote.ts
@@ -36,23 +36,23 @@ export function applyBridgeQuote(
   subjectAddress?: string,
 ) {
   const quote = bridgeHistory?.quote;
-  if (
-    !bridgeHistory ||
-    !quote ||
-    !isCrossChain(quote.srcChainId, quote.destChainId)
-  ) {
+  if (!bridgeHistory || !quote) {
     return activity;
   }
 
+  const isBridge = isCrossChain(quote.srcChainId, quote.destChainId);
   const fees = 'fees' in activity.data ? activity.data.fees : undefined;
-  const status =
+  const bridgeStatus =
     activity.status === 'failed'
       ? 'failed'
       : getBridgeActivityStatus(bridgeHistory);
+  // A same-chain swap is settled as soon as its keyring transaction confirms,
+  // so only bridges take their status from the bridge history.
+  const status = isBridge ? bridgeStatus : undefined;
 
   return {
     ...activity,
-    type: 'bridge',
+    type: isBridge ? 'bridge' : 'swap',
     ...(status ? { status } : {}),
     data: {
       from: subjectAddress,

--- a/app/components/Views/ActivityList/helpers/transformations.ts
+++ b/app/components/Views/ActivityList/helpers/transformations.ts
@@ -11,7 +11,6 @@ import {
   type V1TransactionByHashResponse,
   type V4MultiAccountTransactionsResponse,
 } from '@metamask/core-backend';
-import { isCrossChain } from '@metamask/bridge-controller';
 import type { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import type { Transaction as NonEvmTransaction } from '@metamask/keyring-api';
 import type { InfiniteData } from '@tanstack/react-query';
@@ -201,13 +200,8 @@ export function mapNonEvmTransactions(
       raw: { type: 'keyringTransaction' as const, data: transaction },
     } as ActivityListItem);
     const bridgeHistoryItem = getBridgeHistoryItem?.(transaction.id);
-    const quote = bridgeHistoryItem?.quote;
 
-    if (quote && isCrossChain(quote.srcChainId, quote.destChainId)) {
-      return applyBridgeQuote(activity, bridgeHistoryItem, subjectAddress);
-    }
-
-    return activity;
+    return applyBridgeQuote(activity, bridgeHistoryItem, subjectAddress);
   });
 }
 

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.test.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.test.tsx
@@ -319,7 +319,7 @@ describe('MultichainTransactionsView', () => {
     },
   );
 
-  it('keeps swaps carrying bridge history on the redesigned row instead of the legacy bridge row', async () => {
+  it('enriches same-chain swaps with quote tokens on the redesigned row', async () => {
     const bridgeHistoryItem = {
       status: { srcChain: { txHash: 'tx-123' } },
       quote: {
@@ -352,7 +352,17 @@ describe('MultichainTransactionsView', () => {
     );
 
     expect(ActivityListItemRow).toHaveBeenCalledWith(
-      expect.objectContaining({ bridgeHistoryItem }),
+      expect.objectContaining({
+        bridgeHistoryItem,
+        item: expect.objectContaining({
+          type: 'swap',
+          status: 'success',
+          data: expect.objectContaining({
+            sourceToken: expect.objectContaining({ symbol: 'SOL' }),
+            destinationToken: expect.objectContaining({ symbol: 'USDC' }),
+          }),
+        }),
+      }),
       undefined,
     );
   });

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -28,7 +28,6 @@ import PriceChartContext, {
   PriceChartProvider,
 } from '../../UI/AssetOverview/PriceChart/PriceChart.context';
 import MultichainBridgeTransactionListItem from '../../../components/UI/MultichainBridgeTransactionListItem';
-import { isCrossChain } from '@metamask/bridge-controller';
 import { KnownCaipNamespace, parseCaipChainId } from '@metamask/utils';
 import { SupportedCaipChainId } from '@metamask/multichain-network-controller';
 import { TabEmptyState } from '../../../component-library/components-temp/TabEmptyState';
@@ -250,11 +249,7 @@ const MultichainTransactionsView = ({
         const bridgeHistoryItem =
           bridgeHistoryItemsBySrcTxHash[transaction.id] ??
           bridgeHistoryItemsByDestTxHash[transaction.id];
-        const quote = bridgeHistoryItem?.quote;
-
-        if (quote && isCrossChain(quote.srcChainId, quote.destChainId)) {
-          activity = applyBridgeQuote(activity, bridgeHistoryItem, address);
-        }
+        activity = applyBridgeQuote(activity, bridgeHistoryItem, address);
 
         sourceTransactions.set(activity, transaction);
         return activity;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

After a confirmed Tron same-chain swap (Tron native TRX -> TRC20 USDT), the destination token details page showed no activity. The Tron keyring transaction often records only the native TRX movement (send transaction), while the received token lives on the unified-swap quote.

This PR includes that quote when filtering token-details activity, so the swap appears on the received token page. `applyBridgeQuote` now also maps same-chain quotes as `swap` rows and keeps the keyring confirmed status, instead of treating only cross-chain quotes.

The most important changes are:

This pull request enhances the handling and display of same-chain swaps (such as Solana or Tron swaps) in the token transaction history, activity details, and activity list. The main improvements ensure that swaps occurring on the same chain but tracked via bridge quotes are correctly shown on the destination token's details page, have their activity enriched with quote information, and are not misclassified as cross-chain bridges. Several tests are updated or added to verify this behavior.

**Token Transaction Filtering and Display Improvements**
- Updated `useTokenTransactions` to include same-chain swaps on the destination token's page by checking bridge quote assets, ensuring these swaps appear for both source and destination tokens even if the keyring transaction only records the native send. [[1]](diffhunk://#diff-4796eaaad3e348f3f03b4ea6c2ccd2c6068878a740cd0716b6d19c243855a093R224-R248) [[2]](diffhunk://#diff-4796eaaad3e348f3f03b4ea6c2ccd2c6068878a740cd0716b6d19c243855a093L234-R267) [[3]](diffhunk://#diff-4796eaaad3e348f3f03b4ea6c2ccd2c6068878a740cd0716b6d19c243855a093L266-R295)
- Extended asset identifier extraction in `getSwapLegTokenIdentifiers` to cover asset IDs from bridge quotes, improving asset matching for swaps.

**Activity List and Swap Enrichment**
- Modified `applyBridgeQuote` to enrich same-chain send transactions as swaps (not bridges), using quote data for display, and only applying bridge-specific status and amounts to true cross-chain bridges. [[1]](diffhunk://#diff-0954d789f2fe2f56be0f5feb56b64c50849f4c627e4c9fb38b1f3e9c9f48489bL39-R61) [[2]](diffhunk://#diff-0954d789f2fe2f56be0f5feb56b64c50849f4c627e4c9fb38b1f3e9c9f48489bL67-R73)
- Updated activity mapping logic to always apply bridge quote enrichment when available, regardless of whether the swap is cross-chain, and removed redundant cross-chain checks. [[1]](diffhunk://#diff-62d6c7f6c5108190c980cdffb616ce1794443fe042eaba691b31963651149525L204-L210) [[2]](diffhunk://#diff-56e7a122803fdcd063cb7159bed0deb4ff1c4cf76deb9a4d1bd0b70ab54ef9f1L253-L257)

**UI and Human-Readable Amounts**
- Refined the logic in `SwapDetails` to only mark amounts as human-readable for non-EVM swaps if decimals are not present, ensuring atomic amounts from quotes remain convertible for display/fiat.

**Test Coverage Enhancements**
- Added and updated tests to verify that same-chain swaps are included in token transaction lists, properly enriched in activity details, and correctly rendered in the redesigned activity row. [[1]](diffhunk://#diff-39a0806fc3f1fe793b1254dce4baef7488de764e9ec7172da6c3707290a3fb10L953-R963) [[2]](diffhunk://#diff-39a0806fc3f1fe793b1254dce4baef7488de764e9ec7172da6c3707290a3fb10R1004-R1023) [[3]](diffhunk://#diff-39a0806fc3f1fe793b1254dce4baef7488de764e9ec7172da6c3707290a3fb10R1077-R1113) [[4]](diffhunk://#diff-cf7653ce563fbb07934c3d093aa01ff03e4281b83478b0be90011126406383c7L116-R136) [[5]](diffhunk://#diff-f908a943a9e1289dfe9898357bf7c47bd12ed6802dded57d428f0436e977ca56R236-R267) [[6]](diffhunk://#diff-1f7199d628a1d9d72ac77dbdeed216a3c23d345d2483494f0cdf2c875e2f968fL322-R322) [[7]](diffhunk://#diff-1f7199d628a1d9d72ac77dbdeed216a3c23d345d2483494f0cdf2c875e2f968fL355-R365)

**Code Cleanup**
- Removed unnecessary imports of `isCrossChain` from files where bridge/swap type is now determined by `applyBridgeQuote`. [[1]](diffhunk://#diff-62d6c7f6c5108190c980cdffb616ce1794443fe042eaba691b31963651149525L14) [[2]](diffhunk://#diff-56e7a122803fdcd063cb7159bed0deb4ff1c4cf76deb9a4d1bd0b70ab54ef9f1L31)

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Tron same-chain swaps not appearing in the received token’s activity list

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: #35299

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Tron token details activity for same-chain swaps

  Background:
    Given I am logged into MetaMask Mobile
    And I have a Tron account with enough TRX to swap

  Scenario: received token shows the swap after TRX to USDT
    Given I swap TRX to USDT on Tron
    And the transaction is confirmed

    When user opens USDT token details
    Then Your Activity should include the swap
    And the row should show source TRX and destination USDT

  Scenario: source token still shows the swap after confirmation
    Given I completed a TRX to USDT swap on Tron

    When user opens TRX token details
    Then Your Activity should include the confirmed swap
    And the row should not stay on "Interaction in progress"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="400" height="800" alt="before" src="https://github.com/user-attachments/assets/eb30a469-a4ca-4401-a93b-9cdbac8c83a2" />


### **After**

<img width="400" height="800" alt="TRX3" src="https://github.com/user-attachments/assets/43aa5578-bea5-41d7-a172-b22f99abe1b5" />
<img width="400" height="800" alt="USDT3" src="https://github.com/user-attachments/assets/5a6b9124-ab04-4fdf-9cf7-1fef909ed567" />



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.
Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches non-EVM activity filtering and bridge-quote mapping across token details and multichain activity; wrong matching could show swaps on the wrong token page or mis-label status, but changes are scoped and well covered by tests.
> 
> **Overview**
> Fixes **missing activity on the received token** after Tron (and similar) same-chain swaps when the keyring transaction only records the native leg (e.g. TRX send) while the other leg lives on the unified-swap **bridge quote**.
> 
> **Token details:** `useTokenTransactions` now matches non-EVM txs against quote **asset IDs** (via `getSwapLegTokenIdentifiers` and `quoteIncludesAsset`) so swaps still appear on the destination token page. **Activity list:** `applyBridgeQuote` runs for every quote—same-chain rows become **`swap`** with quote tokens and **confirmed keyring status**; only true cross-chain quotes stay **`bridge`** and read pending/success from bridge history. Call sites no longer gate on `isCrossChain`.
> 
> **Swap details:** Non-EVM amounts are marked human-readable only when decimals are absent, so quote-enriched atomic amounts still format correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2ef3b27a73d40da300a1faadb6e81742e36ec25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->