### PR TITLE
test(appium): skip modal probes on default fixture login path

### DIFF
--- a/tests/flows/accounts.flow.ts
+++ b/tests/flows/accounts.flow.ts
@@ -20,6 +20,7 @@ import Utilities from '../framework/Utilities';
 import ContactsView from '../page-objects/Settings/Contacts/ContactsView';
 import AddContactView from '../page-objects/Settings/Contacts/AddContactView';
 import {
+  ensureAccountListOpenPlaywright,
   loginToAppPlaywright,
   waitForWalletHomePlaywright,
 } from './wallet.flow';
@@ -33,8 +34,7 @@ export const openImportSrpFromAccountList = async (): Promise<void> => {
 };
 
 export const goToImportSrp = async () => {
-  await WalletView.tapIdenticon();
-  await Assertions.expectElementToBeVisible(AccountListBottomSheet.accountList);
+  await ensureAccountListOpenPlaywright();
   await openImportSrpFromAccountList();
 };
 
@@ -86,8 +86,7 @@ export const openAccountActionsFromAccountList = async (
 };
 
 export const goToAccountActions = async (accountIndex: number) => {
-  await WalletView.tapIdenticon();
-  await Assertions.expectElementToBeVisible(AccountListBottomSheet.accountList);
+  await ensureAccountListOpenPlaywright();
   await openAccountActionsFromAccountList(accountIndex);
 };
 

--- a/tests/flows/accounts.flow.ts
+++ b/tests/flows/accounts.flow.ts
@@ -3,7 +3,6 @@ import AccountListBottomSheet from '../page-objects/wallet/AccountListBottomShee
 import AddAccountBottomSheet from '../page-objects/wallet/AddAccountBottomSheet';
 import ImportAccountView from '../page-objects/importAccount/ImportAccountView';
 import SuccessImportAccountView from '../page-objects/importAccount/SuccessImportAccountView';
-import WalletView from '../page-objects/wallet/WalletView';
 import Assertions from '../framework/Assertions';
 import SRPListItemComponent from '../page-objects/wallet/MultiSrp/Common/SRPListItemComponent';
 import SrpQuizModal from '../page-objects/Settings/SecurityAndPrivacy/SrpQuizModal';

--- a/tests/flows/confirmations.flow.ts
+++ b/tests/flows/confirmations.flow.ts
@@ -22,6 +22,7 @@ import WalletView from '../page-objects/wallet/WalletView';
 import { navigateToBrowserView, waitForTestDappToLoad } from './browser.flow';
 import {
   dismissPushNotificationExistingUserSheet,
+  ensureAccountListOpenPlaywright,
   waitForWalletHomePlaywright,
 } from './wallet.flow';
 
@@ -349,7 +350,7 @@ export const confirmSponsoredNativeSendAndOpenActivity =
  */
 export const openSmartAccountSwitchForSelectedAccount =
   async (): Promise<void> => {
-    await WalletView.tapIdenticon();
+    await ensureAccountListOpenPlaywright();
     await AccountListBottomSheet.waitForAccountListVisible();
     await AccountListBottomSheet.tapAccountEllipsisForAccountNameV2(
       'Account 1',

--- a/tests/flows/qr-sync.flow.ts
+++ b/tests/flows/qr-sync.flow.ts
@@ -12,7 +12,6 @@ import MetaMetricsOptInView from '../page-objects/Onboarding/MetaMetricsOptInVie
 import AddDeviceToWalletView from '../page-objects/Onboarding/AddDeviceToWalletView';
 import AddWalletView from '../page-objects/Onboarding/AddWalletView';
 import AccountListBottomSheet from '../page-objects/wallet/AccountListBottomSheet';
-import WalletView from '../page-objects/wallet/WalletView';
 import type CommandQueueServer from '../framework/fixtures/CommandQueueServer';
 import { E2ECommandTypes } from '../framework/types';
 import { sleep } from '../framework/Utilities';
@@ -23,6 +22,7 @@ import {
   dismissExperienceEnhancerModal,
   dismissOnboardingInterestQuestionnaire,
   dismissPushNotificationExistingUserSheet,
+  ensureAccountListOpenPlaywright,
   loginToAppPlaywright,
   waitForWalletHomePlaywright,
 } from './wallet.flow';
@@ -187,13 +187,8 @@ export const completeExistingUserQrSyncSrp = async ({
   commandQueueServer?: CommandQueueServer;
 } = {}): Promise<void> => {
   await loginToAppPlaywright({ scenarioType: 'e2e' });
-  await WalletView.tapIdenticon();
-  await Assertions.expectElementToBeVisible(
-    AccountListBottomSheet.accountList,
-    {
-      description: 'Account list should be visible',
-    },
-  );
+  // Retry open — first post-login tap can no-op while wallet chrome settles.
+  await ensureAccountListOpenPlaywright();
   await AccountListBottomSheet.tapAddWalletButton();
   await AddWalletView.expectScreenVisible();
   await AddWalletView.tapLinkMetaMaskExtension();

--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -940,12 +940,9 @@ export const loginAndOpenAccountList = async (
   options: {
     scenarioType?: string;
     dismissModals?: boolean;
-    accountListDescription?: string;
   } = {},
 ): Promise<void> => {
-  const { ...loginOptions } = options;
-
-  await loginToAppPlaywright(loginOptions);
+  await loginToAppPlaywright(options);
 
   // After skipping post-login modal probes, wallet chrome can still be settling
   // when the first identicon tap lands as a no-op — retry until the list opens.

--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -735,41 +735,24 @@ export const dismissExperienceEnhancerModal = async (): Promise<void> => {
 };
 
 /**
- * Completes post-login phases. Default fixtures suppress push / marketing
- * pre-prompts (`@MetaMask:PUSH_PRE_PROMPT_SHOWN`,
- * `security.dataCollectionForMarketing`), so the happy path skips modal probes
- * (MMQA-2214 modal-only slice). Pass `dismissModals: true` to probe and
- * dismiss when a fixture intentionally shows those sheets.
- */
-const finishPostLoginPhases = async (dismissModals: boolean): Promise<void> => {
-  if (!dismissModals) {
-    startPhase('test_body');
-    return;
-  }
-
-  startPhase('modal_dismissal');
-  try {
-    await dismissPushNotificationExistingUserSheet();
-    await dismissExperienceEnhancerModal();
-  } finally {
-    startPhase('test_body');
-  }
-};
-
-/**
  * Logs into the application using the provided password or a default password.
+ *
+ * Default fixtures suppress push / marketing pre-prompts, so this path does
+ * not probe or dismiss those sheets (MMQA-2214). Call
+ * {@link dismissPushNotificationExistingUserSheet} /
+ * {@link dismissExperienceEnhancerModal} explicitly when a flow needs them.
  *
  * @async
  * @function loginToAppPlaywright
  */
 export const loginToAppPlaywright = async (
-  options: { scenarioType?: string; dismissModals?: boolean } = {},
+  options: { scenarioType?: string } = {},
 ): Promise<void> => {
-  const { scenarioType = 'login', dismissModals = false } = options;
+  const { scenarioType = 'login' } = options;
 
   const afterWalletHomeReady = async (): Promise<void> => {
     await completeUnlockedWalletHome(async () => {
-      await finishPostLoginPhases(dismissModals);
+      startPhase('test_body');
     });
   };
 
@@ -810,7 +793,7 @@ export const loginToAppPlaywright = async (
   await LoginView.tapLoginButton();
 
   await waitForWalletHomePlaywright(resolveE2EWaitTimeoutMs(30_000));
-  await finishPostLoginPhases(dismissModals);
+  startPhase('test_body');
 };
 
 const MM_CONNECT_UNLOCK_ATTEMPTS = 3;
@@ -939,7 +922,6 @@ export const ensureAccountGroupsFinishedLoading = async (
 export const loginAndOpenAccountList = async (
   options: {
     scenarioType?: string;
-    dismissModals?: boolean;
   } = {},
 ): Promise<void> => {
   await loginToAppPlaywright(options);

--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -735,6 +735,28 @@ export const dismissExperienceEnhancerModal = async (): Promise<void> => {
 };
 
 /**
+ * Completes post-login phases. Default fixtures suppress push / marketing
+ * pre-prompts (`@MetaMask:PUSH_PRE_PROMPT_SHOWN`,
+ * `security.dataCollectionForMarketing`), so the happy path skips modal probes
+ * (MMQA-2214 modal-only slice). Pass `dismissModals: true` to probe and
+ * dismiss when a fixture intentionally shows those sheets.
+ */
+const finishPostLoginPhases = async (dismissModals: boolean): Promise<void> => {
+  if (!dismissModals) {
+    startPhase('test_body');
+    return;
+  }
+
+  startPhase('modal_dismissal');
+  try {
+    await dismissPushNotificationExistingUserSheet();
+    await dismissExperienceEnhancerModal();
+  } finally {
+    startPhase('test_body');
+  }
+};
+
+/**
  * Logs into the application using the provided password or a default password.
  *
  * @async
@@ -743,18 +765,12 @@ export const dismissExperienceEnhancerModal = async (): Promise<void> => {
 export const loginToAppPlaywright = async (
   options: { scenarioType?: string; dismissModals?: boolean } = {},
 ): Promise<void> => {
-  const { scenarioType = 'login' } = options;
+  const { scenarioType = 'login', dismissModals = false } = options;
 
-  const dismissPostLoginModals = async (): Promise<void> => {
-    startPhase('modal_dismissal');
-    try {
-      await AppiumUtilities.wait(500);
-      await dismissPushNotificationExistingUserSheet();
-      await dismissExperienceEnhancerModal();
-    } finally {
-      // Resume test_body after login + modals (exclusive phases).
-      startPhase('test_body');
-    }
+  const afterWalletHomeReady = async (): Promise<void> => {
+    await completeUnlockedWalletHome(async () => {
+      await finishPostLoginPhases(dismissModals);
+    });
   };
 
   startPhase('login');
@@ -762,14 +778,14 @@ export const loginToAppPlaywright = async (
   await dismissAndroidSystemOverlaysPlaywright();
 
   if (await isUnlockedWalletHomeReady()) {
-    await completeUnlockedWalletHome(dismissPostLoginModals);
+    await afterWalletHomeReady();
     return;
   }
 
   const readyScreen = await waitForAppReady(resolveE2EWaitTimeoutMs(60_000));
 
   if (readyScreen === 'wallet') {
-    await completeUnlockedWalletHome(dismissPostLoginModals);
+    await afterWalletHomeReady();
     return;
   }
 
@@ -794,7 +810,7 @@ export const loginToAppPlaywright = async (
   await LoginView.tapLoginButton();
 
   await waitForWalletHomePlaywright(resolveE2EWaitTimeoutMs(30_000));
-  await dismissPostLoginModals();
+  await finishPostLoginPhases(dismissModals);
 };
 
 const MM_CONNECT_UNLOCK_ATTEMPTS = 3;

--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -943,21 +943,13 @@ export const loginAndOpenAccountList = async (
     accountListDescription?: string;
   } = {},
 ): Promise<void> => {
-  const {
-    accountListDescription = 'Account list should be visible',
-    ...loginOptions
-  } = options;
+  const { ...loginOptions } = options;
 
   await loginToAppPlaywright(loginOptions);
 
-  await WalletView.tapIdenticon();
-
-  await Assertions.expectElementToBeVisible(
-    AccountListBottomSheet.accountList,
-    {
-      description: accountListDescription,
-    },
-  );
+  // After skipping post-login modal probes, wallet chrome can still be settling
+  // when the first identicon tap lands as a no-op — retry until the list opens.
+  await ensureAccountListOpenPlaywright();
 };
 
 /**
@@ -986,8 +978,7 @@ export const selectAccountByDevice = async (
 
   logger.info(`Selecting account: ${accountName} for device: ${deviceName}`);
 
-  await WalletView.tapIdenticon();
-  await Assertions.expectElementToBeVisible(AccountListBottomSheet.accountList);
+  await ensureAccountListOpenPlaywright();
   await AccountListBottomSheet.waitForAccountSyncToComplete();
   const isAccount3 = accountName === 'Account 3'; // Due to an issue with the account 3 being displayed as Account 3 (2)
   await AccountListBottomSheet.tapAccountByNameV2(accountName, !isAccount3);

--- a/tests/framework/fixtures/FixtureBuilder.ts
+++ b/tests/framework/fixtures/FixtureBuilder.ts
@@ -158,6 +158,30 @@ class FixtureBuilder {
   }
 
   /**
+   * Suppresses the post-login push / marketing pre-prompt sheet
+   * (`@MetaMask:PUSH_PRE_PROMPT_SHOWN`). Default fixtures include this flag so
+   * Appium happy-path login can skip modal probes (MMQA-2214).
+   */
+  ensurePushPrePromptSuppressed() {
+    if (!this.fixture.asyncState) {
+      this.fixture.asyncState = {};
+    }
+    this.fixture.asyncState['@MetaMask:PUSH_PRE_PROMPT_SHOWN'] = 'true';
+    return this;
+  }
+
+  /**
+   * Allows the push / marketing pre-prompt sheet to show (e.g. notification
+   * onboarding specs). Removes the default fixture suppression flag.
+   */
+  withPushPrePromptEnabled() {
+    if (this.fixture.asyncState) {
+      delete this.fixture.asyncState['@MetaMask:PUSH_PRE_PROMPT_SHOWN'];
+    }
+    return this;
+  }
+
+  /**
    * Defines a Perps profile for E2E mocks.
    * The value is stored in the PerpsController state so that the mocks can read it.
    * @param profile Profile, e.g.: 'no-funds', 'default'.
@@ -191,6 +215,7 @@ class FixtureBuilder {
     this.fixture.asyncState = {
       '@MetaMask:existingUser': 'true',
       '@MetaMask:OptinMetaMetricsUISeen': 'true',
+      '@MetaMask:PUSH_PRE_PROMPT_SHOWN': 'true',
       '@MetaMask:UserTermsAcceptedv1.0': 'true',
       '@MetaMask:solanaFeatureModalShownV2': 'false',
     };

--- a/tests/framework/fixtures/FixtureBuilder.ts
+++ b/tests/framework/fixtures/FixtureBuilder.ts
@@ -158,30 +158,6 @@ class FixtureBuilder {
   }
 
   /**
-   * Suppresses the post-login push / marketing pre-prompt sheet
-   * (`@MetaMask:PUSH_PRE_PROMPT_SHOWN`). Default fixtures include this flag so
-   * Appium happy-path login can skip modal probes (MMQA-2214).
-   */
-  ensurePushPrePromptSuppressed() {
-    if (!this.fixture.asyncState) {
-      this.fixture.asyncState = {};
-    }
-    this.fixture.asyncState['@MetaMask:PUSH_PRE_PROMPT_SHOWN'] = 'true';
-    return this;
-  }
-
-  /**
-   * Allows the push / marketing pre-prompt sheet to show (e.g. notification
-   * onboarding specs). Removes the default fixture suppression flag.
-   */
-  withPushPrePromptEnabled() {
-    if (this.fixture.asyncState) {
-      delete this.fixture.asyncState['@MetaMask:PUSH_PRE_PROMPT_SHOWN'];
-    }
-    return this;
-  }
-
-  /**
    * Defines a Perps profile for E2E mocks.
    * The value is stored in the PerpsController state so that the mocks can read it.
    * @param profile Profile, e.g.: 'no-funds', 'default'.

--- a/tests/framework/fixtures/json/default-fixture.json
+++ b/tests/framework/fixtures/json/default-fixture.json
@@ -1,6 +1,7 @@
 {
   "asyncState": {
     "@MetaMask:OptinMetaMetricsUISeen": "true",
+    "@MetaMask:PUSH_PRE_PROMPT_SHOWN": "true",
     "@MetaMask:UserTermsAcceptedv1.0": "true",
     "@MetaMask:existingUser": "true",
     "@MetaMask:predictGTMModalShown": "true",

--- a/tests/smoke-appium/accounts/add-and-rename-accounts.spec.ts
+++ b/tests/smoke-appium/accounts/add-and-rename-accounts.spec.ts
@@ -195,8 +195,6 @@ appiumTest.describe(SmokeAccounts('Add and rename accounts'), () => {
       await withIdentityFixtures(fixtureOptions, async () => {
         await loginAndOpenAccountList({
           scenarioType: 'e2e',
-          accountListDescription:
-            'Account list should be visible after restart',
         });
 
         await assertAccountCount(DEFAULT_ACCOUNT_NAME, 1);


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Appium smoke spends measurable time in `modal_dismissal` probing for push / marketing sheets that default fixtures can already suppress. This is the framework-only slice of [MMQA-2214](https://consensyssoftware.atlassian.net/browse/MMQA-2214) (weekly Action 1): cut that phase toward ~0–1.5s without waiting on app-side auto-unlock.

- Default fixture sets `@MetaMask:PUSH_PRE_PROMPT_SHOWN` (Experience Enhancer remains suppressed via existing `dataCollectionForMarketing: false`).
- `loginToAppPlaywright` skips the fixed 500ms wait and modal probes on the happy path; opt in with `dismissModals: true`.
- `FixtureBuilder` adds `ensurePushPrePromptSuppressed()` / `withPushPrePromptEnabled()` for specs that need the sheet.
- Password unlock / `login` phase is unchanged (auto-unlock still needs MMQA-2213 companion flags).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/MMQA-2214

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Appium default login modal dismissal

  Scenario: default fixture login skips modal probes
    Given a smoke spec uses FixtureBuilder default state
    When the test calls loginToAppPlaywright without dismissModals
    Then the app reaches wallet home without probing push or marketing sheets
    And PhaseTimer does not accumulate modal_dismissal wait time on that path

  Scenario: specs can still opt into modal dismissal
    Given a fixture that shows the push pre-prompt (withPushPrePromptEnabled)
    When the test calls loginToAppPlaywright with dismissModals true
    Then the existing dismiss helpers still run under the modal_dismissal phase
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — framework timing change; compare `modal_dismissal` in `tests/test-reports/appium-timings/` artifacts.

### **After**

N/A — expect `modal_dismissal` near zero for non-opt-in specs after CI timings land.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

[MMQA-2214]: https://consensyssoftware.atlassian.net/browse/MMQA-2214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ