### PR TITLE
Add verify-metamask-mobile agent verification skill

### DIFF
--- a/scripts/verification/verify-metamask-mobile/SKILL.md
+++ b/scripts/verification/verify-metamask-mobile/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: verify-metamask-mobile
+description: Prove MetaMask Mobile UI and Predict changes via Jest view/unit tests, ESLint, and TypeScript — the user-facing behavior agents can drive on Linux CI and Cloud Agents without a simulator. Use after mobile or Predict UI changes; pair with walkthrough-artifacts when a simulator is available.
+---
+
+# Verify MetaMask Mobile
+
+React Native wallet (Expo + native). **Primary agent-verifiable surface on Linux:** Jest test layers and static analysis. Full Appium smoke requires iOS/Android simulators and is CI-only unless explicitly available.
+
+Repo root: `/agent/repos/metamask-mobile`
+
+| Layer | Harness | When |
+|-------|---------|------|
+| ESLint + TypeScript | `yarn lint`, `yarn lint:tsc` | Every change |
+| Unit tests (`*.test.tsx`) | `yarn jest <path>` | Logic/hooks |
+| Component view tests (`*.view.test.tsx`) | `yarn jest -c jest.config.view.js <path>` | Screens/components |
+| Integration tests (`*.integration.test.tsx`) | `yarn jest -c jest.config.integration.js <path>` | Controller wiring |
+| Appium smoke | `yarn appium-smoke:ios\|android` | CI / local sim only |
+| Visual walkthrough | `walkthrough-artifacts` skill | Simulator available |
+
+## Launch
+
+No long-lived server is required for the default verification path.
+
+One-time / stale checkout:
+
+```bash
+cd /agent/repos/metamask-mobile
+export PATH="/home/ubuntu/.nvm/versions/node/v24.18.0/bin:$PATH"
+yarn install --immutable
+# JS-only work:
+yarn setup:expo
+cp .js.env.example .js.env   # if missing; set MM_INFURA_PROJECT_ID when needed
+```
+
+Optional Metro (manual UI only):
+
+```bash
+yarn watch:clean   # tmux session recommended
+```
+
+Ready for test harness when `doctor` passes.
+
+## Doctor
+
+```bash
+bash scripts/verification/verify-metamask-mobile/helpers/metamask-mobile-verify.sh doctor
+```
+
+Pass criteria: Node/Yarn available, `node_modules` present, `.js.env` or `.js.env.example` exists.
+
+## Drive
+
+Read `scripts/verification/verify-metamask-mobile/features/README.md` first.
+
+**Scoped static check (Predict default):**
+
+```bash
+export RUN_ID="mm-verify-$(date +%s)"
+bash scripts/verification/verify-metamask-mobile/helpers/metamask-mobile-verify.sh drive-static app/components/UI/Predict/
+```
+
+**Predict view tests (user-visible screens):**
+
+```bash
+bash scripts/verification/verify-metamask-mobile/helpers/metamask-mobile-verify.sh drive-predict-views
+```
+
+**Changed-file targeted unit test:**
+
+```bash
+yarn jest app/components/UI/Predict/hooks/useLiveMarketPrices.test.ts --runInBand
+```
+
+**Full unit gate (CI subset):**
+
+```bash
+yarn test:unit
+```
+
+**Appium (skip unless simulator + main-e2e build confirmed):**
+
+```bash
+yarn build:ios:main:e2e   # or android
+yarn appium-smoke:ios
+```
+
+## Evidence
+
+Artifacts root: `/tmp/metamask-mobile-verify-$RUN_ID/` (override `MM_VERIFY_ARTIFACTS`).
+
+Each drive writes logs plus `*-proof.txt` with command, exit code, and feature id.
+
+Proof standards:
+
+- View tests assert rendered user-visible output — prefer them for UI changes
+- Capture Jest stdout/log file, not just pass/fail boolean
+- Do not claim Appium coverage when only Jest ran — report skipped with reason
+- With simulator: use `walkthrough-artifacts` for screenshots/video of the changed screen
+
+## Cleanup
+
+```bash
+bash scripts/verification/verify-metamask-mobile/helpers/metamask-mobile-verify.sh cleanup
+```
+
+Test harness leaves no processes. Stop Metro manually if you started it for walkthrough.
+
+Artifacts survive cleanup.
+
+## Helpers
+
+| Command | Purpose |
+|---------|---------|
+| `... doctor` | Tooling + deps check |
+| `... drive-static [path]` | ESLint + tsc (default Predict tree) |
+| `... drive-predict-views` | All Predict `*.view.test.tsx` under `views/` |
+| `... cleanup` | No-op except artifact preservation notice |
+
+Predict-specific commands also documented in `docs/predict/implementation-guide.md` (Verification Commands section).
+
+Maintained under `scripts/verification/verify-metamask-mobile/features/`. For Cursor auto-discovery, symlink or copy this folder to `.cursor/skills/verify-metamask-mobile/` (gitignored in this repo).
+
+Run `/maintain-verification-skill` when navigation, test ids, or Predict routes change.

--- a/scripts/verification/verify-metamask-mobile/features/README.md
+++ b/scripts/verification/verify-metamask-mobile/features/README.md
@@ -1,0 +1,34 @@
+# MetaMask Mobile verification map
+
+User-facing Predict UI and shared mobile quality gates. Read this index, then the feature file matching the screen or command you need to prove.
+
+## Baseline preconditions
+
+- Repo: `/agent/repos/metamask-mobile`
+- Node ^24 and Yarn 4 on PATH
+- `yarn install --immutable` completed
+- `.js.env` present (copy from `.js.env.example` if needed)
+- Helper: `scripts/verification/verify-metamask-mobile/helpers/metamask-mobile-verify.sh`
+- Assign `RUN_ID`; artifacts under `/tmp/metamask-mobile-verify-$RUN_ID/`
+
+## Driving conventions
+
+- Prefer component view tests for screen behavior; unit tests for hooks/selectors
+- Scope lint to changed paths when possible; full `lint:tsc` for type safety
+- Appium smoke is not the default on Linux Cloud Agents
+- Match existing Jest config files (`jest.config.view.js`, `jest.config.integration.js`)
+- Sync agent coding skills when needed: `yarn skills`
+
+## Proof and skip reporting
+
+- Save Jest log output and proof.txt with exit code
+- UI proof without simulator = view test artifacts, not screenshots
+- Report Appium/E2E as skipped when no emulator — do not substitute unit tests silently
+
+## Features
+
+- [Static analysis gate](./static-analysis.md) — ESLint + TypeScript on changed trees
+- [Predict home screen views](./predict-home.md) — Predict home view tests
+- [Predict feed browsing](./predict-feed.md) — feed list and feed view tests
+- [Predict positions](./predict-positions.md) — positions screen view tests
+- [Predict market details](./predict-market-details.md) — market detail view tests

--- a/scripts/verification/verify-metamask-mobile/features/predict-feed.md
+++ b/scripts/verification/verify-metamask-mobile/features/predict-feed.md
@@ -1,0 +1,29 @@
+# Predict feed browsing
+
+Users scroll curated feeds (e.g. sports) and open individual markets from feed rows.
+
+## Sub-features
+
+- `predict-feed-list` — feed container renders market rows
+- `predict-feed-view` — dedicated feed screen navigation
+
+## How to get to it (user POV)
+
+- Tap a feed card on Predict home
+- Land on feed detail with market list
+
+## Driving it with metamask-mobile-verify.sh
+
+Preconditions:
+
+- `doctor` passes
+
+- **Feed container.** `yarn jest -c jest.config.view.js app/components/UI/Predict/views/PredictFeed/PredictFeed.view.test.tsx --runInBand --silent --coverage=false`
+- **Feed view screen.** `yarn jest -c jest.config.view.js app/components/UI/Predict/views/PredictFeedView/PredictFeedView.view.test.tsx --runInBand --silent --coverage=false`
+- **Batch.** `drive-predict-views` helper runs entire `views/` tree
+- **Proof.** Jest logs with exit 0
+
+## Gotchas
+
+- API responses are mocked in view tests
+- Feed ids must match test fixtures, not production Kalshi ids

--- a/scripts/verification/verify-metamask-mobile/features/predict-home.md
+++ b/scripts/verification/verify-metamask-mobile/features/predict-home.md
@@ -1,0 +1,28 @@
+# Predict home screen views
+
+Predict home is the entry surface for browsing prediction markets inside MetaMask.
+
+## Sub-features
+
+- `predict-home-render` — home layout renders expected headings and navigation affordances
+- `predict-home-states` — loading/empty/error states (per view test cases)
+
+## How to get to it (user POV)
+
+- User opens Predict tab from wallet bottom navigation
+- Deeplink / feature flag may gate visibility
+
+## Driving it with metamask-mobile-verify.sh
+
+Preconditions:
+
+- `doctor` passes
+
+- **View tests.** `yarn jest -c jest.config.view.js app/components/UI/Predict/views/PredictHome/PredictHome.view.test.tsx --runInBand --silent --coverage=false`
+- **Or batch.** `bash scripts/verification/verify-metamask-mobile/helpers/metamask-mobile-verify.sh drive-predict-views` (includes this file)
+- **Proof.** Jest exit 0; log saved under `$MM_VERIFY_ARTIFACTS/predict-views.log`
+
+## Gotchas
+
+- View tests mock network/controllers — they prove UI wiring, not live Kalshi data
+- Feature flags may affect rendered branches; tests encode expected flag state

--- a/scripts/verification/verify-metamask-mobile/features/predict-market-details.md
+++ b/scripts/verification/verify-metamask-mobile/features/predict-market-details.md
@@ -1,0 +1,26 @@
+# Predict market details
+
+Users inspect a single market (prices, chart, trade actions) from the market details screen.
+
+## Sub-features
+
+- `market-details-render` — title, prices, and primary actions visible
+- `market-details-chart` — chart region renders per test mocks
+
+## How to get to it (user POV)
+
+- Tap a market row from home or feed → market details screen
+
+## Driving it with metamask-mobile-verify.sh
+
+Preconditions:
+
+- `doctor` passes
+
+- **View test.** `yarn jest -c jest.config.view.js app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.view.test.tsx --runInBand --silent --coverage=false`
+- **Proof.** Jest exit 0 with saved log
+
+## Gotchas
+
+- Live price hooks (`useLiveMarketPrices`) have separate unit tests — run both when changing streaming logic
+- Chart data tests may be slow; `--runInBand` avoids flake

--- a/scripts/verification/verify-metamask-mobile/features/predict-positions.md
+++ b/scripts/verification/verify-metamask-mobile/features/predict-positions.md
@@ -1,0 +1,26 @@
+# Predict positions
+
+Users review open prediction positions and unrealized PnL from the positions screen.
+
+## Sub-features
+
+- `positions-list` — renders position rows
+- `positions-empty` — empty state when user has no positions
+
+## How to get to it (user POV)
+
+- Navigate to Predict → Positions tab/screen
+
+## Driving it with metamask-mobile-verify.sh
+
+Preconditions:
+
+- `doctor` passes
+
+- **View test.** `yarn jest -c jest.config.view.js app/components/UI/Predict/views/PredictPositionsView/PredictPositionsView.view.test.tsx --runInBand --silent --coverage=false`
+- **Proof.** Exit 0; capture log under artifacts dir
+
+## Gotchas
+
+- Live positions require backend + wallet state — view tests use fixtures
+- PnL formatting tests may live in hook unit tests (`useUnrealizedPnL`)

--- a/scripts/verification/verify-metamask-mobile/features/static-analysis.md
+++ b/scripts/verification/verify-metamask-mobile/features/static-analysis.md
@@ -1,0 +1,30 @@
+# Static analysis gate
+
+Every change must pass ESLint and TypeScript before merge. This is the fastest user-trust signal that the app still compiles cleanly.
+
+## Sub-features
+
+- `eslint-scoped` — lint changed directories
+- `typescript-project` — full project typecheck via `yarn lint:tsc`
+
+## How to get to it (user POV)
+
+- CI runs lint + tsc on every PR
+- Developers run the same locally before push
+
+## Driving it with metamask-mobile-verify.sh
+
+Preconditions:
+
+- `doctor` passes
+- Dependencies installed
+
+- **Predict tree (default).** `bash scripts/verification/verify-metamask-mobile/helpers/metamask-mobile-verify.sh drive-static app/components/UI/Predict/`
+- **Custom path.** Pass directory as second argument for other features.
+- **Proof.** `static-proof.txt` shows `lint_exit: 0` and `tsc_exit: 0`; logs in `lint.log` and `tsc.log`.
+
+## Gotchas
+
+- `yarn lint -- path` requires `--` before paths
+- Full-repo lint can be slow — scope to changed folders when verifying a focused change
+- Native-only type errors may still surface in full `lint:tsc`

--- a/scripts/verification/verify-metamask-mobile/helpers/metamask-mobile-verify.sh
+++ b/scripts/verification/verify-metamask-mobile/helpers/metamask-mobile-verify.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Verification harness for MetaMask Mobile (JS test layers).
+# Usage: metamask-mobile-verify.sh <doctor|drive-predict-views|drive-static|cleanup> [path...]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+RUN_ID="${RUN_ID:-mm-verify-$(date +%s)}"
+ARTIFACTS_DIR="${MM_VERIFY_ARTIFACTS:-/tmp/metamask-mobile-verify-${RUN_ID}}"
+
+export PATH="/home/ubuntu/.nvm/versions/node/v24.18.0/bin:${PATH:-}"
+
+mkdir -p "$ARTIFACTS_DIR"
+
+doctor() {
+  echo "== metamask-mobile doctor =="
+  echo "repo: $REPO_ROOT"
+  echo "run_id: $RUN_ID"
+  echo "artifacts: $ARTIFACTS_DIR"
+  echo "node: $(node -v)"
+  echo "yarn: $(yarn -v)"
+
+  if [[ -f "${REPO_ROOT}/.js.env" || -f "${REPO_ROOT}/.js.env.example" ]]; then
+    echo "js_env: ok"
+  else
+    echo "js_env: missing .js.env and .js.env.example"
+    return 1
+  fi
+
+  if [[ -d "${REPO_ROOT}/node_modules" ]]; then
+    echo "node_modules: present"
+  else
+    echo "node_modules: missing — run yarn install"
+    return 1
+  fi
+
+  echo "doctor: pass"
+}
+
+drive_predict_views() {
+  cd "$REPO_ROOT"
+  local log="${ARTIFACTS_DIR}/predict-views.log"
+  yarn jest -c jest.config.view.js app/components/UI/Predict/views \
+    --runInBand --silent --coverage=false 2>&1 | tee "$log"
+  local exit_code="${PIPESTATUS[0]}"
+  {
+    echo "feature: predict-views"
+    echo "run_id: $RUN_ID"
+    echo "command: yarn jest -c jest.config.view.js app/components/UI/Predict/views --runInBand"
+    echo "exit_code: $exit_code"
+  } >"${ARTIFACTS_DIR}/predict-views-proof.txt"
+  if [[ "$exit_code" -ne 0 ]]; then
+    echo "drive-predict-views: failed — see $log" >&2
+    return "$exit_code"
+  fi
+  echo "drive-predict-views: pass — artifacts in $ARTIFACTS_DIR"
+}
+
+drive_static() {
+  cd "$REPO_ROOT"
+  local target="${1:-app/components/UI/Predict/}"
+  local lint_log="${ARTIFACTS_DIR}/lint.log"
+  local tsc_log="${ARTIFACTS_DIR}/tsc.log"
+
+  yarn lint -- "$target" 2>&1 | tee "$lint_log"
+  local lint_code="${PIPESTATUS[0]}"
+
+  yarn lint:tsc 2>&1 | tee "$tsc_log"
+  local tsc_code="${PIPESTATUS[0]}"
+
+  {
+    echo "feature: static-analysis"
+    echo "run_id: $RUN_ID"
+    echo "lint_target: $target"
+    echo "lint_exit: $lint_code"
+    echo "tsc_exit: $tsc_code"
+  } >"${ARTIFACTS_DIR}/static-proof.txt"
+
+  if [[ "$lint_code" -ne 0 || "$tsc_code" -ne 0 ]]; then
+    echo "drive-static: failed" >&2
+    return 1
+  fi
+  echo "drive-static: pass — artifacts in $ARTIFACTS_DIR"
+}
+
+cleanup() {
+  echo "cleanup: no processes to stop (test-only harness)"
+  echo "cleanup: artifacts preserved at $ARTIFACTS_DIR"
+}
+
+usage() {
+  echo "Usage: $0 <doctor|drive-predict-views|drive-static> [lint-target]"
+  exit 1
+}
+
+case "${1:-}" in
+  doctor) doctor ;;
+  drive-predict-views) drive_predict_views ;;
+  drive-static) shift; drive_static "${1:-app/components/UI/Predict/}" ;;
+  cleanup) cleanup ;;
+  *) usage ;;
+esac


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a tracked agent verification skill for MetaMask Mobile so Cloud Agents and CI environments can prove Predict UI changes without simulators.

## What's included

- `scripts/verification/verify-metamask-mobile/SKILL.md` — doctor, drive, evidence, and cleanup for Jest view tests
- `helpers/metamask-mobile-verify.sh` — runs Predict view tests and scoped lint/tsc
- Feature map for static analysis and Predict screens (home, feed, positions, market details)

Placed under `scripts/verification/` because `.cursor/skills/` and `.agents/skills/` are gitignored by repo policy. Symlink to `.cursor/skills/verify-metamask-mobile/` locally for Cursor auto-discovery.

## Proof run

Verified end-to-end after `yarn install`:

- `doctor` — Node, Yarn, deps OK
- `drive-predict-views` — 5 suites, 88 tests passed
- `cleanup` — artifacts preserved

## Usage

```bash
export RUN_ID="mm-verify-$(date +%s)"
bash scripts/verification/verify-metamask-mobile/helpers/metamask-mobile-verify.sh doctor
bash scripts/verification/verify-metamask-mobile/helpers/metamask-mobile-verify.sh drive-predict-views
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc3b1cc5-5fae-46c7-92a8-30e70a62e1a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc3b1cc5-5fae-46c7-92a8-30e70a62e1a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

