### PR TITLE
fix: Update eth-json-rpc-middleware package to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
     "@metamask/ens-resolver-snap": "^1.2.0",
     "@metamask/eth-hd-keyring": "^15.0.0",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
-    "@metamask/eth-json-rpc-middleware": "^24.0.1",
+    "@metamask/eth-json-rpc-middleware": "^24.0.2",
     "@metamask/eth-ledger-bridge-keyring": "^13.1.0",
     "@metamask/eth-money-keyring": "^4.0.0",
     "@metamask/eth-qr-keyring": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8624,13 +8624,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-middleware@npm:^24.0.1":
-  version: 24.0.1
-  resolution: "@metamask/eth-json-rpc-middleware@npm:24.0.1"
+"@metamask/eth-json-rpc-middleware@npm:^24.0.2":
+  version: 24.0.2
+  resolution: "@metamask/eth-json-rpc-middleware@npm:24.0.2"
   dependencies:
     "@metamask/eth-block-tracker": "npm:^15.0.1"
     "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/eth-sig-util": "npm:^9.0.0"
     "@metamask/json-rpc-engine": "npm:^10.5.0"
     "@metamask/message-manager": "npm:^14.1.2"
     "@metamask/rpc-errors": "npm:^7.0.2"
@@ -8638,7 +8638,7 @@ __metadata:
     "@metamask/utils": "npm:^11.11.0"
     klona: "npm:^2.0.6"
     safe-stable-stringify: "npm:^2.4.3"
-  checksum: 10/54ebe641625c1dec7c8d2e9b46551ca9b0006b2b0f0cbdb6aa79644334222711b15cc660250710c4d5bfd0767e5a5e27a35f62dc93e63d90e35e1cf83727be28
+  checksum: 10/f01d71878e994b43a50f97e9da67373167a1f3e02343f16a692ee91ae99348336a278273c91d1c1c09203bc5c158390ba664bd8bd6a7b906138b922c75b30922
   languageName: node
   linkType: hard
 
@@ -35802,7 +35802,7 @@ __metadata:
     "@metamask/eslint-plugin-design-tokens": "npm:^1.0.0"
     "@metamask/eth-hd-keyring": "npm:^15.0.0"
     "@metamask/eth-json-rpc-filters": "npm:^9.0.0"
-    "@metamask/eth-json-rpc-middleware": "npm:^24.0.1"
+    "@metamask/eth-json-rpc-middleware": "npm:^24.0.2"
     "@metamask/eth-ledger-bridge-keyring": "npm:^13.1.0"
     "@metamask/eth-money-keyring": "npm:^4.0.0"
     "@metamask/eth-qr-keyring": "npm:^2.1.0"


### PR DESCRIPTION
## **Description**

Bumps `@metamask/eth-json-rpc-middleware` from `24.0.1` to `24.0.2`. This patch release updates the `@metamask/eth-sig-util` dependency from `^8.2.0` to `^9.0.0`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

No manual testing required — this is a dependency version bump with no behavioral changes.

## **Screenshots/Recordings**

<!--
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Ethereum JSON-RPC middleware on the dapp provider path (signing-related transitive deps), but scope is a patch bump with lockfile-only changes and no local code edits.
> 
> **Overview**
> Bumps **`@metamask/eth-json-rpc-middleware`** from **24.0.1** to **24.0.2** in `package.json` and refreshes **`yarn.lock`**. There are no application source changes.
> 
> The resolved middleware package now depends on **`@metamask/eth-sig-util` ^9.0.0** (was ^8.2.0 on 24.0.1), matching the app’s existing direct dependency and **`resolutions`** entry for `eth-sig-util`. This package still powers the provider middleware stack (e.g. **`providerAsMiddleware`** in `BackgroundBridge`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf358f668f93f4c118152f14d66198c49f3b9fb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->