### PR TITLE
refactor(activity): remove predict raw usages

### DIFF
--- a/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
+++ b/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
@@ -253,12 +253,8 @@ function perpsPositionSubtitle(
   );
 }
 
-function getPredictActivity(item: ActivityListItem) {
-  return item.raw?.type === 'predictActivity' ? item.raw.data : undefined;
-}
-
 function predictMarketSubtitle(item: ActivityListItem): string | undefined {
-  return getPredictActivity(item)?.title;
+  return 'marketTitle' in item.data ? item.data.marketTitle : undefined;
 }
 
 function protocolSubtitle(item: ActivityListItem): string | undefined {
@@ -1267,7 +1263,9 @@ export function useActivityListItemRowContent(
       : undefined
     : undefined;
   const predictIconUrl = isPredictTradeKind(item.type)
-    ? getPredictActivity(item)?.icon
+    ? 'icon' in item.data
+      ? item.data.icon
+      : undefined
     : undefined;
 
   let avatarTokens: TokenAmount[];

--- a/app/components/Views/ActivityDetails/ActivityDetails.tsx
+++ b/app/components/Views/ActivityDetails/ActivityDetails.tsx
@@ -50,11 +50,11 @@ const ActivityDetails = () => {
   const isFocused = useIsFocused();
   const { chainId, txIdentifier, preloadKey } =
     useParams<ActivityDetailsParams>();
-  // Provider-backed rows (Perps / Predict) are handed off via a transient store
-  // keyed by `preloadKey` (params stay serializable). Capture the row once per
-  // key and hold it, so a later store eviction can't blank a still-mounted
-  // screen on re-render; re-read only when the key changes (the screen is reused
-  // across navigations).
+  // Provider-backed rows (Perps) are handed off via a transient store keyed by
+  // `preloadKey` (params stay serializable). Capture the row once per key and
+  // hold it, so a later store eviction can't blank a still-mounted screen on
+  // re-render; re-read only when the key changes (the screen is reused across
+  // navigations). Predict rows re-resolve from the provider feed by id.
   const preloadedRef = useRef<{
     key?: string;
     item: ReturnType<typeof getPreloadedActivityItem>;

--- a/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import type { CaipChainId } from '@metamask/utils';
 import {
   type ActivityListItem,
+  isPredictProviderActivityKind,
   preferLocalOrApiActivityItem,
 } from '../../../../util/activity-adapters';
 import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../../selectors/multichain/multichain';
@@ -10,6 +11,7 @@ import { selectSelectedAccountGroupInternalAccounts } from '../../../../selector
 /* eslint-disable import-x/no-restricted-paths -- TODO(ADR-0020): reuses the activity list's data sources; route-isolation backlog */
 import { useLocalActivityItems } from '../../ActivityList/hooks/useLocalActivityItems';
 import { useRampActivityItems } from '../../ActivityList/hooks/useRampActivityItems';
+import { usePredictActivityItems } from '../../ActivityList/hooks/usePredictActivityItems';
 import { useTransactionsQuery } from '../../ActivityList/useTransactionsQuery';
 import { mapNonEvmTransactions } from '../../ActivityList/helpers/transformations';
 /* eslint-enable import-x/no-restricted-paths */
@@ -86,10 +88,19 @@ function buildLocalItemsByLookupKey(
 }
 
 function isProviderBackedItem(item: ActivityListItem): boolean {
-  return (
-    item.raw?.type === 'perpsTransaction' ||
-    item.raw?.type === 'predictActivity'
-  );
+  return item.raw?.type === 'perpsTransaction';
+}
+
+function getProviderBackedIdentifier(
+  item: ActivityListItem,
+): string | undefined {
+  if (item.raw?.type === 'perpsTransaction' || item.raw?.type === 'rampOrder') {
+    return item.raw.data.id;
+  }
+  if (isPredictProviderActivityKind(item.type)) {
+    return item.hash;
+  }
+  return undefined;
 }
 
 function buildItemsByIdentifier(
@@ -97,12 +108,7 @@ function buildItemsByIdentifier(
 ): Map<string, ActivityListItem> {
   const byIdentifier = buildItemsByHash(items);
   for (const item of items) {
-    const domainId =
-      item.raw?.type === 'perpsTransaction' ||
-      item.raw?.type === 'predictActivity' ||
-      item.raw?.type === 'rampOrder'
-        ? item.raw.data.id
-        : undefined;
+    const domainId = getProviderBackedIdentifier(item);
     const normalizedDomainId = domainId?.toLowerCase();
     if (normalizedDomainId && !byIdentifier.has(normalizedDomainId)) {
       byIdentifier.set(normalizedDomainId, item);
@@ -157,6 +163,7 @@ export function useActivityDetailsItem(
 ): ActivityListItem | undefined {
   const localActivityItems = useLocalActivityItems();
   const rampActivityItems = useRampActivityItems();
+  const { items: predictActivityItems } = usePredictActivityItems();
   const { data: evmTransactions } = useTransactionsQuery();
   const nonEvmState = useSelector(
     selectNonEvmTransactionsForSelectedAccountGroup,
@@ -209,6 +216,10 @@ export function useActivityDetailsItem(
     () => buildItemsByIdentifier(filterByChain(rampActivityItems, chainId)),
     [rampActivityItems, chainId],
   );
+  const predictByIdentifier = useMemo(
+    () => buildItemsByIdentifier(filterByChain(predictActivityItems, chainId)),
+    [predictActivityItems, chainId],
+  );
 
   return useMemo(() => {
     const id = txIdentifier?.toLowerCase();
@@ -241,9 +252,14 @@ export function useActivityDetailsItem(
     );
     const nonEvmItem = nonEvmByHash.get(id);
     const rampItem = rampByIdentifier.get(id);
+    const predictItem = predictByIdentifier.get(id);
 
     if (rampItem) {
       return rampItem;
+    }
+
+    if (predictItem) {
+      return predictItem;
     }
 
     if (localItem) {
@@ -274,5 +290,6 @@ export function useActivityDetailsItem(
     nonEvmByHash,
     preloadedByIdentifier,
     rampByIdentifier,
+    predictByIdentifier,
   ]);
 }

--- a/app/components/Views/ActivityDetails/hooks/usePredictActivityById.ts
+++ b/app/components/Views/ActivityDetails/hooks/usePredictActivityById.ts
@@ -1,0 +1,19 @@
+import { useMemo } from 'react';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import { usePredictActivity } from '../../../UI/Predict/hooks/usePredictActivity';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import type { PredictActivity } from '../../../UI/Predict/types';
+
+export function usePredictActivityById(
+  activityId: string | undefined,
+): PredictActivity | undefined {
+  const { activity } = usePredictActivity();
+
+  return useMemo(() => {
+    if (!activityId) {
+      return undefined;
+    }
+    const normalizedId = activityId.toLowerCase();
+    return activity.find((entry) => entry.id.toLowerCase() === normalizedId);
+  }, [activity, activityId]);
+}

--- a/app/components/Views/ActivityDetails/templates/PredictDetails/PredictDetails.types.ts
+++ b/app/components/Views/ActivityDetails/templates/PredictDetails/PredictDetails.types.ts
@@ -1,7 +1,5 @@
 import { strings } from '../../../../../../locales/i18n';
 import type { ActivityListItem } from '../../../../../util/activity-adapters';
-// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import type { PredictActivity } from '../../../../UI/Predict/types';
 
 export type PredictActivityType =
   | 'predictionsAddFunds'
@@ -18,12 +16,6 @@ export function asPredictActivityItem(
   item: ActivityListItem,
 ): PredictActivityListItem {
   return item as PredictActivityListItem;
-}
-
-export function getPredictActivity(
-  item: ActivityListItem,
-): PredictActivity | undefined {
-  return item.raw?.type === 'predictActivity' ? item.raw.data : undefined;
 }
 
 export function formatPredictDate(timestamp: number): string {

--- a/app/components/Views/ActivityDetails/templates/PredictDetails/PredictProviderActivityDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/PredictDetails/PredictProviderActivityDetails.tsx
@@ -21,9 +21,11 @@ import {
 } from '../../../../UI/Predict/utils/format';
 /* eslint-enable import-x/no-restricted-paths */
 import {
-  getPredictActivity,
+  formatPredictDate,
+  getPredictFundsStepLabels,
   type PredictActivityListItem,
 } from './PredictDetails.types';
+import { usePredictActivityById } from '../../hooks/usePredictActivityById';
 import {
   ClaimWinningsBreakdown,
   PredictHero,
@@ -38,7 +40,7 @@ export function PredictProviderActivityDetails({
 }: {
   item: PredictActivityListItem;
 }) {
-  const activity = getPredictActivity(item);
+  const activity = usePredictActivityById(item.hash);
   const openPredictHome = useOpenPredictHome();
 
   if (!activity) {

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -125,7 +125,6 @@ import {
 import { selectPerpsEnabledFlag } from '../../UI/Perps';
 import { selectPredictEnabledFlag } from '../../UI/Predict';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import { predictActivityToItem } from '../../UI/Predict/utils/predictActivityToItem';
 import {
   ActivityTypeFilter,
   activityKindMatchesTypeFilter,
@@ -912,14 +911,6 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
               transaction: perpsTx,
             });
           }
-          return;
-        }
-
-        if (raw.type === 'predictActivity') {
-          navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-            screen: Routes.PREDICT.ACTIVITY_DETAIL,
-            params: { activity: predictActivityToItem(raw.data) },
-          });
           return;
         }
 

--- a/app/components/Views/ActivityList/getActivityDetailsRoute.ts
+++ b/app/components/Views/ActivityList/getActivityDetailsRoute.ts
@@ -17,8 +17,8 @@ function getLocalTransactionMetaId(item: ActivityListItem): string | undefined {
  *
  * Local EVM rows use `TransactionMeta.id` rather than the hash, which can change
  * on STX submission, and are stashed in `preloadedActivityItemStore` so Details
- * can recover if the live hash diverges. Provider-backed rows (Perps/Predict)
- * are stashed too, so call this only when about to navigate.
+ * can recover if the live hash diverges. Perps rows are stashed too, so call
+ * this only when about to navigate.
  */
 export function getActivityDetailsRoute(
   item: ActivityListItem,
@@ -31,9 +31,7 @@ export function getActivityDetailsRoute(
 
   const { raw } = item;
   const shouldPreload =
-    raw?.type === 'perpsTransaction' ||
-    raw?.type === 'predictActivity' ||
-    raw?.type === 'localTransaction';
+    raw?.type === 'perpsTransaction' || raw?.type === 'localTransaction';
   const preloadKey = shouldPreload
     ? stashPreloadedActivityItem(item)
     : undefined;

--- a/app/util/activity-adapters/adapters/predict-activity.ts
+++ b/app/util/activity-adapters/adapters/predict-activity.ts
@@ -81,6 +81,8 @@ export function mapPredictActivity({
         raw,
         data: {
           token: toFiatToken(entry.amount, 'out', quoteAsset),
+          marketTitle: activity.title,
+          icon: activity.icon,
         },
       };
 
@@ -94,6 +96,8 @@ export function mapPredictActivity({
         raw,
         data: {
           token: toFiatToken(entry.amount, 'in', quoteAsset),
+          marketTitle: activity.title,
+          icon: activity.icon,
         },
       };
 
@@ -107,6 +111,8 @@ export function mapPredictActivity({
         raw,
         data: {
           token: toFiatToken(entry.amount, 'in', quoteAsset),
+          marketTitle: activity.title,
+          icon: activity.icon,
         },
       };
 

--- a/app/util/activity-adapters/index.ts
+++ b/app/util/activity-adapters/index.ts
@@ -12,6 +12,7 @@ export type {
   TokenAmount,
 } from './types';
 export { PERPS_ORDER_KINDS, isPerpsOrderKind } from './types';
+export { isPredictProviderActivityKind } from './predict-activity-kinds';
 export {
   isNftTransferType,
   isUnlimitedApprovalAmount,

--- a/app/util/activity-adapters/predict-activity-kinds.ts
+++ b/app/util/activity-adapters/predict-activity-kinds.ts
@@ -1,0 +1,11 @@
+import type { ActivityKind } from './types';
+
+const PREDICT_PROVIDER_ACTIVITY_KINDS = new Set<ActivityKind>([
+  'predictionPlaced',
+  'predictionCashedOut',
+  'predictionClaimWinnings',
+]);
+
+export function isPredictProviderActivityKind(kind: ActivityKind): boolean {
+  return PREDICT_PROVIDER_ACTIVITY_KINDS.has(kind);
+}

--- a/app/util/activity-adapters/types.ts
+++ b/app/util/activity-adapters/types.ts
@@ -93,6 +93,10 @@ type WithMobileTokenAmount<T> = T extends ClientUtilsTokenAmount
 
 interface MobileDataExtras {
   fees?: ActivityFee[];
+  /** Polymarket market title for predict provider activity list rows. */
+  marketTitle?: string;
+  /** Provider market icon URL for predict provider activity list rows. */
+  icon?: string;
 }
 
 type WithMobileDataTokens<T> = T extends { data: infer D }


### PR DESCRIPTION
## **Description**

First step toward removing `MobileFields.raw` for Activity alignment with extension. Predict provider activity rows no longer read `item.raw` at call sites — list display fields live on `item.data`, and the Details page resolves the full `PredictActivity` just-in-time via `usePredictActivityById` (mirroring extension JIT hooks).

The `raw` field is still populated by `mapPredictActivity` for now; a follow-up PR will drop it from the type once all domains are migrated.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Predict activity details without raw

  Scenario: user opens a predict trade from Activity list
    Given Predict is enabled and activity history has buy/sell/claim rows

    When user taps a predictionPlaced / predictionCashedOut / predictionClaimWinnings row
    Then ActivityDetails renders market metadata, amounts, and Polymarket link from the provider feed
    And the list row still shows market title subtitle and icon without reading item.raw
```

## **Screenshots/Recordings**

N/A — refactor only; visual parity expected.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)