### PR TITLE
fix(perps): remove the order type card border in Pro mode

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -1375,6 +1375,17 @@ describe('PerpsProOrderForm', () => {
       expect(screen.getByTestId(ids.CONTAINER)).toHaveStyle({ gap: 16 });
     });
 
+    // The order type card was the only bordered surface in the form (TAT-3780).
+    it('draws the order type card borderless, like the other muted surfaces', () => {
+      renderForm();
+
+      const cardStyle = StyleSheet.flatten(
+        screen.getByTestId(ids.ORDER_TYPE_CARD).props.style,
+      );
+
+      expect(cardStyle.borderWidth).toBeFalsy();
+    });
+
     it('left-aligns margin mode and leverage with 8-point spacing', () => {
       renderForm();
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -744,7 +744,7 @@ const PerpsProOrderForm = ({
           </Box>
           <Box
             ref={orderTypeCardRef}
-            twClassName="overflow-hidden rounded-xl border border-muted bg-muted"
+            twClassName="overflow-hidden rounded-xl bg-muted"
             testID={ids.ORDER_TYPE_CARD}
           >
             <ButtonBase

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProSizeInput.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProSizeInput.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
 import { TextVariant } from '@metamask/design-system-react-native';
 import {
   ImpactMoment,
@@ -265,5 +266,15 @@ describe('PerpsProSizeInput', () => {
     expect(onAddFundsPress).not.toHaveBeenCalled();
     expect(playImpact).not.toHaveBeenCalled();
     expect(mockInputFocus).not.toHaveBeenCalled();
+  });
+
+  it('draws the size card borderless', () => {
+    renderInput();
+
+    const cardStyle = StyleSheet.flatten(
+      screen.getByTestId(PerpsProOrderFormSelectorsIDs.SIZE_CARD).props.style,
+    );
+
+    expect(cardStyle.borderWidth).toBeFalsy();
   });
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProSizeInput.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProSizeInput.tsx
@@ -162,7 +162,7 @@ const PerpsProSizeInput = ({
   return (
     <Box
       ref={containerRef}
-      twClassName="overflow-visible rounded-2xl border border-muted bg-muted"
+      twClassName="overflow-visible rounded-xl bg-muted"
       testID={ids.SIZE_CARD}
     >
       <Box twClassName="relative">


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Two cards in the Pro order form carried `border border-muted` while every other muted surface — including the TP/SL row — has none. Removed the border from both the order type card and the size card so all three match.

- `PerpsProOrderForm` order type card: `overflow-hidden rounded-xl border border-muted bg-muted` → `overflow-hidden rounded-xl bg-muted`
- `PerpsProSizeInput` size card: `overflow-visible rounded-2xl border border-muted bg-muted` → `overflow-visible rounded-xl bg-muted`

The size card was also `rounded-2xl` against `rounded-xl` on its peers, so that is aligned here too. Internal row dividers (`border-t` in `PerpsProCompactInput`, `PerpsProTwapFields`, and inside the size card) are untouched — those separate rows *within* a card and are not part of this.

Caught during screenshot review: the first pass removed only the order type card's border, which left the size card as a new inconsistency rather than fixing the old one. An earlier revision of this description claimed the order type card was the only bordered surface in the form; that was wrong, and this corrects it.

`overflow-hidden` stays on the order type card, since it clips the order type button and trigger price field to its rounded corners.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed an inconsistent border on the order type card in Perps Pro mode

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3780

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps Pro order type card styling

  Scenario: user views the Pro order form
    Given the user is on a Perps market screen in Pro mode

    When the user looks at the order type card showing "Market"
    Then the card has no border
    And it matches the TP/SL row directly below it
    And its rounded corners still clip the trigger price field when shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**
<img width="440" height="967" alt="Screenshot 2026-09-01 at 11 42 58 AM" src="https://github.com/user-attachments/assets/d3687a12-11df-4cc3-a7a7-f5f2421cd8a2" />

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="440" height="967" alt="Screenshot 2026-09-01 at 12 07 29 PM" src="https://github.com/user-attachments/assets/485b9333-0b46-4633-a11b-6765e953b041" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only Tailwind class tweaks and regression tests; no trading, auth, or data logic.
> 
> **Overview**
> Aligns **Perps Pro** order form muted cards with the rest of the form by dropping the extra outline on the order type and size surfaces (TAT-3780).
> 
> In `PerpsProOrderForm`, the order type card no longer uses `border border-muted`; it stays `rounded-xl` with `overflow-hidden` so trigger-price content still clips to the corners. In `PerpsProSizeInput`, the size card loses the same border and its corner radius changes from `rounded-2xl` to `rounded-xl` to match peers. **Internal** row separators (`border-t` inside the size card and related compact inputs) are unchanged.
> 
> **Figma layout** tests assert both cards render with no `borderWidth` via `StyleSheet.flatten`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0fc7fe20340782eb45502dceefea91db5ee7591. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

