### PR TITLE
fix(perps): upgrade perps-controller to 14.0.0 for TP/SL update failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -358,7 +358,7 @@
     "@metamask/network-enablement-controller": "patch:@metamask/network-enablement-controller@npm%3A5.4.1#~/.yarn/patches/@metamask-network-enablement-controller-npm-5.4.1-020a82a308.patch",
     "@metamask/notification-services-controller": "^26.0.0",
     "@metamask/permission-controller": "^13.1.1",
-    "@metamask/perps-controller": "^13.0.0",
+    "@metamask/perps-controller": "^14.0.0",
     "@metamask/phishing-controller": "^17.3.1",
     "@metamask/post-message-stream": "^10.0.0",
     "@metamask/preferences-controller": "^23.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9677,9 +9677,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/perps-controller@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "@metamask/perps-controller@npm:13.0.0"
+"@metamask/perps-controller@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "@metamask/perps-controller@npm:14.0.0"
   dependencies:
     "@metamask/abi-utils": "npm:^2.0.3"
     "@metamask/base-controller": "npm:^9.1.0"
@@ -9695,7 +9695,7 @@ __metadata:
   dependenciesMeta:
     "@myx-trade/sdk":
       optional: true
-  checksum: 10/1203a718f27a570912ffbea756a5c62d9c89383475789c66d12d3993e4143f0058c2ba285474b21762472b5e0dc7fe32257d4c9ad463fdc459fa197b1b462805
+  checksum: 10/8cbb91b3a8f92a83dc678fe8edf5e240d97ce714a7027c74be75b37201e37c2538f7d821e1fce21d14bf1ebe240e35e43925f920b0439210bc32c74ef408a717
   languageName: node
   linkType: hard
 
@@ -35852,7 +35852,7 @@ __metadata:
     "@metamask/notification-services-controller": "npm:^26.0.0"
     "@metamask/object-multiplex": "npm:^1.1.0"
     "@metamask/permission-controller": "npm:^13.1.1"
-    "@metamask/perps-controller": "npm:^13.0.0"
+    "@metamask/perps-controller": "npm:^14.0.0"
     "@metamask/phishing-controller": "npm:^17.3.1"
     "@metamask/post-message-stream": "npm:^10.0.0"
     "@metamask/preferences-controller": "npm:^23.0.0"


### PR DESCRIPTION
Fixes the 8.10 release blocker where creating or updating TP/SL shows a failure toast even though the orders were created ([#35453](https://github.com/MetaMask/metamask-mobile/issues/35453) / TAT-3846). One-line dependency bump plus lockfile, no application code.

## Cause

`@metamask/perps-controller` 13.0.0 only counts `resting` and `filled` placements, so a HyperLiquid trigger returned as `waitingForTrigger` matches nothing and `updatePositionTPSL` throws `TPSL_UPDATE_FAILED` **after** the orders were already accepted.

Fixed upstream in 14.0.0:
- [MetaMask/core#9995](https://github.com/MetaMask/core/pull/9995) — reconcile accepted `waitingForTrigger` triggers
- [MetaMask/core#9997](https://github.com/MetaMask/core/pull/9997) — check builder-fee approval over HTTP, so a transient WebSocket disconnect no longer fails the first TP/SL update

## Why a direct patch instead of a cherry-pick

`main` is already past this on 15.0.0, but the only PR carrying that bump is #35176 (Scale orders to Pro mode, 45 files, `risk:high`), which is not appropriate for a patch release. This upgrades to the minimum fixed version instead. Approved by @victor.pintorico.

## Why no app changes are needed

The 14.0.0 type surface is additive — no exported names removed or changed. Its breaking change only requires `previewPositionModify` from implementors of the `PerpsProvider` interface, which mobile does not implement and never calls.

## Validation

iOS simulator, Perps testnet, BTC, on `release/8.10.0`:

| Path | 13.0.0 (before) | 14.0.0 (after) |
| --- | --- | --- |
| TP/SL on existing position | `TPSL_UPDATE_FAILED`, orders created anyway | `success: true`, both triggers created |
| Attached TP/SL on a new order | `TPSL_UPDATE_FAILED`, orders created anyway | `success: true`, position + both triggers created |

Both paths were reproduced failing on 13.0.0 and confirmed passing on 14.0.0 on the same build, account and market. Test positions and orders were cleaned up (0 open orders, 0 open positions).

Note: this is a separate blocker from #35475 (Pro `Cancel all`), which reproduces on both `main` and `release` and is handled in #35500.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Perps order/TP-SL reconciliation in a trading dependency with no app-layer diff, so behavior shifts are entirely in `@metamask/perps-controller` at runtime.
> 
> **Overview**
> Bumps **`@metamask/perps-controller`** from **13.0.0** to **14.0.0** in `package.json` and `yarn.lock` only—no mobile app code changes.
> 
> This targets the 8.10 blocker where creating or updating take-profit/stop-loss can show a failure toast even though HyperLiquid accepted the trigger orders. In 13.0.0, `updatePositionTPSL` only treats `resting` and `filled` placements as success, so triggers returned as **`waitingForTrigger`** are ignored and the controller throws **`TPSL_UPDATE_FAILED`** after the orders are already on the book. **14.0.0** reconciles those accepted trigger states and improves builder-fee approval checks so a transient WebSocket drop is less likely to fail the first TP/SL update.
> 
> The upgrade is the minimum fixed release for a patch branch rather than pulling a larger mainline bump; the public API used by mobile stays compatible (additive types only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 549894752dfde317168f154e959ab3344774e20b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->