### PR TITLE
fix(activity): show Money Account transfers in EOA activity

### DIFF
--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
@@ -686,7 +686,7 @@ describe('ActivityListItemRow — row content', () => {
     );
   });
 
-  it('renders a Money Account deposit as a sent transfer with Money account counterparty', () => {
+  it('renders an EOA transfer to Money as a deposit with Money account counterparty', () => {
     const item = makeItem({
       type: 'send',
       from: OWNED_ACCOUNT_ADDRESS,
@@ -703,7 +703,7 @@ describe('ActivityListItemRow — row content', () => {
     );
 
     expect(getByTestId('activity-title-0xabc').props.children).toBe(
-      'Sent mUSD',
+      'Deposited mUSD',
     );
     expect(getByTestId('activity-subtitle-0xabc').props.children).toBe(
       `To: ${strings('transaction_details.label.money_account')}`,

--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
@@ -31,6 +31,7 @@ const LINEA_MUSD_CHECKSUM_ADDRESS =
   '0xacA92E438df0B2401fF60dA7E4337B687a2435DA';
 const OWNED_ACCOUNT_ADDRESS = '0xAa60919dd0d0964B76620dAaF08bF357e1c9DD73';
 const OWNED_SOLANA_ADDRESS = '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV';
+const MOCK_MONEY_ACCOUNT_ADDRESS = '0x3333333333333333333333333333333333333333';
 
 const mockState = {
   user: {
@@ -169,6 +170,12 @@ jest.mock('../../../selectors/multichain', () => ({
   selectMultichainAssetsRates: jest.fn(() => ({})),
 }));
 
+jest.mock('../../../selectors/moneyAccountController', () => ({
+  selectPrimaryMoneyAccount: jest.fn(() => ({
+    address: MOCK_MONEY_ACCOUNT_ADDRESS,
+  })),
+}));
+
 jest.mock('../../hooks/useTokensData/useTokensData', () => ({
   useTokensData: jest.fn(() => ({})),
 }));
@@ -203,6 +210,10 @@ jest.mock('../../../util/networks', () => ({
 }));
 
 jest.mock('../../../util/address', () => ({
+  areAddressesEqual: jest.fn(
+    (first: string, second: string) =>
+      first.toLowerCase() === second.toLowerCase(),
+  ),
   renderShortAddress: jest.fn((address: string) => `${address.slice(0, 6)}...`),
   safeToChecksumAddress: jest.requireActual('../../../util/address')
     .safeToChecksumAddress,
@@ -672,6 +683,60 @@ describe('ActivityListItemRow — row content', () => {
     );
     expect(getByTestId('activity-secondary-amount-0xabc').props.children).toBe(
       '+$200.34',
+    );
+  });
+
+  it('renders a Money Account deposit as a sent transfer with Money account counterparty', () => {
+    const item = makeItem({
+      type: 'send',
+      from: OWNED_ACCOUNT_ADDRESS,
+      to: MOCK_MONEY_ACCOUNT_ADDRESS,
+      token: {
+        amount: '2500000',
+        decimals: 6,
+        direction: 'out',
+        symbol: 'mUSD',
+      },
+    });
+    const { getByTestId } = render(
+      <ActivityListItemRow item={item} index={0} />,
+    );
+
+    expect(getByTestId('activity-title-0xabc').props.children).toBe(
+      'Sent mUSD',
+    );
+    expect(getByTestId('activity-subtitle-0xabc').props.children).toBe(
+      `To: ${strings('transaction_details.label.money_account')}`,
+    );
+    expect(getByTestId('activity-primary-amount-0xabc').props.children).toBe(
+      '-2.5 mUSD',
+    );
+  });
+
+  it('renders a Money Account withdrawal as a received transfer with Money account counterparty', () => {
+    const item = makeItem({
+      type: 'receive',
+      from: MOCK_MONEY_ACCOUNT_ADDRESS,
+      to: OWNED_ACCOUNT_ADDRESS,
+      token: {
+        amount: '1750000',
+        decimals: 6,
+        direction: 'in',
+        symbol: 'mUSD',
+      },
+    });
+    const { getByTestId } = render(
+      <ActivityListItemRow item={item} index={0} />,
+    );
+
+    expect(getByTestId('activity-title-0xabc').props.children).toBe(
+      'Received mUSD',
+    );
+    expect(getByTestId('activity-subtitle-0xabc').props.children).toBe(
+      `From: ${strings('transaction_details.label.money_account')}`,
+    );
+    expect(getByTestId('activity-primary-amount-0xabc').props.children).toBe(
+      '+1.75 mUSD',
     );
   });
 

--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
@@ -713,6 +713,30 @@ describe('ActivityListItemRow — row content', () => {
     );
   });
 
+  it('uses deposit copy and hides amounts for a cancelled EOA transfer to Money', () => {
+    const item = makeItem({
+      type: 'send',
+      status: 'cancelled',
+      from: OWNED_ACCOUNT_ADDRESS,
+      to: MOCK_MONEY_ACCOUNT_ADDRESS,
+      token: {
+        amount: '2500000',
+        decimals: 6,
+        direction: 'out',
+        symbol: 'mUSD',
+      },
+    });
+    const { getByTestId, queryByTestId } = render(
+      <ActivityListItemRow item={item} index={0} />,
+    );
+
+    expect(getByTestId('activity-title-0xabc').props.children).toBe(
+      'Deposit cancelled',
+    );
+    expect(queryByTestId('activity-primary-amount-0xabc')).toBeNull();
+    expect(queryByTestId('activity-secondary-amount-0xabc')).toBeNull();
+  });
+
   it('renders a Money Account withdrawal as a received transfer with Money account counterparty', () => {
     const item = makeItem({
       type: 'receive',

--- a/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
+++ b/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
@@ -534,8 +534,11 @@ function resolveCoreContent(
         : item.type === 'receive'
           ? 'Receive failed'
           : 'Send failed';
-      const cancelledLabel =
-        item.type === 'receive' ? 'Receive cancelled' : 'Send cancelled';
+      const cancelledLabel = isMoneyDeposit
+        ? 'Deposit cancelled'
+        : item.type === 'receive'
+          ? 'Receive cancelled'
+          : 'Send cancelled';
       const subtitlePrefix = item.type === 'receive' ? 'From' : 'To';
       const counterpartyLabel =
         counterpartyName ||

--- a/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
+++ b/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
@@ -507,6 +507,7 @@ function resolveCoreContent(
   formatters: Formatters,
   bridgeHistoryItem?: BridgeHistoryItem,
   counterpartyName?: string,
+  isMoneyAccountCounterparty = false,
 ): Omit<
   ActivityListItemRowContent,
   'avatarTokens' | 'primaryAmount' | 'secondaryAmount'
@@ -517,10 +518,22 @@ function resolveCoreContent(
       const token = item.data.token;
       const symbol = token?.symbol ?? '';
       const address = item.type === 'receive' ? item.data.from : item.data.to;
-      const label = item.type === 'receive' ? 'Received' : 'Sent';
-      const pendingLabel = item.type === 'receive' ? 'Receiving' : 'Sending';
-      const failedLabel =
-        item.type === 'receive' ? 'Receive failed' : 'Send failed';
+      const isMoneyDeposit = item.type === 'send' && isMoneyAccountCounterparty;
+      const label = isMoneyDeposit
+        ? strings('money.transaction.deposited')
+        : item.type === 'receive'
+          ? 'Received'
+          : 'Sent';
+      const pendingLabel = isMoneyDeposit
+        ? strings('money.transaction.depositing')
+        : item.type === 'receive'
+          ? 'Receiving'
+          : 'Sending';
+      const failedLabel = isMoneyDeposit
+        ? strings('money.transaction.deposit_failed')
+        : item.type === 'receive'
+          ? 'Receive failed'
+          : 'Send failed';
       const cancelledLabel =
         item.type === 'receive' ? 'Receive cancelled' : 'Send cancelled';
       const subtitlePrefix = item.type === 'receive' ? 'From' : 'To';
@@ -1140,18 +1153,21 @@ export function useActivityListItemRowContent(
       : [],
   )[0];
   const moneyAccountAddress = useSelector(selectPrimaryMoneyAccount)?.address;
-  const counterpartyName =
+  const isMoneyAccountCounterparty = Boolean(
     counterpartyAddress &&
-    moneyAccountAddress &&
-    areAddressesEqual(counterpartyAddress, moneyAccountAddress)
-      ? strings('transaction_details.label.money_account')
-      : accountGroupName;
+      moneyAccountAddress &&
+      areAddressesEqual(counterpartyAddress, moneyAccountAddress),
+  );
+  const counterpartyName = isMoneyAccountCounterparty
+    ? strings('transaction_details.label.money_account')
+    : accountGroupName;
 
   const content = resolveCoreContent(
     item,
     formatters,
     bridgeHistoryItem,
     counterpartyName,
+    isMoneyAccountCounterparty,
   );
 
   let basePrimaryToken: TokenAmount | undefined;

--- a/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
+++ b/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
@@ -10,6 +10,7 @@ import {
   selectCurrentCurrency,
   selectUSDConversionRateByChainId,
 } from '../../../selectors/currencyRateController';
+import { selectPrimaryMoneyAccount } from '../../../selectors/moneyAccountController';
 import { getFormatters, useFormatters } from '../../hooks/useFormatters';
 import { useConvertToFiat } from '../../hooks/useConvertToFiat';
 import { useTokensData } from '../../hooks/useTokensData/useTokensData';
@@ -19,7 +20,7 @@ import {
   MUSD_TOKEN_ADDRESS_BY_CHAIN,
   MUSD_TOKEN_ASSET_ID_BY_CHAIN,
 } from '../Earn/constants/musd';
-import { renderShortAddress } from '../../../util/address';
+import { areAddressesEqual, renderShortAddress } from '../../../util/address';
 import {
   applyDisplaySign,
   type ActivityKind,
@@ -1127,7 +1128,7 @@ export function useActivityListItemRowContent(
       : item.type === 'send'
         ? item.data.to
         : undefined;
-  const counterpartyName = useAccountNames(
+  const accountGroupName = useAccountNames(
     counterpartyAddress
       ? [
           {
@@ -1138,6 +1139,13 @@ export function useActivityListItemRowContent(
         ]
       : [],
   )[0];
+  const moneyAccountAddress = useSelector(selectPrimaryMoneyAccount)?.address;
+  const counterpartyName =
+    counterpartyAddress &&
+    moneyAccountAddress &&
+    areAddressesEqual(counterpartyAddress, moneyAccountAddress)
+      ? strings('transaction_details.label.money_account')
+      : accountGroupName;
 
   const content = resolveCoreContent(
     item,

--- a/app/components/UI/Money/constants/activityStyles.ts
+++ b/app/components/UI/Money/constants/activityStyles.ts
@@ -11,6 +11,7 @@ import {
   MUSD_TOKEN,
 } from '../../Earn/constants/musd';
 import { isPerpsPredictMoneyWithdraw } from '../utils/moneyTransactionGuards';
+import { decodeErc20Transfer } from '../../../../util/transactions/erc20-transfer';
 
 function formatNumber(num: number): string {
   return getIntlNumberFormatter(I18n.locale, {
@@ -46,49 +47,6 @@ export function getMoneyAmountPrefixForTransactionMeta(
     return '-';
   }
   return '+';
-}
-
-// `0x` + 8 hex chars selector + 64 hex chars (address) + 64 hex chars (uint256).
-export const ERC20_TRANSFER_CALLDATA_LENGTH = 138;
-// `0x` + 8 hex chars selector + 3 × 64 hex chars (from, to, uint256).
-export const ERC20_TRANSFER_FROM_CALLDATA_LENGTH = 202;
-// Slot offsets into calldata (chars). 10 = `0x` + 8-char selector; each slot
-// is 64 chars (32 bytes). transfer: [recipient, amount]. transferFrom:
-// [from, to, amount].
-const TRANSFER_AMOUNT_START = 10 + 64;
-const TRANSFER_AMOUNT_END = 10 + 64 + 64;
-const TRANSFER_FROM_AMOUNT_START = 10 + 64 + 64;
-const TRANSFER_FROM_AMOUNT_END = 10 + 64 + 64 + 64;
-
-/**
- * Decoded ERC-20 transfer amount from calldata (decimal string), or
- * `undefined` if calldata is missing/truncated/non-hex. We slice the uint256
- * slot ourselves and parse with `BigInt` to avoid the precision loss in
- * `decodeTransferData`'s `parseInt(slot, 16)` (which truncates above 2^53).
- */
-function decodeErc20TransferAmount(
-  data: string | undefined,
-  type: EvmTransactionType | undefined,
-): string | undefined {
-  if (!data) return undefined;
-  let slot: string | undefined;
-  if (
-    type === EvmTransactionType.tokenMethodTransfer &&
-    data.length >= ERC20_TRANSFER_CALLDATA_LENGTH
-  ) {
-    slot = data.substring(TRANSFER_AMOUNT_START, TRANSFER_AMOUNT_END);
-  } else if (
-    type === EvmTransactionType.tokenMethodTransferFrom &&
-    data.length >= ERC20_TRANSFER_FROM_CALLDATA_LENGTH
-  ) {
-    slot = data.substring(TRANSFER_FROM_AMOUNT_START, TRANSFER_FROM_AMOUNT_END);
-  }
-  if (!slot) return undefined;
-  try {
-    return BigInt(`0x${slot}`).toString();
-  } catch {
-    return undefined;
-  }
 }
 
 export interface ResolvedMusdTransferMeta {
@@ -130,7 +88,7 @@ export function resolveMusdTransferMeta(
     isErc20TransferType &&
     isMusdOnMoneyAccountChain(tx.txParams?.to, tx.chainId)
   ) {
-    amount = amount ?? decodeErc20TransferAmount(tx.txParams?.data, tx.type);
+    amount = amount ?? decodeErc20Transfer(tx.txParams?.data, tx.type)?.amount;
     decimals = decimals ?? MUSD_DECIMALS;
     symbol = symbol ?? MUSD_TOKEN.symbol;
     contractAddress = contractAddress ?? tx.txParams?.to;
@@ -149,10 +107,8 @@ export function resolveMusdTransferMeta(
     if (nestedMusdTransfer) {
       amount =
         amount ??
-        decodeErc20TransferAmount(
-          nestedMusdTransfer.data,
-          nestedMusdTransfer.type,
-        );
+        decodeErc20Transfer(nestedMusdTransfer.data, nestedMusdTransfer.type)
+          ?.amount;
       decimals = decimals ?? MUSD_DECIMALS;
       symbol = symbol ?? MUSD_TOKEN.symbol;
       contractAddress = contractAddress ?? nestedMusdTransfer.to;

--- a/app/components/UI/Money/hooks/useMoneyAccountTransactions.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountTransactions.ts
@@ -16,12 +16,8 @@ import {
 } from '../constants/moneyActivityFilters';
 import { selectNonReplacedTransactions } from '../../../../selectors/transactionController';
 import { areAddressesEqual } from '../../../../util/address';
-import { decodeTransferData } from '../../../../util/transactions';
+import { decodeErc20Transfer } from '../../../../util/transactions/erc20-transfer';
 import { isMusdOnMoneyAccountChain } from '../../Earn/constants/musd';
-import {
-  ERC20_TRANSFER_CALLDATA_LENGTH,
-  ERC20_TRANSFER_FROM_CALLDATA_LENGTH,
-} from '../constants/activityStyles';
 import { getMoneyActivityStatus } from '../utils/classifyMoneyActivity';
 import { isPerpsPredictMoneyActivity } from '../utils/moneyTransactionGuards';
 
@@ -54,36 +50,10 @@ function isMoneyAccountTxVisible(tx: TransactionMeta): boolean {
 /**
  * Extracts the call's recipient from ERC-20 `transfer`/`transferFrom` calldata.
  * For both types, `txParams.to` is the token contract, not the recipient — the
- * recipient must be decoded from the calldata. Returns `undefined` if the
- * calldata is missing or truncated; `decodeTransferData` does not throw on
- * short input, so length must be checked.
+ * recipient must be decoded from the calldata.
  */
 function getErc20TransferRecipient(tx: TransactionMeta): string | undefined {
-  const data = tx.txParams?.data;
-  if (!data) return undefined;
-  try {
-    if (
-      tx.type === TransactionType.tokenMethodTransfer &&
-      data.length >= ERC20_TRANSFER_CALLDATA_LENGTH
-    ) {
-      const [recipient] = decodeTransferData('transfer', data) as string[];
-      return recipient;
-    }
-    if (
-      tx.type === TransactionType.tokenMethodTransferFrom &&
-      data.length >= ERC20_TRANSFER_FROM_CALLDATA_LENGTH
-    ) {
-      // transferFrom(address from, address to, uint256 amount) → recipient at [1].
-      const [, recipient] = decodeTransferData(
-        'transferFrom',
-        data,
-      ) as string[];
-      return recipient;
-    }
-    return undefined;
-  } catch {
-    return undefined;
-  }
+  return decodeErc20Transfer(tx.txParams?.data, tx.type)?.recipient;
 }
 
 export interface UseMoneyAccountTransactionsResult {

--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
@@ -12,6 +12,7 @@ import EngineService from '../../../../core/EngineService';
 import NavigationService from '../../../../core/NavigationService/NavigationService';
 import Logger from '../../../../util/Logger';
 import { fromTokenMinimalUnitString } from '../../../../util/number/bigint';
+import { decodeErc20Transfer } from '../../../../util/transactions/erc20-transfer';
 import { strings } from '../../../../../locales/i18n';
 import { store } from '../../../../store';
 import { getMemoizedInternalAccountByAddress } from '../../../../selectors/accountsController';
@@ -41,33 +42,6 @@ import {
 } from './useMoneyAccount';
 
 const TELLER_INTERFACE = new ethers.utils.Interface(TELLER_ABI);
-const ERC20_TRANSFER_INTERFACE = new ethers.utils.Interface([
-  'function transfer(address to, uint256 amount)',
-]);
-
-interface DecodedErc20Transfer {
-  recipient: string;
-  amount: bigint;
-}
-
-function decodeErc20Transfer(
-  data: string | undefined,
-): DecodedErc20Transfer | undefined {
-  if (!data) return undefined;
-  try {
-    const [to, amount] = ERC20_TRANSFER_INTERFACE.decodeFunctionData(
-      'transfer',
-      data,
-    );
-    return { recipient: to as string, amount: BigInt(amount.toString()) };
-  } catch (error) {
-    Logger.error(
-      error as Error,
-      'useMoneyTransactionStatus: failed to decode erc20 transfer calldata',
-    );
-    return undefined;
-  }
-}
 
 function resolveWithdrawDestination(
   recipient: string | undefined,
@@ -327,9 +301,10 @@ export const useMoneyTransactionStatus = () => {
         const transfer = decodeErc20Transfer(
           nestedTxWithType(transactionMeta, TransactionType.tokenMethodTransfer)
             ?.data,
+          TransactionType.tokenMethodTransfer,
         );
         const amountFiat = transfer
-          ? formatMusdAmountForToast(transfer.amount)
+          ? formatMusdAmountForToast(BigInt(transfer.amount))
           : undefined;
         const destination =
           resolveWithdrawDestination(transfer?.recipient) ??

--- a/app/components/Views/ActivityList/hooks/useLocalActivityItems.test.ts
+++ b/app/components/Views/ActivityList/hooks/useLocalActivityItems.test.ts
@@ -9,11 +9,14 @@ import { useLocalActivityItems } from './useLocalActivityItems';
 import {
   selectLocalTransactions,
   selectReplacedLocalTransactions,
+  selectRequiredTransactions,
 } from '../../../../selectors/transactionController';
 import { selectBridgeHistoryForAccount } from '../../../../selectors/bridgeStatusController';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../selectors/networkController';
 import { selectAllTokens } from '../../../../selectors/tokensController';
 import { selectSelectedAccountGroupEvmInternalAccount } from '../../../../selectors/multichainAccounts/accountTreeController';
+import { MUSD_TOKEN_ADDRESS_BY_CHAIN } from '../../../UI/Earn/constants/musd';
+import { selectTransactionPayTransactionData } from '../../../../selectors/transactionPayController';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -22,6 +25,7 @@ jest.mock('react-redux', () => ({
 jest.mock('../../../../selectors/transactionController', () => ({
   selectLocalTransactions: jest.fn(),
   selectReplacedLocalTransactions: jest.fn(),
+  selectRequiredTransactions: jest.fn(),
 }));
 
 jest.mock('../../../../selectors/bridgeStatusController', () => ({
@@ -34,6 +38,10 @@ jest.mock('../../../../selectors/networkController', () => ({
 
 jest.mock('../../../../selectors/tokensController', () => ({
   selectAllTokens: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/transactionPayController', () => ({
+  selectTransactionPayTransactionData: jest.fn(),
 }));
 
 jest.mock(
@@ -74,6 +82,8 @@ const selectorState = {
   groupAccount: { address: from },
   localTransactions: [] as unknown[],
   replacedTransactions: [] as unknown[],
+  requiredTransactions: [] as TransactionMeta[],
+  transactionPayData: {},
   networks: {
     '0x2105': { nativeCurrency: 'ETH' },
   },
@@ -84,6 +94,8 @@ describe('useLocalActivityItems', () => {
     jest.clearAllMocks();
     selectorState.localTransactions = [];
     selectorState.replacedTransactions = [];
+    selectorState.requiredTransactions = [];
+    selectorState.transactionPayData = {};
     selectorState.bridgeHistory = {};
     (useSelector as unknown as jest.Mock).mockImplementation((selector) => {
       switch (selector) {
@@ -91,6 +103,10 @@ describe('useLocalActivityItems', () => {
           return selectorState.localTransactions;
         case selectReplacedLocalTransactions:
           return selectorState.replacedTransactions;
+        case selectRequiredTransactions:
+          return selectorState.requiredTransactions;
+        case selectTransactionPayTransactionData:
+          return selectorState.transactionPayData;
         case selectBridgeHistoryForAccount:
           return selectorState.bridgeHistory;
         case selectEvmNetworkConfigurationsByChainId:
@@ -527,6 +543,76 @@ describe('useLocalActivityItems', () => {
     expect(result.current[0]).toMatchObject({
       type: 'perpsAddFunds',
       hash: '0xperpsdeposit',
+      raw: { type: 'localTransaction' },
+    });
+  });
+
+  it('maps a Money deposit from the Money signer into a send from the active EOA', () => {
+    const moneyAccountAddress = '0x3333333333333333333333333333333333333333';
+    selectorState.requiredTransactions = [
+      makeTx({
+        id: 'money-source-transfer',
+        chainId: '0x2105',
+        type: TransactionType.tokenMethodTransfer,
+        txParams: {
+          from,
+          nonce: '0x2',
+          to: usdc,
+          value: '0x0',
+        },
+        transferInformation: {
+          amount: '4000000',
+          contractAddress: usdc,
+          decimals: 6,
+          symbol: 'USDC',
+        },
+      }),
+    ];
+    selectorState.localTransactions = [
+      makeTx({
+        id: 'money-deposit-id',
+        hash: '0xmoneydeposit',
+        chainId: '0x8f',
+        status: TransactionStatus.confirmed,
+        type: TransactionType.batch,
+        txParams: {
+          from: moneyAccountAddress,
+          nonce: '0x1',
+          to: recipient,
+          value: '0x0',
+        },
+        nestedTransactions: [{ type: TransactionType.moneyAccountDeposit }],
+        requiredTransactionIds: ['money-source-transfer'],
+        requiredAssets: [
+          {
+            address: MUSD_TOKEN_ADDRESS_BY_CHAIN['0x8f'],
+            amount: '0x2625a0',
+            standard: 'erc20',
+          },
+        ],
+        metamaskPay: {
+          chainId: '0x2105',
+          tokenAddress: usdc,
+        },
+      }),
+    ];
+
+    const { result } = renderHook(() => useLocalActivityItems());
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toMatchObject({
+      type: 'send',
+      hash: '0xmoneydeposit',
+      data: {
+        from,
+        to: moneyAccountAddress,
+        token: {
+          amount: '4000000',
+          decimals: 6,
+          direction: 'out',
+          symbol: 'USDC',
+        },
+      },
       raw: { type: 'localTransaction' },
     });
   });

--- a/app/components/Views/ActivityList/hooks/useLocalActivityItems.ts
+++ b/app/components/Views/ActivityList/hooks/useLocalActivityItems.ts
@@ -3,7 +3,7 @@
  * to ActivityListItem[] using mapLocalTransaction from @metamask/client-utils.
  */
 import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import { mapLocalTransaction } from '@metamask/client-utils';
 import {
   TransactionMeta,
@@ -15,6 +15,7 @@ import type { Hex } from '@metamask/utils';
 import {
   selectLocalTransactions,
   selectReplacedLocalTransactions,
+  selectRequiredTransactions,
 } from '../../../../selectors/transactionController';
 import { selectBridgeHistoryForAccount } from '../../../../selectors/bridgeStatusController';
 import { findBridgeHistoryItem } from '../../../../util/bridge/findBridgeHistoryItem';
@@ -31,6 +32,8 @@ import {
   type TokenAmount,
 } from '../../../../util/activity-adapters';
 import { isHardwareAccount } from '../../../../util/address';
+import { selectTransactionPayTransactionData } from '../../../../selectors/transactionPayController';
+import type { RootState } from '../../../../reducers';
 
 const BRIDGE_FAIL_STATUSES = [
   TransactionStatus.failed,
@@ -44,6 +47,9 @@ const QUEUE_BLOCKING_STATUSES = new Set<string>([
   'approved',
   'unapproved',
 ]);
+const EMPTY_TRANSACTION_PAY_DATA: ReturnType<
+  typeof selectTransactionPayTransactionData
+> = {};
 
 /**
  * Checks whether a transaction is a TransactionMeta (vs SmartTransaction).
@@ -284,6 +290,7 @@ export function useLocalActivityItems(): ActivityListItem[] {
   // Outgoing / user-initiated txs only — excludes incoming spam from TransactionController.
   const localTransactions = useSelector(selectLocalTransactions);
   const replacedTransactions = useSelector(selectReplacedLocalTransactions);
+  const requiredTransactions = useSelector(selectRequiredTransactions);
   const bridgeHistory = useSelector(selectBridgeHistoryForAccount);
   const networkConfigurations = useSelector(
     selectEvmNetworkConfigurationsByChainId,
@@ -301,6 +308,30 @@ export function useLocalActivityItems(): ActivityListItem[] {
   const transactionMetaList = useMemo(
     () => localTransactions.filter(isTransactionMetaLike),
     [localTransactions],
+  );
+  const transactionPayData =
+    useSelector((state: RootState) => {
+      const allTransactionPayData = selectTransactionPayTransactionData(state);
+      return transactionMetaList.reduce(
+        (selected, transaction) => {
+          const data = allTransactionPayData[transaction.id];
+          if (data) {
+            selected[transaction.id] = data;
+          }
+          return selected;
+        },
+        {} as typeof allTransactionPayData,
+      );
+    }, shallowEqual) ?? EMPTY_TRANSACTION_PAY_DATA;
+  const requiredTransactionsById = useMemo(
+    () =>
+      new Map(
+        requiredTransactions.map((transaction) => [
+          transaction.id,
+          transaction,
+        ]),
+      ),
+    [requiredTransactions],
   );
 
   return useMemo(() => {
@@ -366,6 +397,14 @@ export function useLocalActivityItems(): ActivityListItem[] {
 
       const group: TransactionGroup = {
         ...baseGroup,
+        activityAccountAddress: groupEvmAccountAddress,
+        relatedTransactions: (tx.requiredTransactionIds ?? [])
+          .map((id) => requiredTransactionsById.get(id))
+          .filter(
+            (transaction): transaction is TransactionMeta =>
+              transaction !== undefined,
+          ),
+        transactionPayData: transactionPayData[tx.id],
         activityStatus,
         sourceToken,
         destinationToken,
@@ -396,5 +435,7 @@ export function useLocalActivityItems(): ActivityListItem[] {
     networkConfigurations,
     allTokens,
     groupEvmAccountAddress,
+    requiredTransactionsById,
+    transactionPayData,
   ]);
 }

--- a/app/selectors/transactionController.test.ts
+++ b/app/selectors/transactionController.test.ts
@@ -4,6 +4,7 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
+import { MUSD_TOKEN_ADDRESS_BY_CHAIN } from '@metamask/money-account-utils';
 import {
   selectTransactions,
   selectHasUnapprovedTransactions,
@@ -438,6 +439,10 @@ describe('TransactionController Selectors', () => {
 
   describe('selectLocalTransactions', () => {
     const evmAddress = '0x0000000000000000000000000000000000000001';
+    const moneyAddress = '0x0000000000000000000000000000000000000002';
+    const otherEvmAddress = '0x0000000000000000000000000000000000000003';
+    const encodeTransfer = (recipient: string) =>
+      `0xa9059cbb${recipient.slice(2).padStart(64, '0')}${'1'.padStart(64, '0')}`;
 
     const buildLocalTxState = ({
       groupEvmAccount = { address: evmAddress },
@@ -478,6 +483,134 @@ describe('TransactionController Selectors', () => {
       expect(selectLocalTransactions(buildLocalTxState())).toStrictEqual([
         expect.objectContaining({ id: 'parent' }),
       ]);
+    });
+
+    it('includes a Money deposit parent linked to the EOA through its required funding transaction', () => {
+      const state = buildLocalTxState({
+        transactions: [
+          {
+            id: 'funding-child',
+            chainId: '0x1',
+            time: 200,
+            txParams: { from: evmAddress, nonce: '0x1' },
+          },
+          {
+            id: 'money-deposit',
+            chainId: '0x8f',
+            requiredTransactionIds: ['funding-child'],
+            nestedTransactions: [{ type: TransactionType.moneyAccountDeposit }],
+            time: 100,
+            type: TransactionType.batch,
+            txParams: { from: moneyAddress },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state)).toStrictEqual([
+        expect.objectContaining({ id: 'money-deposit' }),
+      ]);
+    });
+
+    it('includes a Money withdrawal whose nested transfer targets the EOA', () => {
+      const state = buildLocalTxState({
+        transactions: [
+          {
+            id: 'money-withdraw',
+            chainId: '0x8f',
+            nestedTransactions: [
+              { type: TransactionType.moneyAccountWithdraw },
+              {
+                type: TransactionType.tokenMethodTransfer,
+                to: MUSD_TOKEN_ADDRESS_BY_CHAIN['0x8f'],
+                data: encodeTransfer(evmAddress),
+              },
+            ],
+            time: 100,
+            type: TransactionType.batch,
+            txParams: { from: moneyAddress },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state)).toStrictEqual([
+        expect.objectContaining({ id: 'money-withdraw' }),
+      ]);
+    });
+
+    it('excludes a Money withdrawal targeting a different EOA', () => {
+      const state = buildLocalTxState({
+        transactions: [
+          {
+            id: 'other-money-withdraw',
+            chainId: '0x8f',
+            nestedTransactions: [
+              { type: TransactionType.moneyAccountWithdraw },
+              {
+                type: TransactionType.tokenMethodTransfer,
+                to: MUSD_TOKEN_ADDRESS_BY_CHAIN['0x8f'],
+                data: encodeTransfer(otherEvmAddress),
+              },
+            ],
+            time: 100,
+            type: TransactionType.batch,
+            txParams: { from: moneyAddress },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state)).toStrictEqual([]);
+    });
+
+    it('ignores non-mUSD nested transfer recipients in a Money withdrawal', () => {
+      const state = buildLocalTxState({
+        transactions: [
+          {
+            id: 'money-withdraw-with-refund',
+            chainId: '0x8f',
+            nestedTransactions: [
+              { type: TransactionType.moneyAccountWithdraw },
+              {
+                type: TransactionType.tokenMethodTransfer,
+                to: '0x00000000000000000000000000000000000000aa',
+                data: encodeTransfer(evmAddress),
+              },
+              {
+                type: TransactionType.tokenMethodTransfer,
+                to: MUSD_TOKEN_ADDRESS_BY_CHAIN['0x8f'],
+                data: encodeTransfer(otherEvmAddress),
+              },
+            ],
+            time: 100,
+            type: TransactionType.batch,
+            txParams: { from: moneyAddress },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state)).toStrictEqual([]);
+    });
+
+    it('does not associate a non-Money parent through its required child sender', () => {
+      const state = buildLocalTxState({
+        transactions: [
+          {
+            id: 'non-money-child',
+            chainId: '0x1',
+            time: 200,
+            txParams: { from: evmAddress, nonce: '0x1' },
+          },
+          {
+            id: 'non-money-parent',
+            chainId: '0x1',
+            requiredTransactionIds: ['non-money-child'],
+            time: 100,
+            type: TransactionType.contractInteraction,
+            txParams: { from: moneyAddress },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state)).toStrictEqual([]);
     });
 
     it('filters gas_payment fee legs when activity redesign is on', () => {

--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -11,10 +11,13 @@ import {
   TransactionMeta,
   TransactionStatus,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { SmartTransaction } from '@metamask/smart-transactions-controller';
+import { isMusdOnMoneyAccountChain } from '@metamask/money-account-utils';
 import { areAddressesEqual } from '../util/address';
+import { decodeErc20Transfer } from '../util/transactions/erc20-transfer';
 
 interface MetaMaskPayToken {
   address: Hex;
@@ -22,6 +25,8 @@ interface MetaMaskPayToken {
 }
 
 type LocalTransaction = TransactionMeta | SmartTransaction;
+const MONEY_DEPOSIT_TYPES = [TransactionType.moneyAccountDeposit];
+const MONEY_WITHDRAW_TYPES = [TransactionType.moneyAccountWithdraw];
 
 function isTerminalFailedStatus(status: unknown): boolean {
   return (
@@ -228,6 +233,76 @@ export const selectRelatedChainIdsByTransactionId = createSelector(
   },
 );
 
+function getMoneyWithdrawRecipients(transaction: TransactionMeta): string[] {
+  return (transaction.nestedTransactions ?? []).flatMap((nestedTransaction) => {
+    if (!isMusdOnMoneyAccountChain(nestedTransaction.to, transaction.chainId)) {
+      return [];
+    }
+    const transfer = decodeErc20Transfer(
+      nestedTransaction.data,
+      nestedTransaction.type,
+    );
+    if (!transfer) {
+      return [];
+    }
+    return [transfer.recipient];
+  });
+}
+
+/**
+ * Addresses related to each local transaction.
+ *
+ * MetaMask Pay parent transactions can be signed by a product account rather
+ * than the EOA shown in Activity. Required child senders identify the EOA that
+ * funded a Money deposit, while the nested ERC-20 recipient identifies the EOA
+ * receiving a Money withdrawal.
+ */
+const selectRelatedAddressesByTransactionId = createSelector(
+  selectTransactionsStrict,
+  (transactions) => {
+    const transactionsById = new Map<string, TransactionMeta>(
+      transactions.map((transaction) => [transaction.id, transaction]),
+    );
+
+    return new Map<string, string[]>(
+      transactions.flatMap((transaction) => {
+        const isMoneyDeposit = hasTransactionType(
+          transaction,
+          MONEY_DEPOSIT_TYPES,
+        );
+        const isMoneyWithdraw = hasTransactionType(
+          transaction,
+          MONEY_WITHDRAW_TYPES,
+        );
+        if (!isMoneyDeposit && !isMoneyWithdraw) {
+          return [];
+        }
+        const requiredTransactionSenders = isMoneyDeposit
+          ? (transaction.requiredTransactionIds ?? []).map(
+              (transactionId) =>
+                transactionsById.get(transactionId)?.txParams?.from,
+            )
+          : [];
+        const addresses = [
+          ...requiredTransactionSenders,
+          ...(isMoneyWithdraw ? getMoneyWithdrawRecipients(transaction) : []),
+        ]
+          .filter((address): address is string => Boolean(address))
+          .map((address) => address.toLowerCase());
+
+        return addresses.length
+          ? [
+              [transaction.id, [...new Set(addresses)]] satisfies [
+                string,
+                string[],
+              ],
+            ]
+          : [];
+      }),
+    );
+  },
+);
+
 export const selectTransactions = createDeepEqualSelector(
   selectTransactionsStrict,
   (transactions) => transactions,
@@ -256,16 +331,22 @@ function isReplacedTransaction(
   return Boolean(replacedBy && replacedById && hash);
 }
 
-/** Whether a transaction was sent from the active account's EVM address. */
+/** Whether a transaction belongs to the active account directly or through a related product flow. */
 function belongsToActiveAccount(
   transaction: LocalTransaction,
   activeEvmAddress: string | undefined,
+  relatedAddresses: string[] = [],
 ): boolean {
-  const fromAddress = transaction.txParams?.from;
-  if (!fromAddress || !activeEvmAddress) {
+  if (!activeEvmAddress) {
     return false;
   }
-  return areAddressesEqual(fromAddress, activeEvmAddress);
+
+  const addresses = [transaction.txParams?.from, ...relatedAddresses].filter(
+    (address): address is string => Boolean(address),
+  );
+  return addresses.some((address) =>
+    areAddressesEqual(address, activeEvmAddress),
+  );
 }
 
 export const selectNonReplacedTransactions = createDeepEqualSelector(
@@ -361,6 +442,7 @@ export const selectLocalTransactions = createDeepEqualSelector(
     selectEvmAddress,
     selectRequiredTransactionIds,
     selectGasPaymentTransactionIds,
+    selectRelatedAddressesByTransactionId,
   ],
   (
     nonReplacedTransactions,
@@ -369,6 +451,7 @@ export const selectLocalTransactions = createDeepEqualSelector(
     fallbackEvmAddress,
     requiredTransactionIds,
     gasPaymentTransactionIds,
+    relatedAddressesByTransactionId,
   ) => {
     const activeEvmAddress = groupEvmAccount?.address ?? fallbackEvmAddress;
 
@@ -379,7 +462,11 @@ export const selectLocalTransactions = createDeepEqualSelector(
       if (gasPaymentTransactionIds.has(transaction.id)) {
         return false;
       }
-      return belongsToActiveAccount(transaction, activeEvmAddress);
+      return belongsToActiveAccount(
+        transaction,
+        activeEvmAddress,
+        relatedAddressesByTransactionId.get(transaction.id),
+      );
     });
 
     const pendingSmartTransactionsForActiveAddress =
@@ -409,6 +496,7 @@ export const selectReplacedLocalTransactions = createDeepEqualSelector(
     selectEvmAddress,
     selectRequiredTransactionIds,
     selectGasPaymentTransactionIds,
+    selectRelatedAddressesByTransactionId,
   ],
   (
     transactions,
@@ -416,6 +504,7 @@ export const selectReplacedLocalTransactions = createDeepEqualSelector(
     fallbackEvmAddress,
     requiredTransactionIds,
     gasPaymentTransactionIds,
+    relatedAddressesByTransactionId,
   ) => {
     const activeEvmAddress = groupEvmAccount?.address ?? fallbackEvmAddress;
 
@@ -429,7 +518,11 @@ export const selectReplacedLocalTransactions = createDeepEqualSelector(
       if (gasPaymentTransactionIds.has(transaction.id)) {
         return false;
       }
-      return belongsToActiveAccount(transaction, activeEvmAddress);
+      return belongsToActiveAccount(
+        transaction,
+        activeEvmAddress,
+        relatedAddressesByTransactionId.get(transaction.id),
+      );
     });
   },
 );

--- a/app/util/activity-adapters/activity-list-helpers.test.ts
+++ b/app/util/activity-adapters/activity-list-helpers.test.ts
@@ -1,3 +1,4 @@
+import { TransactionType } from '@metamask/transaction-controller';
 import type { ActivityListItem, TokenAmount } from './types';
 import { GAS_FEE_SPONSORED } from './fees';
 import {
@@ -179,6 +180,45 @@ describe('activity list helpers', () => {
     it('keeps the local item when there is no API counterpart', () => {
       const local = makeItem({ type: 'send' });
       expect(preferLocalOrApiActivityItem(local, undefined)).toBe(local);
+    });
+
+    it('keeps a richer same-type API copy over a local Money Account row', () => {
+      const transaction = {
+        id: 'money-withdraw',
+        type: TransactionType.batch,
+        txParams: { from: '0xmoney' },
+        nestedTransactions: [{ type: TransactionType.moneyAccountWithdraw }],
+      };
+      const local = makeItem({
+        type: 'receive',
+        data: {
+          from: '0xmoney',
+          to: '0xeoa',
+          token: { direction: 'in', symbol: 'mUSD' },
+        },
+        raw: {
+          type: 'localTransaction',
+          data: {
+            initialTransaction: transaction,
+            primaryTransaction: transaction,
+          },
+        } as never,
+      });
+      const api = makeItem({
+        type: 'receive',
+        data: {
+          from: '0xmoney',
+          to: '0xeoa',
+          token: {
+            amount: '2500000',
+            decimals: 6,
+            direction: 'in',
+            symbol: 'USDC',
+          },
+        },
+      });
+
+      expect(preferLocalOrApiActivityItem(local, api)).toBe(api);
     });
 
     it('prefers a local spending cap carrying a cap amount', () => {

--- a/app/util/activity-adapters/adapters/enrich-local-activity.test.ts
+++ b/app/util/activity-adapters/adapters/enrich-local-activity.test.ts
@@ -6,6 +6,10 @@ import {
   enrichLocalActivity,
   prepareLocalTransactionGroup,
 } from './enrich-local-activity';
+import {
+  MUSD_TOKEN_ADDRESS_BY_CHAIN,
+  MUSD_TOKEN_ASSET_ID_BY_CHAIN,
+} from '../../../components/UI/Earn/constants/musd';
 
 const chainId = '0x1';
 const from = '0x1111111111111111111111111111111111111111';
@@ -118,6 +122,230 @@ describe('local activity call-site mapping', () => {
         amount: '1',
       },
     });
+  });
+
+  it('maps a Money Account deposit to an EOA send with the transferred mUSD amount', () => {
+    const moneyAccountAddress = '0x3333333333333333333333333333333333333333';
+    const moneyChainId = '0x8f';
+    const musdAddress = MUSD_TOKEN_ADDRESS_BY_CHAIN[moneyChainId];
+    const item = mapLocalActivity(
+      buildGroup(
+        {
+          chainId: moneyChainId,
+          type: TransactionType.batch,
+          txParams: {
+            from: moneyAccountAddress,
+            to,
+            value: '0x0',
+            data: '0x',
+          },
+          nestedTransactions: [{ type: TransactionType.moneyAccountDeposit }],
+          requiredAssets: [
+            {
+              address: musdAddress,
+              amount: '0x2625a0',
+              standard: 'erc20',
+            },
+          ],
+        },
+        { activityAccountAddress: from },
+      ),
+    );
+
+    expect(item).toMatchObject({
+      type: 'send',
+      data: {
+        from,
+        to: moneyAccountAddress,
+        token: {
+          amount: '0x2625a0',
+          assetId: MUSD_TOKEN_ASSET_ID_BY_CHAIN[moneyChainId],
+          decimals: 6,
+          direction: 'out',
+          symbol: 'mUSD',
+        },
+      },
+    });
+  });
+
+  it('uses the EOA payment token for a cross-token Money Account deposit', () => {
+    const moneyAccountAddress = '0x3333333333333333333333333333333333333333';
+    const usdcAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+    const sourceTransaction = buildGroup({
+      id: 'source-transfer',
+      chainId: '0x1',
+      type: TransactionType.tokenMethodTransfer,
+      txParams: {
+        from,
+        to: usdcAddress,
+        value: '0x0',
+        data: '0x',
+      },
+      transferInformation: {
+        amount: '4000000',
+        contractAddress: usdcAddress,
+        decimals: 6,
+        symbol: 'USDC',
+      },
+    }).initialTransaction;
+    const item = mapLocalActivity(
+      buildGroup(
+        {
+          chainId: '0x8f',
+          type: TransactionType.batch,
+          txParams: {
+            from: moneyAccountAddress,
+            to,
+            value: '0x0',
+            data: '0x',
+          },
+          metamaskPay: {
+            chainId: '0x1',
+            tokenAddress: usdcAddress,
+          },
+          nestedTransactions: [{ type: TransactionType.moneyAccountDeposit }],
+          requiredAssets: [
+            {
+              address: MUSD_TOKEN_ADDRESS_BY_CHAIN['0x8f'],
+              amount: '0x2625a0',
+              standard: 'erc20',
+            },
+          ],
+        },
+        {
+          activityAccountAddress: from,
+          relatedTransactions: [sourceTransaction],
+        },
+      ),
+    );
+
+    expect(item).toMatchObject({
+      type: 'send',
+      data: {
+        from,
+        to: moneyAccountAddress,
+        token: {
+          amount: '4000000',
+          decimals: 6,
+          direction: 'out',
+          symbol: 'USDC',
+        },
+      },
+    });
+  });
+
+  it('maps a Money Account withdrawal to an EOA receive with the transferred mUSD amount', () => {
+    const moneyAccountAddress = '0x3333333333333333333333333333333333333333';
+    const moneyChainId = '0x8f';
+    const musdAddress = MUSD_TOKEN_ADDRESS_BY_CHAIN[moneyChainId];
+    const transferData = `0xa9059cbb${from
+      .slice(2)
+      .padStart(64, '0')}${(1_750_000)
+      .toString(16)
+      .padStart(64, '0')}` as `0x${string}`;
+    const item = mapLocalActivity(
+      buildGroup(
+        {
+          chainId: moneyChainId,
+          type: TransactionType.batch,
+          txParams: {
+            from: moneyAccountAddress,
+            to,
+            value: '0x0',
+            data: '0x',
+          },
+          nestedTransactions: [
+            { type: TransactionType.moneyAccountWithdraw },
+            {
+              type: TransactionType.tokenMethodTransfer,
+              to: musdAddress,
+              data: transferData,
+            },
+          ],
+        },
+        { activityAccountAddress: from },
+      ),
+    );
+
+    expect(item).toMatchObject({
+      type: 'receive',
+      data: {
+        from: moneyAccountAddress,
+        to: from,
+        token: {
+          amount: '1750000',
+          assetId: MUSD_TOKEN_ASSET_ID_BY_CHAIN[moneyChainId],
+          decimals: 6,
+          direction: 'in',
+          symbol: 'mUSD',
+        },
+      },
+    });
+  });
+
+  it('does not mislabel a post-quote source amount as the destination token amount', () => {
+    const moneyAccountAddress = '0x3333333333333333333333333333333333333333';
+    const usdcAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as const;
+    const item = mapLocalActivity(
+      buildGroup(
+        {
+          chainId: '0x8f',
+          type: TransactionType.batch,
+          txParams: {
+            from: moneyAccountAddress,
+            to,
+            value: '0x0',
+            data: '0x',
+          },
+          metamaskPay: {
+            chainId: '0x1',
+            isPostQuote: true,
+            tokenAddress: usdcAddress,
+          },
+          nestedTransactions: [{ type: TransactionType.moneyAccountWithdraw }],
+        },
+        {
+          activityAccountAddress: from,
+          transactionPayData: {
+            isPostQuote: true,
+            paymentToken: {
+              address: usdcAddress,
+              balanceFiat: '100',
+              balanceHuman: '100',
+              balanceRaw: '100000000',
+              balanceUsd: '100',
+              chainId: '0x1',
+              decimals: 6,
+              symbol: 'USDC',
+            },
+            sourceAmounts: [
+              {
+                sourceAmountHuman: '5',
+                sourceAmountRaw: '5000000',
+                targetTokenAddress: usdcAddress,
+              },
+            ],
+          },
+        },
+      ),
+    );
+
+    expect(item).toMatchObject({
+      type: 'receive',
+      data: {
+        from: moneyAccountAddress,
+        to: from,
+        token: {
+          decimals: 6,
+          direction: 'in',
+          symbol: 'USDC',
+        },
+      },
+    });
+    expect(item.type).toBe('receive');
+    if (item.type === 'receive') {
+      expect(item.data.token).not.toHaveProperty('amount');
+    }
   });
 
   it('attaches prepared fees when client-utils omitted them', () => {

--- a/app/util/activity-adapters/adapters/enrich-local-activity.test.ts
+++ b/app/util/activity-adapters/adapters/enrich-local-activity.test.ts
@@ -362,8 +362,12 @@ describe('local activity call-site mapping', () => {
     });
     expect(item.type).toBe('receive');
     if (item.type === 'receive') {
-      expect(item.data.token).toEqual({ direction: 'in' });
-      expect(getHumanReadableTokenAmount(item.data.token)).toBeUndefined();
+      const token = item.data.token;
+      expect(token).toEqual({ direction: 'in' });
+      if (!token) {
+        throw new Error('Expected the receive activity to include a token');
+      }
+      expect(getHumanReadableTokenAmount(token)).toBeUndefined();
     }
   });
 

--- a/app/util/activity-adapters/adapters/enrich-local-activity.test.ts
+++ b/app/util/activity-adapters/adapters/enrich-local-activity.test.ts
@@ -10,6 +10,7 @@ import {
   MUSD_TOKEN_ADDRESS_BY_CHAIN,
   MUSD_TOKEN_ASSET_ID_BY_CHAIN,
 } from '../../../components/UI/Earn/constants/musd';
+import { getHumanReadableTokenAmount } from '../fiat';
 
 const chainId = '0x1';
 const from = '0x1111111111111111111111111111111111111111';
@@ -286,6 +287,24 @@ describe('local activity call-site mapping', () => {
   it('does not mislabel a post-quote source amount as the destination token amount', () => {
     const moneyAccountAddress = '0x3333333333333333333333333333333333333333';
     const usdcAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as const;
+    const relatedTransaction = buildGroup({
+      id: 'pay-leg',
+      type: TransactionType.tokenMethodTransfer,
+      txParams: {
+        from: moneyAccountAddress,
+        to: usdcAddress,
+        value: '0x0',
+        data: `0xa9059cbb${from.slice(2).padStart(64, '0')}${(7_000_000)
+          .toString(16)
+          .padStart(64, '0')}` as `0x${string}`,
+      },
+      transferInformation: {
+        amount: '7000000',
+        contractAddress: usdcAddress,
+        decimals: 6,
+        symbol: 'USDC',
+      },
+    }).initialTransaction;
     const item = mapLocalActivity(
       buildGroup(
         {
@@ -326,6 +345,7 @@ describe('local activity call-site mapping', () => {
               },
             ],
           },
+          relatedTransactions: [relatedTransaction],
         },
       ),
     );
@@ -336,15 +356,14 @@ describe('local activity call-site mapping', () => {
         from: moneyAccountAddress,
         to: from,
         token: {
-          decimals: 6,
           direction: 'in',
-          symbol: 'USDC',
         },
       },
     });
     expect(item.type).toBe('receive');
     if (item.type === 'receive') {
-      expect(item.data.token).not.toHaveProperty('amount');
+      expect(item.data.token).toEqual({ direction: 'in' });
+      expect(getHumanReadableTokenAmount(item.data.token)).toBeUndefined();
     }
   });
 

--- a/app/util/activity-adapters/adapters/enrich-local-activity.ts
+++ b/app/util/activity-adapters/adapters/enrich-local-activity.ts
@@ -170,18 +170,24 @@ function getEoaFacingMoneyToken(
     return undefined;
   }
 
+  const isPostQuote =
+    transactionGroup.transactionPayData?.isPostQuote ??
+    transaction.metamaskPay?.isPostQuote;
+  if (isPostQuote) {
+    // The Pay source amount is not the amount of the token received by the EOA.
+    // Keep the transfer direction, but omit all token metadata so Activity does
+    // not interpret a metadata-only token as zero or backfill it from Pay legs.
+    return { direction };
+  }
+
   const caipChainId = toCaipChainId(
     KnownCaipNamespace.Eip155,
     Number.parseInt(tokenChainId, 16).toString(),
   );
   const isNative =
     tokenAddress.toLowerCase() === environment.nativeTokenAddress.toLowerCase();
-  const isPostQuote =
-    transactionGroup.transactionPayData?.isPostQuote ??
-    transaction.metamaskPay?.isPostQuote;
-  let amount = isPostQuote
-    ? undefined
-    : transactionGroup.transactionPayData?.sourceAmounts?.[0]?.sourceAmountRaw;
+  let amount =
+    transactionGroup.transactionPayData?.sourceAmounts?.[0]?.sourceAmountRaw;
   let symbol = paymentToken?.symbol;
   let decimals = paymentToken?.decimals;
 

--- a/app/util/activity-adapters/adapters/enrich-local-activity.ts
+++ b/app/util/activity-adapters/adapters/enrich-local-activity.ts
@@ -2,9 +2,11 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { KnownCaipNamespace, toCaipChainId, type Hex } from '@metamask/utils';
 import { getClaimPayoutFromReceipt } from '../../../components/UI/Earn/utils/musd';
 import {
+  isMusdOnMoneyAccountChain,
   MUSD_DECIMALS,
   MUSD_TOKEN,
   MUSD_TOKEN_ADDRESS,
+  MUSD_TOKEN_ADDRESS_BY_CHAIN,
   MUSD_TOKEN_ASSET_ID_BY_CHAIN,
 } from '../../../components/UI/Earn/constants/musd';
 import type { ActivityListItem, TokenAmount } from '../types';
@@ -20,6 +22,7 @@ import {
   mobileActivityAdapterEnvironment,
   type ActivityAdapterEnvironment,
 } from './environment';
+import { decodeErc20Transfer } from '../../transactions/erc20-transfer';
 
 const tokenTransferTypes = new Set<TransactionType>([
   TransactionType.tokenMethodTransfer,
@@ -30,12 +33,17 @@ const tokenTransferTypes = new Set<TransactionType>([
 const evmNativeDecimals = 18;
 const predictCollateralDecimals = 6;
 const predictCollateralSymbol = 'USDC';
-const erc20TransferSelector = '0xa9059cbb';
 const perpsDepositTypes: TransactionType[] = [
   TransactionType.perpsDeposit,
   TransactionType.perpsDepositAndOrder,
 ];
 const perpsWithdrawTypes: TransactionType[] = [TransactionType.perpsWithdraw];
+const moneyDepositTypes: TransactionType[] = [
+  TransactionType.moneyAccountDeposit,
+];
+const moneyWithdrawTypes: TransactionType[] = [
+  TransactionType.moneyAccountWithdraw,
+];
 
 function getNativeTokenAmount(
   transactionGroup: TransactionGroup,
@@ -90,22 +98,6 @@ function hasTransactionType(
   );
 }
 
-function getNestedTransferAmount(data: string | undefined): string | undefined {
-  if (
-    !data ||
-    !data.toLowerCase().startsWith(erc20TransferSelector) ||
-    data.length < 138
-  ) {
-    return undefined;
-  }
-
-  try {
-    return BigInt(`0x${data.slice(74, 138)}`).toString();
-  } catch {
-    return undefined;
-  }
-}
-
 function getPredictFundsToken(
   fundsTx: { to?: string; data?: string },
   direction: TokenAmount['direction'],
@@ -119,7 +111,10 @@ function getPredictFundsToken(
   const assetId = contractAddress
     ? environment.toAssetId(contractAddress, chainId)
     : undefined;
-  const amount = getNestedTransferAmount(fundsTx.data);
+  const amount = decodeErc20Transfer(
+    fundsTx.data,
+    TransactionType.tokenMethodTransfer,
+  )?.amount;
 
   return {
     direction,
@@ -127,6 +122,180 @@ function getPredictFundsToken(
     decimals: tokenMetadata?.decimals ?? predictCollateralDecimals,
     ...(assetId ? { assetId } : {}),
     ...(amount ? { amount } : {}),
+  };
+}
+
+function resolveMoneyMovementType(
+  transactionGroup: TransactionGroup,
+): 'deposit' | 'withdraw' | undefined {
+  const { initialTransaction, primaryTransaction } = transactionGroup;
+  const nested = initialTransaction.nestedTransactions ?? [];
+  if (
+    hasTransactionType(initialTransaction, moneyDepositTypes) ||
+    hasTransactionType(primaryTransaction, moneyDepositTypes) ||
+    nested.some((transaction) =>
+      hasTransactionType(transaction, moneyDepositTypes),
+    )
+  ) {
+    return 'deposit';
+  }
+  if (
+    hasTransactionType(initialTransaction, moneyWithdrawTypes) ||
+    hasTransactionType(primaryTransaction, moneyWithdrawTypes) ||
+    nested.some((transaction) =>
+      hasTransactionType(transaction, moneyWithdrawTypes),
+    )
+  ) {
+    return 'withdraw';
+  }
+  return undefined;
+}
+
+function getEoaFacingMoneyToken(
+  transactionGroup: TransactionGroup,
+  direction: TokenAmount['direction'],
+  environment: ActivityAdapterEnvironment,
+): TokenAmount | undefined {
+  const transaction = transactionGroup.initialTransaction;
+  const paymentToken = transactionGroup.transactionPayData?.paymentToken;
+  const tokenAddress =
+    paymentToken?.address ?? transaction.metamaskPay?.tokenAddress;
+  const tokenChainId =
+    paymentToken?.chainId ?? transaction.metamaskPay?.chainId;
+  if (
+    !tokenAddress ||
+    !tokenChainId ||
+    isMusdOnMoneyAccountChain(tokenAddress, tokenChainId)
+  ) {
+    return undefined;
+  }
+
+  const caipChainId = toCaipChainId(
+    KnownCaipNamespace.Eip155,
+    Number.parseInt(tokenChainId, 16).toString(),
+  );
+  const isNative =
+    tokenAddress.toLowerCase() === environment.nativeTokenAddress.toLowerCase();
+  const isPostQuote =
+    transactionGroup.transactionPayData?.isPostQuote ??
+    transaction.metamaskPay?.isPostQuote;
+  let amount = isPostQuote
+    ? undefined
+    : transactionGroup.transactionPayData?.sourceAmounts?.[0]?.sourceAmountRaw;
+  let symbol = paymentToken?.symbol;
+  let decimals = paymentToken?.decimals;
+
+  for (const relatedTransaction of transactionGroup.relatedTransactions ?? []) {
+    if (
+      relatedTransaction.chainId.toLowerCase() !== tokenChainId.toLowerCase()
+    ) {
+      continue;
+    }
+
+    const transferInformation = relatedTransaction.transferInformation;
+    if (
+      transferInformation?.contractAddress.toLowerCase() ===
+      tokenAddress.toLowerCase()
+    ) {
+      amount ??= transferInformation.amount;
+      symbol ??= transferInformation.symbol;
+      decimals ??= transferInformation.decimals;
+    }
+
+    const transferCalls = [
+      {
+        data: relatedTransaction.txParams.data,
+        to: relatedTransaction.txParams.to,
+        type: relatedTransaction.type,
+      },
+      ...(relatedTransaction.nestedTransactions ?? []),
+    ];
+    const tokenTransfer = transferCalls.find(
+      (call) => call.to?.toLowerCase() === tokenAddress.toLowerCase(),
+    );
+    const decodedTransfer = decodeErc20Transfer(
+      tokenTransfer?.data,
+      tokenTransfer?.type,
+    );
+    if (decodedTransfer) {
+      amount ??= decodedTransfer.amount;
+      break;
+    }
+
+    if (isNative && relatedTransaction.txParams.value) {
+      amount ??= relatedTransaction.txParams.value;
+      break;
+    }
+  }
+
+  const knownMetadata = isNative
+    ? environment.getNativeAssetForChainId(tokenChainId)
+    : getKnownTokenMetadata(caipChainId, tokenAddress, environment);
+  const assetId =
+    knownMetadata?.assetId ?? environment.toAssetId(tokenAddress, caipChainId);
+  const resolvedSymbol = symbol ?? knownMetadata?.symbol;
+  const resolvedDecimals = decimals ?? knownMetadata?.decimals;
+
+  return {
+    direction,
+    ...(resolvedSymbol ? { symbol: resolvedSymbol } : {}),
+    ...(resolvedDecimals === undefined ? {} : { decimals: resolvedDecimals }),
+    ...(amount ? { amount } : {}),
+    ...(assetId ? { assetId } : {}),
+  };
+}
+
+function getMoneyMovementToken(
+  transactionGroup: TransactionGroup,
+  direction: TokenAmount['direction'],
+  chainId: ActivityListItem['chainId'],
+  environment: ActivityAdapterEnvironment,
+): TokenAmount {
+  const transaction = transactionGroup.initialTransaction;
+  const eoaFacingToken = getEoaFacingMoneyToken(
+    transactionGroup,
+    direction,
+    environment,
+  );
+  if (eoaFacingToken) {
+    return eoaFacingToken;
+  }
+
+  const transferInformation = isMusdOnMoneyAccountChain(
+    transaction.transferInformation?.contractAddress,
+    transaction.chainId,
+  )
+    ? transaction.transferInformation
+    : undefined;
+  const nestedTransfer = transaction.nestedTransactions?.find(
+    (nested) =>
+      (nested.type === TransactionType.tokenMethodTransfer ||
+        nested.type === TransactionType.tokenMethodTransferFrom) &&
+      isMusdOnMoneyAccountChain(nested.to, transaction.chainId),
+  );
+  const requiredAsset = transaction.requiredAssets?.find((asset) =>
+    isMusdOnMoneyAccountChain(asset.address, transaction.chainId),
+  );
+  const tokenAddress =
+    transferInformation?.contractAddress ??
+    nestedTransfer?.to ??
+    requiredAsset?.address ??
+    MUSD_TOKEN_ADDRESS_BY_CHAIN[transaction.chainId as Hex] ??
+    MUSD_TOKEN_ADDRESS;
+  const amount =
+    transferInformation?.amount ??
+    decodeErc20Transfer(nestedTransfer?.data, nestedTransfer?.type)?.amount ??
+    requiredAsset?.amount;
+  const assetId =
+    MUSD_TOKEN_ASSET_ID_BY_CHAIN[transaction.chainId as Hex] ??
+    environment.toAssetId(tokenAddress, chainId);
+
+  return {
+    direction,
+    symbol: MUSD_TOKEN.symbol,
+    decimals: MUSD_DECIMALS,
+    ...(amount ? { amount } : {}),
+    ...(assetId ? { assetId } : {}),
   };
 }
 
@@ -180,6 +349,30 @@ function enrichLocalActivityKind(
       break;
   }
 
+  const nested = initialTransaction.nestedTransactions ?? [];
+  const moneyMovementType = resolveMoneyMovementType(transactionGroup);
+  if (moneyMovementType) {
+    const isDeposit = moneyMovementType === 'deposit';
+    const moneyAccountAddress = initialTransaction.txParams.from ?? '';
+    const activityAccountAddress =
+      transactionGroup.activityAccountAddress ?? '';
+    return {
+      ...activity,
+      type: isDeposit ? 'send' : 'receive',
+      data: {
+        from: isDeposit ? activityAccountAddress : moneyAccountAddress,
+        to: isDeposit ? moneyAccountAddress : activityAccountAddress,
+        token: getMoneyMovementToken(
+          transactionGroup,
+          isDeposit ? 'out' : 'in',
+          activity.chainId,
+          environment,
+        ),
+        ...(fees ? { fees } : {}),
+      },
+    };
+  }
+
   if (initialTransaction.txParams.authorizationList?.length) {
     return {
       ...activity,
@@ -192,7 +385,6 @@ function enrichLocalActivityKind(
     };
   }
 
-  const nested = initialTransaction.nestedTransactions ?? [];
   const hasPredictDeposit = nested.some(
     (call) =>
       call.type === TransactionType.predictDeposit ||

--- a/app/util/activity-adapters/adapters/transaction-group.ts
+++ b/app/util/activity-adapters/adapters/transaction-group.ts
@@ -4,6 +4,7 @@
  * TODO: Replace with shared @metamask/activity-adapters package when published.
  */
 import type { TransactionMeta } from '@metamask/transaction-controller';
+import type { TransactionData } from '@metamask/transaction-pay-controller';
 import type { ActivityFee, Status, TokenAmount } from '../types';
 
 export interface TransactionGroup {
@@ -27,6 +28,15 @@ export interface TransactionGroup {
   contractTokenMetadata?: { symbol?: string; decimals?: number };
   /** Whether the signing account cannot use gas sponsorship. */
   isHardwareWalletAccount?: boolean;
+  /** EOA whose Activity feed is rendering this group, when different from the signer. */
+  activityAccountAddress?: string;
+  /** Required MetaMask Pay child transactions associated with the parent intent. */
+  relatedTransactions?: TransactionMeta[];
+  /** Ephemeral Pay data used to render the pending EOA-facing token. */
+  transactionPayData?: Pick<
+    TransactionData,
+    'isPostQuote' | 'paymentToken' | 'sourceAmounts'
+  >;
   /** Precomputed fees for `@metamask/client-utils` mapLocalTransaction. */
   fees?: ActivityFee[];
 }

--- a/app/util/transactions/erc20-transfer.test.ts
+++ b/app/util/transactions/erc20-transfer.test.ts
@@ -1,0 +1,66 @@
+import { TransactionType } from '@metamask/transaction-controller';
+import {
+  decodeErc20Transfer,
+  ERC20_TRANSFER_FROM_SELECTOR,
+  ERC20_TRANSFER_SELECTOR,
+} from './erc20-transfer';
+
+const sender = '0x1111111111111111111111111111111111111111';
+const recipient = '0x2222222222222222222222222222222222222222';
+const addressSlot = (address: string) =>
+  address.slice(2).toLowerCase().padStart(64, '0');
+const amountSlot = (amount: bigint) => amount.toString(16).padStart(64, '0');
+
+describe('decodeErc20Transfer', () => {
+  it('decodes transfer recipient and amount', () => {
+    const data = `${ERC20_TRANSFER_SELECTOR}${addressSlot(
+      recipient,
+    )}${amountSlot(2_500_000n)}`;
+
+    expect(
+      decodeErc20Transfer(data, TransactionType.tokenMethodTransfer),
+    ).toEqual({
+      recipient,
+      amount: '2500000',
+    });
+  });
+
+  it('decodes transferFrom recipient and amount', () => {
+    const data = `${ERC20_TRANSFER_FROM_SELECTOR}${addressSlot(
+      sender,
+    )}${addressSlot(recipient)}${amountSlot(1_750_000n)}`;
+
+    expect(
+      decodeErc20Transfer(data, TransactionType.tokenMethodTransferFrom),
+    ).toEqual({
+      recipient,
+      amount: '1750000',
+    });
+  });
+
+  it('infers transfer calldata for a Relay child transaction', () => {
+    const data = `${ERC20_TRANSFER_SELECTOR}${addressSlot(
+      recipient,
+    )}${amountSlot(3_000_000n)}`;
+
+    expect(decodeErc20Transfer(data, TransactionType.relayDeposit)).toEqual({
+      recipient,
+      amount: '3000000',
+    });
+  });
+
+  it.each([
+    [undefined, TransactionType.tokenMethodTransfer],
+    ['0x', TransactionType.tokenMethodTransfer],
+    [
+      `${ERC20_TRANSFER_SELECTOR}${'z'.repeat(128)}`,
+      TransactionType.tokenMethodTransfer,
+    ],
+    [
+      `${ERC20_TRANSFER_SELECTOR}${addressSlot(recipient)}${amountSlot(1n)}`,
+      TransactionType.tokenMethodTransferFrom,
+    ],
+  ])('rejects malformed or mismatched calldata', (data, type) => {
+    expect(decodeErc20Transfer(data, type)).toBeUndefined();
+  });
+});

--- a/app/util/transactions/erc20-transfer.ts
+++ b/app/util/transactions/erc20-transfer.ts
@@ -1,0 +1,63 @@
+import { TransactionType } from '@metamask/transaction-controller';
+
+export const ERC20_TRANSFER_SELECTOR = '0xa9059cbb';
+export const ERC20_TRANSFER_FROM_SELECTOR = '0x23b872dd';
+export const ERC20_TRANSFER_CALLDATA_LENGTH = 138;
+export const ERC20_TRANSFER_FROM_CALLDATA_LENGTH = 202;
+
+interface DecodedErc20Transfer {
+  amount: string;
+  recipient: string;
+}
+
+/**
+ * Decodes the recipient and exact integer amount from standard ERC-20
+ * `transfer` and `transferFrom` calldata.
+ */
+export function decodeErc20Transfer(
+  data: string | undefined,
+  type: TransactionType | undefined,
+): DecodedErc20Transfer | undefined {
+  if (!data) {
+    return undefined;
+  }
+
+  const normalizedData = data.toLowerCase();
+  const hasTransferCalldata =
+    normalizedData.startsWith(ERC20_TRANSFER_SELECTOR) &&
+    normalizedData.length >= ERC20_TRANSFER_CALLDATA_LENGTH;
+  const hasTransferFromCalldata =
+    normalizedData.startsWith(ERC20_TRANSFER_FROM_SELECTOR) &&
+    normalizedData.length >= ERC20_TRANSFER_FROM_CALLDATA_LENGTH;
+  const hasDeclaredStandardType =
+    type === TransactionType.tokenMethodTransfer ||
+    type === TransactionType.tokenMethodTransferFrom;
+  const isTransfer =
+    hasTransferCalldata &&
+    (!hasDeclaredStandardType || type === TransactionType.tokenMethodTransfer);
+  const isTransferFrom =
+    hasTransferFromCalldata &&
+    (!hasDeclaredStandardType ||
+      type === TransactionType.tokenMethodTransferFrom);
+  if (!isTransfer && !isTransferFrom) {
+    return undefined;
+  }
+
+  const recipientSlot = isTransfer
+    ? normalizedData.slice(10, 74)
+    : normalizedData.slice(74, 138);
+  const amountSlot = isTransfer
+    ? normalizedData.slice(74, 138)
+    : normalizedData.slice(138, 202);
+  if (
+    !/^[0-9a-f]{64}$/u.test(recipientSlot) ||
+    !/^[0-9a-f]{64}$/u.test(amountSlot)
+  ) {
+    return undefined;
+  }
+
+  return {
+    recipient: `0x${recipientSlot.slice(-40)}`,
+    amount: BigInt(`0x${amountSlot}`).toString(),
+  };
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Money Account deposits and withdrawals were missing from the active EOA's Activity view because their parent transactions can be signed by the Money Account rather than the selected EOA.

This change associates Money Account deposits with the EOA that funds their required transaction and withdrawals with the EOA that receives the nested mUSD transfer. It renders those local activities as Send/Receive rows with the EOA-facing token, amount when known, and `Money account` counterparty label. It also centralizes ERC-20 `transfer`/`transferFrom` calldata decoding and keeps richer canonical API activity when local and remote entries overlap.

Pending post-quote cross-token withdrawals intentionally omit the amount until canonical API data is available, preventing a source amount from being displayed in the destination token's denomination.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed missing Money Account transfers in EOA activity and displayed them as sends or receives

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1071

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money Account transfers in EOA activity

  Scenario: Deposit funds from an EOA into a Money Account
    Given the user has an EOA and a Money Account
    And the EOA has funds available to deposit
    When the user deposits funds into the Money Account
    And opens the EOA Activity view with the Transactions filter selected
    Then the deposit is shown as a Send to "Money account"
    And the row shows the EOA-facing token and transferred amount

  Scenario: Withdraw funds from a Money Account to an EOA
    Given the user has funds in a Money Account
    When the user withdraws funds to the EOA
    And opens the EOA Activity view with the Transactions filter selected
    Then the withdrawal is shown as a Receive from "Money account"
    And the row shows the EOA-facing token and transferred amount when known

  Scenario: Keep unrelated account activity excluded
    Given the user has multiple EOAs
    When a Money Account transfer is associated with a different EOA
    Then the transfer is not shown in the selected EOA's Activity view
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="385" height="424" alt="Screenshot 2026-09-01 at 13 07 11" src="https://github.com/user-attachments/assets/7c5a6c7d-823b-43d5-8597-c20de0578eb1" />

<!-- [screenshots/recordings] -->

### **After**
<img width="391" height="552" alt="Screenshot 2026-09-01 at 14 54 33" src="https://github.com/user-attachments/assets/23e91895-4001-418e-a637-2864754007db" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction filtering and activity mapping for Money/Pay flows; incorrect address association could show another user’s transfers or wrong amounts, though new selector and adapter tests cover the main cases.
> 
> **Overview**
> Money Account deposits and withdrawals now appear on the selected EOA’s Activity feed even when the on-chain parent is signed by the Money account.
> 
> **Local transaction filtering** extends `belongsToActiveAccount` with related addresses: funding EOAs from required child txs for deposits, and nested mUSD `transfer` recipients for withdrawals (with guards so other EOAs and non-mUSD legs stay excluded).
> 
> **Local activity mapping** rewrites Money deposit/withdraw batches into EOA-facing **send** / **receive** rows (from/to the Money account), including cross-token MetaMask Pay flows via `relatedTransactions` and `transactionPayData`. Pending **post-quote** withdrawals omit misleading token amounts until API data is richer; `preferLocalOrApiActivityItem` prefers richer API rows when they overlap.
> 
> **Row UI** treats the primary Money account as counterparty with deposit-specific titles/subtitles (e.g. “Deposited”, “Money account”) instead of generic send copy.
> 
> **ERC-20 calldata** decoding is centralized in `decodeErc20Transfer` and wired through Money hooks, activity styles, and withdraw toasts (BigInt-safe amounts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d75a2213729c1e8540aae7a0ba45d8b145e9f2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->