### PR TITLE
refactor(activity): remove ramp raw usages

### DIFF
--- a/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import type { CaipChainId } from '@metamask/utils';
 import {
   type ActivityListItem,
+  isRampActivityKind,
   preferLocalOrApiActivityItem,
 } from '../../../../util/activity-adapters';
 import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../../selectors/multichain/multichain';
@@ -92,17 +93,25 @@ function isProviderBackedItem(item: ActivityListItem): boolean {
   );
 }
 
+function getDomainIdentifier(item: ActivityListItem): string | undefined {
+  if (isRampActivityKind(item.type)) {
+    return item.hash;
+  }
+  if (
+    item.raw?.type === 'perpsTransaction' ||
+    item.raw?.type === 'predictActivity'
+  ) {
+    return item.raw.data.id;
+  }
+  return undefined;
+}
+
 function buildItemsByIdentifier(
   items: ActivityListItem[],
 ): Map<string, ActivityListItem> {
   const byIdentifier = buildItemsByHash(items);
   for (const item of items) {
-    const domainId =
-      item.raw?.type === 'perpsTransaction' ||
-      item.raw?.type === 'predictActivity' ||
-      item.raw?.type === 'rampOrder'
-        ? item.raw.data.id
-        : undefined;
+    const domainId = getDomainIdentifier(item);
     const normalizedDomainId = domainId?.toLowerCase();
     if (normalizedDomainId && !byIdentifier.has(normalizedDomainId)) {
       byIdentifier.set(normalizedDomainId, item);

--- a/app/components/Views/ActivityDetails/templates/RampDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampDetails.tsx
@@ -4,8 +4,12 @@ import type { RampsOrder } from '@metamask/ramps-controller';
 import {
   isRampFiatOrder,
   isRampRampsOrder,
+  isRampActivityListRow,
   type ActivityListItem,
 } from '../../../../util/activity-adapters';
+/* eslint-disable import-x/no-restricted-paths -- TODO(ADR-0020): shared ramp order lookup with ActivityList hook */
+import { useRampOrderById } from '../../ActivityList/hooks/useRampOrderLookup';
+/* eslint-enable import-x/no-restricted-paths */
 import {
   RampFiatOrderDetails,
   type RampFiatActivityListItem,
@@ -17,13 +21,40 @@ import {
 
 export type RampActivityListItem = ActivityListItem & {
   type: 'buy' | 'sell';
-  raw: { type: 'rampOrder'; data: FiatOrder | RampsOrder };
 };
 
 export function isRampActivityListItem(
   item: ActivityListItem,
 ): item is RampActivityListItem {
-  return item.raw?.type === 'rampOrder';
+  return isRampActivityListRow(item);
+}
+
+function RampOrderDetails({
+  item,
+  order,
+}: Readonly<{
+  item: RampActivityListItem;
+  order: FiatOrder | RampsOrder;
+}>) {
+  if (isRampRampsOrder(order)) {
+    return (
+      <RampRampsOrderDetails
+        item={item as RampRampsActivityListItem}
+        order={order}
+      />
+    );
+  }
+
+  if (isRampFiatOrder(order)) {
+    return (
+      <RampFiatOrderDetails
+        item={item as RampFiatActivityListItem}
+        order={order}
+      />
+    );
+  }
+
+  return null;
 }
 
 /**
@@ -33,15 +64,11 @@ export function isRampActivityListItem(
 export function RampDetails({
   item,
 }: Readonly<{ item: RampActivityListItem }>) {
-  const { data } = item.raw;
+  const order = useRampOrderById(item.hash);
 
-  if (isRampRampsOrder(data)) {
-    return <RampRampsOrderDetails item={item as RampRampsActivityListItem} />;
+  if (!order) {
+    return null;
   }
 
-  if (isRampFiatOrder(data)) {
-    return <RampFiatOrderDetails item={item as RampFiatActivityListItem} />;
-  }
-
-  return null;
+  return <RampOrderDetails item={item} order={order} />;
 }

--- a/app/components/Views/ActivityDetails/templates/RampFiatOrderDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampFiatOrderDetails.tsx
@@ -25,14 +25,13 @@ import {
 
 export type RampFiatActivityListItem = ActivityListItem & {
   type: 'buy' | 'sell';
-  raw: { type: 'rampOrder'; data: FiatOrder };
 };
 
 /** Legacy FiatOrder ActivityDetails template — extract of prior RampDetails. */
 export function RampFiatOrderDetails({
   item,
-}: Readonly<{ item: RampFiatActivityListItem }>) {
-  const order = item.raw.data;
+  order,
+}: Readonly<{ item: RampFiatActivityListItem; order: FiatOrder }>) {
   const isSell = isRampSellOrder(order);
   const transactionHash = getRampActivityTransactionHash(order);
   const chainId = getRampActivityExplorerChainId(order.network);

--- a/app/components/Views/ActivityDetails/templates/RampRampsOrderDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampRampsOrderDetails.tsx
@@ -26,7 +26,6 @@ import {
 
 export type RampRampsActivityListItem = ActivityListItem & {
   type: 'buy' | 'sell';
-  raw: { type: 'rampOrder'; data: RampsOrder };
 };
 
 function isRampsSellOrder(order: RampsOrder) {
@@ -57,8 +56,8 @@ function getRampsExplorerChainId(order: RampsOrder) {
 /** Native RampsOrder ActivityDetails template — visual parity with Fiat path. */
 export function RampRampsOrderDetails({
   item,
-}: Readonly<{ item: RampRampsActivityListItem }>) {
-  const order = item.raw.data;
+  order,
+}: Readonly<{ item: RampRampsActivityListItem; order: RampsOrder }>) {
   const isSell = isRampsSellOrder(order);
   const transactionHash = getRampsOrderTransactionHash(order);
   const chainId = getRampsExplorerChainId(order);

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -93,11 +93,13 @@ import { type ActivityListItem } from './types';
 import {
   getGroupedActivityListItemKey,
   groupActivityListItems,
+  isRampActivityListRow,
   preferLocalOrApiActivityItem,
   type ActivityKind,
   type GroupedActivityListItem,
   type TransactionGroup,
 } from '../../../util/activity-adapters';
+import { useRampOrderLookup } from './hooks/useRampOrderLookup';
 import {
   isBridgeHistoryForEvmTransaction,
   mergeTransactionsByTime,
@@ -813,6 +815,7 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
       signLedgerTransaction,
       cancelUnsignedQRTransaction,
     } = useUnifiedTxActions();
+    const findRampOrder = useRampOrderLookup();
 
     const perpsRefetch = perpsSource.refetch;
     const predictRefetch = predictSource.refetch;
@@ -833,23 +836,26 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
     const handleActivityItemPress = useCallback(
       async (item: ActivityListItem) => {
         const { raw } = item;
-        if (!raw) return;
-
         // Ramp rows own their redesign gate: flag ON → ActivityDetails /
         // TemplateLoader; flag OFF → OrdersList destinations. Kept ahead of the
         // shared redesign early-return so CREATED deposits always resume buy and
         // flag-OFF never accidentally hits ActivityDetails.
         // Sell/offramp always uses legacy OrderDetails — that screen owns the
         // Continue → Send Transaction flow which ActivityDetails does not.
-        if (raw.type === 'rampOrder') {
-          if (resolveRampOrderTarget(raw.data) === 'deposit-resume-buy') {
+        if (isRampActivityListRow(item)) {
+          const rampOrder = findRampOrder(item.hash);
+          if (!rampOrder) {
+            return;
+          }
+
+          if (resolveRampOrderTarget(rampOrder) === 'deposit-resume-buy') {
             goToBuy(undefined, { surface: RAMPS_BUY_CUF_SURFACE.ACTIVITY });
             return;
           }
 
           if (item.type === 'sell') {
             navigateToRampOrderTarget({
-              data: raw.data,
+              data: rampOrder,
               navigation,
               goToBuy,
             });
@@ -861,15 +867,14 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
             navigation.navigate(Routes.ACTIVITY_DETAILS, detailsRoute);
             return;
           }
-          // Mappers always set hash (txHash || id); keep the pre-native
-          // fallback keyed by order id if a row somehow lacks hash.
           navigation.navigate(Routes.ACTIVITY_DETAILS, {
             chainId: item.chainId,
-            txIdentifier: item.hash ?? raw.data.id,
+            txIdentifier: item.hash ?? rampOrder.id,
           });
           return;
         }
 
+        if (!raw) return;
         const detailsRoute = getActivityDetailsRoute(item);
         if (detailsRoute) {
           navigation.navigate(Routes.ACTIVITY_DETAILS, detailsRoute);
@@ -944,7 +949,13 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
           }
         }
       },
-      [bridgeHistory, getBridgeHistoryItemByHash, goToBuy, navigation],
+      [
+        bridgeHistory,
+        findRampOrder,
+        getBridgeHistoryItemByHash,
+        goToBuy,
+        navigation,
+      ],
     );
 
     // Index of the last API-confirmed EVM item — used to trigger pagination.

--- a/app/components/Views/ActivityList/hooks/useRampOrderLookup.ts
+++ b/app/components/Views/ActivityList/hooks/useRampOrderLookup.ts
@@ -1,0 +1,51 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import type { RampsOrder } from '@metamask/ramps-controller';
+import { getOrders } from '../../../../reducers/fiatOrders';
+import type { FiatOrder } from '../../../../reducers/fiatOrders/types';
+import { useRampsOrders } from '../../../UI/Ramp/hooks/useRampsOrders';
+
+function indexRampOrders(
+  legacyOrders: FiatOrder[],
+  v2Orders: RampsOrder[],
+): Map<string, FiatOrder | RampsOrder> {
+  const byId = new Map<string, FiatOrder | RampsOrder>();
+
+  for (const order of legacyOrders) {
+    byId.set(order.id.toLowerCase(), order);
+  }
+
+  for (const order of v2Orders) {
+    byId.set(order.id.toLowerCase(), order);
+    if (order.providerOrderId) {
+      byId.set(order.providerOrderId.toLowerCase(), order);
+    }
+  }
+
+  return byId;
+}
+
+export function useRampOrderLookup() {
+  const legacyOrders = useSelector(getOrders);
+  const { orders: v2Orders } = useRampsOrders();
+
+  return useMemo(() => {
+    const ordersById = indexRampOrders(legacyOrders, v2Orders);
+
+    return (
+      identifier: string | undefined,
+    ): FiatOrder | RampsOrder | undefined => {
+      if (!identifier) {
+        return undefined;
+      }
+      return ordersById.get(identifier.toLowerCase());
+    };
+  }, [legacyOrders, v2Orders]);
+}
+
+export function useRampOrderById(
+  orderId: string | undefined,
+): FiatOrder | RampsOrder | undefined {
+  const findRampOrder = useRampOrderLookup();
+  return useMemo(() => findRampOrder(orderId), [findRampOrder, orderId]);
+}

--- a/app/util/activity-adapters/index.ts
+++ b/app/util/activity-adapters/index.ts
@@ -13,6 +13,10 @@ export type {
 } from './types';
 export { PERPS_ORDER_KINDS, isPerpsOrderKind } from './types';
 export {
+  isRampActivityKind,
+  isRampActivityListRow,
+} from './ramp-activity-kinds';
+export {
   isNftTransferType,
   isUnlimitedApprovalAmount,
 } from './adapters/helpers';

--- a/app/util/activity-adapters/ramp-activity-kinds.ts
+++ b/app/util/activity-adapters/ramp-activity-kinds.ts
@@ -1,0 +1,16 @@
+import type { ActivityKind, ActivityListItem } from './types';
+
+const RAMP_ACTIVITY_KINDS = new Set<ActivityKind>([
+  'buy',
+  'sell',
+  'rampBuy',
+  'rampSell',
+]);
+
+export function isRampActivityKind(kind: ActivityKind): boolean {
+  return RAMP_ACTIVITY_KINDS.has(kind);
+}
+
+export function isRampActivityListRow(item: ActivityListItem): boolean {
+  return isRampActivityKind(item.type) && 'from' in item.data;
+}


### PR DESCRIPTION
## **Description**

Removes ramp `item.raw` reads for Activity/extension alignment. Ramp Details resolves `FiatOrder` / `RampsOrder` just-in-time via `useRampOrderById`, ActivityList ramp navigation uses `useRampOrderLookup`, and ramp rows are identified via activity kind + mapped `data.from` instead of `raw.type === 'rampOrder'`.

The `raw` field is still populated by ramp mappers for now.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Ramp activity details without raw

  Scenario: user opens a ramp buy from Activity list
    Given ramp orders exist in legacy and/or v2 controllers

    When user taps a buy row
    Then ActivityDetails renders fiat/ramps order details from live order lookup
```

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)