### PR TITLE
fix(content): follow-up sentence case and punctuation corrections (#35255)

### DIFF
--- a/app/component-library/components-temp/KeyValueRow/KeyValueRow.stories.tsx
+++ b/app/component-library/components-temp/KeyValueRow/KeyValueRow.stories.tsx
@@ -38,7 +38,7 @@ export const KeyValueRow = {
               text: 'Sample key text',
             },
           }}
-          value={{ label: { text: 'Sample Value Text' } }}
+          value={{ label: { text: 'Sample value text' } }}
         />
         <KeyValueRowComponent
           field={{
@@ -50,12 +50,12 @@ export const KeyValueRow = {
           }}
           value={{
             label: {
-              text: 'Sample Value Text',
+              text: 'Sample value text',
               variant: TextVariant.BodySMBold,
               color: TextColor.Success,
             },
             tooltip: {
-              title: 'Sample Title',
+              title: 'Sample title',
               content:
                 'Pariatur nisi pariatur ex veniam ad. Non tempor nostrud sint velit cupidatat aliquip elit ut pariatur reprehenderit enim enim commodo eu.',
             },
@@ -67,14 +67,14 @@ export const KeyValueRow = {
               text: 'Sample key text',
             },
             tooltip: {
-              title: 'Sample Tooltip',
+              title: 'Sample tooltip',
               content:
                 'Pariatur nisi pariatur ex veniam ad. Non tempor nostrud sint velit cupidatat aliquip elit ut pariatur reprehenderit enim enim commodo eu.',
             },
           }}
           value={{
             label: {
-              text: 'Sample Value Text',
+              text: 'Sample value text',
             },
           }}
         />
@@ -92,7 +92,7 @@ export const KeyValueRow = {
           }}
           value={{
             label: {
-              text: 'Sample Value Text',
+              text: 'Sample value text',
             },
             icon: {
               name: IconName.Wifi,
@@ -108,7 +108,7 @@ export const KeyValueRow = {
             label: { text: 'Sample key' },
             icon: { name: IconName.UserCircleAdd, color: IconColor.Primary },
             tooltip: {
-              title: 'Sample Tooltip',
+              title: 'Sample tooltip',
               content:
                 'Pariatur nisi pariatur ex veniam ad. Non tempor nostrud sint velit cupidatat aliquip elit ut pariatur reprehenderit enim enim commodo eu.',
             },

--- a/app/component-library/components/Banners/Banner/Banner.constants.ts
+++ b/app/component-library/components/Banners/Banner/Banner.constants.ts
@@ -12,7 +12,7 @@ export const DEFAULT_BANNER_VARIANT = BannerVariant.Alert;
 
 // Sample consts
 export const SAMPLE_BANNER_TITLE = 'Sample banner title';
-export const SAMPLE_BANNER_DESCRIPTION = 'Sample Banner Description';
+export const SAMPLE_BANNER_DESCRIPTION = 'Sample banner description';
 export const SAMPLE_BANNER_ACTIONBUTTONLABEL = 'Sample action button label';
 
 export const SAMPLE_BANNER_PROPS: BannerProps = {

--- a/app/component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert.constants.ts
+++ b/app/component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert.constants.ts
@@ -29,7 +29,7 @@ export const BANNERALERT_TEST_ID = 'banneralert';
 
 // Sample consts
 export const SAMPLE_BANNERALERT_TITLE = 'Sample banner alert title';
-export const SAMPLE_BANNERALERT_DESCRIPTION = 'Sample Banner Alert Description';
+export const SAMPLE_BANNERALERT_DESCRIPTION = 'Sample banner alert description';
 export const SAMPLE_BANNERALERT_ACTIONBUTTONLABEL =
   'Sample action button label';
 export const SAMPLE_BANNERALERT_PROPS: BannerAlertProps = {

--- a/app/component-library/components/Banners/Banner/variants/BannerTip/BannerTip.constants.ts
+++ b/app/component-library/components/Banners/Banner/variants/BannerTip/BannerTip.constants.ts
@@ -30,7 +30,7 @@ export const IMAGESOURCE_BY_BANNERTIPLOGOTYPE: ImageSourceByBannerTipLogoType =
 
 // Sample consts
 export const SAMPLE_BANNERTIP_TITLE = 'Sample banner tip title';
-export const SAMPLE_BANNERTIP_DESCRIPTION = 'Sample Banner Tip Description';
+export const SAMPLE_BANNERTIP_DESCRIPTION = 'Sample banner tip description';
 export const SAMPLE_BANNERTIP_ACTIONBUTTONLABEL = 'Sample action button label';
 export const SAMPLE_BANNERTIP_PROPS: BannerTipProps = {
   logoType: DEFAULT_BANNERTIP_LOGOTYPE,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1027,7 +1027,7 @@
       "description": "Card purchases typically take a few minutes",
       "bank_transfer_description": "Bank transfers typically take a few business days",
       "success_title": "Deposit complete",
-      "success_description": "Your deposit of {{amount}} {{currency}} was successful!",
+      "success_description": "Your deposit of {{amount}} {{currency}} was successful",
       "error_title": "Deposit failed",
       "error_description": "We were unable to complete your deposit",
       "cancel_order_description": "You requested a cancellation of your deposit.",
@@ -1080,7 +1080,7 @@
       "deposit_failed_description": "Verify your payment method and card support",
       "deposit_cancelled_title": "Your deposit was cancelled",
       "deposit_cancelled_description": "You requested a cancellation of your deposit.",
-      "deposit_completed_title": "Your deposit of {{amount}} {{currency}} was successful!",
+      "deposit_completed_title": "Your deposit of {{amount}} {{currency}} was successful",
       "deposit_completed_description": "Your {{currency}} is now available in your wallet",
       "deposit_pending_title": "Processing your deposit of {{currency}}",
       "deposit_pending_description": "This should only take a few minutes..."
@@ -1456,7 +1456,7 @@
       "processing": {
         "title": "Processing deposit"
       },
-      "deposit_completed": "Deposit completed successfully!",
+      "deposit_completed": "Deposit completed successfully",
       "deposit_failed": "Deposit failed",
       "retry_deposit": "Retry deposit",
       "go_back": "Go back",
@@ -1486,7 +1486,7 @@
       "bridge_quote_timeout": "Unable to fetch bridge quote. Please try again or select a different token.",
       "no_quotes_available": "No routes available for this swap. Try a different token or amount.",
       "success": {
-        "title": "Deposit successful!",
+        "title": "Deposit successful",
         "description": "Your USDC has been successfully deposited to your HyperLiquid trading account",
         "amount": "Amount",
         "processing_time": "Processing time",
@@ -6092,7 +6092,7 @@
     "title": "Confirm Secret Recovery Phrase",
     "info_text": "Insert each word in the order it was presented to you on the previous screen.",
     "cta_text": "Confirm phrase",
-    "modal_title": "Secret Recovery Phrase confirmed!",
+    "modal_title": "Secret Recovery Phrase confirmed",
     "modal_text": "This was to ensure you follow this security measure",
     "modal_button": "Next"
   },
@@ -6258,10 +6258,10 @@
     "pending_deposit_title": "Deposit in progress",
     "pending_withdrawal_title": "Withdrawal in progress",
     "cancelled_title": "Transaction cancelled",
-    "success_title": "Transaction #{{nonce}} Complete!",
+    "success_title": "Transaction #{{nonce}} complete",
     "speedup_title": "Speeding up #{{nonce}}",
-    "success_deposit_title": "Deposit complete!",
-    "success_withdrawal_title": "Withdrawal complete!",
+    "success_deposit_title": "Deposit complete",
+    "success_withdrawal_title": "Withdrawal complete",
     "error_title": "Oops, something went wrong :/",
     "received_title": "You received {{amount}} {{assetType}}",
     "erc20_sent_title": "Funds sent",


### PR DESCRIPTION
## **Description**

Follow-up to [#35255](https://github.com/MetaMask/metamask-mobile/pull/35255), which applied sentence case to Storybook/constants sample strings and removed exclamation points from several locale strings. This PR addresses the remaining issues that were missed:

**Banner description constants** — three description sample strings were left in Title Case:
- `SAMPLE_BANNER_DESCRIPTION`: `'Sample Banner Description'` → `'Sample banner description'`
- `SAMPLE_BANNERALERT_DESCRIPTION`: `'Sample Banner Alert Description'` → `'Sample banner alert description'`
- `SAMPLE_BANNERTIP_DESCRIPTION`: `'Sample Banner Tip Description'` → `'Sample banner tip description'`

**KeyValueRow stories** — value labels and tooltip titles were left in Title Case:
- `text: 'Sample Value Text'` (4 instances) → `'Sample value text'`
- `title: 'Sample Title'` → `'Sample title'`
- `title: 'Sample Tooltip'` (2 instances) → `'Sample tooltip'`

**`locales/languages/en.json`** — success/confirmation titles still had trailing exclamation points:
- `"success_description"`: `"Your deposit of {{amount}} {{currency}} was successful!"` → removes `!`
- `"deposit_completed_title"`: `"Your deposit of {{amount}} {{currency}} was successful!"` → removes `!`
- `"deposit_completed"`: `"Deposit completed successfully!"` → removes `!`
- `"title"` (HyperLiquid deposit success): `"Deposit successful!"` → removes `!`
- `"modal_title"` (SRP confirmation): `"Secret Recovery Phrase confirmed!"` → removes `!`
- `"success_title"` (transaction): `"Transaction #{{nonce}} Complete!"` → `"Transaction #{{nonce}} complete"` (removes `!`, fixes Title Case on "Complete")
- `"success_deposit_title"` / `"success_withdrawal_title"`: `"Deposit complete!"` / `"Withdrawal complete!"` → removes `!`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #35255

## **Manual testing steps**

```gherkin
Feature: Sentence case and punctuation in sample strings and locale

  Scenario: User views Banner component stories in Storybook
    Given the app is running with Storybook enabled
    When user navigates to Banner, BannerAlert, or BannerTip in Storybook
    Then description text is displayed in sentence case (not Title Case)

  Scenario: User views KeyValueRow stories in Storybook
    When user navigates to KeyValueRow in Storybook
    Then value labels and tooltip titles are displayed in sentence case

  Scenario: Locale success/confirmation strings
    Given the app is running
    When a deposit, withdrawal, or transaction completes
    Then the success/confirmation message does not end with an exclamation point
```

## **Screenshots/Recordings**

N/A — changes are demo/sample strings in Storybook constants and user-facing locale strings in `en.json`. No UI layout or logic changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.