### PR TITLE
feat: wire up swaps limit order details card

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { CaipChainId } from '@metamask/utils';
-import { fireEvent } from '@testing-library/react-native';
+import { fireEvent, act } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { strings } from '../../../../../../../locales/i18n';
 import { createBridgeTestState } from '../../../testUtils';
@@ -12,8 +12,12 @@ import { useSwapsLimitOrderPriceAdjust } from '../../../hooks/useSwapsLimitOrder
 import { useSwapsLimitOrderKeypad } from '../../../hooks/useSwapsLimitOrderKeypad';
 import { useHasMissingQuoteAndAssetsPriceData } from '../../../hooks/useHasMissingQuoteAndAssetsPriceData';
 import { useLatestBalance } from '../../../hooks/useLatestBalance';
-import { LimitOrderExecutionType } from '../../../constants/limitOrders';
+import {
+  LimitOrderExecutionType,
+  getSwapsLimitOrderExpirationLabel,
+} from '../../../constants/limitOrders';
 import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
+import Routes from '../../../../../../constants/navigation/Routes';
 import BridgeLimitOrderView from './index';
 
 /**
@@ -69,6 +73,18 @@ jest.mock('../../../hooks/useSwapsLimitOrderKeypad', () => ({
 jest.mock('../../../hooks/useHasMissingQuoteAndAssetsPriceData', () => ({
   useHasMissingQuoteAndAssetsPriceData: jest.fn(() => false),
 }));
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+    }),
+  };
+});
 
 jest.mock('../../../components/SwapsKeypad', () => {
   const ReactActual = jest.requireActual('react');
@@ -177,9 +193,44 @@ jest.mock('../../../components/LimitOrderPriceAdjustCard', () => {
   };
 });
 
+jest.mock('../../../components/LimitOrderDetails', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text } = jest.requireActual('react-native');
+
+  return {
+    __esModule: true,
+    default: ({
+      slippage,
+      onPricePress,
+      expiration,
+      onExpirationPress,
+    }: {
+      slippage: string;
+      onPricePress: () => void;
+      expiration: string;
+      onExpirationPress: () => void;
+    }) => (
+      <View>
+        <View
+          testID="limit-order-details-expiration-row"
+          onTouchEnd={onExpirationPress}
+        >
+          <Text>{expiration}</Text>
+        </View>
+        <View testID="limit-order-details-price-row" onTouchEnd={onPricePress}>
+          <Text>{slippage}</Text>
+        </View>
+      </View>
+    ),
+  };
+});
+
 const mockSourceToken = createMockTokenWithBalance({
   symbol: 'ETH',
   name: 'Ether',
+});
+const mockDestToken = createMockTokenWithBalance({
+  symbol: 'USDC',
 });
 
 const mockCommitCustomPercent = jest.fn();
@@ -196,7 +247,7 @@ let mockSourceAmount = '';
 
 function buildSwapInputsMock() {
   return {
-    destToken: createMockTokenWithBalance({ symbol: 'USDC' }),
+    destToken: mockDestToken,
     destTokenAmount: '24.44',
     enabledChainIds: ['eip155:1'] as CaipChainId[],
     handleDestTokenPress: jest.fn(),
@@ -275,11 +326,16 @@ function buildKeypadMock() {
   };
 }
 
-function renderLimitOrderView() {
+function renderLimitOrderView(
+  bridgeReducerOverrides: NonNullable<
+    Parameters<typeof createBridgeTestState>[0]
+  >['bridgeReducerOverrides'] = {},
+) {
   return renderWithProvider(<BridgeLimitOrderView />, {
     state: createBridgeTestState({
       bridgeReducerOverrides: {
         sourceToken: mockSourceToken,
+        ...bridgeReducerOverrides,
       },
     }),
   });
@@ -463,5 +519,69 @@ describe('BridgeLimitOrderView', () => {
     expect(
       queryByTestId('limit-order-price-adjust-with-banner'),
     ).not.toBeOnTheScreen();
+  });
+
+  it('displays 2% when slippage is not set', () => {
+    const { getByText } = renderLimitOrderView();
+
+    expect(getByText('2%')).toBeOnTheScreen();
+  });
+
+  it('displays the selected slippage percent from state', () => {
+    const { getByText } = renderLimitOrderView({ slippage: '2' });
+
+    expect(getByText('2%')).toBeOnTheScreen();
+  });
+
+  it('navigates to the swap default slippage modal when the slippage row is pressed', () => {
+    const { getByTestId } = renderLimitOrderView();
+
+    fireEvent(getByTestId('limit-order-details-price-row'), 'touchEnd');
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.SWAP_DEFAULT_SLIPPAGE_MODAL,
+      params: {
+        sourceChainId: mockSourceToken.chainId,
+        destChainId: mockDestToken.chainId,
+      },
+    });
+  });
+
+  it('displays 1 hour as the default expiration', () => {
+    const { getByText } = renderLimitOrderView();
+
+    expect(getByText(getSwapsLimitOrderExpirationLabel(60))).toBeOnTheScreen();
+  });
+
+  it('navigates to the expiration modal when the expiration row is pressed', () => {
+    const { getByTestId } = renderLimitOrderView();
+
+    fireEvent(getByTestId('limit-order-details-expiration-row'), 'touchEnd');
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.SWAPS_LIMIT_ORDER_EXPIRATION_MODAL,
+      params: {
+        selectedMinutes: 60,
+        onConfirm: expect.any(Function),
+      },
+    });
+  });
+
+  it('saves the selected expiration in minutes when the modal confirms', () => {
+    const { getByTestId, getByText, queryByText } = renderLimitOrderView();
+
+    fireEvent(getByTestId('limit-order-details-expiration-row'), 'touchEnd');
+
+    const navigateConfig = mockNavigate.mock.calls[0][1] as {
+      params: { onConfirm: (minutes: number) => void };
+    };
+    act(() => {
+      navigateConfig.params.onConfirm(10080);
+    });
+
+    expect(
+      getByText(getSwapsLimitOrderExpirationLabel(10080)),
+    ).toBeOnTheScreen();
+    expect(queryByText(getSwapsLimitOrderExpirationLabel(60))).toBeNull();
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
@@ -1,11 +1,16 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ScrollView, type LayoutChangeEvent } from 'react-native';
-import { useSelector } from 'react-redux';
+import { useNavigation } from '@react-navigation/native';
+import { useDispatch, useSelector } from 'react-redux';
 import { Box } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import type { AppNavigationProp } from '../../../../../../core/NavigationService/types';
+import Routes from '../../../../../../constants/navigation/Routes';
 import {
   selectBridgeBalanceRefreshKey,
+  selectSlippage,
   selectSourceToken,
+  setSlippage,
 } from '../../../../../../core/redux/slices/bridge';
 import { BridgeQuoteDataProvider } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import type { TokenInputAreaRef } from '../../../components/TokenInputArea';
@@ -28,12 +33,19 @@ import { LIMIT_MOCK_HISTORY_TAB } from './BridgeLimitOrderView.mockHistory';
 import { LIMIT_MOCK_OPEN_ORDERS_TAB } from './BridgeLimitOrderView.mockOpenOrders';
 import { BridgeLimitOrderFooterView } from './BridgeLimitOrderFooterView';
 import { SwapsLimitOrderConfirmButton } from '../../../components/SwapsLimitOrderConfirmButton';
+import LimitOrderDetails from '../../../components/LimitOrderDetails';
 import { LimitOrderPriceAdjustCard } from '../../../components/LimitOrderPriceAdjustCard';
 import type {
   ButtonPricePresetsSectionRef,
   InputSectionRef,
 } from '../../../components/LimitOrderPriceAdjustCard/types';
-import { LIMIT_ORDER_BUTTON_PRICE_PRESETS } from '../../../constants/limitOrders';
+import {
+  LIMIT_ORDER_BUTTON_PRICE_PRESETS,
+  LIMIT_ORDER_DEFAULT_SLIPPAGE,
+  SWAPS_LIMIT_ORDER_DEFAULT_EXPIRATION_MINUTES,
+  getSwapsLimitOrderExpirationLabel,
+  type SwapsLimitOrderExpirationMinutes,
+} from '../../../constants/limitOrders';
 import { useSwapsLimitOrderPriceAdjust } from '../../../hooks/useSwapsLimitOrderPriceAdjust';
 import { useSwapsLimitOrderKeypad } from '../../../hooks/useSwapsLimitOrderKeypad';
 import { useHasMissingQuoteAndAssetsPriceData } from '../../../hooks/useHasMissingQuoteAndAssetsPriceData';
@@ -46,6 +58,9 @@ const BridgeLimitOrderViewContent = ({
   latestSourceBalance,
 }: BridgeLimitOrderViewContentProps) => {
   const tw = useTailwind();
+  const navigation = useNavigation<AppNavigationProp>();
+  const dispatch = useDispatch();
+  const slippage = useSelector(selectSlippage);
   const inputRef = useRef<TokenInputAreaRef>(null);
   const limitPriceInputRef = useRef<InputSectionRef>(null);
   const customPercentInputRef = useRef<ButtonPricePresetsSectionRef>(null);
@@ -115,6 +130,16 @@ const BridgeLimitOrderViewContent = ({
 
   const [hasVisibleBanner, setHasVisibleBanner] = useState(false);
   const isMissingPrice = useHasMissingQuoteAndAssetsPriceData();
+  const [expirationMinutes, setExpirationMinutes] =
+    useState<SwapsLimitOrderExpirationMinutes>(
+      SWAPS_LIMIT_ORDER_DEFAULT_EXPIRATION_MINUTES,
+    );
+
+  useEffect(() => {
+    if (slippage === undefined) {
+      dispatch(setSlippage(LIMIT_ORDER_DEFAULT_SLIPPAGE));
+    }
+  }, [dispatch, slippage]);
 
   const blurLimitAdjustInputs = useCallback(() => {
     limitPriceInputRef.current?.blur();
@@ -174,6 +199,39 @@ const BridgeLimitOrderViewContent = ({
       current === nextHasVisibleBanner ? current : nextHasVisibleBanner,
     );
   }, []);
+
+  const handleSlippagePress = useCallback(() => {
+    navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.SWAP_DEFAULT_SLIPPAGE_MODAL,
+      params: {
+        sourceChainId: sourceToken?.chainId,
+        destChainId: destToken?.chainId,
+      },
+    });
+  }, [destToken?.chainId, navigation, sourceToken?.chainId]);
+
+  const handleExpirationConfirm = useCallback(
+    (minutes: SwapsLimitOrderExpirationMinutes) => {
+      setExpirationMinutes(minutes);
+    },
+    [],
+  );
+
+  const handleExpirationPress = useCallback(() => {
+    dismissInputAndKeypad();
+    navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.SWAPS_LIMIT_ORDER_EXPIRATION_MODAL,
+      params: {
+        selectedMinutes: expirationMinutes,
+        onConfirm: handleExpirationConfirm,
+      },
+    });
+  }, [
+    dismissInputAndKeypad,
+    expirationMinutes,
+    handleExpirationConfirm,
+    navigation,
+  ]);
 
   return (
     <Box twClassName="flex-1 bg-default">
@@ -247,6 +305,19 @@ const BridgeLimitOrderViewContent = ({
               limitPriceInputRef={limitPriceInputRef}
               customPercentInputRef={customPercentInputRef}
             />
+
+            <Box twClassName="flex-grow-0" onTouchEnd={dismissInputAndKeypad}>
+              <LimitOrderDetails
+                expiration={getSwapsLimitOrderExpirationLabel(
+                  expirationMinutes,
+                )}
+                onExpirationPress={handleExpirationPress}
+                slippage={`${slippage ?? LIMIT_ORDER_DEFAULT_SLIPPAGE}%`}
+                onPricePress={handleSlippagePress}
+                networkFee="$1.69"
+                feeToken={sourceToken}
+              />
+            </Box>
 
             <Box
               twClassName="flex-grow-0 pb-3"

--- a/app/components/UI/Bridge/routes.tsx
+++ b/app/components/UI/Bridge/routes.tsx
@@ -32,6 +32,7 @@ import { BatchSellFinalReviewModal } from './components/BatchSellFinalReviewModa
 import { BatchSellNetworkFeeInfoModal } from './components/BatchSellNetworkFeeInfoModal';
 import { BatchSellMinimumReceivedInfoModal } from './components/BatchSellMinimumReceivedInfoModal';
 import { BatchSellPriceImpactInfoModal } from './components/BatchSellPriceImpactInfoModal';
+import { SwapsLimitOrderExpirationModalScreen } from './components/SwapsLimitOrderExpirationModal/SwapsLimitOrderExpirationModalScreen';
 import type {
   BridgeModalsNavigationParamList,
   BridgeScreensStackParamList,
@@ -163,6 +164,10 @@ export const BridgeModalStack = () => (
     <ModalStack.Screen
       name={Routes.BRIDGE.MODALS.BATCH_SELL_PRICE_IMPACT_INFO_MODAL}
       component={BatchSellPriceImpactInfoModal}
+    />
+    <ModalStack.Screen
+      name={Routes.BRIDGE.MODALS.SWAPS_LIMIT_ORDER_EXPIRATION_MODAL}
+      component={SwapsLimitOrderExpirationModalScreen}
     />
   </ModalStack.Navigator>
 );

--- a/app/components/UI/Bridge/types/navigation.ts
+++ b/app/components/UI/Bridge/types/navigation.ts
@@ -21,6 +21,7 @@ import type { BatchSellPriceImpactInfoModalParams } from '../components/BatchSel
 import type { BatchSellNetworkFeeInfoModalParams } from '../components/BatchSellNetworkFeeInfoModal/BatchSellNetworkFeeInfoModal.types';
 import type { BatchSellMinimumReceivedInfoModalParams } from '../components/BatchSellMinimumReceivedInfoModal/BatchSellMinimumReceivedInfoModal.types';
 import type { NetworkListModalParams } from '../components/BridgeTokenSelector/NetworkListModal';
+import type { SwapsLimitOrderExpirationModalParams } from '../components/SwapsLimitOrderExpirationModal/types';
 
 /**
  * Param list for screens inside the Bridge screen stack (`BridgeScreenStack`).
@@ -67,6 +68,7 @@ export type BridgeModalsNavigationParamList = {
     | BatchSellMinimumReceivedInfoModalParams
     | undefined;
   BatchSellPriceImpactInfoModal: BatchSellPriceImpactInfoModalParams;
+  SwapsLimitOrderExpirationModal: SwapsLimitOrderExpirationModalParams;
 };
 
 /**

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -373,6 +373,7 @@ const Routes = {
       BATCH_SELL_MINIMUM_RECEIVED_INFO_MODAL:
         'BatchSellMinimumReceivedInfoModal',
       BATCH_SELL_PRICE_IMPACT_INFO_MODAL: 'BatchSellPriceImpactInfoModal',
+      SWAPS_LIMIT_ORDER_EXPIRATION_MODAL: 'SwapsLimitOrderExpirationModal',
     },
     BRIDGE_TRANSACTION_DETAILS: 'BridgeTransactionDetails',
   },

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -937,6 +937,7 @@ export type RootStackParamList = {
   BatchSellFinalReviewModal: BridgeModalsNavigationParamList['BatchSellFinalReviewModal'];
   BatchSellNetworkFeeInfoModal: BridgeModalsNavigationParamList['BatchSellNetworkFeeInfoModal'];
   BatchSellMinimumReceivedInfoModal: BridgeModalsNavigationParamList['BatchSellMinimumReceivedInfoModal'];
+  SwapsLimitOrderExpirationModal: BridgeModalsNavigationParamList['SwapsLimitOrderExpirationModal'];
   BridgeTransactionDetails:
     | BridgeTransactionDetailsParams
     | BridgeModalsNavigationParamList['TransactionDetailsBlockExplorer'];


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The swaps limit order screen already had token inputs and price presets, but users could not see or change expiration and slippage from that flow.

This mounts `LimitOrderDetails` on `BridgeLimitOrderView`, seeds default slippage (2%) and expiration (1 hour), registers `SwapsLimitOrderExpirationModal` on the Bridge modal stack, and opens the existing default slippage modal from the slippage row. Confirming an expiration updates the details card; dismissing the sheet leaves the current value. Unit tests cover default labels, both navigations, and saving a confirmed expiration.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs:  https://consensyssoftware.atlassian.net/browse/SWAPS-4905

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Limit order details card

  Background:
    Given I am logged into MetaMask Mobile
    And I am on the Swaps limit order screen
    And I have entered a source amount so the details card is visible

  Scenario: user sees default expiration and slippage
    Then I should see expiration labeled as 1 hour
    And I should see slippage labeled as 2%

  Scenario: user changes expiration
    When user taps the expiration row
    Then the expiration picker should open with 1 hour selected
    When user selects "1 week" and confirms
    Then the details card should show "1 week"

  Scenario: user dismisses expiration picker without confirming
    Given the details card shows "1 hour"

    When user taps the expiration row
    And user selects a different duration
    And user dismisses the sheet without confirming
    Then the details card should still show "1 hour"

  Scenario: user opens slippage settings
    When user taps the slippage row
    Then the default slippage modal should open
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI wiring and navigation to existing/new modals; slippage uses shared bridge Redux. No auth or payment changes; placeholder network fee is not yet quote-driven.
> 
> **Overview**
> **Adds a limit order details card** on `BridgeLimitOrderView` so users can see and change **expiration** and **slippage** from the limit-order flow.
> 
> The view renders **`LimitOrderDetails`** (default **1 hour** expiration in local state, **2%** slippage from bridge Redux with a one-time seed when unset). Tapping **slippage** opens the existing **swap default slippage** modal with source/dest chain IDs; tapping **expiration** dismisses the keypad and opens the new **`SwapsLimitOrderExpirationModal`**, and a confirmed choice updates the card label. The expiration screen is registered on the Bridge modal stack with route and navigation typing updates.
> 
> Unit tests cover default labels, both navigations, and persisting expiration after modal confirm. **Network fee** is still passed as a **hardcoded** placeholder (`$1.69`) on the details card.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31e61de4cea47d38f2508e5bd70f70543899a5f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->