### PR TITLE
feat: add limit order expiration modal

### DIFF
--- a/app/components/UI/Bridge/components/SwapsLimitOrderExpirationModal/SwapsLimitOrderExpirationModal.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsLimitOrderExpirationModal/SwapsLimitOrderExpirationModal.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
+import {
+  SWAPS_LIMIT_ORDER_DEFAULT_EXPIRATION_MINUTES,
+  SWAPS_LIMIT_ORDER_EXPIRATION_OPTIONS_MINUTES,
+  getSwapsLimitOrderExpirationLabel,
+} from '../../constants/limitOrders';
+import SwapsLimitOrderExpirationModal from './SwapsLimitOrderExpirationModal';
+import { SwapsLimitOrderExpirationModalSelectorsIDs } from './testIds';
+import type { SwapsLimitOrderExpirationModalProps } from './types';
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactModule = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+
+  return {
+    ...actual,
+    BottomSheet: ReactModule.forwardRef(
+      (
+        {
+          children,
+          onClose,
+          testID,
+        }: {
+          children?: React.ReactNode;
+          onClose?: () => void;
+          testID?: string;
+        },
+        ref: React.Ref<{
+          onCloseBottomSheet: (callback?: () => void) => void;
+        }>,
+      ) => {
+        ReactModule.useImperativeHandle(ref, () => ({
+          onCloseBottomSheet: (callback?: () => void) => {
+            callback?.();
+            onClose?.();
+          },
+        }));
+
+        return <View testID={testID}>{children}</View>;
+      },
+    ),
+  };
+});
+
+const renderModal = (
+  overrides: Partial<SwapsLimitOrderExpirationModalProps> = {},
+) => {
+  const props: SwapsLimitOrderExpirationModalProps = {
+    selectedMinutes: SWAPS_LIMIT_ORDER_DEFAULT_EXPIRATION_MINUTES,
+    onSelect: jest.fn(),
+    onConfirm: jest.fn(),
+    onClose: jest.fn(),
+    ...overrides,
+  };
+
+  return {
+    ...render(<SwapsLimitOrderExpirationModal {...props} />),
+    props,
+  };
+};
+
+describe('SwapsLimitOrderExpirationModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the title, options, and confirm button', () => {
+    const { getByTestId, getByText } = renderModal();
+
+    expect(
+      getByTestId(SwapsLimitOrderExpirationModalSelectorsIDs.SHEET),
+    ).toBeOnTheScreen();
+    expect(getByText(strings('bridge.limit.expiration'))).toBeOnTheScreen();
+    expect(
+      getByTestId(SwapsLimitOrderExpirationModalSelectorsIDs.CONFIRM_BUTTON),
+    ).toBeOnTheScreen();
+
+    SWAPS_LIMIT_ORDER_EXPIRATION_OPTIONS_MINUTES.forEach((minutes) => {
+      expect(
+        getByTestId(SwapsLimitOrderExpirationModalSelectorsIDs.OPTION(minutes)),
+      ).toBeOnTheScreen();
+      expect(
+        getByText(getSwapsLimitOrderExpirationLabel(minutes)),
+      ).toBeOnTheScreen();
+    });
+  });
+
+  it('calls onSelect with the option minutes when an option is pressed', () => {
+    const { getByTestId, props } = renderModal();
+
+    fireEvent.press(
+      getByTestId(SwapsLimitOrderExpirationModalSelectorsIDs.OPTION(10080)),
+    );
+
+    expect(props.onSelect).toHaveBeenCalledTimes(1);
+    expect(props.onSelect).toHaveBeenCalledWith(10080);
+  });
+
+  it('calls onConfirm with the selected minutes when confirm is pressed', () => {
+    const { getByTestId, props } = renderModal({
+      selectedMinutes: 10080,
+    });
+
+    fireEvent.press(
+      getByTestId(SwapsLimitOrderExpirationModalSelectorsIDs.CONFIRM_BUTTON),
+    );
+
+    expect(props.onConfirm).toHaveBeenCalledTimes(1);
+    expect(props.onConfirm).toHaveBeenCalledWith(10080);
+  });
+
+  it('calls onClose when the close button is pressed', () => {
+    const { getByTestId, props } = renderModal();
+
+    fireEvent.press(
+      getByTestId(SwapsLimitOrderExpirationModalSelectorsIDs.CLOSE_BUTTON),
+    );
+
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose after confirm closes the sheet', () => {
+    const { getByTestId, props } = renderModal();
+
+    fireEvent.press(
+      getByTestId(SwapsLimitOrderExpirationModalSelectorsIDs.CONFIRM_BUTTON),
+    );
+
+    expect(props.onConfirm).toHaveBeenCalledTimes(1);
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/Bridge/components/SwapsLimitOrderExpirationModal/SwapsLimitOrderExpirationModal.tsx
+++ b/app/components/UI/Bridge/components/SwapsLimitOrderExpirationModal/SwapsLimitOrderExpirationModal.tsx
@@ -1,0 +1,77 @@
+import React, { useCallback, useRef } from 'react';
+import {
+  BottomSheet,
+  BottomSheetFooter,
+  BottomSheetHeader,
+  Box,
+  ListItemSelect,
+  type BottomSheetRef,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import {
+  SWAPS_LIMIT_ORDER_EXPIRATION_OPTIONS_MINUTES,
+  getSwapsLimitOrderExpirationLabel,
+} from '../../constants/limitOrders';
+import { SwapsLimitOrderExpirationModalSelectorsIDs } from './testIds';
+import type { SwapsLimitOrderExpirationModalProps } from './types';
+
+const SwapsLimitOrderExpirationModal: React.FC<
+  SwapsLimitOrderExpirationModalProps
+> = ({
+  selectedMinutes,
+  onSelect,
+  onConfirm,
+  onClose,
+  goBack,
+  testID = SwapsLimitOrderExpirationModalSelectorsIDs.SHEET,
+}) => {
+  const sheetRef = useRef<BottomSheetRef>(null);
+
+  const closeSheet = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    onConfirm(selectedMinutes);
+    closeSheet();
+  }, [closeSheet, onConfirm, selectedMinutes]);
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      testID={testID}
+      goBack={goBack}
+      onClose={onClose}
+    >
+      <BottomSheetHeader
+        onClose={closeSheet}
+        closeButtonProps={{
+          testID: SwapsLimitOrderExpirationModalSelectorsIDs.CLOSE_BUTTON,
+        }}
+      >
+        {strings('bridge.limit.expiration')}
+      </BottomSheetHeader>
+      <Box paddingBottom={2}>
+        {SWAPS_LIMIT_ORDER_EXPIRATION_OPTIONS_MINUTES.map((minutes) => (
+          <ListItemSelect
+            key={minutes}
+            title={getSwapsLimitOrderExpirationLabel(minutes)}
+            isSelected={selectedMinutes === minutes}
+            showSelectedIcon
+            onPress={() => onSelect(minutes)}
+            testID={SwapsLimitOrderExpirationModalSelectorsIDs.OPTION(minutes)}
+          />
+        ))}
+      </Box>
+      <BottomSheetFooter
+        primaryButtonProps={{
+          children: strings('bridge.confirm'),
+          onPress: handleConfirm,
+          testID: SwapsLimitOrderExpirationModalSelectorsIDs.CONFIRM_BUTTON,
+        }}
+      />
+    </BottomSheet>
+  );
+};
+
+export default SwapsLimitOrderExpirationModal;

--- a/app/components/UI/Bridge/components/SwapsLimitOrderExpirationModal/SwapsLimitOrderExpirationModalScreen.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsLimitOrderExpirationModal/SwapsLimitOrderExpirationModalScreen.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { useParams } from '../../../../../util/navigation/navUtils';
+import { SWAPS_LIMIT_ORDER_DEFAULT_EXPIRATION_MINUTES } from '../../constants/limitOrders';
+import { SwapsLimitOrderExpirationModalScreen } from './SwapsLimitOrderExpirationModalScreen';
+import { SwapsLimitOrderExpirationModalSelectorsIDs } from './testIds';
+
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ goBack: mockGoBack }),
+}));
+
+jest.mock('../../../../../util/navigation/navUtils', () => ({
+  useParams: jest.fn(),
+}));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactModule = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+
+  return {
+    ...actual,
+    BottomSheet: ReactModule.forwardRef(
+      (
+        {
+          children,
+          goBack,
+          testID,
+        }: {
+          children?: React.ReactNode;
+          goBack?: () => void;
+          testID?: string;
+        },
+        ref: React.Ref<{
+          onCloseBottomSheet: (callback?: () => void) => void;
+        }>,
+      ) => {
+        ReactModule.useImperativeHandle(ref, () => ({
+          onCloseBottomSheet: (callback?: () => void) => {
+            callback?.();
+            goBack?.();
+          },
+        }));
+
+        return <View testID={testID}>{children}</View>;
+      },
+    ),
+  };
+});
+
+const mockUseParams = useParams as jest.MockedFunction<typeof useParams>;
+
+describe('SwapsLimitOrderExpirationModalScreen', () => {
+  const mockOnConfirm = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseParams.mockReturnValue({
+      selectedMinutes: SWAPS_LIMIT_ORDER_DEFAULT_EXPIRATION_MINUTES,
+      onConfirm: mockOnConfirm,
+    });
+  });
+
+  it('confirms the initial selection when confirm is pressed without changing options', () => {
+    const { getByTestId } = render(<SwapsLimitOrderExpirationModalScreen />);
+
+    fireEvent.press(
+      getByTestId(SwapsLimitOrderExpirationModalSelectorsIDs.CONFIRM_BUTTON),
+    );
+
+    expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+    expect(mockOnConfirm).toHaveBeenCalledWith(
+      SWAPS_LIMIT_ORDER_DEFAULT_EXPIRATION_MINUTES,
+    );
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('confirms the newly selected expiration minutes', () => {
+    const { getByTestId } = render(<SwapsLimitOrderExpirationModalScreen />);
+
+    fireEvent.press(
+      getByTestId(SwapsLimitOrderExpirationModalSelectorsIDs.OPTION(10080)),
+    );
+    fireEvent.press(
+      getByTestId(SwapsLimitOrderExpirationModalSelectorsIDs.CONFIRM_BUTTON),
+    );
+
+    expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+    expect(mockOnConfirm).toHaveBeenCalledWith(10080);
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not confirm when the sheet is closed', () => {
+    const { getByTestId } = render(<SwapsLimitOrderExpirationModalScreen />);
+
+    fireEvent.press(
+      getByTestId(SwapsLimitOrderExpirationModalSelectorsIDs.OPTION(10080)),
+    );
+    fireEvent.press(
+      getByTestId(SwapsLimitOrderExpirationModalSelectorsIDs.CLOSE_BUTTON),
+    );
+
+    expect(mockOnConfirm).not.toHaveBeenCalled();
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/Bridge/components/SwapsLimitOrderExpirationModal/SwapsLimitOrderExpirationModalScreen.tsx
+++ b/app/components/UI/Bridge/components/SwapsLimitOrderExpirationModal/SwapsLimitOrderExpirationModalScreen.tsx
@@ -1,0 +1,36 @@
+import React, { useCallback, useState } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
+import { useParams } from '../../../../../util/navigation/navUtils';
+import {
+  SWAPS_LIMIT_ORDER_DEFAULT_EXPIRATION_MINUTES,
+  type SwapsLimitOrderExpirationMinutes,
+} from '../../constants/limitOrders';
+import SwapsLimitOrderExpirationModal from './SwapsLimitOrderExpirationModal';
+import type { SwapsLimitOrderExpirationModalParams } from './types';
+
+export const SwapsLimitOrderExpirationModalScreen = () => {
+  const { goBack } = useNavigation<AppNavigationProp>();
+  const { selectedMinutes: initialMinutes, onConfirm } =
+    useParams<SwapsLimitOrderExpirationModalParams>();
+  const [pendingMinutes, setPendingMinutes] =
+    useState<SwapsLimitOrderExpirationMinutes>(
+      initialMinutes ?? SWAPS_LIMIT_ORDER_DEFAULT_EXPIRATION_MINUTES,
+    );
+
+  const handleConfirm = useCallback(
+    (minutes: SwapsLimitOrderExpirationMinutes) => {
+      onConfirm(minutes);
+    },
+    [onConfirm],
+  );
+
+  return (
+    <SwapsLimitOrderExpirationModal
+      selectedMinutes={pendingMinutes}
+      onSelect={setPendingMinutes}
+      onConfirm={handleConfirm}
+      goBack={goBack}
+    />
+  );
+};

--- a/app/components/UI/Bridge/components/SwapsLimitOrderExpirationModal/testIds.ts
+++ b/app/components/UI/Bridge/components/SwapsLimitOrderExpirationModal/testIds.ts
@@ -1,0 +1,9 @@
+import type { SwapsLimitOrderExpirationMinutes } from '../../constants/limitOrders';
+
+export const SwapsLimitOrderExpirationModalSelectorsIDs = {
+  SHEET: 'swaps-limit-order-expiration-modal',
+  CLOSE_BUTTON: 'swaps-limit-order-expiration-modal-close',
+  CONFIRM_BUTTON: 'swaps-limit-order-expiration-modal-confirm',
+  OPTION: (minutes: SwapsLimitOrderExpirationMinutes) =>
+    `swaps-limit-order-expiration-option-${minutes}`,
+} as const;

--- a/app/components/UI/Bridge/components/SwapsLimitOrderExpirationModal/types.ts
+++ b/app/components/UI/Bridge/components/SwapsLimitOrderExpirationModal/types.ts
@@ -1,0 +1,39 @@
+import type { SwapsLimitOrderExpirationMinutes } from '../../constants/limitOrders';
+
+export interface SwapsLimitOrderExpirationModalParams {
+  /**
+   * Currently committed expiration, in minutes, used as the initial selection.
+   */
+  selectedMinutes: SwapsLimitOrderExpirationMinutes;
+  /**
+   * Fired when the user confirms an expiration. The parent owns the committed value.
+   */
+  onConfirm: (minutes: SwapsLimitOrderExpirationMinutes) => void;
+}
+
+export interface SwapsLimitOrderExpirationModalProps {
+  /**
+   * Currently selected expiration, in minutes.
+   */
+  selectedMinutes: SwapsLimitOrderExpirationMinutes;
+  /**
+   * Fired when the user taps an expiration option.
+   */
+  onSelect: (minutes: SwapsLimitOrderExpirationMinutes) => void;
+  /**
+   * Fired when the user confirms the selected expiration.
+   */
+  onConfirm: (minutes: SwapsLimitOrderExpirationMinutes) => void;
+  /**
+   * Fired when the sheet is dismissed. Used by tests and non-navigation hosts.
+   */
+  onClose?: () => void;
+  /**
+   * Pops the Bridge modal route when the sheet closes.
+   */
+  goBack?: () => void;
+  /**
+   * Optional test ID for the sheet container.
+   */
+  testID?: string;
+}

--- a/app/components/UI/Bridge/constants/limitOrders.test.ts
+++ b/app/components/UI/Bridge/constants/limitOrders.test.ts
@@ -1,0 +1,17 @@
+import { getSwapsLimitOrderExpirationLabel } from './limitOrders';
+
+describe('getSwapsLimitOrderExpirationLabel', () => {
+  it.each([
+    { minutes: 10, label: '10 minutes' },
+    { minutes: 60, label: '1 hour' },
+    { minutes: 1440, label: '1 day' },
+    { minutes: 4320, label: '3 days' },
+    { minutes: 10080, label: '1 week' },
+    { minutes: 43200, label: '1 month' },
+  ] as const)(
+    'returns "$label" when expiration is $minutes minutes',
+    ({ minutes, label }) => {
+      expect(getSwapsLimitOrderExpirationLabel(minutes)).toBe(label);
+    },
+  );
+});

--- a/app/components/UI/Bridge/constants/limitOrders.ts
+++ b/app/components/UI/Bridge/constants/limitOrders.ts
@@ -1,6 +1,41 @@
+import AppConstants from '../../../../core/AppConstants';
+import { strings } from '../../../../../locales/i18n';
+
 export enum LimitOrderExecutionType {
   BUY = 'buy',
   SELL = 'sell',
 }
 
 export const LIMIT_ORDER_BUTTON_PRICE_PRESETS = [5, 10];
+
+export const LIMIT_ORDER_DEFAULT_SLIPPAGE = String(
+  AppConstants.SWAPS.DEFAULT_SLIPPAGE,
+);
+
+export const SWAPS_LIMIT_ORDER_EXPIRATION_OPTIONS_MINUTES = [
+  10, 60, 1440, 4320, 10080, 43200,
+] as const;
+
+export type SwapsLimitOrderExpirationMinutes =
+  (typeof SWAPS_LIMIT_ORDER_EXPIRATION_OPTIONS_MINUTES)[number];
+
+export const SWAPS_LIMIT_ORDER_DEFAULT_EXPIRATION_MINUTES: SwapsLimitOrderExpirationMinutes = 60;
+
+export const SWAPS_LIMIT_ORDER_EXPIRATION_LABEL: Record<
+  SwapsLimitOrderExpirationMinutes,
+  { key: string; count: number }
+> = {
+  10: { key: 'bridge.limit.expiration_option.minutes', count: 10 },
+  60: { key: 'bridge.limit.expiration_option.hour', count: 1 },
+  1440: { key: 'bridge.limit.expiration_option.day', count: 1 },
+  4320: { key: 'bridge.limit.expiration_option.days', count: 3 },
+  10080: { key: 'bridge.limit.expiration_option.week', count: 1 },
+  43200: { key: 'bridge.limit.expiration_option.month', count: 1 },
+};
+
+export const getSwapsLimitOrderExpirationLabel = (
+  minutes: SwapsLimitOrderExpirationMinutes,
+): string => {
+  const { key, count } = SWAPS_LIMIT_ORDER_EXPIRATION_LABEL[minutes];
+  return strings(key, { count });
+};


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Limit orders need a dedicated picker so users can choose how long an order remains open before it expires, without committing a selection until they confirm.

This adds a `SwapsLimitOrderExpirationModal` bottom sheet (header, preset duration list, confirm/close) and a navigation screen wrapper that holds a pending selection from route params. Confirm reports the chosen minutes back to the parent; dismiss closes the sheet without confirming. Unit tests cover option selection, confirm, and close-without-confirm.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:  https://consensyssoftware.atlassian.net/browse/SWAPS-4904

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — this commit adds the modal component and unit tests only; the sheet is not registered on the Bridge modal stack yet.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New UI and constants with unit tests only; no navigation wiring or swap execution path changes yet.
> 
> **Overview**
> Adds a **limit order expiration** bottom sheet so users can pick how long an order stays open before confirming.
> 
> `SwapsLimitOrderExpirationModal` lists preset durations from shared Bridge constants (10 minutes through 1 month), shows localized labels, and only commits the choice on **Confirm**; closing dismisses without calling `onConfirm`. `SwapsLimitOrderExpirationModalScreen` reads route params, keeps a pending selection in local state, and pops navigation on dismiss.
> 
> `limitOrders.ts` gains expiration option minutes, a default (60), i18n label mapping via `getSwapsLimitOrderExpirationLabel`, and `LIMIT_ORDER_DEFAULT_SLIPPAGE`. Unit tests cover the modal, screen, and label helper. The sheet is **not** registered on the Bridge modal stack in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3f588974c64fc06f3ec1f2c9b3af8160ca2b315. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->