### PR TITLE
refactor(activity): remove perps raw usages

### DIFF
--- a/app/components/Views/ActivityDetails/ActivityDetails.tsx
+++ b/app/components/Views/ActivityDetails/ActivityDetails.tsx
@@ -50,11 +50,8 @@ const ActivityDetails = () => {
   const isFocused = useIsFocused();
   const { chainId, txIdentifier, preloadKey } =
     useParams<ActivityDetailsParams>();
-  // Provider-backed rows (Perps / Predict) are handed off via a transient store
-  // keyed by `preloadKey` (params stay serializable). Capture the row once per
-  // key and hold it, so a later store eviction can't blank a still-mounted
-  // screen on re-render; re-read only when the key changes (the screen is reused
-  // across navigations).
+  // Predict rows are handed off via a transient store keyed by `preloadKey`.
+  // Perps rows re-resolve from HyperLiquid history by id/hash.
   const preloadedRef = useRef<{
     key?: string;
     item: ReturnType<typeof getPreloadedActivityItem>;

--- a/app/components/Views/ActivityDetails/components/ActivityDetailsPerps.utils.ts
+++ b/app/components/Views/ActivityDetails/components/ActivityDetailsPerps.utils.ts
@@ -4,7 +4,8 @@ import type {
   ActivityListItem,
   PerpsOrderKind,
 } from '../../../../util/activity-adapters';
-/* eslint-disable import-x/no-restricted-paths -- TODO(ADR-0020): reuse Perps UI utilities until shared perps utilities are extracted. */
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): reuse Perps UI utilities until shared perps utilities are extracted.
+import type { PerpsTransaction } from '../../../UI/Perps/types/transactionHistory';
 import {
   formatTransactionDate as formatPerpsTransactionDate,
   formatPerpsFiat,
@@ -12,12 +13,8 @@ import {
   PRICE_RANGES_UNIVERSAL,
 } from '../../../UI/Perps/utils/formatUtils';
 import { getAssetIconUrls as getPerpsAssetIconUrls } from '../../../UI/Perps/utils/marketUtils';
-/* eslint-enable import-x/no-restricted-paths */
 
-export type PerpsTransaction = Extract<
-  NonNullable<ActivityListItem['raw']>,
-  { type: 'perpsTransaction' }
->['data'];
+export type { PerpsTransaction };
 
 export type PerpsDepositWithdrawalStatus = NonNullable<
   PerpsTransaction['depositWithdrawal']
@@ -43,12 +40,6 @@ export type PerpsActivityType =
 export type PerpsActivityListItem = ActivityListItem & {
   type: PerpsActivityType;
 };
-
-export function getPerpsTransaction(
-  item: ActivityListItem,
-): PerpsTransaction | undefined {
-  return item.raw?.type === 'perpsTransaction' ? item.raw.data : undefined;
-}
 
 export {
   formatPerpsTransactionDate,

--- a/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import type { CaipChainId } from '@metamask/utils';
 import {
   type ActivityListItem,
+  isPerpsProviderActivityKind,
   preferLocalOrApiActivityItem,
 } from '../../../../util/activity-adapters';
 import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../../selectors/multichain/multichain';
@@ -10,6 +11,7 @@ import { selectSelectedAccountGroupInternalAccounts } from '../../../../selector
 /* eslint-disable import-x/no-restricted-paths -- TODO(ADR-0020): reuses the activity list's data sources; route-isolation backlog */
 import { useLocalActivityItems } from '../../ActivityList/hooks/useLocalActivityItems';
 import { useRampActivityItems } from '../../ActivityList/hooks/useRampActivityItems';
+import { usePerpsActivityItems } from '../../ActivityList/hooks/usePerpsActivityItems';
 import { useTransactionsQuery } from '../../ActivityList/useTransactionsQuery';
 import { mapNonEvmTransactions } from '../../ActivityList/helpers/transformations';
 /* eslint-enable import-x/no-restricted-paths */
@@ -86,10 +88,17 @@ function buildLocalItemsByLookupKey(
 }
 
 function isProviderBackedItem(item: ActivityListItem): boolean {
-  return (
-    item.raw?.type === 'perpsTransaction' ||
-    item.raw?.type === 'predictActivity'
-  );
+  return item.raw?.type === 'predictActivity';
+}
+
+function getDomainIdentifier(item: ActivityListItem): string | undefined {
+  if (isPerpsProviderActivityKind(item.type)) {
+    return item.hash;
+  }
+  if (item.raw?.type === 'predictActivity' || item.raw?.type === 'rampOrder') {
+    return item.raw.data.id;
+  }
+  return undefined;
 }
 
 function buildItemsByIdentifier(
@@ -97,12 +106,7 @@ function buildItemsByIdentifier(
 ): Map<string, ActivityListItem> {
   const byIdentifier = buildItemsByHash(items);
   for (const item of items) {
-    const domainId =
-      item.raw?.type === 'perpsTransaction' ||
-      item.raw?.type === 'predictActivity' ||
-      item.raw?.type === 'rampOrder'
-        ? item.raw.data.id
-        : undefined;
+    const domainId = getDomainIdentifier(item);
     const normalizedDomainId = domainId?.toLowerCase();
     if (normalizedDomainId && !byIdentifier.has(normalizedDomainId)) {
       byIdentifier.set(normalizedDomainId, item);
@@ -157,6 +161,7 @@ export function useActivityDetailsItem(
 ): ActivityListItem | undefined {
   const localActivityItems = useLocalActivityItems();
   const rampActivityItems = useRampActivityItems();
+  const { items: perpsActivityItems } = usePerpsActivityItems();
   const { data: evmTransactions } = useTransactionsQuery();
   const nonEvmState = useSelector(
     selectNonEvmTransactionsForSelectedAccountGroup,
@@ -209,6 +214,10 @@ export function useActivityDetailsItem(
     () => buildItemsByIdentifier(filterByChain(rampActivityItems, chainId)),
     [rampActivityItems, chainId],
   );
+  const perpsByIdentifier = useMemo(
+    () => buildItemsByIdentifier(filterByChain(perpsActivityItems, chainId)),
+    [perpsActivityItems, chainId],
+  );
 
   return useMemo(() => {
     const id = txIdentifier?.toLowerCase();
@@ -241,9 +250,14 @@ export function useActivityDetailsItem(
     );
     const nonEvmItem = nonEvmByHash.get(id);
     const rampItem = rampByIdentifier.get(id);
+    const perpsItem = perpsByIdentifier.get(id);
 
     if (rampItem) {
       return rampItem;
+    }
+
+    if (perpsItem) {
+      return perpsItem;
     }
 
     if (localItem) {
@@ -274,5 +288,6 @@ export function useActivityDetailsItem(
     nonEvmByHash,
     preloadedByIdentifier,
     rampByIdentifier,
+    perpsByIdentifier,
   ]);
 }

--- a/app/components/Views/ActivityDetails/hooks/usePerpsTransactionById.ts
+++ b/app/components/Views/ActivityDetails/hooks/usePerpsTransactionById.ts
@@ -1,0 +1,61 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  ARBITRUM_MAINNET_CAIP_CHAIN_ID,
+  formatAccountToCaipAccountId,
+} from '@metamask/perps-controller';
+import type { CaipChainId } from '@metamask/utils';
+import { selectSelectedAccountGroupEvmInternalAccount } from '../../../../selectors/multichainAccounts/accountTreeController';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import {
+  usePerpsConnection,
+  usePerpsTransactionHistory,
+} from '../../../UI/Perps/hooks';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import type { PerpsTransaction } from '../../../UI/Perps/types/transactionHistory';
+
+const PERPS_ACTIVITY_CHAIN_ID = ARBITRUM_MAINNET_CAIP_CHAIN_ID as CaipChainId;
+
+function matchesPerpsTransactionLookup(
+  transaction: PerpsTransaction,
+  lookupId: string,
+): boolean {
+  if (transaction.id.toLowerCase() === lookupId) {
+    return true;
+  }
+  const txHash = transaction.depositWithdrawal?.txHash?.toLowerCase();
+  return Boolean(txHash && txHash === lookupId);
+}
+
+export function usePerpsTransactionById(
+  transactionId: string | undefined,
+): PerpsTransaction | undefined {
+  const { isConnected } = usePerpsConnection();
+  const evmAccount = useSelector(selectSelectedAccountGroupEvmInternalAccount);
+  const selectedAddress = evmAccount?.address;
+
+  const accountId = useMemo(() => {
+    if (!selectedAddress) {
+      return undefined;
+    }
+    return (
+      formatAccountToCaipAccountId(selectedAddress, PERPS_ACTIVITY_CHAIN_ID) ??
+      undefined
+    );
+  }, [selectedAddress]);
+
+  const { transactions } = usePerpsTransactionHistory({
+    accountId,
+    skipInitialFetch: !isConnected,
+  });
+
+  return useMemo(() => {
+    if (!transactionId) {
+      return undefined;
+    }
+    const normalizedId = transactionId.toLowerCase();
+    return transactions.find((transaction) =>
+      matchesPerpsTransactionLookup(transaction, normalizedId),
+    );
+  }, [transactions, transactionId]);
+}

--- a/app/components/Views/ActivityDetails/templates/PerpsDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/PerpsDetails.tsx
@@ -34,6 +34,7 @@ import {
   useFormatActivityTokenAmount,
 } from '../components';
 import { ActivityDetailsSelectorsIDs } from '../ActivityDetails.testIds';
+import { usePerpsTransactionById } from '../hooks/usePerpsTransactionById';
 import {
   asPerpsActivityItem,
   formatPerpsOrderFee,
@@ -44,7 +45,6 @@ import {
   getPerpsPositionSize,
   getPerpsPriceLabel,
   getPerpsPriceValue,
-  getPerpsTransaction,
   shouldShowPerpsPnl,
   type PerpsActivityListItem,
   type PerpsDepositWithdrawalStatus,
@@ -474,7 +474,7 @@ function LocalFundsDetails({ item }: { item: PerpsActivityListItem }) {
 
 export function PerpsDetails({ item }: { item: ActivityListItem }) {
   const perpsItem = asPerpsActivityItem(item);
-  const transaction = getPerpsTransaction(item);
+  const transaction = usePerpsTransactionById(item.hash);
 
   if (!transaction) {
     if (item.type === 'perpsAddFunds' || item.type === 'perpsWithdraw') {

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -894,27 +894,6 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
           }
         }
 
-        // Perps rows route to the dedicated perps detail screens, mirroring the
-        // legacy perps transactions view (trade → position, funding → funding,
-        // order → order). Deposits/withdrawals have no detail screen.
-        if (raw.type === 'perpsTransaction') {
-          const perpsTx = raw.data;
-          if (perpsTx.type === 'trade') {
-            navigation.navigate(Routes.PERPS.POSITION_TRANSACTION, {
-              transaction: perpsTx,
-            });
-          } else if (perpsTx.type === 'funding') {
-            navigation.navigate(Routes.PERPS.FUNDING_TRANSACTION, {
-              transaction: perpsTx,
-            });
-          } else if (perpsTx.type === 'order') {
-            navigation.navigate(Routes.PERPS.ORDER_TRANSACTION, {
-              transaction: perpsTx,
-            });
-          }
-          return;
-        }
-
         if (raw.type === 'predictActivity') {
           navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
             screen: Routes.PREDICT.ACTIVITY_DETAIL,

--- a/app/components/Views/ActivityList/getActivityDetailsRoute.ts
+++ b/app/components/Views/ActivityList/getActivityDetailsRoute.ts
@@ -17,8 +17,8 @@ function getLocalTransactionMetaId(item: ActivityListItem): string | undefined {
  *
  * Local EVM rows use `TransactionMeta.id` rather than the hash, which can change
  * on STX submission, and are stashed in `preloadedActivityItemStore` so Details
- * can recover if the live hash diverges. Provider-backed rows (Perps/Predict)
- * are stashed too, so call this only when about to navigate.
+ * can recover if the live hash diverges. Predict rows are stashed too, so call
+ * this only when about to navigate.
  */
 export function getActivityDetailsRoute(
   item: ActivityListItem,
@@ -31,9 +31,7 @@ export function getActivityDetailsRoute(
 
   const { raw } = item;
   const shouldPreload =
-    raw?.type === 'perpsTransaction' ||
-    raw?.type === 'predictActivity' ||
-    raw?.type === 'localTransaction';
+    raw?.type === 'predictActivity' || raw?.type === 'localTransaction';
   const preloadKey = shouldPreload
     ? stashPreloadedActivityItem(item)
     : undefined;

--- a/app/util/activity-adapters/index.ts
+++ b/app/util/activity-adapters/index.ts
@@ -12,6 +12,7 @@ export type {
   TokenAmount,
 } from './types';
 export { PERPS_ORDER_KINDS, isPerpsOrderKind } from './types';
+export { isPerpsProviderActivityKind } from './perps-activity-kinds';
 export {
   isNftTransferType,
   isUnlimitedApprovalAmount,

--- a/app/util/activity-adapters/perps-activity-kinds.ts
+++ b/app/util/activity-adapters/perps-activity-kinds.ts
@@ -1,0 +1,27 @@
+import {
+  type ActivityKind,
+  isPerpsOrderKind,
+  PERPS_ORDER_KINDS,
+} from './types';
+
+const PERPS_PROVIDER_ACTIVITY_KINDS = new Set<ActivityKind>([
+  ...PERPS_ORDER_KINDS,
+  'perpsAddFunds',
+  'perpsWithdraw',
+  'perpsOpenLong',
+  'perpsCloseLong',
+  'perpsCloseLongLiquidated',
+  'perpsCloseLongStopLoss',
+  'perpsOpenShort',
+  'perpsCloseShort',
+  'perpsCloseShortLiquidated',
+  'perpsCloseShortStopLoss',
+  'perpsPaidFundingFees',
+  'perpsReceivedFundingFees',
+  'perpsCloseShortTakeProfit',
+  'perpsCloseLongTakeProfit',
+]);
+
+export function isPerpsProviderActivityKind(kind: ActivityKind): boolean {
+  return PERPS_PROVIDER_ACTIVITY_KINDS.has(kind) || isPerpsOrderKind(kind);
+}


### PR DESCRIPTION
## **Description**

Removes perps `item.raw` reads as part of Activity/extension alignment. Perps Details now loads the full `PerpsTransaction` just-in-time via `usePerpsTransactionById`, and `useActivityDetailsItem` re-resolves perps rows from `usePerpsActivityItems` by hash/id instead of stashed raw payloads.

The `raw` field is still set by `mapPerpsTransaction` for now.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Perps activity details without raw

  Scenario: user opens a perps trade from Activity list
    Given Perps is connected and history includes trades, funding, and deposits

    When user taps a perps trade/funding/deposit row
    Then ActivityDetails renders the correct perps template from live history lookup
```

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)