### PR TITLE
fix: [Bug]: Cancel all orders button not functional in pro mode cp-8.10.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.tsx
+++ b/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.tsx
@@ -122,12 +122,16 @@ const PerpsCancelAllOrdersView: React.FC<PerpsCancelAllOrdersViewProps> = ({
     [showToast, PerpsToastOptions],
   );
 
+  // A caller-supplied list is the exact set the sheet counted for the user, and
+  // it may hold orders the provider-side `cancelAll` refuses to touch (TP/SL
+  // triggers). Scope by orderId whenever we were given one, so confirming
+  // cancels what was listed instead of silently matching nothing.
   const { isCanceling, handleCancelAll, handleKeepOrders } =
     usePerpsCancelAllOrders(orders, {
       onSuccess: handleSuccess,
       onError: handleError,
       navigateBackOnSuccess: !externalSheetRef,
-      isFiltered,
+      isFiltered: isFiltered || Boolean(propOrders),
     });
 
   const handleClose = useCallback(() => {

--- a/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.view.test.tsx
@@ -426,6 +426,55 @@ describe('PerpsCancelAllOrdersView', () => {
     });
   });
 
+  it('cancels the listed orders by id when a caller supplies them unfiltered', async () => {
+    const cancelOrders = Engine.context.PerpsController
+      .cancelOrders as jest.Mock;
+    cancelOrders.mockResolvedValue({
+      success: true,
+      successCount: 2,
+      failureCount: 0,
+      results: [],
+    });
+
+    const SuppliedCancelAll = () => {
+      const sheetRef = useRef<BottomSheetRef | null>(null);
+      return (
+        <PerpsCancelAllOrdersView
+          sheetRef={sheetRef}
+          onClose={jest.fn()}
+          orders={orders}
+        />
+      );
+    };
+
+    renderPerpsView(
+      SuppliedCancelAll as unknown as React.ComponentType,
+      Routes.PERPS.MODALS.CANCEL_ALL_ORDERS,
+      { streamOverrides: { orders } },
+    );
+
+    await screen.findByTestId(
+      PerpsCancelAllOrdersViewSelectorsIDs.CANCEL_ALL_BUTTON,
+    );
+
+    await act(async () => {
+      await fireEvent.press(
+        screen.getByTestId(
+          PerpsCancelAllOrdersViewSelectorsIDs.CANCEL_ALL_BUTTON,
+        ),
+      );
+    });
+
+    // The Pro panel supplies TP/SL orders that provider-side cancelAll skips,
+    // so the listed orders must be cancelled by id even with no active filter.
+    await waitFor(() => {
+      expect(cancelOrders).toHaveBeenCalledWith({
+        orderIds: orders.map((order) => order.orderId),
+      });
+    });
+    expect(cancelOrders).not.toHaveBeenCalledWith({ cancelAll: true });
+  });
+
   it('keeps the confirm label fixed while the body carries the count', async () => {
     const FilteredCancelAll = () => {
       const sheetRef = useRef<BottomSheetRef | null>(null);

--- a/app/components/UI/Perps/hooks/usePerpsCancelAllOrders.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsCancelAllOrders.test.ts
@@ -488,4 +488,63 @@ describe('usePerpsCancelAllOrders', () => {
       .mock.calls[0];
     expect(params.symbols).toBeUndefined();
   });
+  it('surfaces an error when the request matches no cancelable order', async () => {
+    // Arrange
+    const orders = [
+      createMockOrder({ orderId: 'tp-1' }),
+      createMockOrder({ orderId: 'sl-1' }),
+    ];
+    const onError = jest.fn();
+    (
+      Engine.context.PerpsController.cancelOrders as jest.Mock
+    ).mockResolvedValue({
+      success: false,
+      successCount: 0,
+      failureCount: 0,
+      results: [],
+    });
+    const { result } = renderHook(() =>
+      usePerpsCancelAllOrders(orders, { onError }),
+    );
+
+    // Act
+    await act(async () => {
+      await result.current.handleCancelAll();
+    });
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.isCanceling).toBe(false);
+    });
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(result.current.error).not.toBeNull();
+    expect(mockNavigation.goBack).not.toHaveBeenCalled();
+  });
+
+  it('reports every listed order as failed when none could be cancelled', async () => {
+    // Arrange
+    const orders = [
+      createMockOrder({ orderId: 'tp-1' }),
+      createMockOrder({ orderId: 'sl-1' }),
+    ];
+    (
+      Engine.context.PerpsController.cancelOrders as jest.Mock
+    ).mockResolvedValue({
+      success: false,
+      successCount: 0,
+      failureCount: 0,
+      results: [],
+    });
+    const { result } = renderHook(() => usePerpsCancelAllOrders(orders));
+
+    // Act
+    await act(async () => {
+      await result.current.handleCancelAll();
+    });
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe('Failed to cancel 2 orders');
+    });
+  });
 });

--- a/app/components/UI/Perps/hooks/usePerpsCancelAllOrders.ts
+++ b/app/components/UI/Perps/hooks/usePerpsCancelAllOrders.ts
@@ -114,14 +114,6 @@ export const usePerpsCancelAllOrders = (
         }
       }
 
-      if (result.successCount === 0 && result.failureCount === 0) {
-        DevLogger.log(
-          '[PR-35475] BUG_MARKER: cancelAll matched no cancelable orders; sheet listed ' +
-            orders.length +
-            ' order(s) but nothing was cancelled and no feedback was shown',
-        );
-      }
-
       // If complete failure, throw error to trigger catch block
       if (result.successCount === 0 && result.failureCount > 0) {
         throw new Error(

--- a/app/components/UI/Perps/hooks/usePerpsCancelAllOrders.ts
+++ b/app/components/UI/Perps/hooks/usePerpsCancelAllOrders.ts
@@ -114,6 +114,14 @@ export const usePerpsCancelAllOrders = (
         }
       }
 
+      if (result.successCount === 0 && result.failureCount === 0) {
+        DevLogger.log(
+          '[PR-35475] BUG_MARKER: cancelAll matched no cancelable orders; sheet listed ' +
+            orders.length +
+            ' order(s) but nothing was cancelled and no feedback was shown',
+        );
+      }
+
       // If complete failure, throw error to trigger catch block
       if (result.successCount === 0 && result.failureCount > 0) {
         throw new Error(

--- a/app/components/UI/Perps/hooks/usePerpsCancelAllOrders.ts
+++ b/app/components/UI/Perps/hooks/usePerpsCancelAllOrders.ts
@@ -20,7 +20,8 @@ export interface UsePerpsCancelAllOrdersOptions {
   navigateBackOnSuccess?: boolean;
   /**
    * Restricts cancellation to exactly the passed orders. Without it the whole
-   * book is cancelled provider-side, which would over-cancel a filtered view.
+   * book is cancelled provider-side, which would over-cancel a filtered view
+   * and skips the TP/SL orders that a scoped caller may have listed.
    */
   isFiltered?: boolean;
 }
@@ -114,11 +115,14 @@ export const usePerpsCancelAllOrders = (
         }
       }
 
-      // If complete failure, throw error to trigger catch block
-      if (result.successCount === 0 && result.failureCount > 0) {
+      // Nothing cancelled reports as a failure of every order the sheet listed.
+      // `failureCount` is 0 when the request matched no cancelable order at all,
+      // so fall back to the listed count rather than returning quietly — a
+      // silent return reads to the user as a dead button.
+      if (result.successCount === 0) {
         throw new Error(
           strings('perps.cancel_all_modal.error_message', {
-            count: result.failureCount,
+            count: result.failureCount || orders.length,
           }),
         );
       }


### PR DESCRIPTION
## **Description**

In Pro mode the orders panel lists a position's TP/SL trigger orders, but confirming **Cancel all** sent `cancelAll: true` to the controller, and that path deliberately filters TP/SL orders out. When the listed orders were all TP/SL, nothing matched: the controller returned `successCount: 0, failureCount: 0`, which is neither a success (no toast, sheet stays open) nor a failure (the error throw is gated on `failureCount > 0`). The button read as dead.

The sheet now cancels by `orderId` whenever a caller hands it an explicit list — that list is exactly what the sheet counted for the user, so it should be exactly what gets cancelled. A "nothing cancelled" result also now surfaces an error instead of returning quietly, so this can never fail silently again.

Lite is unaffected: it passes no list and keeps using its own `hideTpSl` stream.

## **Changelog**

CHANGELOG entry: Fixed the Cancel all orders button not cancelling anything in Perps Pro mode

## **Related issues**

Fixes: [MetaMask/metamask-mobile#35475](https://github.com/MetaMask/metamask-mobile/issues/35475)

## **Manual testing steps**

```gherkin
Feature: Cancel all orders in Perps Pro mode

  Scenario: user cancels a list made up of TP/SL orders
    Given the user has an open BTC position with Take Profit and Stop Loss set
    And that position's TP/SL orders are the only open orders
    And the user is on the BTC market screen in Pro mode

    When user opens the Orders tab
    And user taps "Cancel all"
    And user confirms in the bottom sheet
    Then the listed orders are cancelled
    And a success toast confirms how many orders were cancelled
    And the bottom sheet closes
```

## **Screenshots/Recordings**

Pro mode Cancel all with only TP/SL orders listed: before it silently did nothing, now it cancels the listed orders and confirms.

<table>
<tr><td colspan="2"><strong>Confirming Cancel all in Pro mode now cancels the listed orders instead of doing nothing</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35500/before-ac1-orders-cleared.png?sha=6c4bb44db16c277f" alt="before" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35500/after-ac1-orders-cleared.png?sha=b02c201330ef86e4" alt="after" width="320" /></td>
</tr>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

The recipe below reproduces the TP/SL-only order state through real UI presses, confirms Cancel all, and asserts the controller has zero open orders afterwards. A sibling baseline recipe asserting the buggy values passes on pre-fix code, which is how the before-evidence was captured.

<details>
<summary>recipe.json</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "Pro mode Cancel all clears TP/SL-only order lists",
  "description": "Reproduces MetaMask/metamask-mobile#35475: with a Pro market whose only open orders are the position's TP/SL trigger orders, confirming Cancel all must actually cancel them instead of silently doing nothing.",
  "workflow": {
    "entry": "setup-status",
    "nodes": {
      "setup-status": {
        "action": "app.status",
        "intent": "Confirm the mobile bridge is reachable before touching Perps state",
        "next": "setup-start-state"
      },
      "setup-start-state": {
        "action": "metamask.perps.start_state",
        "intent": "Restore the unlocked fixture wallet on Perps testnet with a clean BTC market",
        "profile": "clean_market_testnet",
        "market": "BTC",
        "network": "testnet",
        "account_name": "Trading",
        "positions": {
          "state": "none"
        },
        "orders": {
          "state": "none"
        },
        "next": "setup-open-position"
      },
      "setup-open-position": {
        "action": "metamask.perps.ensure_positions",
        "intent": "Open the BTC position that the TP/SL trigger orders will attach to",
        "market": "BTC",
        "side": "long",
        "notional": "12",
        "state": "open",
        "next": "setup-open-market"
      },
      "setup-open-market": {
        "action": "ui.navigate",
        "intent": "Open the BTC market detail screen where the bug is reported",
        "page": "perps-market",
        "symbol": "BTC",
        "next": "setup-ensure-pro"
      },
      "setup-ensure-pro": {
        "action": "metamask.perps.ensure_mode",
        "intent": "Reach Pro mode, the only mode where this defect is reported",
        "mode": "pro",
        "timeout_ms": 30000,
        "next": "setup-open-positions-tab"
      },
      "setup-open-positions-tab": {
        "action": "ui.press",
        "intent": "Show the open BTC position so its Auto close settings can be edited",
        "test_id": "perps-pro-market-positions-panel-tab-positions",
        "next": "setup-wait-edit-tpsl"
      },
      "setup-wait-edit-tpsl": {
        "action": "ui.wait_for",
        "intent": "Confirm the position row exposes its Edit TP/SL control",
        "test_id": "perps-pro-market-position-edit-tpsl",
        "expected": "present",
        "timeout_ms": 20000,
        "next": "setup-press-edit-tpsl"
      },
      "setup-press-edit-tpsl": {
        "action": "ui.press",
        "intent": "Open the Auto close editor for the BTC position",
        "test_id": "perps-pro-market-position-edit-tpsl",
        "next": "setup-wait-tpsl-sheet"
      },
      "setup-wait-tpsl-sheet": {
        "action": "ui.wait_for",
        "intent": "Confirm the Auto close editor is ready for input",
        "test_id": "perps-tpsl-set-button",
        "expected": "present",
        "timeout_ms": 20000,
        "next": "setup-set-take-profit"
      },
      "setup-set-take-profit": {
        "action": "ui.press",
        "intent": "Choose a take profit target through the visible percentage control",
        "test_id": "perps-tpsl-take-profit-percentage-button-25",
        "next": "setup-set-stop-loss"
      },
      "setup-set-stop-loss": {
        "action": "ui.press",
        "intent": "Choose a stop loss target through the visible percentage control",
        "test_id": "perps-tpsl-stop-loss-percentage-button--10",
        "next": "setup-confirm-tpsl"
      },
      "setup-confirm-tpsl": {
        "action": "ui.press",
        "intent": "Apply the Auto close settings so the position holds TP/SL trigger orders",
        "test_id": "perps-tpsl-set-button",
        "next": "gate-orders-present"
      },
      "gate-orders-present": {
        "action": "metamask.perps.assert_orders",
        "intent": "Fail loudly if the TP/SL-only precondition this bug needs was not established",
        "market": "BTC",
        "state": "open",
        "timeout_ms": 30000,
        "next": "ac1-open-orders-tab"
      },
      "ac1-open-orders-tab": {
        "action": "ui.press",
        "intent": "Show the Orders tab that lists the position's TP/SL orders",
        "test_id": "perps-pro-market-positions-panel-tab-orders",
        "next": "ac1-wait-cancel-all"
      },
      "ac1-wait-cancel-all": {
        "action": "ui.wait_for",
        "intent": "Confirm the Orders tab offers Cancel all for the listed orders",
        "test_id": "perps-pro-market-orders-cancel-all",
        "expected": "present",
        "timeout_ms": 20000,
        "next": "ac1-press-cancel-all"
      },
      "ac1-press-cancel-all": {
        "action": "ui.press",
        "intent": "Start the Cancel all journey exactly as the reporter did",
        "test_id": "perps-pro-market-orders-cancel-all",
        "next": "ac1-wait-sheet"
      },
      "ac1-wait-sheet": {
        "action": "ui.wait_for",
        "intent": "Confirm the Cancel all bottom sheet offers its confirm button",
        "test_id": "perps-cancel-all-orders-cancel-all-button",
        "expected": "present",
        "timeout_ms": 20000,
        "next": "ac1-confirm-cancel-all"
      },
      "ac1-confirm-cancel-all": {
        "action": "ui.press",
        "intent": "Confirm cancellation \u2014 the step where the reporter saw nothing happen",
        "test_id": "perps-cancel-all-orders-cancel-all-button",
        "next": "ac1-assert-orders-cancelled"
      },
      "ac1-assert-orders-cancelled": {
        "action": "metamask.perps.assert_orders",
        "intent": "Prove the listed orders were actually cancelled rather than silently ignored",
        "market": "BTC",
        "state": "none",
        "timeout_ms": 30000,
        "next": "ac1-screenshot-orders-cleared"
      },
      "ac1-screenshot-orders-cleared": {
        "action": "ui.screenshot",
        "intent": "The Orders tab no longer lists the cancelled orders after the user confirms Cancel all",
        "label": "AC1: Pro Orders tab after confirming Cancel all",
        "next": "ac2-assert-no-silent-noop"
      },
      "ac2-assert-no-silent-noop": {
        "action": "watch_logs",
        "intent": "Prove the silent no-op condition the reporter hit is no longer reachable",
        "contains": "[usePerpsCancelAllOrders] Cancel result",
        "next": "teardown-state"
      },
      "teardown-state": {
        "action": "metamask.perps.teardown_state",
        "intent": "Restore the BTC Perps test state after the check",
        "market": "BTC",
        "positions": {
          "state": "none"
        },
        "orders": {
          "state": "none"
        },
        "next": "done"
      },
      "done": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
  setup_status["setup-status<br/><i>app.status</i>"]
  setup_start_state["setup-start-state<br/><i>metamask.perps.start_state</i>"]
  setup_open_position["setup-open-position<br/><i>metamask.perps.ensure_positions</i>"]
  setup_open_market["setup-open-market<br/><i>ui.navigate</i>"]
  setup_ensure_pro["setup-ensure-pro<br/><i>metamask.perps.ensure_mode</i>"]
  setup_open_positions_tab["setup-open-positions-tab<br/><i>ui.press</i>"]
  setup_wait_edit_tpsl["setup-wait-edit-tpsl<br/><i>ui.wait_for</i>"]
  setup_press_edit_tpsl["setup-press-edit-tpsl<br/><i>ui.press</i>"]
  setup_wait_tpsl_sheet["setup-wait-tpsl-sheet<br/><i>ui.wait_for</i>"]
  setup_set_take_profit["setup-set-take-profit<br/><i>ui.press</i>"]
  setup_set_stop_loss["setup-set-stop-loss<br/><i>ui.press</i>"]
  setup_confirm_tpsl["setup-confirm-tpsl<br/><i>ui.press</i>"]
  gate_orders_present{{"gate-orders-present<br/><i>metamask.perps.assert_orders</i>"}}
  ac1_open_orders_tab["ac1-open-orders-tab<br/><i>ui.press</i>"]
  ac1_wait_cancel_all["ac1-wait-cancel-all<br/><i>ui.wait_for</i>"]
  ac1_press_cancel_all["ac1-press-cancel-all<br/><i>ui.press</i>"]
  ac1_wait_sheet["ac1-wait-sheet<br/><i>ui.wait_for</i>"]
  ac1_confirm_cancel_all["ac1-confirm-cancel-all<br/><i>ui.press</i>"]
  ac1_assert_orders_cancelled{{"ac1-assert-orders-cancelled<br/><i>metamask.perps.assert_orders</i>"}}
  ac1_screenshot_orders_cleared["ac1-screenshot-orders-cleared<br/><i>ui.screenshot</i>"]
  ac2_assert_no_silent_noop["ac2-assert-no-silent-noop<br/><i>watch_logs</i>"]
  teardown_state["teardown-state<br/><i>metamask.perps.teardown_state</i>"]
  done(["done<br/><i>end</i>"])
  setup_status --> setup_start_state
  setup_start_state --> setup_open_position
  setup_open_position --> setup_open_market
  setup_open_market --> setup_ensure_pro
  setup_ensure_pro --> setup_open_positions_tab
  setup_open_positions_tab --> setup_wait_edit_tpsl
  setup_wait_edit_tpsl --> setup_press_edit_tpsl
  setup_press_edit_tpsl --> setup_wait_tpsl_sheet
  setup_wait_tpsl_sheet --> setup_set_take_profit
  setup_set_take_profit --> setup_set_stop_loss
  setup_set_stop_loss --> setup_confirm_tpsl
  setup_confirm_tpsl --> gate_orders_present
  gate_orders_present --> ac1_open_orders_tab
  ac1_open_orders_tab --> ac1_wait_cancel_all
  ac1_wait_cancel_all --> ac1_press_cancel_all
  ac1_press_cancel_all --> ac1_wait_sheet
  ac1_wait_sheet --> ac1_confirm_cancel_all
  ac1_confirm_cancel_all --> ac1_assert_orders_cancelled
  ac1_assert_orders_cancelled --> ac1_screenshot_orders_cleared
  ac1_screenshot_orders_cleared --> ac2_assert_no_silent_noop
  ac2_assert_no_silent_noop --> teardown_state
  teardown_state --> done
```

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes order-cancellation API parameters and failure handling for a trading flow; scope is limited to Perps cancel-all UI with regression tests.
> 
> **Overview**
> Fixes **Cancel all** in Perps Pro when the sheet only lists TP/SL trigger orders: confirmation no longer calls provider **`cancelAll`** (which skips those orders) and instead cancels the **exact `orderIds`** shown whenever the parent passes an explicit `orders` list—same scoped path as an active filter (`isFiltered: isFiltered || Boolean(propOrders)`).
> 
> **`usePerpsCancelAllOrders`** now treats **`successCount === 0`** as failure even when **`failureCount` is 0**, using the listed order count in the error message so the sheet shows a toast instead of feeling like a dead button.
> 
> Lite flows that omit a list still use **`cancelAll: true`**. New view and hook tests cover Pro-style supplied lists and the zero-success edge case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 454b9f3f5809f6dabdae2ba9c9157a0f5d105187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->