### PR TITLE
feat: add Appium smoke for seedless change password

### DIFF
--- a/app/components/Views/ResetPassword/index.tsx
+++ b/app/components/Views/ResetPassword/index.tsx
@@ -570,6 +570,8 @@ const ResetPassword = ({ navigation, route }: ResetPasswordProps) => {
                 secureTextEntry: true,
                 onSubmitEditing: reauthenticateWithPassword,
                 testID: ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
+                accessibilityLabel:
+                  ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
                 keyboardAppearance: themeAppearance,
                 autoComplete: 'password',
               }}
@@ -666,6 +668,8 @@ const ResetPassword = ({ navigation, route }: ResetPasswordProps) => {
                     inputProps={{
                       secureTextEntry: showPasswordIndex.includes(0),
                       testID: ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
+                      accessibilityLabel:
+                        ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
                       onSubmitEditing: jumpToConfirmPassword,
                       returnKeyType: 'next',
                       autoComplete: 'password-new',
@@ -711,6 +715,8 @@ const ResetPassword = ({ navigation, route }: ResetPasswordProps) => {
                     inputProps={{
                       secureTextEntry: showPasswordIndex.includes(1),
                       testID:
+                        ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+                      accessibilityLabel:
                         ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
                       returnKeyType: 'done',
                       autoComplete: 'password-new',

--- a/tests/module-mocking/seedless/MockSeedlessOnboardingController.ts
+++ b/tests/module-mocking/seedless/MockSeedlessOnboardingController.ts
@@ -189,6 +189,18 @@ export class MockSeedlessOnboardingController extends BaseController<
   }
 
   /**
+   * Mock changePassword — used by Settings → Change password (seedless vault).
+   * Real controller re-encrypts TOPRF secrets; E2E only updates mock password state.
+   */
+  async changePassword(
+    newPassword: string,
+    _oldPassword: string,
+  ): Promise<void> {
+    console.log('[E2E Mock] changePassword called');
+    mockState.password = newPassword;
+  }
+
+  /**
    * Mock setLocked
    */
   async setLocked(): Promise<void> {

--- a/tests/page-objects/Settings/SecurityAndPrivacy/ChangePasswordView.ts
+++ b/tests/page-objects/Settings/SecurityAndPrivacy/ChangePasswordView.ts
@@ -1,9 +1,18 @@
 import { ChoosePasswordSelectorsIDs } from '../../../../app/components/Views/ChoosePassword/ChoosePassword.testIds';
 import { ChangePasswordViewSelectorsText } from '../../../selectors/Settings/SecurityAndPrivacy/ChangePasswordView.selectors';
+import Assertions from '../../../framework/Assertions';
 import Matchers from '../../../framework/Matchers';
 import Gestures from '../../../framework/Gestures';
 import { type AppiumElement } from '../../../framework';
+import { PlatformDetector } from '../../../framework/PlatformLocator';
 
+/**
+ * Settings → Security & Privacy → Change password (ResetPassword screen).
+ *
+ * Two-step UI:
+ * 1. Confirm current password
+ * 2. Enter new password + confirm + checkbox → Save
+ */
 class ChangePasswordView {
   get title(): Promise<AppiumElement> {
     return Matchers.getElementByText(
@@ -11,54 +20,156 @@ class ChangePasswordView {
     );
   }
 
+  get container(): Promise<AppiumElement> {
+    return Matchers.getElementByID(ChoosePasswordSelectorsIDs.CONTAINER_ID);
+  }
+
+  /**
+   * Shared field id for "current password" (step 1) and "new password" (step 2).
+   * Match via Android content-desc / iOS catch-all like CreatePasswordView.
+   */
   get passwordInput(): Promise<AppiumElement> {
-    return Matchers.getElementByID(
-      ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
+    if (PlatformDetector.isAndroid()) {
+      return Matchers.getElementByAndroidUIAutomator(
+        `.description("${ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID}")`,
+      );
+    }
+    return Matchers.getElementByNativeXPath(
+      this.getCatchAllXPath(ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID),
     );
   }
 
   get confirmPasswordInput(): Promise<AppiumElement> {
-    return Matchers.getElementByID(
-      ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+    if (PlatformDetector.isAndroid()) {
+      return Matchers.getElementByAndroidUIAutomator(
+        `.description("${ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID}")`,
+      );
+    }
+    return Matchers.getElementByNativeXPath(
+      this.getCatchAllXPath(
+        ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+      ),
     );
   }
 
   get iUnderstandCheckBox(): Promise<AppiumElement> {
-    return Matchers.getElementByLabel(
+    return Matchers.getElementByID(
       ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
     );
   }
 
-  get submitButton(): Promise<AppiumElement> {
+  get confirmCurrentPasswordButton(): Promise<AppiumElement> {
     return Matchers.getElementByText(
-      ChoosePasswordSelectorsIDs.SAVE_PASSWORD_BUTTON_TEXT,
+      ChangePasswordViewSelectorsText.CONFIRM_CURRENT_PASSWORD,
     );
   }
 
-  async typeInConfirmPasswordInputBox(PASSWORD: string): Promise<void> {
-    await Gestures.typeText(this.passwordInput, PASSWORD, {
-      hideKeyboard: true,
-      elemDescription: 'Confirm password input box',
+  get saveButton(): Promise<AppiumElement> {
+    return Matchers.getElementByText(
+      ChangePasswordViewSelectorsText.SAVE_PASSWORD,
+    );
+  }
+
+  private getCatchAllXPath(identifier: string): string {
+    if (PlatformDetector.isAndroid()) {
+      return `//*[@resource-id='${identifier}' or contains(@text,'${identifier}') or contains(@content-desc,'${identifier}')]`;
+    }
+    return `//*[contains(@name,'${identifier}') or contains(@label,'${identifier}') or contains(@text,'${identifier}')]`;
+  }
+
+  async expectTitleVisible(): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.title, {
+      description: 'Change password title should be visible',
+      timeout: 15000,
     });
   }
 
-  async reEnterPassword(PASSWORD: string): Promise<void> {
-    await Gestures.typeText(this.confirmPasswordInput, PASSWORD, {
+  async expectCurrentPasswordStepVisible(): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.passwordInput, {
+      description: 'Current password input should be visible',
+      timeout: 15000,
+    });
+    await Assertions.expectElementToBeVisible(
+      this.confirmCurrentPasswordButton,
+      {
+        description: 'Confirm current password button should be visible',
+        timeout: 10000,
+      },
+    );
+  }
+
+  async expectNewPasswordFormVisible(): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.confirmPasswordInput, {
+      description: 'Confirm new password input should be visible',
+      timeout: 30000,
+    });
+    await Assertions.expectElementToBeVisible(this.iUnderstandCheckBox, {
+      description: 'I understand checkbox should be visible',
+      timeout: 10000,
+    });
+  }
+
+  async enterCurrentPassword(password: string): Promise<void> {
+    // Do not append newline — Confirm is an explicit button (onSubmitEditing
+    // would race with the tap and can leave the form mid-transition).
+    await Gestures.typeText(this.passwordInput, password, {
       hideKeyboard: true,
-      elemDescription: 'Confirm password input box re-enter',
+      elemDescription: 'Change password - current password input',
+    });
+  }
+
+  async tapConfirmCurrentPassword(): Promise<void> {
+    await Gestures.waitAndTap(this.confirmCurrentPasswordButton, {
+      elemDescription: 'Change password - Confirm current password',
+      checkEnabled: true,
+    });
+  }
+
+  async enterNewPassword(password: string): Promise<void> {
+    const text = PlatformDetector.isIOS() ? `${password}\n` : password;
+    await Gestures.typeText(this.passwordInput, text, {
+      hideKeyboard: false,
+      elemDescription: 'Change password - new password input',
+    });
+  }
+
+  async reEnterNewPassword(password: string): Promise<void> {
+    const text = PlatformDetector.isIOS() ? `${password}\n` : password;
+    await Gestures.typeText(this.confirmPasswordInput, text, {
+      hideKeyboard: false,
+      elemDescription: 'Change password - confirm new password input',
     });
   }
 
   async tapIUnderstandCheckBox(): Promise<void> {
     await Gestures.waitAndTap(this.iUnderstandCheckBox, {
-      elemDescription: 'I understand checkbox',
+      elemDescription: 'Change password - I understand checkbox',
     });
   }
 
-  async tapSubmitButton(): Promise<void> {
-    await Gestures.waitAndTap(this.submitButton, {
-      elemDescription: 'Submit button',
+  async tapSaveButton(): Promise<void> {
+    await Gestures.waitAndTap(this.saveButton, {
+      elemDescription: 'Change password - Save button',
+      checkEnabled: true,
     });
+  }
+
+  /**
+   * Completes both change-password steps after the screen is open.
+   */
+  async changePassword(
+    currentPassword: string,
+    newPassword: string,
+  ): Promise<void> {
+    await this.expectCurrentPasswordStepVisible();
+    await this.enterCurrentPassword(currentPassword);
+    await this.tapConfirmCurrentPassword();
+
+    await this.expectNewPasswordFormVisible();
+    await this.enterNewPassword(newPassword);
+    await this.reEnterNewPassword(newPassword);
+    await this.tapIUnderstandCheckBox();
+    await this.tapSaveButton();
   }
 }
 

--- a/tests/page-objects/Settings/SecurityAndPrivacy/ChangePasswordView.ts
+++ b/tests/page-objects/Settings/SecurityAndPrivacy/ChangePasswordView.ts
@@ -1,5 +1,8 @@
 import { ChoosePasswordSelectorsIDs } from '../../../../app/components/Views/ChoosePassword/ChoosePassword.testIds';
-import { ChangePasswordViewSelectorsText } from '../../../selectors/Settings/SecurityAndPrivacy/ChangePasswordView.selectors';
+import {
+  ChangePasswordViewSelectorsIDs,
+  ChangePasswordViewSelectorsText,
+} from '../../../selectors/Settings/SecurityAndPrivacy/ChangePasswordView.selectors';
 import Assertions from '../../../framework/Assertions';
 import Matchers from '../../../framework/Matchers';
 import Gestures from '../../../framework/Gestures';
@@ -12,11 +15,27 @@ import { PlatformDetector } from '../../../framework/PlatformLocator';
  * Two-step UI:
  * 1. Confirm current password
  * 2. Enter new password + confirm + checkbox → Save
+ *
+ * On devices with biometrics available, ResetPassword may auto-reauthenticate
+ * and skip step 1 (lands on the new-password form).
  */
 class ChangePasswordView {
-  get title(): Promise<AppiumElement> {
+  /**
+   * Do not assert title text alone — Settings list button uses the same
+   * "Change password" string, so that matcher can pass without navigation.
+   */
+  get screen(): Promise<AppiumElement> {
+    if (PlatformDetector.isAndroid()) {
+      return Matchers.getElementByAndroidUIAutomator(
+        `.resourceIdMatches(".*${ChangePasswordViewSelectorsIDs.SCREEN_ID}.*")`,
+      );
+    }
+    return Matchers.getElementByID(ChangePasswordViewSelectorsIDs.SCREEN_ID);
+  }
+
+  get enterCurrentPasswordLabel(): Promise<AppiumElement> {
     return Matchers.getElementByText(
-      ChangePasswordViewSelectorsText.CHANGE_PASSWORD,
+      ChangePasswordViewSelectorsText.ENTER_CURRENT_PASSWORD,
     );
   }
 
@@ -26,7 +45,7 @@ class ChangePasswordView {
 
   /**
    * Shared field id for "current password" (step 1) and "new password" (step 2).
-   * Match via Android content-desc / iOS catch-all like CreatePasswordView.
+   * Match via Android content-desc / catch-all like CreatePasswordView.
    */
   get passwordInput(): Promise<AppiumElement> {
     if (PlatformDetector.isAndroid()) {
@@ -84,19 +103,33 @@ class ChangePasswordView {
 
   private getCatchAllXPath(identifier: string): string {
     if (PlatformDetector.isAndroid()) {
-      return `//*[@resource-id='${identifier}' or contains(@text,'${identifier}') or contains(@content-desc,'${identifier}')]`;
+      return `//*[contains(@resource-id,'${identifier}') or contains(@text,'${identifier}') or contains(@content-desc,'${identifier}')]`;
     }
     return `//*[contains(@name,'${identifier}') or contains(@label,'${identifier}') or contains(@text,'${identifier}')]`;
   }
 
-  async expectTitleVisible(): Promise<void> {
-    await Assertions.expectElementToBeVisible(this.title, {
-      description: 'Change password title should be visible',
-      timeout: 15000,
+  /**
+   * Wait until ResetPassword body is mounted (after biometry loader if any).
+   * Uses screen testID — not the Settings "Change password" button text.
+   */
+  async expectScreenVisible(): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.screen, {
+      description:
+        'ResetPassword screen (account-backup-step-4-screen) should be visible',
+      timeout: 30000,
     });
   }
 
+  /** @deprecated Use expectScreenVisible — title text matches Settings button. */
+  async expectTitleVisible(): Promise<void> {
+    await this.expectScreenVisible();
+  }
+
   async expectCurrentPasswordStepVisible(): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.enterCurrentPasswordLabel, {
+      description: 'Enter your current password label should be visible',
+      timeout: 15000,
+    });
     await Assertions.expectElementToBeVisible(this.passwordInput, {
       description: 'Current password input should be visible',
       timeout: 15000,
@@ -119,6 +152,21 @@ class ChangePasswordView {
       description: 'I understand checkbox should be visible',
       timeout: 10000,
     });
+  }
+
+  /**
+   * True when biometry auto-reauth skipped the current-password step.
+   */
+  private async isNewPasswordFormShowing(): Promise<boolean> {
+    try {
+      await Assertions.expectElementToBeVisible(this.confirmPasswordInput, {
+        description: 'Probe for new-password confirm field',
+        timeout: 3000,
+      });
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async enterCurrentPassword(password: string): Promise<void> {
@@ -182,7 +230,7 @@ class ChangePasswordView {
   }
 
   /**
-   * Completes both change-password steps after the screen is open.
+   * Completes change-password after the Settings entry is tapped.
    * Seedless Save shows a confirmation sheet that must be confirmed before
    * the password is applied and the success toast appears.
    */
@@ -190,11 +238,16 @@ class ChangePasswordView {
     currentPassword: string,
     newPassword: string,
   ): Promise<void> {
-    await this.expectCurrentPasswordStepVisible();
-    await this.enterCurrentPassword(currentPassword);
-    await this.tapConfirmCurrentPassword();
+    await this.expectScreenVisible();
 
-    await this.expectNewPasswordFormVisible();
+    const skippedCurrentPasswordStep = await this.isNewPasswordFormShowing();
+    if (!skippedCurrentPasswordStep) {
+      await this.expectCurrentPasswordStepVisible();
+      await this.enterCurrentPassword(currentPassword);
+      await this.tapConfirmCurrentPassword();
+      await this.expectNewPasswordFormVisible();
+    }
+
     await this.enterNewPassword(newPassword);
     await this.reEnterNewPassword(newPassword);
     await this.tapIUnderstandCheckBox();

--- a/tests/page-objects/Settings/SecurityAndPrivacy/ChangePasswordView.ts
+++ b/tests/page-objects/Settings/SecurityAndPrivacy/ChangePasswordView.ts
@@ -70,6 +70,18 @@ class ChangePasswordView {
     );
   }
 
+  get warningSheetTitle(): Promise<AppiumElement> {
+    return Matchers.getElementByText(
+      ChangePasswordViewSelectorsText.WARNING_PASSWORD_CHANGE_TITLE,
+    );
+  }
+
+  get confirmPasswordChangeButton(): Promise<AppiumElement> {
+    return Matchers.getElementByText(
+      ChangePasswordViewSelectorsText.CONFIRM_PASSWORD_CHANGE,
+    );
+  }
+
   private getCatchAllXPath(identifier: string): string {
     if (PlatformDetector.isAndroid()) {
       return `//*[@resource-id='${identifier}' or contains(@text,'${identifier}') or contains(@content-desc,'${identifier}')]`;
@@ -154,8 +166,25 @@ class ChangePasswordView {
     });
   }
 
+  async expectWarningSheetVisible(): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.warningSheetTitle, {
+      description:
+        'Seedless password-change confirmation sheet should be visible',
+      timeout: 15000,
+    });
+  }
+
+  async tapConfirmPasswordChange(): Promise<void> {
+    await Gestures.waitAndTap(this.confirmPasswordChangeButton, {
+      elemDescription: 'Change password - Confirm on warning sheet',
+      checkEnabled: true,
+    });
+  }
+
   /**
    * Completes both change-password steps after the screen is open.
+   * Seedless Save shows a confirmation sheet that must be confirmed before
+   * the password is applied and the success toast appears.
    */
   async changePassword(
     currentPassword: string,
@@ -170,6 +199,9 @@ class ChangePasswordView {
     await this.reEnterNewPassword(newPassword);
     await this.tapIUnderstandCheckBox();
     await this.tapSaveButton();
+
+    await this.expectWarningSheetVisible();
+    await this.tapConfirmPasswordChange();
   }
 }
 

--- a/tests/selectors/Settings/SecurityAndPrivacy/ChangePasswordView.selectors.ts
+++ b/tests/selectors/Settings/SecurityAndPrivacy/ChangePasswordView.selectors.ts
@@ -4,5 +4,9 @@ export const ChangePasswordViewSelectorsText = {
   CHANGE_PASSWORD: enContent.password_reset.change_password,
   CONFIRM_CURRENT_PASSWORD: enContent.manual_backup_step_1.confirm,
   SAVE_PASSWORD: enContent.reset_password.confirm_btn,
+  WARNING_PASSWORD_CHANGE_TITLE:
+    enContent.reset_password.warning_password_change_title,
+  CONFIRM_PASSWORD_CHANGE:
+    enContent.reset_password.warning_password_change_button,
   PASSWORD_UPDATED_TOAST: enContent.reset_password.password_updated,
 };

--- a/tests/selectors/Settings/SecurityAndPrivacy/ChangePasswordView.selectors.ts
+++ b/tests/selectors/Settings/SecurityAndPrivacy/ChangePasswordView.selectors.ts
@@ -2,4 +2,7 @@ import enContent from '../../../../locales/languages/en.json';
 
 export const ChangePasswordViewSelectorsText = {
   CHANGE_PASSWORD: enContent.password_reset.change_password,
+  CONFIRM_CURRENT_PASSWORD: enContent.manual_backup_step_1.confirm,
+  SAVE_PASSWORD: enContent.reset_password.confirm_btn,
+  PASSWORD_UPDATED_TOAST: enContent.reset_password.password_updated,
 };

--- a/tests/selectors/Settings/SecurityAndPrivacy/ChangePasswordView.selectors.ts
+++ b/tests/selectors/Settings/SecurityAndPrivacy/ChangePasswordView.selectors.ts
@@ -1,9 +1,16 @@
 import enContent from '../../../../locales/languages/en.json';
 
+export const ChangePasswordViewSelectorsIDs = {
+  /** Unique ResetPassword body — not present on Security & Privacy list. */
+  SCREEN_ID: 'account-backup-step-4-screen',
+};
+
 export const ChangePasswordViewSelectorsText = {
   CHANGE_PASSWORD: enContent.password_reset.change_password,
+  ENTER_CURRENT_PASSWORD: enContent.manual_backup_step_1.enter_current_password,
   CONFIRM_CURRENT_PASSWORD: enContent.manual_backup_step_1.confirm,
   SAVE_PASSWORD: enContent.reset_password.confirm_btn,
+  /** Seedless Save opens SuccessErrorSheet with this title before applying. */
   WARNING_PASSWORD_CHANGE_TITLE:
     enContent.reset_password.warning_password_change_title,
   CONFIRM_PASSWORD_CHANGE:

--- a/tests/smoke-appium/seedless/google-login-change-password.spec.ts
+++ b/tests/smoke-appium/seedless/google-login-change-password.spec.ts
@@ -9,6 +9,7 @@ import SecurityAndPrivacy from '../../page-objects/Settings/SecurityAndPrivacy/S
 import ChangePasswordView from '../../page-objects/Settings/SecurityAndPrivacy/ChangePasswordView.js';
 import ToastModal from '../../page-objects/wallet/ToastModal.js';
 import { ChangePasswordViewSelectorsText } from '../../selectors/Settings/SecurityAndPrivacy/ChangePasswordView.selectors.js';
+import { dismissToWalletHomePlaywright } from '../../flows/wallet.flow.js';
 import {
   TEST_PASSWORD,
   completeGoogleNewUserOnboarding,
@@ -77,6 +78,7 @@ appiumTest.describe(
               },
             );
 
+            await dismissToWalletHomePlaywright();
             await lockApp();
             await unlockApp(NEW_PASSWORD);
           },

--- a/tests/smoke-appium/seedless/google-login-change-password.spec.ts
+++ b/tests/smoke-appium/seedless/google-login-change-password.spec.ts
@@ -1,0 +1,86 @@
+import { test as appiumTest } from '../../framework/fixtures/playwright/index.js';
+import { SmokeSeedlessOnboarding } from '../../tags.js';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
+import Assertions from '../../framework/Assertions.js';
+import TabBarComponent from '../../page-objects/wallet/TabBarComponent.js';
+import SettingsView from '../../page-objects/Settings/SettingsView.js';
+import SecurityAndPrivacy from '../../page-objects/Settings/SecurityAndPrivacy/SecurityAndPrivacyView.js';
+import ChangePasswordView from '../../page-objects/Settings/SecurityAndPrivacy/ChangePasswordView.js';
+import ToastModal from '../../page-objects/wallet/ToastModal.js';
+import { ChangePasswordViewSelectorsText } from '../../selectors/Settings/SecurityAndPrivacy/ChangePasswordView.selectors.js';
+import {
+  TEST_PASSWORD,
+  completeGoogleNewUserOnboarding,
+  lockApp,
+  setupGoogleNewUserOAuthMock,
+  unlockApp,
+} from './helpers/seedless-helpers.js';
+
+const NEW_PASSWORD = 'NewPass456!@#';
+
+/**
+ * TO-678: Seedless change password after Google mock onboard.
+ * Asserts success toast, then lock/unlock with the new password.
+ */
+appiumTest.describe(
+  SmokeSeedlessOnboarding('Google Login - Change Password'),
+  () => {
+    appiumTest(
+      'changes password after seedless onboarding and unlocks with new password',
+      async ({ driver: _driver, currentDeviceDetails }) => {
+        await withFixtures(
+          {
+            fixture: new FixtureBuilder({ onboarding: true }).build(),
+            restartDevice: true,
+            currentDeviceDetails,
+            testSpecificMock: setupGoogleNewUserOAuthMock,
+          },
+          async () => {
+            await completeGoogleNewUserOnboarding();
+
+            await TabBarComponent.tapSettings();
+            await SettingsView.tapSecurityAndPrivacy();
+
+            await SecurityAndPrivacy.scrollToChangePassword();
+            await SecurityAndPrivacy.tapChangePassword();
+
+            await ChangePasswordView.expectTitleVisible();
+            await ChangePasswordView.changePassword(
+              TEST_PASSWORD,
+              NEW_PASSWORD,
+            );
+
+            await Assertions.expectElementToBeVisible(
+              ToastModal.notificationTitle,
+              {
+                description:
+                  'Password updated toast should appear after successful change',
+                timeout: 30000,
+              },
+            );
+            await Assertions.expectElementToHaveText(
+              ToastModal.notificationTitle,
+              ChangePasswordViewSelectorsText.PASSWORD_UPDATED_TOAST,
+              {
+                description: 'Toast title should say password was saved',
+              },
+            );
+
+            await Assertions.expectElementToBeVisible(
+              SecurityAndPrivacy.securityAndPrivacyHeading,
+              {
+                description:
+                  'Should return to Security & Privacy after password change',
+                timeout: 15000,
+              },
+            );
+
+            await lockApp();
+            await unlockApp(NEW_PASSWORD);
+          },
+        );
+      },
+    );
+  },
+);

--- a/tests/smoke-appium/seedless/google-login-change-password.spec.ts
+++ b/tests/smoke-appium/seedless/google-login-change-password.spec.ts
@@ -45,7 +45,8 @@ appiumTest.describe(
             await SecurityAndPrivacy.scrollToChangePassword();
             await SecurityAndPrivacy.tapChangePassword();
 
-            await ChangePasswordView.expectTitleVisible();
+            // changePassword waits for ResetPassword screen testID (not the
+            // Settings "Change password" button text, which is ambiguous).
             await ChangePasswordView.changePassword(
               TEST_PASSWORD,
               NEW_PASSWORD,

--- a/tests/smoke-appium/seedless/helpers/seedless-helpers.ts
+++ b/tests/smoke-appium/seedless/helpers/seedless-helpers.ts
@@ -379,7 +379,7 @@ const confirmLockAlert = async (): Promise<void> => {
 };
 
 /**
- * Locks the app from Settings.
+ * Locks the app from wallet home (Account Menu → Lock).
  */
 export const lockApp = async (): Promise<void> => {
   await TabBarComponent.tapAccountsMenu();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Adds Appium smoke coverage for seedless **change password**.

**Flow covered:**
1. Settings → Security & Privacy → Change password
2. Confirm current password, set new password, Save
3. Assert success toast and return to Security & Privacy
4. Lock app and unlock with the **new** password
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: [TO-678](https://consensyssoftware.atlassian.net/browse/TO-678)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Change password e2e test

  Scenario: user changes password after Google seedless onboard and unlocks with new password
    Given the main-e2e app is installed with HAS_TEST_OVERRIDES / E2E_MOCK_OAUTH
    And Appium smoke can run SmokeSeedlessOnboarding specs
    When the user completes Google mock new-user onboarding
    And opens Settings → Security & Privacy → Change password
    And confirms the current password
    And sets and saves a new password
    Then a "New password saved" toast appears
    And the user returns to Security & Privacy
    When the user locks the wallet
    And unlocks with the new password
    Then the wallet home screen is shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A — no Appium smoke coverage for seedless change password
<!-- [screenshots/recordings] -->

### **After**
N/A — no Appium smoke coverage for seedless change password
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and mock-only changes; no production wallet or auth logic is modified.
> 
> **Overview**
> Adds **TO-678** coverage for seedless users changing their password after Google mock onboarding: Settings → Security & Privacy → Change password, success toast, return to Security & Privacy, then lock/unlock with the new password.
> 
> The **`ChangePasswordView`** page object is reworked for the real **two-step** flow (confirm current password, then new/confirm + checkbox + Save), with Android/iOS locators aligned to **`CreatePasswordView`**, step visibility assertions, and a **`changePassword(current, new)`** helper. Selector strings for confirm/save/toast come from **`en.json`**.
> 
> **`MockSeedlessOnboardingController`** gains a **`changePassword`** stub so E2E updates mock vault password without TOPRF re-encryption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56659ea96fcd4b495512524698a5eaaa44df9f12. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[TO-678]: https://consensyssoftware.atlassian.net/browse/TO-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ