### PR TITLE
feat: implement swaps limit orders details card

### DIFF
--- a/app/components/UI/Bridge/components/LimitOrderDetails/ExpirationRow/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/ExpirationRow/index.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import ExpirationRow from './index';
+import { ExpirationRowSelectorsIDs } from './testIds';
+
+const defaultProps = {
+  value: '1 hour',
+  onPress: jest.fn(),
+};
+
+describe('ExpirationRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the expiration value', () => {
+    const { getByTestId } = render(<ExpirationRow {...defaultProps} />);
+
+    expect(getByTestId(ExpirationRowSelectorsIDs.CONTAINER)).toBeOnTheScreen();
+    expect(getByTestId(ExpirationRowSelectorsIDs.VALUE)).toHaveTextContent(
+      '1 hour',
+    );
+  });
+
+  it('renders the expires label', () => {
+    const { getByText } = render(<ExpirationRow {...defaultProps} />);
+
+    expect(getByText(strings('bridge.limit.expires'))).toBeOnTheScreen();
+  });
+
+  it('calls onPress when the value is pressed', () => {
+    const { getByTestId } = render(<ExpirationRow {...defaultProps} />);
+
+    fireEvent.press(getByTestId(ExpirationRowSelectorsIDs.CONTAINER));
+
+    expect(defaultProps.onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies a custom testID when provided', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ExpirationRow {...defaultProps} testID="custom-expiration-row" />,
+    );
+
+    expect(getByTestId('custom-expiration-row')).toBeOnTheScreen();
+    expect(queryByTestId(ExpirationRowSelectorsIDs.CONTAINER)).toBeNull();
+  });
+});

--- a/app/components/UI/Bridge/components/LimitOrderDetails/ExpirationRow/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/ExpirationRow/index.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  KeyValueRow,
+  KeyValueRowVariant,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import { ExpirationRowSelectorsIDs } from './testIds';
+import type { ExpirationRowProps } from './types';
+
+const ExpirationRow: React.FC<ExpirationRowProps> = ({
+  value,
+  onPress,
+  testID = ExpirationRowSelectorsIDs.CONTAINER,
+}) => (
+  <KeyValueRow
+    variant={KeyValueRowVariant.Summary}
+    keyLabel={strings('bridge.limit.expires')}
+    keyTextProps={{
+      variant: TextVariant.BodySm,
+      color: TextColor.TextAlternative,
+    }}
+    value={
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel={strings('bridge.limit.expires')}
+        onPress={onPress}
+        activeOpacity={0.6}
+        testID={testID}
+      >
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={1}
+        >
+          <Text
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextDefault}
+            testID={ExpirationRowSelectorsIDs.VALUE}
+          >
+            {value}
+          </Text>
+          <Icon
+            name={IconName.ArrowRight}
+            size={IconSize.Sm}
+            color={IconColor.IconAlternative}
+          />
+        </Box>
+      </TouchableOpacity>
+    }
+    twClassName="h-8"
+  />
+);
+
+export default ExpirationRow;

--- a/app/components/UI/Bridge/components/LimitOrderDetails/ExpirationRow/testIds.ts
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/ExpirationRow/testIds.ts
@@ -1,0 +1,4 @@
+export const ExpirationRowSelectorsIDs = {
+  CONTAINER: 'limit-order-details-expiration-row',
+  VALUE: 'limit-order-details-expiration-row-value',
+} as const;

--- a/app/components/UI/Bridge/components/LimitOrderDetails/ExpirationRow/types.ts
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/ExpirationRow/types.ts
@@ -1,0 +1,14 @@
+export interface ExpirationRowProps {
+  /**
+   * Human-readable expiration, e.g. "1 week".
+   */
+  value: string;
+  /**
+   * Fired when the expiration value is pressed.
+   */
+  onPress: () => void;
+  /**
+   * Optional test ID for the root element.
+   */
+  testID?: string;
+}

--- a/app/components/UI/Bridge/components/LimitOrderDetails/LimitOrderDetailsSkeleton.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/LimitOrderDetailsSkeleton.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  BoxAlignItems,
+} from '@metamask/design-system-react-native';
+import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
+import { LimitOrderDetailsSelectorsIDs } from './testIds';
+
+const ROWS: readonly (readonly [string, string])[] = [
+  ['35%', '42%'],
+  ['28%', '24%'],
+  ['30%', '18%'],
+];
+
+const LimitOrderDetailsSkeleton = () => (
+  <Box
+    twClassName="mx-4 mt-3 p-4 rounded-xl border border-muted bg-default gap-3.5"
+    testID={LimitOrderDetailsSelectorsIDs.SKELETON}
+  >
+    {ROWS.map(([left, right], i) => (
+      <Box
+        key={i}
+        testID={LimitOrderDetailsSelectorsIDs.SKELETON_ROW}
+        flexDirection={BoxFlexDirection.Row}
+        justifyContent={BoxJustifyContent.Between}
+        alignItems={BoxAlignItems.Center}
+      >
+        <Skeleton width={left} height={18} />
+        <Skeleton width={right} height={18} />
+      </Box>
+    ))}
+  </Box>
+);
+
+export default LimitOrderDetailsSkeleton;

--- a/app/components/UI/Bridge/components/LimitOrderDetails/NetworkFeeRow/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/NetworkFeeRow/index.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import { getNetworkImageSource } from '../../../../../../util/networks';
+import { getTokenImageSource } from '../../../utils';
+import { createMockTokenWithBalance } from '../../../testUtils';
+import NetworkFeeRow from './index';
+import { NetworkFeeRowSelectorsIDs } from './testIds';
+
+jest.mock('../../../../../../util/networks', () => ({
+  ...jest.requireActual('../../../../../../util/networks'),
+  getNetworkImageSource: jest.fn(() => ({ uri: 'https://network.icon' })),
+}));
+
+jest.mock('../../../utils', () => ({
+  ...jest.requireActual('../../../utils'),
+  getTokenImageSource: jest.fn(() => ({ uri: 'https://token.icon' })),
+}));
+
+const mockFeeToken = createMockTokenWithBalance({
+  symbol: 'ETH',
+  name: 'Ether',
+});
+
+const defaultProps = {
+  amount: '$1.69',
+  token: mockFeeToken,
+  onPress: jest.fn(),
+};
+
+describe('NetworkFeeRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .mocked(getNetworkImageSource)
+      .mockReturnValue({ uri: 'https://network.icon' });
+    jest
+      .mocked(getTokenImageSource)
+      .mockReturnValue({ uri: 'https://token.icon' });
+  });
+
+  it('renders the estimated network fee amount', () => {
+    const { getByTestId } = render(<NetworkFeeRow {...defaultProps} />);
+
+    expect(getByTestId(NetworkFeeRowSelectorsIDs.CONTAINER)).toBeOnTheScreen();
+    expect(getByTestId(NetworkFeeRowSelectorsIDs.VALUE)).toHaveTextContent(
+      '$1.69',
+    );
+  });
+
+  it('renders the estimated network fee label', () => {
+    const { getByText } = render(<NetworkFeeRow {...defaultProps} />);
+
+    expect(
+      getByText(strings('bridge.limit.est_network_fee')),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders the fee token avatar when a token is provided', () => {
+    const { getByTestId } = render(<NetworkFeeRow {...defaultProps} />);
+
+    expect(getByTestId(NetworkFeeRowSelectorsIDs.AVATAR)).toBeOnTheScreen();
+  });
+
+  it('hides the fee token avatar when no token is provided', () => {
+    const { queryByTestId } = render(
+      <NetworkFeeRow {...defaultProps} token={undefined} />,
+    );
+
+    expect(queryByTestId(NetworkFeeRowSelectorsIDs.AVATAR)).toBeNull();
+  });
+
+  it('calls onPress when the fee value is pressed', () => {
+    const { getByTestId } = render(<NetworkFeeRow {...defaultProps} />);
+
+    fireEvent.press(getByTestId(NetworkFeeRowSelectorsIDs.CONTAINER));
+
+    expect(defaultProps.onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a non-interactive amount when onPress is omitted', () => {
+    const { getByTestId } = render(
+      <NetworkFeeRow amount="$1.69" token={mockFeeToken} />,
+    );
+
+    expect(getByTestId(NetworkFeeRowSelectorsIDs.CONTAINER)).toBeOnTheScreen();
+    expect(getByTestId(NetworkFeeRowSelectorsIDs.VALUE)).toHaveTextContent(
+      '$1.69',
+    );
+    expect(getByTestId(NetworkFeeRowSelectorsIDs.AVATAR)).toBeOnTheScreen();
+  });
+
+  it('applies a custom testID when provided', () => {
+    const { getByTestId, queryByTestId } = render(
+      <NetworkFeeRow {...defaultProps} testID="custom-network-fee-row" />,
+    );
+
+    expect(getByTestId('custom-network-fee-row')).toBeOnTheScreen();
+    expect(queryByTestId(NetworkFeeRowSelectorsIDs.CONTAINER)).toBeNull();
+  });
+});

--- a/app/components/UI/Bridge/components/LimitOrderDetails/NetworkFeeRow/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/NetworkFeeRow/index.tsx
@@ -1,0 +1,136 @@
+import React, { useMemo } from 'react';
+import { Image, TouchableOpacity } from 'react-native';
+import {
+  AvatarToken,
+  AvatarTokenSize,
+  BadgeWrapper,
+  BadgeWrapperPosition,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  FontWeight,
+  KeyValueRow,
+  KeyValueRowVariant,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { strings } from '../../../../../../../locales/i18n';
+import { getNetworkImageSource } from '../../../../../../util/networks';
+import { getTokenImageSource } from '../../../utils';
+import { NetworkFeeRowSelectorsIDs } from './testIds';
+import type { NetworkFeeRowProps } from './types';
+
+const NETWORK_FEE_BADGE_SIZE = 8;
+
+const NetworkFeeRow: React.FC<NetworkFeeRowProps> = ({
+  amount,
+  token,
+  onPress,
+  testID = NetworkFeeRowSelectorsIDs.CONTAINER,
+}) => {
+  const tw = useTailwind();
+
+  const tokenImageSource = useMemo(
+    () =>
+      token
+        ? getTokenImageSource(
+            token.symbol,
+            token.image,
+            token.address,
+            token.chainId,
+          )
+        : undefined,
+    [token],
+  );
+
+  const networkImageSource = useMemo(
+    () =>
+      token ? getNetworkImageSource({ chainId: token.chainId }) : undefined,
+    [token],
+  );
+
+  const feeTokenAvatar = token ? (
+    <BadgeWrapper
+      testID={NetworkFeeRowSelectorsIDs.AVATAR}
+      position={BadgeWrapperPosition.BottomRight}
+      badge={
+        <Box
+          twClassName="overflow-hidden border-2 border-background-default bg-default rounded-[2px]"
+          style={{
+            width: NETWORK_FEE_BADGE_SIZE,
+            height: NETWORK_FEE_BADGE_SIZE,
+          }}
+        >
+          {networkImageSource ? (
+            <Image
+              source={networkImageSource}
+              style={tw.style('h-full w-full')}
+            />
+          ) : null}
+        </Box>
+      }
+    >
+      <AvatarToken
+        name={token.symbol}
+        src={tokenImageSource}
+        size={AvatarTokenSize.Xs}
+      />
+    </BadgeWrapper>
+  ) : undefined;
+
+  const value = onPress ? (
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={strings('bridge.limit.est_network_fee')}
+      onPress={onPress}
+      activeOpacity={0.6}
+      testID={testID}
+    >
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={1}
+      >
+        {feeTokenAvatar}
+        <Text
+          variant={TextVariant.BodySm}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextDefault}
+          testID={NetworkFeeRowSelectorsIDs.VALUE}
+        >
+          {amount}
+        </Text>
+      </Box>
+    </TouchableOpacity>
+  ) : (
+    amount
+  );
+
+  return (
+    <KeyValueRow
+      variant={KeyValueRowVariant.Summary}
+      keyLabel={strings('bridge.limit.est_network_fee')}
+      keyTextProps={{
+        variant: TextVariant.BodySm,
+        color: TextColor.TextAlternative,
+      }}
+      valueStartAccessory={onPress ? undefined : feeTokenAvatar}
+      value={value}
+      valueTextProps={
+        onPress
+          ? undefined
+          : {
+              variant: TextVariant.BodySm,
+              color: TextColor.TextDefault,
+              testID: NetworkFeeRowSelectorsIDs.VALUE,
+            }
+      }
+      twClassName="h-8"
+      testID={onPress ? undefined : testID}
+    />
+  );
+};
+
+export default NetworkFeeRow;

--- a/app/components/UI/Bridge/components/LimitOrderDetails/NetworkFeeRow/testIds.ts
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/NetworkFeeRow/testIds.ts
@@ -1,0 +1,5 @@
+export const NetworkFeeRowSelectorsIDs = {
+  CONTAINER: 'limit-order-details-network-fee-row',
+  VALUE: 'limit-order-details-network-fee-row-value',
+  AVATAR: 'limit-order-details-network-fee-row-avatar',
+} as const;

--- a/app/components/UI/Bridge/components/LimitOrderDetails/NetworkFeeRow/types.ts
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/NetworkFeeRow/types.ts
@@ -1,0 +1,20 @@
+import type { BridgeToken } from '../../../types';
+
+export interface NetworkFeeRowProps {
+  /**
+   * Formatted estimated network fee, e.g. "$1.69".
+   */
+  amount: string;
+  /**
+   * Token whose avatar and network badge are shown beside the fee.
+   */
+  token?: BridgeToken;
+  /**
+   * Press handler. When omitted the row is not interactive.
+   */
+  onPress?: () => void;
+  /**
+   * Optional test ID for the root element.
+   */
+  testID?: string;
+}

--- a/app/components/UI/Bridge/components/LimitOrderDetails/PriceRow/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/PriceRow/index.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import PriceRow from './index';
+import { PriceRowSelectorsIDs } from './testIds';
+
+const defaultProps = {
+  value: '2%',
+  onPress: jest.fn(),
+};
+
+describe('PriceRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the slippage value', () => {
+    const { getByTestId } = render(<PriceRow {...defaultProps} />);
+
+    expect(getByTestId(PriceRowSelectorsIDs.CONTAINER)).toBeOnTheScreen();
+    expect(getByTestId(PriceRowSelectorsIDs.VALUE)).toHaveTextContent('2%');
+  });
+
+  it('renders the slippage label', () => {
+    const { getByText } = render(<PriceRow {...defaultProps} />);
+
+    expect(getByText(strings('bridge.slippage'))).toBeOnTheScreen();
+  });
+
+  it('calls onPress when the value is pressed', () => {
+    const { getByTestId } = render(<PriceRow {...defaultProps} />);
+
+    fireEvent.press(getByTestId(PriceRowSelectorsIDs.CONTAINER));
+
+    expect(defaultProps.onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies a custom testID when provided', () => {
+    const { getByTestId, queryByTestId } = render(
+      <PriceRow {...defaultProps} testID="custom-price-row" />,
+    );
+
+    expect(getByTestId('custom-price-row')).toBeOnTheScreen();
+    expect(queryByTestId(PriceRowSelectorsIDs.CONTAINER)).toBeNull();
+  });
+});

--- a/app/components/UI/Bridge/components/LimitOrderDetails/PriceRow/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/PriceRow/index.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  KeyValueRow,
+  KeyValueRowVariant,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import { PriceRowSelectorsIDs } from './testIds';
+import type { PriceRowProps } from './types';
+
+const PriceRow: React.FC<PriceRowProps> = ({
+  value,
+  onPress,
+  testID = PriceRowSelectorsIDs.CONTAINER,
+}) => (
+  <KeyValueRow
+    variant={KeyValueRowVariant.Summary}
+    keyLabel={strings('bridge.slippage')}
+    keyTextProps={{
+      variant: TextVariant.BodySm,
+      color: TextColor.TextAlternative,
+    }}
+    value={
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel={strings('bridge.slippage')}
+        onPress={onPress}
+        activeOpacity={0.6}
+        testID={testID}
+      >
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={1}
+        >
+          <Text
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextDefault}
+            testID={PriceRowSelectorsIDs.VALUE}
+          >
+            {value}
+          </Text>
+          <Icon
+            name={IconName.Edit}
+            size={IconSize.Sm}
+            color={IconColor.IconAlternative}
+          />
+        </Box>
+      </TouchableOpacity>
+    }
+    twClassName="h-8"
+  />
+);
+
+export default PriceRow;

--- a/app/components/UI/Bridge/components/LimitOrderDetails/PriceRow/testIds.ts
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/PriceRow/testIds.ts
@@ -1,0 +1,4 @@
+export const PriceRowSelectorsIDs = {
+  CONTAINER: 'limit-order-details-price-row',
+  VALUE: 'limit-order-details-price-row-value',
+} as const;

--- a/app/components/UI/Bridge/components/LimitOrderDetails/PriceRow/types.ts
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/PriceRow/types.ts
@@ -1,0 +1,14 @@
+export interface PriceRowProps {
+  /**
+   * Slippage shown on the row, e.g. "2%".
+   */
+  value: string;
+  /**
+   * Fired when the slippage value is pressed.
+   */
+  onPress: () => void;
+  /**
+   * Optional test ID for the root element.
+   */
+  testID?: string;
+}

--- a/app/components/UI/Bridge/components/LimitOrderDetails/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/index.test.tsx
@@ -47,9 +47,9 @@ const setQuoteData = (overrides: Partial<QuoteContextValue> = {}) => {
 };
 
 function renderLimitOrderDetails(
-  bridgeReducerOverrides: Parameters<
-    typeof createBridgeTestState
-  >[0]['bridgeReducerOverrides'] = {},
+  bridgeReducerOverrides: NonNullable<
+    Parameters<typeof createBridgeTestState>[0]
+  >['bridgeReducerOverrides'] = {},
   props: Partial<LimitOrderDetailsProps> = {},
 ) {
   return renderWithProvider(

--- a/app/components/UI/Bridge/components/LimitOrderDetails/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/index.test.tsx
@@ -1,0 +1,235 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { mockUseBridgeQuoteData } from '../../_mocks_/useBridgeQuoteData.mock';
+import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import {
+  createBridgeTestState,
+  createMockTokenWithBalance,
+} from '../../testUtils';
+import LimitOrderDetails from './index';
+import { LimitOrderDetailsSelectorsIDs } from './testIds';
+import { ExpirationRowSelectorsIDs } from './ExpirationRow/testIds';
+import { NetworkFeeRowSelectorsIDs } from './NetworkFeeRow/testIds';
+import { PriceRowSelectorsIDs } from './PriceRow/testIds';
+import type { LimitOrderDetailsProps } from './types';
+
+/**
+ * Unit fallback: LimitOrderDetails is a nested card, not a screen. Visibility
+ * depends on quote context that component-view tests would need the full
+ * BridgeQuoteDataProvider and quote fetch to drive.
+ */
+jest.mock('../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => ({
+  useBridgeQuoteDataContext: jest.fn(),
+}));
+
+type QuoteContextValue = ReturnType<typeof useBridgeQuoteDataContext>;
+
+const mockFeeToken = createMockTokenWithBalance({
+  symbol: 'ETH',
+  name: 'Ether',
+});
+
+const defaultProps: LimitOrderDetailsProps = {
+  expiration: '1 hour',
+  onExpirationPress: jest.fn(),
+  slippage: '2%',
+  onPricePress: jest.fn(),
+  networkFee: '$1.69',
+  feeToken: mockFeeToken,
+};
+
+const setQuoteData = (overrides: Partial<QuoteContextValue> = {}) => {
+  jest.mocked(useBridgeQuoteDataContext).mockReturnValue({
+    ...mockUseBridgeQuoteData,
+    ...overrides,
+  } as unknown as QuoteContextValue);
+};
+
+function renderLimitOrderDetails(
+  bridgeReducerOverrides: Parameters<
+    typeof createBridgeTestState
+  >[0]['bridgeReducerOverrides'] = {},
+  props: Partial<LimitOrderDetailsProps> = {},
+) {
+  return renderWithProvider(
+    <LimitOrderDetails {...defaultProps} {...props} />,
+    {
+      state: createBridgeTestState({
+        bridgeReducerOverrides,
+      }),
+    },
+  );
+}
+
+describe('LimitOrderDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setQuoteData();
+  });
+
+  it('renders expiration, slippage, and network fee rows when an active quote exists', () => {
+    const { getByTestId } = renderLimitOrderDetails();
+
+    expect(
+      getByTestId(LimitOrderDetailsSelectorsIDs.CONTAINER),
+    ).toBeOnTheScreen();
+    expect(getByTestId(ExpirationRowSelectorsIDs.CONTAINER)).toBeOnTheScreen();
+    expect(getByTestId(PriceRowSelectorsIDs.CONTAINER)).toBeOnTheScreen();
+    expect(getByTestId(NetworkFeeRowSelectorsIDs.CONTAINER)).toBeOnTheScreen();
+  });
+
+  it('applies a custom testID when provided', () => {
+    const { getByTestId, queryByTestId } = renderLimitOrderDetails(
+      {},
+      { testID: 'custom-limit-order-details' },
+    );
+
+    expect(getByTestId('custom-limit-order-details')).toBeOnTheScreen();
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.CONTAINER)).toBeNull();
+  });
+
+  it('renders nothing when source amount is missing', () => {
+    const { queryByTestId } = renderLimitOrderDetails({
+      sourceAmount: undefined,
+    });
+
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.CONTAINER)).toBeNull();
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.SKELETON)).toBeNull();
+  });
+
+  it('renders nothing when source amount is empty', () => {
+    const { queryByTestId } = renderLimitOrderDetails({
+      sourceAmount: '',
+    });
+
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.CONTAINER)).toBeNull();
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.SKELETON)).toBeNull();
+  });
+
+  it('renders nothing when source amount is zero', () => {
+    const { queryByTestId } = renderLimitOrderDetails({
+      sourceAmount: '0',
+    });
+
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.CONTAINER)).toBeNull();
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.SKELETON)).toBeNull();
+  });
+
+  it('renders a three-row loading skeleton when quotes are still loading', () => {
+    setQuoteData({
+      activeQuote: undefined,
+      isLoading: true,
+      needsNewQuote: false,
+      quoteFetchError: null,
+      isNoQuotesAvailable: false,
+    });
+
+    const { getByTestId, getAllByTestId, queryByTestId } =
+      renderLimitOrderDetails();
+
+    expect(
+      getByTestId(LimitOrderDetailsSelectorsIDs.SKELETON),
+    ).toBeOnTheScreen();
+    expect(
+      getAllByTestId(LimitOrderDetailsSelectorsIDs.SKELETON_ROW),
+    ).toHaveLength(3);
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.CONTAINER)).toBeNull();
+  });
+
+  it('renders a loading skeleton when a non-zero amount has no active quote yet', () => {
+    setQuoteData({
+      activeQuote: undefined,
+      isLoading: false,
+      needsNewQuote: false,
+      quoteFetchError: null,
+      isNoQuotesAvailable: false,
+    });
+
+    const { getByTestId, queryByTestId } = renderLimitOrderDetails();
+
+    expect(
+      getByTestId(LimitOrderDetailsSelectorsIDs.SKELETON),
+    ).toBeOnTheScreen();
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.CONTAINER)).toBeNull();
+  });
+
+  it('renders nothing when a new quote is required and none is active', () => {
+    setQuoteData({
+      activeQuote: undefined,
+      needsNewQuote: true,
+      isLoading: false,
+      quoteFetchError: null,
+      isNoQuotesAvailable: false,
+    });
+
+    const { queryByTestId } = renderLimitOrderDetails();
+
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.CONTAINER)).toBeNull();
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.SKELETON)).toBeNull();
+  });
+
+  it('renders nothing when no quotes are available', () => {
+    setQuoteData({
+      activeQuote: undefined,
+      isNoQuotesAvailable: true,
+      isLoading: false,
+    });
+
+    const { queryByTestId } = renderLimitOrderDetails();
+
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.CONTAINER)).toBeNull();
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.SKELETON)).toBeNull();
+  });
+
+  it('renders nothing when quote fetch fails', () => {
+    setQuoteData({
+      activeQuote: undefined,
+      quoteFetchError: 'Quote fetch failed',
+      isLoading: false,
+    });
+
+    const { queryByTestId } = renderLimitOrderDetails();
+
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.CONTAINER)).toBeNull();
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.SKELETON)).toBeNull();
+  });
+
+  it('keeps details visible while refreshing an existing quote', () => {
+    setQuoteData({
+      isLoading: true,
+    });
+
+    const { getByTestId, queryByTestId } = renderLimitOrderDetails();
+
+    expect(
+      getByTestId(LimitOrderDetailsSelectorsIDs.CONTAINER),
+    ).toBeOnTheScreen();
+    expect(queryByTestId(LimitOrderDetailsSelectorsIDs.SKELETON)).toBeNull();
+  });
+
+  it('calls onExpirationPress when the expiration row is pressed', () => {
+    const { getByTestId } = renderLimitOrderDetails();
+
+    fireEvent.press(getByTestId(ExpirationRowSelectorsIDs.CONTAINER));
+
+    expect(defaultProps.onExpirationPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onPricePress when the slippage row is pressed', () => {
+    const { getByTestId } = renderLimitOrderDetails();
+
+    fireEvent.press(getByTestId(PriceRowSelectorsIDs.CONTAINER));
+
+    expect(defaultProps.onPricePress).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onNetworkFeePress when the network fee row is pressed', () => {
+    const onNetworkFeePress = jest.fn();
+    const { getByTestId } = renderLimitOrderDetails({}, { onNetworkFeePress });
+
+    fireEvent.press(getByTestId(NetworkFeeRowSelectorsIDs.CONTAINER));
+
+    expect(onNetworkFeePress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/Bridge/components/LimitOrderDetails/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/index.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Box } from '@metamask/design-system-react-native';
+import { selectSourceAmount } from '../../../../../core/redux/slices/bridge';
+import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import ExpirationRow from './ExpirationRow';
+import LimitOrderDetailsSkeleton from './LimitOrderDetailsSkeleton';
+import { LimitOrderDetailsSelectorsIDs } from './testIds';
+import type { LimitOrderDetailsProps } from './types';
+import NetworkFeeRow from './NetworkFeeRow';
+import PriceRow from './PriceRow';
+
+const LimitOrderDetails: React.FC<LimitOrderDetailsProps> = ({
+  expiration,
+  onExpirationPress,
+  slippage,
+  onPricePress,
+  networkFee,
+  feeToken,
+  onNetworkFeePress,
+  testID = LimitOrderDetailsSelectorsIDs.CONTAINER,
+}) => {
+  const sourceAmount = useSelector(selectSourceAmount);
+  const { activeQuote, needsNewQuote, quoteFetchError, isNoQuotesAvailable } =
+    useBridgeQuoteDataContext();
+
+  const isZeroState = !sourceAmount || !(Number(sourceAmount) > 0);
+
+  if (isZeroState) {
+    return null;
+  }
+
+  const shouldShowSkeleton =
+    !activeQuote && !needsNewQuote && !quoteFetchError && !isNoQuotesAvailable;
+
+  if (shouldShowSkeleton) {
+    return <LimitOrderDetailsSkeleton />;
+  }
+
+  if (!activeQuote) {
+    return null;
+  }
+
+  return (
+    <Box testID={testID} twClassName="w-full py-3 gap-3">
+      <ExpirationRow value={expiration} onPress={onExpirationPress} />
+      <PriceRow value={slippage} onPress={onPricePress} />
+      <NetworkFeeRow
+        amount={networkFee}
+        token={feeToken}
+        onPress={onNetworkFeePress}
+      />
+    </Box>
+  );
+};
+
+export default LimitOrderDetails;

--- a/app/components/UI/Bridge/components/LimitOrderDetails/testIds.ts
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/testIds.ts
@@ -1,0 +1,5 @@
+export const LimitOrderDetailsSelectorsIDs = {
+  CONTAINER: 'limit-order-details',
+  SKELETON: 'limit-order-details-skeleton',
+  SKELETON_ROW: 'limit-order-details-skeleton-row',
+} as const;

--- a/app/components/UI/Bridge/components/LimitOrderDetails/types.ts
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/types.ts
@@ -1,0 +1,36 @@
+import type { BridgeToken } from '../../types';
+
+export interface LimitOrderDetailsProps {
+  /**
+   * Human-readable expiration, e.g. "1 week".
+   */
+  expiration: string;
+  /**
+   * Fired when the expiration row is pressed.
+   */
+  onExpirationPress: () => void;
+  /**
+   * Slippage shown on the price row, e.g. "2%".
+   */
+  slippage: string;
+  /**
+   * Fired when the price / slippage row is pressed.
+   */
+  onPricePress: () => void;
+  /**
+   * Formatted estimated network fee, e.g. "$1.69".
+   */
+  networkFee: string;
+  /**
+   * Token whose avatar and network badge are shown on the fee row.
+   */
+  feeToken?: BridgeToken;
+  /**
+   * Press handler for the network fee row. When omitted the row is not interactive.
+   */
+  onNetworkFeePress?: () => void;
+  /**
+   * Optional test ID for the root element.
+   */
+  testID?: string;
+}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8742,7 +8742,18 @@
       "from_market": "(-{{percent}}% from market)",
       "from_market_above": "(+{{percent}}% from market)",
       "market": "Market",
-      "custom": "Custom"
+      "custom": "Custom",
+      "expires": "Expires",
+      "expiration": "Expiration",
+      "expiration_option": {
+        "minutes": "{{count}} minutes",
+        "hour": "{{count}} hour",
+        "day": "{{count}} day",
+        "days": "{{count}} days",
+        "week": "{{count}} week",
+        "month": "{{count}} month"
+      },
+      "est_network_fee": "Est. network fee"
     },
     "recurring": {
       "you_get": "You get",


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Limit-order traders need expiration, slippage, and estimated network fee in one place once a quote is available, without showing empty or stale details while quotes are loading or failing.

This adds a `LimitOrderDetails` card with three rows (expiration, slippage, and estimated network fee with a token/network avatar). The card shows a three-row skeleton while a non-zero amount is waiting on a quote, stays visible while an existing quote refreshes, and hides when the amount is empty or zero, a new quote is required, fetch fails, or no quotes are available. English copy for expiration presets and the Est. network fee label is included.

This commit introduces the card and strings only; it is not yet mounted on the limit order screen.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/SWAPS-4999

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — the card is not mounted on a screen in this commit. Unit tests cover row rendering, press handlers, skeleton visibility, and hide conditions.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New, unmounted UI with no changes to quote execution or transaction flows; behavior is covered by unit tests.
> 
> **Overview**
> Introduces a new **`LimitOrderDetails`** Bridge UI module (not wired into a screen in this PR) that surfaces **expiration**, **slippage**, and **estimated network fee** once a limit-order quote is ready.
> 
> The parent card reads **source amount** from Redux and **quote state** from `useBridgeQuoteDataContext`: it stays hidden for empty/zero amounts and for error, no-quote, or “needs new quote” states; shows a **three-row skeleton** while waiting for a first quote; and **keeps the filled card visible** during quote refresh. Row components use design-system `KeyValueRow` with tappable values (expiration/slippage with chevron/edit icons; network fee with optional token + network badge avatar and optional non-interactive mode).
> 
> Adds **English i18n** under `bridge.limit` (`expires`, `expiration` presets, `est_network_fee`) and **unit tests** for each row and the parent visibility/press behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29074c793e146d887a05ff68dd68549b4ee36f6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->