### PR TITLE
chore: Quick follow up to softening security alerts warning copy

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useAddressTrustSignalAlerts.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useAddressTrustSignalAlerts.test.ts
@@ -150,7 +150,7 @@ describe('useAddressTrustSignalAlerts', () => {
         field: RowAlertKey.FromToAddress,
         message:
           "Security partners don't have enough reliable history to verify this address.",
-        title: 'Limited or mixed address signals',
+        title: 'Limited address signals',
         severity: Severity.Warning,
         isBlocking: false,
       },

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -169,7 +169,7 @@
       },
       "warning": {
         "message": "Security partners don't have enough reliable history to verify this address.",
-        "title": "Limited or mixed address signals"
+        "title": "Limited address signals"
       }
     },
     "url_trust_signal": {
@@ -5036,13 +5036,13 @@
     "malicious_token_description_no_symbol": "Security partners flag this token as high risk.",
     "malicious_token_banner_description": "Security partners flag {{symbol}} as high risk.",
     "malicious_token_banner_description_no_symbol": "Security partners flag this token as high risk.",
-    "suspicious_token_description": "{{symbol}} has limited history or risk signals.",
-    "suspicious_token_description_no_symbol": "This token has limited history or risk signals.",
+    "suspicious_token_description": "Security partners found risk signals in {{symbol}}'s contract or trading activity.",
+    "suspicious_token_description_no_symbol": "Security partners found risk signals in this token's contract or trading activity.",
     "verified_token_title": "Verified token",
     "verified_token_description": "{{symbol}} is actively traded and is widely recognized. Verification is not an endorsement by MetaMask.",
     "risky_token_title": "Suspicious token",
-    "risky_token_description": "{{symbol}} has limited history or risk signals.",
-    "risky_token_description_no_symbol": "This token has limited history or risk signals.",
+    "risky_token_description": "Security partners found risk signals in {{symbol}}'s contract or trading activity.",
+    "risky_token_description_no_symbol": "Security partners found risk signals in this token's contract or trading activity.",
     "malicious_token_sheet_description": "Security partners flag {{symbol}} as high risk.",
     "malicious_token_sheet_description_no_symbol": "Security partners flag this token as high risk.",
     "got_it": "Got it",
@@ -5052,7 +5052,7 @@
     "data_unavailable": "Security data unavailable",
     "subtitle_known": "No risk signals detected. Always research any asset before trading.",
     "subtitle_no_issues": "No risk signals detected. Always research any asset before trading.",
-    "subtitle_suspicious": "This token has limited history or risk signals.",
+    "subtitle_suspicious": "Security partners found risk signals in this token's contract or trading activity.",
     "subtitle_malicious": "Security partners flag this token as high risk.",
     "subtitle_unavailable": "Security analysis could not be loaded for this token.",
     "token_distribution": "Token distribution",


### PR DESCRIPTION
## **Description**

Lands a fix that was written for [PSAFE-509](https://consensyssoftware.atlassian.net/browse/PSAFE-509) (P1: [fix: soften trust-signal address and token security copy (#34782)](https://github.com/MetaMask/metamask-mobile/pull/34782)) but never actually merged: the commit existed on the `fix/psafe-509-alert-copy-p1` branch, but was authored *after* #34782 had already been squash-merged into `main`, so it was silently left behind on a now-dead branch. Flagged by Martin in [Slack](https://consensys.slack.com/archives/D0AGT68GU1H/p1787066900105709): mobile 8.10 still shows the pre-feedback copy for suspicious tokens.

**What's missing from `main` today, restored here:**

- `alert_system.address_trust_signal.warning.title`: "Limited or mixed address signals" → "Limited address signals"
- `security_trust.suspicious_token_description` / `_no_symbol`: "{{symbol}} has limited history or risk signals." → "Security partners found risk signals in {{symbol}}'s contract or trading activity."
- `security_trust.risky_token_description` / `_no_symbol`: same wording change (rendered via `AssetOverviewContent.tsx` and `SecurityTrust/utils/securityUtils.ts`)
- `security_trust.subtitle_suspicious`: same wording change

Verified before pushing that no other stale keys are hiding in this area: enumerated every locale key containing "suspicious"/"risky" on current `main` and confirmed the only two render sites (`AssetOverviewContent.tsx`, `securityUtils.ts`) are both covered by this change. `bridge.token_warning_*` is a separate, deliberately out-of-scope surface (bridge/swap banners), unaffected.

## **Changelog**

CHANGELOG entry: Updated the address trust-signal warning title and suspicious/risky token security copy to match the finalized PSAFE-509 wording.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PSAFE-509

## **Manual testing steps**

1. Open the token details screen for a token flagged suspicious/risky by the security provider.
2. Open the "Security and trust" section.
3. Confirm the description reads "Security partners found risk signals in <SYMBOL>'s contract or trading activity." rather than "<SYMBOL> has limited history or risk signals."
4. Trigger a confirmation whose interacting-with address is flagged Warning (not Malicious).
5. Confirm the trust-signal alert title reads "Limited address signals" rather than "Limited or mixed address signals".

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[PSAFE-509]: https://consensyssoftware.atlassian.net/browse/PSAFE-509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only updates in `en.json` plus one test assertion; no security logic, API, or data-handling changes.
> 
> **Overview**
> Restores finalized **PSAFE-509** English strings that were missing from `main`: user-facing security copy only, no behavior changes.
> 
> **Address trust signals:** the confirmation alert warning title changes from *"Limited or mixed address signals"* to **"Limited address signals"** (`alert_system.address_trust_signal.warning.title`). The hook test expectation is updated to match.
> 
> **Suspicious/risky tokens:** in **Security and trust**, descriptions for suspicious and risky tokens (with and without symbol) and `subtitle_suspicious` no longer say the token *"has limited history or risk signals"*; they now state that **security partners found risk signals in the token's contract or trading activity**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3b79ff69d50687e0f01da5d7a4f74f87f4a3135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->