### PR TITLE
feat(explore): refresh the search header and browser tabs entry

### DIFF
--- a/app/components/Views/Browser/Browser.types.ts
+++ b/app/components/Views/Browser/Browser.types.ts
@@ -7,6 +7,7 @@ export interface BrowserParams {
   showTabsView?: boolean;
   existingTabId?: number;
   fromTrending?: boolean;
+  fromExploreSearch?: boolean;
   fromPerps?: boolean;
   fromBenefit?: boolean;
   fromCard?: boolean;

--- a/app/components/Views/Browser/index.js
+++ b/app/components/Views/Browser/index.js
@@ -466,6 +466,7 @@ export const BrowserPure = (props) => {
               isInTabsView={shouldShowTabs}
               homePageUrl={homePageUrl()}
               fromTrending={route.params?.fromTrending}
+              fromExploreSearch={route.params?.fromExploreSearch}
               fromPerps={route.params?.fromPerps}
               fromBenefit={route.params?.fromBenefit}
               fromCard={route.params?.fromCard}
@@ -495,6 +496,7 @@ export const BrowserPure = (props) => {
       updateTabInfo,
       showTabsView,
       route.params?.fromTrending,
+      route.params?.fromExploreSearch,
       route.params?.fromPerps,
       route.params?.fromBenefit,
       route.params?.fromCard,

--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -162,6 +162,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
     ipfsGateway,
     newTab,
     activeChainId,
+    fromExploreSearch,
     fromPerps,
     fromBenefit,
     fromCard,
@@ -1474,7 +1475,9 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
     }, []);
 
     const handleClosePress = useCallback(() => {
-      if (fromPerps) {
+      if (fromExploreSearch) {
+        navigation.navigate(Routes.HOME_TABS, undefined, { pop: true });
+      } else if (fromPerps) {
         navigateToPerpsHome();
       } else if (fromBenefit) {
         navigation.goBack();
@@ -1514,6 +1517,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
     }, [
       navigation,
       navigateToPerpsHome,
+      fromExploreSearch,
       fromPerps,
       fromBenefit,
       fromCard,

--- a/app/components/Views/BrowserTab/index.test.tsx
+++ b/app/components/Views/BrowserTab/index.test.tsx
@@ -240,6 +240,29 @@ describe('BrowserTab', () => {
       );
     });
 
+    it('returns to the home tabs when close button is pressed and opened from explore search', async () => {
+      renderWithProvider(<BrowserTab {...mockProps} fromExploreSearch />, {
+        state: mockInitialState,
+      });
+
+      await waitFor(() =>
+        expect(screen.getByTestId('browser-webview')).toBeVisible(),
+      );
+
+      fireEvent.press(screen.getByTestId('browser-tab-close-button'));
+
+      // Pops the Explore search screen too, so the last visited tab is shown.
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        Routes.HOME_TABS,
+        undefined,
+        { pop: true },
+      );
+      expect(mockNavigation.navigate).not.toHaveBeenCalledWith(
+        Routes.TRENDING_VIEW,
+        expect.anything(),
+      );
+    });
+
     it('navigates to Card Home when close button is pressed and opened from card', async () => {
       renderWithProvider(<BrowserTab {...mockProps} fromCard />, {
         state: mockInitialState,

--- a/app/components/Views/BrowserTab/types.ts
+++ b/app/components/Views/BrowserTab/types.ts
@@ -128,6 +128,11 @@ export type BrowserTabProps = SharedTabProps & {
    */
   fromTrending?: boolean;
   /**
+   * Whether browser was opened from the Explore search screen, which lives in
+   * the root stack — closing must pop back to it, not jump to the Explore tab.
+   */
+  fromExploreSearch?: boolean;
+  /**
    * Whether browser was opened from Perps view
    */
   fromPerps?: boolean;

--- a/app/components/Views/TrendingView/TrendingView.testIds.ts
+++ b/app/components/Views/TrendingView/TrendingView.testIds.ts
@@ -15,6 +15,7 @@ export const TrendingViewSelectorsIDs = {
   CLOSE_BUTTON: 'close-button',
   TRENDING_TOKENS_HEADER_SEARCH_TOGGLE: 'trending-tokens-header-search-toggle',
   EXPLORE_SEARCH_CANCEL_BUTTON: 'explore-search-cancel-button',
+  EXPLORE_SEARCH_BACK_BUTTON: 'explore-search-back-button',
   SECTION_HEADER_VIEW_ALL_STOCKS: 'section-header-view-all-stocks',
   SECTION_HEADER_VIEW_ALL_SITES: 'section-header-view-all-sites',
   RWA_TOKENS_HEADER: 'rwa-tokens-header',

--- a/app/components/Views/TrendingView/TrendingView.tsx
+++ b/app/components/Views/TrendingView/TrendingView.tsx
@@ -17,8 +17,6 @@ import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
-  Text,
-  TextVariant,
   IconName,
   Icon,
   IconSize,
@@ -37,6 +35,7 @@ import { selectBasicFunctionalityEnabled } from '../../../selectors/settings';
 import BasicFunctionalityEmptyState from '../../UI/BasicFunctionality/BasicFunctionalityEmptyState/BasicFunctionalityEmptyState';
 import TrendingFeedSessionManager from '../../UI/Trending/services/TrendingFeedSessionManager';
 import ExploreSearchBar from './components/ExploreSearchBar/ExploreSearchBar';
+import BrowserTabsButton from './components/BrowserTabsButton/BrowserTabsButton';
 import { ExploreActiveTabProvider } from './ExploreActiveTabContext';
 import { useExploreRefresh } from './hooks/useExploreRefresh';
 import NowTab from './tabs/NowTab';
@@ -331,18 +330,20 @@ export const ExploreFeed: React.FC = () => {
             <ExploreSearchBar type="button" onPress={handleSearchPress} />
           </Box>
 
-          <TouchableOpacity
-            onPress={handleBrowserPress}
-            testID="trending-view-browser-button"
-          >
-            {browserTabsCount > 0 ? (
-              <Box twClassName="rounded-lg items-center justify-center h-8 w-8 border border-muted bg-section">
-                <Text variant={TextVariant.BodyMd}>{browserTabsCount}</Text>
-              </Box>
-            ) : (
+          {browserTabsCount > 0 ? (
+            <BrowserTabsButton
+              tabCount={browserTabsCount}
+              onPress={handleBrowserPress}
+              testID="trending-view-browser-button"
+            />
+          ) : (
+            <TouchableOpacity
+              onPress={handleBrowserPress}
+              testID="trending-view-browser-button"
+            >
               <Icon name={IconName.Explore} size={IconSize.Xl} />
-            )}
-          </TouchableOpacity>
+            </TouchableOpacity>
+          )}
         </Box>
 
         {!isBasicFunctionalityEnabled ? (

--- a/app/components/Views/TrendingView/TrendingView.tsx
+++ b/app/components/Views/TrendingView/TrendingView.tsx
@@ -17,6 +17,8 @@ import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
+  Text,
+  TextVariant,
   IconName,
   Icon,
   IconSize,
@@ -38,6 +40,7 @@ import ExploreSearchBar from './components/ExploreSearchBar/ExploreSearchBar';
 import BrowserTabsButton from './components/BrowserTabsButton/BrowserTabsButton';
 import { ExploreActiveTabProvider } from './ExploreActiveTabContext';
 import { useExploreRefresh } from './hooks/useExploreRefresh';
+import { useIsExploreHeaderRefreshEnabled } from './hooks/useIsExploreHeaderRefreshEnabled';
 import NowTab from './tabs/NowTab';
 import MacroTab from './tabs/MacroTab';
 import RwasTab from './tabs/RwasTab';
@@ -229,6 +232,7 @@ export const ExploreFeed: React.FC = () => {
   const browserTabsCount = useSelector(
     (state: { browser: { tabs: unknown[] } }) => state.browser.tabs.length,
   );
+  const isHeaderRefreshEnabled = useIsExploreHeaderRefreshEnabled();
   const isBasicFunctionalityEnabled = useSelector(
     selectBasicFunctionalityEnabled,
   );
@@ -330,7 +334,7 @@ export const ExploreFeed: React.FC = () => {
             <ExploreSearchBar type="button" onPress={handleSearchPress} />
           </Box>
 
-          {browserTabsCount > 0 ? (
+          {isHeaderRefreshEnabled && browserTabsCount > 0 ? (
             <BrowserTabsButton
               tabCount={browserTabsCount}
               onPress={handleBrowserPress}
@@ -341,7 +345,13 @@ export const ExploreFeed: React.FC = () => {
               onPress={handleBrowserPress}
               testID="trending-view-browser-button"
             >
-              <Icon name={IconName.Explore} size={IconSize.Xl} />
+              {browserTabsCount > 0 ? (
+                <Box twClassName="rounded-lg items-center justify-center h-8 w-8 border border-muted bg-section">
+                  <Text variant={TextVariant.BodyMd}>{browserTabsCount}</Text>
+                </Box>
+              ) : (
+                <Icon name={IconName.Explore} size={IconSize.Xl} />
+              )}
             </TouchableOpacity>
           )}
         </Box>

--- a/app/components/Views/TrendingView/TrendingView.view.test.tsx
+++ b/app/components/Views/TrendingView/TrendingView.view.test.tsx
@@ -316,7 +316,7 @@ describeForPlatforms('ExploreFeed - Component Tests', () => {
     });
   });
 
-  it('exits search mode when cancel is pressed and restores the search button', async () => {
+  it('exits search mode when the inline back button is pressed and restores the search button', async () => {
     const { findByTestId, getByTestId, queryByTestId } =
       renderTrendingViewWithRoutes();
 
@@ -338,7 +338,7 @@ describeForPlatforms('ExploreFeed - Component Tests', () => {
     await findByTestId(TrendingViewSelectorsIDs.TRENDING_SEARCH_RESULTS_LIST);
 
     await actButtonPress(
-      getByTestId(TrendingViewSelectorsIDs.EXPLORE_SEARCH_CANCEL_BUTTON),
+      getByTestId(TrendingViewSelectorsIDs.EXPLORE_SEARCH_BACK_BUTTON),
     );
 
     await waitFor(() => {

--- a/app/components/Views/TrendingView/TrendingView.view.test.tsx
+++ b/app/components/Views/TrendingView/TrendingView.view.test.tsx
@@ -1,6 +1,9 @@
 import '../../../../tests/component-view/mocks';
 import { describeForPlatforms } from '../../../../tests/component-view/platform';
-import { renderTrendingViewWithRoutes } from '../../../../tests/component-view/renderers/trending';
+import {
+  HeaderNavBarVariant,
+  renderTrendingViewWithRoutes,
+} from '../../../../tests/component-view/renderers/trending';
 import { strings } from '../../../../locales/i18n';
 import { TrendingViewSelectorsIDs } from './TrendingView.testIds';
 import { EXPLORE_TAB_INDEX } from './TrendingView';
@@ -318,7 +321,9 @@ describeForPlatforms('ExploreFeed - Component Tests', () => {
 
   it('exits search mode when the inline back button is pressed and restores the search button', async () => {
     const { findByTestId, getByTestId, queryByTestId } =
-      renderTrendingViewWithRoutes();
+      renderTrendingViewWithRoutes({
+        headerNavBarVariant: HeaderNavBarVariant.TreatmentA,
+      });
 
     await waitFor(() => {
       expect(

--- a/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.testIds.ts
+++ b/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.testIds.ts
@@ -24,6 +24,8 @@ export const ExploreSearchScreenSelectorsIDs = {
   PILL_PREDICTIONS: 'explore-search-pill-predictions',
   /** Sites feed pill */
   PILL_SITES: 'explore-search-pill-sites',
+  /** Open-browser-tabs button, rendered only when at least one tab is open */
+  BROWSER_TABS_BUTTON: 'explore-search-browser-tabs-button',
 } as const;
 
 export type ExploreSearchScreenSelectorsIDsType =

--- a/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.tsx
+++ b/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.tsx
@@ -52,6 +52,7 @@ import { strings } from '../../../../../../locales/i18n';
 import { useScreenTransitionComplete } from '../../../../hooks/useScreenTransitionComplete';
 import { MAX_ITEMS_PER_SECTION } from '../../search/viewMoreLabel';
 import { selectBrowserTabCount } from '../../../../../reducers/browser/selectors';
+import { useIsExploreHeaderRefreshEnabled } from '../../hooks/useIsExploreHeaderRefreshEnabled';
 import Routes from '../../../../../constants/navigation/Routes';
 import { ExploreSearchScreenSelectorsIDs } from './ExploreSearchScreen.testIds';
 import type { ExploreSearchRouteParams } from './ExploreSearchScreen.types';
@@ -331,7 +332,9 @@ const ExploreSearchScreen: React.FC = () => {
   // Gates the keyboard, which iOS paints dark grey mid-push, and the results
   // subtree, whose mount blocks the JS thread while the screen slides in.
   const isTransitionComplete = useScreenTransitionComplete();
+  const isHeaderRefreshEnabled = useIsExploreHeaderRefreshEnabled();
   const browserTabsCount = useSelector(selectBrowserTabCount);
+  const showBrowserTabsButton = isHeaderRefreshEnabled && browserTabsCount > 0;
 
   useEffect(() => {
     if (!routeParams?.entryPoint) {
@@ -377,11 +380,11 @@ const ExploreSearchScreen: React.FC = () => {
             onSearchChange={setSearchQuery}
             onCancel={handleSearchCancel}
             autoFocus={isTransitionComplete}
-            dismissVariant="back"
+            dismissVariant={isHeaderRefreshEnabled ? 'back' : 'cancel'}
           />
         </Box>
 
-        {browserTabsCount > 0 ? (
+        {showBrowserTabsButton ? (
           <BrowserTabsButton
             tabCount={browserTabsCount}
             onPress={handleBrowserTabsPress}

--- a/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.tsx
+++ b/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { ActivityIndicator, Keyboard, Platform } from 'react-native';
+import { useSelector } from 'react-redux';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import TrendingQuickBuy from '../../../../UI/Trending/components/TrendingQuickBuy/TrendingQuickBuy';
 import { useABTest } from '../../../../../hooks/useABTest';
@@ -19,9 +20,14 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { Box } from '@metamask/design-system-react-native';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+} from '@metamask/design-system-react-native';
 import { FlashList, FlashListRef, ListRenderItem } from '@shopify/flash-list';
 import ExploreSearchBar from '../../components/ExploreSearchBar/ExploreSearchBar';
+import BrowserTabsButton from '../../components/BrowserTabsButton/BrowserTabsButton';
 import PillRow, { type PillOption } from '../../components/PillRow';
 import ExploreSearchResults from '../../search/ExploreSearchResults';
 import SearchFeedRow, {
@@ -45,6 +51,9 @@ import SitesSearchFooter from '../../../../UI/Sites/components/SitesSearchFooter
 import { strings } from '../../../../../../locales/i18n';
 import { useScreenTransitionComplete } from '../../../../hooks/useScreenTransitionComplete';
 import { MAX_ITEMS_PER_SECTION } from '../../search/viewMoreLabel';
+import { selectBrowserTabCount } from '../../../../../reducers/browser/selectors';
+import Routes from '../../../../../constants/navigation/Routes';
+import { ExploreSearchScreenSelectorsIDs } from './ExploreSearchScreen.testIds';
 import type { ExploreSearchRouteParams } from './ExploreSearchScreen.types';
 
 const ALL_PILL_KEY = 'all' as const;
@@ -322,6 +331,7 @@ const ExploreSearchScreen: React.FC = () => {
   // Gates the keyboard, which iOS paints dark grey mid-push, and the results
   // subtree, whose mount blocks the JS thread while the screen slides in.
   const isTransitionComplete = useScreenTransitionComplete();
+  const browserTabsCount = useSelector(selectBrowserTabCount);
 
   useEffect(() => {
     if (!routeParams?.entryPoint) {
@@ -338,19 +348,46 @@ const ExploreSearchScreen: React.FC = () => {
     navigation.goBack();
   }, [navigation]);
 
+  const handleBrowserTabsPress = useCallback(() => {
+    Keyboard.dismiss();
+    navigation.navigate(Routes.BROWSER.HOME, {
+      screen: Routes.BROWSER.VIEW,
+      params: {
+        showTabsView: true,
+        timestamp: Date.now(),
+        fromExploreSearch: true,
+      },
+    });
+  }, [navigation]);
+
   return (
     <Box
       style={{ paddingTop: insets.top + (Platform.OS === 'android' ? 16 : 0) }}
       twClassName="flex-1 bg-default"
     >
-      <Box twClassName="px-4 pb-3">
-        <ExploreSearchBar
-          type="interactive"
-          searchQuery={searchQuery}
-          onSearchChange={setSearchQuery}
-          onCancel={handleSearchCancel}
-          autoFocus={isTransitionComplete}
-        />
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        twClassName="gap-2 px-4 pb-3"
+      >
+        <Box twClassName="flex-1">
+          <ExploreSearchBar
+            type="interactive"
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            onCancel={handleSearchCancel}
+            autoFocus={isTransitionComplete}
+            dismissVariant="back"
+          />
+        </Box>
+
+        {browserTabsCount > 0 ? (
+          <BrowserTabsButton
+            tabCount={browserTabsCount}
+            onPress={handleBrowserTabsPress}
+            testID={ExploreSearchScreenSelectorsIDs.BROWSER_TABS_BUTTON}
+          />
+        ) : null}
       </Box>
 
       {isTransitionComplete ? (

--- a/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.view.test.tsx
+++ b/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.view.test.tsx
@@ -1,6 +1,9 @@
 import '../../../../../../tests/component-view/mocks';
 import { describeForPlatforms } from '../../../../../../tests/component-view/platform';
-import { renderExploreSearchScreenWithRoutes } from '../../../../../../tests/component-view/renderers/trending';
+import {
+  HeaderNavBarVariant,
+  renderExploreSearchScreenWithRoutes,
+} from '../../../../../../tests/component-view/renderers/trending';
 import { getRouteProbeTestId } from '../../../../../../tests/component-view/render';
 import Routes from '../../../../../constants/navigation/Routes';
 import {
@@ -304,15 +307,30 @@ describeForPlatforms('ExploreSearchScreen - Component Tests', () => {
     ).toBe(true);
   });
 
-  it('renders the inline back button instead of a cancel button', async () => {
-    const { findByTestId, queryByTestId } =
-      renderExploreSearchScreenWithRoutes();
+  it('renders the inline back button instead of a cancel button on a treatment arm', async () => {
+    const { findByTestId, queryByTestId } = renderExploreSearchScreenWithRoutes(
+      {
+        headerNavBarVariant: HeaderNavBarVariant.TreatmentA,
+      },
+    );
 
     expect(
       await findByTestId(TrendingViewSelectorsIDs.EXPLORE_SEARCH_BACK_BUTTON),
     ).toBeOnTheScreen();
     expect(
       queryByTestId(TrendingViewSelectorsIDs.EXPLORE_SEARCH_CANCEL_BUTTON),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('keeps the cancel button on the control arm', async () => {
+    const { findByTestId, queryByTestId } =
+      renderExploreSearchScreenWithRoutes();
+
+    expect(
+      await findByTestId(TrendingViewSelectorsIDs.EXPLORE_SEARCH_CANCEL_BUTTON),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(TrendingViewSelectorsIDs.EXPLORE_SEARCH_BACK_BUTTON),
     ).not.toBeOnTheScreen();
   });
 
@@ -329,6 +347,7 @@ describeForPlatforms('ExploreSearchScreen - Component Tests', () => {
 
   it('shows the open-tabs count and opens the browser when tabs are open', async () => {
     const { findByTestId, getByText } = renderExploreSearchScreenWithRoutes({
+      headerNavBarVariant: HeaderNavBarVariant.TreatmentA,
       overrides: {
         browser: {
           tabs: [
@@ -349,6 +368,27 @@ describeForPlatforms('ExploreSearchScreen - Component Tests', () => {
     expect(
       await findByTestId(getRouteProbeTestId(Routes.BROWSER.HOME)),
     ).toBeOnTheScreen();
+  });
+
+  it('hides the open-tabs button on the control arm even with tabs open', async () => {
+    const { findByTestId, queryByTestId } = renderExploreSearchScreenWithRoutes(
+      {
+        overrides: {
+          browser: {
+            tabs: [
+              { id: 1, url: 'https://app.uniswap.org' },
+              { id: 2, url: 'https://metamask.io' },
+            ],
+          },
+        },
+      },
+    );
+
+    await findByTestId(TrendingViewSelectorsIDs.EXPLORE_VIEW_SEARCH_TEXT_INPUT);
+
+    expect(
+      queryByTestId(ExploreSearchScreenSelectorsIDs.BROWSER_TABS_BUTTON),
+    ).not.toBeOnTheScreen();
   });
 
   it('"All" pill is selected by default and pill row is present on mount', async () => {

--- a/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.view.test.tsx
+++ b/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.view.test.tsx
@@ -1,6 +1,8 @@
 import '../../../../../../tests/component-view/mocks';
 import { describeForPlatforms } from '../../../../../../tests/component-view/platform';
 import { renderExploreSearchScreenWithRoutes } from '../../../../../../tests/component-view/renderers/trending';
+import { getRouteProbeTestId } from '../../../../../../tests/component-view/render';
+import Routes from '../../../../../constants/navigation/Routes';
 import {
   setupTrendingApiFetchMock,
   clearTrendingApiMocks,
@@ -300,6 +302,53 @@ describeForPlatforms('ExploreSearchScreen - Component Tests', () => {
       getByTestId(TrendingViewSelectorsIDs.EXPLORE_VIEW_SEARCH_TEXT_INPUT).props
         .autoFocus,
     ).toBe(true);
+  });
+
+  it('renders the inline back button instead of a cancel button', async () => {
+    const { findByTestId, queryByTestId } =
+      renderExploreSearchScreenWithRoutes();
+
+    expect(
+      await findByTestId(TrendingViewSelectorsIDs.EXPLORE_SEARCH_BACK_BUTTON),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(TrendingViewSelectorsIDs.EXPLORE_SEARCH_CANCEL_BUTTON),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('hides the open-tabs button when no browser tabs are open', async () => {
+    const { findByTestId, queryByTestId } =
+      renderExploreSearchScreenWithRoutes();
+
+    await findByTestId(TrendingViewSelectorsIDs.EXPLORE_VIEW_SEARCH_TEXT_INPUT);
+
+    expect(
+      queryByTestId(ExploreSearchScreenSelectorsIDs.BROWSER_TABS_BUTTON),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('shows the open-tabs count and opens the browser when tabs are open', async () => {
+    const { findByTestId, getByText } = renderExploreSearchScreenWithRoutes({
+      overrides: {
+        browser: {
+          tabs: [
+            { id: 1, url: 'https://app.uniswap.org' },
+            { id: 2, url: 'https://metamask.io' },
+          ],
+        },
+      },
+    });
+
+    const tabsButton = await findByTestId(
+      ExploreSearchScreenSelectorsIDs.BROWSER_TABS_BUTTON,
+    );
+    expect(getByText('2')).toBeOnTheScreen();
+
+    await actButtonPress(tabsButton);
+
+    expect(
+      await findByTestId(getRouteProbeTestId(Routes.BROWSER.HOME)),
+    ).toBeOnTheScreen();
   });
 
   it('"All" pill is selected by default and pill row is present on mount', async () => {

--- a/app/components/Views/TrendingView/components/BrowserTabsButton/BrowserTabsButton.test.tsx
+++ b/app/components/Views/TrendingView/components/BrowserTabsButton/BrowserTabsButton.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import BrowserTabsButton from './BrowserTabsButton';
+
+describe('BrowserTabsButton', () => {
+  it('renders the open tab count', () => {
+    const { getByText } = render(
+      <BrowserTabsButton tabCount={3} onPress={jest.fn()} testID="tabs" />,
+    );
+
+    expect(getByText('3')).toBeDefined();
+  });
+
+  it('calls onPress when pressed', () => {
+    const mockOnPress = jest.fn();
+
+    const { getByTestId } = render(
+      <BrowserTabsButton tabCount={1} onPress={mockOnPress} testID="tabs" />,
+    );
+
+    fireEvent.press(getByTestId('tabs'));
+
+    expect(mockOnPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/Views/TrendingView/components/BrowserTabsButton/BrowserTabsButton.tsx
+++ b/app/components/Views/TrendingView/components/BrowserTabsButton/BrowserTabsButton.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+
+interface BrowserTabsButtonProps {
+  tabCount: number;
+  onPress: () => void;
+  testID?: string;
+}
+
+const BrowserTabsButton: React.FC<BrowserTabsButtonProps> = ({
+  tabCount,
+  onPress,
+  testID,
+}) => (
+  <TouchableOpacity
+    onPress={onPress}
+    accessibilityRole="button"
+    accessibilityLabel={strings('browser.opened_tabs')}
+    testID={testID}
+  >
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      twClassName="h-12 gap-1 rounded-full border border-border-muted bg-muted px-3"
+    >
+      <Icon
+        name={IconName.Global}
+        size={IconSize.Md}
+        color={IconColor.IconAlternative}
+      />
+      <Text variant={TextVariant.BodyMd}>{tabCount}</Text>
+    </Box>
+  </TouchableOpacity>
+);
+
+export default BrowserTabsButton;

--- a/app/components/Views/TrendingView/components/ExploreSearchBar/ExploreSearchBar.test.tsx
+++ b/app/components/Views/TrendingView/components/ExploreSearchBar/ExploreSearchBar.test.tsx
@@ -250,6 +250,50 @@ describe('ExploreSearchBar', () => {
       expect(input.props.keyboardAppearance).toBe('light');
     });
 
+    it('renders an inline back button instead of cancel when dismissVariant is back', () => {
+      const mockOnSearchChange = jest.fn();
+      const mockOnCancel = jest.fn();
+
+      const { getByTestId, queryByTestId } = render(
+        <ExploreSearchBar
+          type="interactive"
+          searchQuery="bitcoin"
+          onSearchChange={mockOnSearchChange}
+          onCancel={mockOnCancel}
+          dismissVariant="back"
+        />,
+      );
+
+      expect(
+        getByTestId(TrendingViewSelectorsIDs.EXPLORE_SEARCH_BACK_BUTTON),
+      ).toBeDefined();
+      expect(
+        queryByTestId(TrendingViewSelectorsIDs.EXPLORE_SEARCH_CANCEL_BUTTON),
+      ).toBeNull();
+    });
+
+    it('clears query and calls onCancel when the inline back button is pressed', () => {
+      const mockOnSearchChange = jest.fn();
+      const mockOnCancel = jest.fn();
+
+      const { getByTestId } = render(
+        <ExploreSearchBar
+          type="interactive"
+          searchQuery="bitcoin"
+          onSearchChange={mockOnSearchChange}
+          onCancel={mockOnCancel}
+          dismissVariant="back"
+        />,
+      );
+
+      fireEvent.press(
+        getByTestId(TrendingViewSelectorsIDs.EXPLORE_SEARCH_BACK_BUTTON),
+      );
+
+      expect(mockOnSearchChange).toHaveBeenCalledWith('');
+      expect(mockOnCancel).toHaveBeenCalledTimes(1);
+    });
+
     it('turns autoFocus on when the caller enables it after mount', () => {
       const mockOnSearchChange = jest.fn();
       const mockOnCancel = jest.fn();

--- a/app/components/Views/TrendingView/components/ExploreSearchBar/ExploreSearchBar.tsx
+++ b/app/components/Views/TrendingView/components/ExploreSearchBar/ExploreSearchBar.tsx
@@ -4,6 +4,8 @@ import {
   Box,
   BoxFlexDirection,
   BoxAlignItems,
+  ButtonIcon,
+  ButtonIconSize,
   Text,
   TextVariant,
   TextFieldSearch,
@@ -46,6 +48,7 @@ interface ExploreSearchBarInteractiveProps {
    * keyboard dark grey until the animation settles.
    */
   autoFocus?: boolean;
+  dismissVariant?: 'cancel' | 'back';
 }
 
 type ExploreSearchBarProps =
@@ -64,7 +67,17 @@ const ExploreSearchBar: React.FC<ExploreSearchBarProps> = (props) => {
   const isButtonMode = props.type === 'button';
   const rowTwClassName = props.rowTwClassName ?? 'gap-2';
   const shouldFocus = props.type === 'interactive' && (props.autoFocus ?? true);
+  const isBackVariant =
+    props.type === 'interactive' && props.dismissVariant === 'back';
   const inputRef = useRef<TextInput>(null);
+
+  const dismissSearch = () => {
+    if (props.type !== 'interactive') {
+      return;
+    }
+    props.onSearchChange('');
+    props.onCancel();
+  };
 
   // `autoFocus` only applies on mount, so callers turning it on later need this.
   useEffect(() => {
@@ -133,6 +146,17 @@ const ExploreSearchBar: React.FC<ExploreSearchBarProps> = (props) => {
                 props.onSearchChange('');
               }}
               clearButtonProps={{ testID: 'explore-search-clear-button' }}
+              startAccessory={
+                isBackVariant ? (
+                  <ButtonIcon
+                    iconName={IconName.Arrow2Left}
+                    size={ButtonIconSize.Md}
+                    onPress={dismissSearch}
+                    accessibilityLabel={strings('navigation.back')}
+                    testID={TrendingViewSelectorsIDs.EXPLORE_SEARCH_BACK_BUTTON}
+                  />
+                ) : undefined
+              }
               inputProps={{
                 autoCapitalize: 'none',
                 keyboardAppearance,
@@ -140,20 +164,19 @@ const ExploreSearchBar: React.FC<ExploreSearchBarProps> = (props) => {
               }}
             />
           </Box>
-          <TouchableOpacity
-            onPress={() => {
-              props.onSearchChange('');
-              props.onCancel();
-            }}
-            testID="explore-search-cancel-button"
-          >
-            <Text
-              variant={TextVariant.BodyMd}
-              style={tw.style('text-default font-medium')}
+          {!isBackVariant && (
+            <TouchableOpacity
+              onPress={dismissSearch}
+              testID={TrendingViewSelectorsIDs.EXPLORE_SEARCH_CANCEL_BUTTON}
             >
-              {strings('transaction.cancel')}
-            </Text>
-          </TouchableOpacity>
+              <Text
+                variant={TextVariant.BodyMd}
+                style={tw.style('text-default font-medium')}
+              >
+                {strings('transaction.cancel')}
+              </Text>
+            </TouchableOpacity>
+          )}
         </>
       )}
     </Box>

--- a/app/components/Views/TrendingView/hooks/useIsExploreHeaderRefreshEnabled.ts
+++ b/app/components/Views/TrendingView/hooks/useIsExploreHeaderRefreshEnabled.ts
@@ -1,0 +1,30 @@
+/* eslint-disable import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog.
+ * The Header & NavBar experiment config lives in the Homepage route. This hook
+ * is the single place Explore reads it, so the violation stays contained here. */
+import { useABTest } from '../../../../hooks/useABTest';
+import {
+  HEADER_NAV_BAR_AB_KEY,
+  HEADER_NAV_BAR_VARIANTS,
+} from '../../Homepage/abTestConfig';
+
+/**
+ * Whether the Explore header shows its refreshed chrome: the browser tab count
+ * button, and the back arrow that replaces the Cancel text in search.
+ *
+ * Rides the Header & NavBar refresh experiment, so both treatment arms get it
+ * and control keeps the current header. Exposure is tracked where the
+ * experiment surface is owned — the wallet home header and the tab bar — so
+ * this read is assignment-only and must not emit `Experiment Viewed`.
+ * TODO: Remove this after the experiment is complete.
+ */
+export const useIsExploreHeaderRefreshEnabled = (): boolean => {
+  const { variant } = useABTest(
+    HEADER_NAV_BAR_AB_KEY,
+    HEADER_NAV_BAR_VARIANTS,
+    {
+      trackExposure: false,
+    },
+  );
+
+  return variant.isCompactHeaderEnabled;
+};

--- a/tests/api-mocking/mock-responses/feature-flags-mocks.ts
+++ b/tests/api-mocking/mock-responses/feature-flags-mocks.ts
@@ -145,6 +145,15 @@ export const remoteFeatureFlagTrendingTokensEnabled = (enabled = true) => ({
   trendingTokens: enabled,
 });
 
+/**
+ * Header & NavBar refresh A/B arm. The refreshed Explore header — browser tab
+ * count button, back-arrow dismiss in search — only renders on a treatment
+ * arm, so specs covering it must opt in.
+ */
+export const remoteFeatureFlagHeaderNavBar = (variant = 'treatmentA') => ({
+  homeTMCU1276AbtestHeaderNavBar: variant,
+});
+
 export const remoteFeatureFlagTronAccounts = (enabled = true) => ({
   tronAccounts: {
     enabled,

--- a/tests/component-view/renderers/trending.ts
+++ b/tests/component-view/renderers/trending.ts
@@ -113,7 +113,7 @@ export function renderExploreSearchScreenWithRoutes(
   return renderScreenWithRoutes(
     ExploreSearchScreen as unknown as React.ComponentType,
     { name: Routes.EXPLORE_SEARCH },
-    [],
+    [{ name: Routes.BROWSER.HOME }],
     { state },
     initialParams,
   );

--- a/tests/component-view/renderers/trending.ts
+++ b/tests/component-view/renderers/trending.ts
@@ -11,11 +11,48 @@ import TrendingTokensFullView from '../../../app/components/UI/Trending/Views/Tr
 import RWATokensFullView from '../../../app/components/UI/Trending/Views/RWATokensFullView/RWATokensFullView';
 import { TrendingQuickBuySheetProvider } from '../../../app/components/UI/Trending/contexts';
 import { initialStateTrending } from '../presets/trending';
+import {
+  HEADER_NAV_BAR_AB_KEY,
+  HeaderNavBarVariant,
+} from '../../../app/components/Views/Homepage/abTestConfig';
+
+// Re-exported so Explore view tests can pick an arm without importing across
+// route boundaries (ADR-0020).
+export { HeaderNavBarVariant };
 
 interface RenderTrendingViewOptions {
   overrides?: DeepPartial<RootState>;
   deterministicFiat?: boolean;
   initialParams?: Record<string, unknown>;
+  headerNavBarVariant?: HeaderNavBarVariant;
+}
+
+type TrendingStateBuilder = ReturnType<typeof initialStateTrending>;
+
+function buildTrendingState(
+  options: RenderTrendingViewOptions,
+): ReturnType<TrendingStateBuilder['build']> {
+  const { overrides, deterministicFiat, headerNavBarVariant } = options;
+
+  const builder = initialStateTrending({ deterministicFiat });
+  if (overrides) {
+    builder.withOverrides(overrides);
+  }
+  if (headerNavBarVariant) {
+    builder.withOverrides({
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [HEADER_NAV_BAR_AB_KEY]: headerNavBarVariant,
+            },
+          },
+        },
+      },
+    });
+  }
+
+  return builder.build();
 }
 
 function withQueryClient(
@@ -59,13 +96,8 @@ function withExploreFeedProviders(
 export function renderTrendingViewWithRoutes(
   options: RenderTrendingViewOptions = {},
 ): ReturnType<typeof renderScreenWithRoutes> {
-  const { overrides, deterministicFiat, initialParams } = options;
-
-  const builder = initialStateTrending({ deterministicFiat });
-  if (overrides) {
-    builder.withOverrides(overrides);
-  }
-  const state = builder.build();
+  const { initialParams } = options;
+  const state = buildTrendingState(options);
 
   return renderScreenWithRoutes(
     withExploreFeedProviders(
@@ -102,13 +134,8 @@ export function renderTrendingViewWithRoutes(
 export function renderExploreSearchScreenWithRoutes(
   options: RenderTrendingViewOptions = {},
 ): ReturnType<typeof renderScreenWithRoutes> {
-  const { overrides, deterministicFiat, initialParams } = options;
-
-  const builder = initialStateTrending({ deterministicFiat });
-  if (overrides) {
-    builder.withOverrides(overrides);
-  }
-  const state = builder.build();
+  const { initialParams } = options;
+  const state = buildTrendingState(options);
 
   return renderScreenWithRoutes(
     ExploreSearchScreen as unknown as React.ComponentType,

--- a/tests/locators/Trending/TrendingView.selectors.ts
+++ b/tests/locators/Trending/TrendingView.selectors.ts
@@ -7,7 +7,9 @@ export const TrendingViewSelectorsIDs = {
   BROWSER_BUTTON: 'trending-view-browser-button',
   SEARCH_INPUT: 'explore-view-search-input',
   SEARCH_TEXT_INPUT: 'explore-view-search-text-input',
-  SEARCH_CANCEL_BUTTON: 'explore-search-cancel-button',
+  SEARCH_BACK_BUTTON: AppTrendingViewSelectorsIDs.EXPLORE_SEARCH_BACK_BUTTON,
+  SEARCH_BROWSER_TABS_BUTTON:
+    ExploreSearchScreenSelectorsIDs.BROWSER_TABS_BUTTON,
   SEARCH_PILL_ALL: ExploreSearchScreenSelectorsIDs.PILL_ALL,
   SEARCH_PILL_CRYPTOS: ExploreSearchScreenSelectorsIDs.PILL_CRYPTOS,
   TOKEN_ROW_ITEM_PREFIX: 'trending-token-row-item-',

--- a/tests/page-objects/Trending/TrendingView.ts
+++ b/tests/page-objects/Trending/TrendingView.ts
@@ -36,9 +36,13 @@ class TrendingView {
     return Matchers.getElementByID(TrendingViewSelectorsIDs.SEARCH_TEXT_INPUT);
   }
 
-  get searchCancelButton(): Promise<AppiumElement> {
+  get searchBackButton(): Promise<AppiumElement> {
+    return Matchers.getElementByID(TrendingViewSelectorsIDs.SEARCH_BACK_BUTTON);
+  }
+
+  get searchBrowserTabsButton(): Promise<AppiumElement> {
     return Matchers.getElementByID(
-      TrendingViewSelectorsIDs.SEARCH_CANCEL_BUTTON,
+      TrendingViewSelectorsIDs.SEARCH_BROWSER_TABS_BUTTON,
     );
   }
 
@@ -157,9 +161,9 @@ class TrendingView {
     });
   }
 
-  async tapSearchCancelButton(): Promise<void> {
-    await Gestures.tap(this.searchCancelButton, {
-      elemDescription: 'Tap Search Cancel button',
+  async tapSearchBackButton(): Promise<void> {
+    await Gestures.tap(this.searchBackButton, {
+      elemDescription: 'Tap Search Back button',
     });
   }
 

--- a/tests/smoke-appium/trending/trending-search.spec.ts
+++ b/tests/smoke-appium/trending/trending-search.spec.ts
@@ -9,15 +9,18 @@ import Assertions from '../../framework/Assertions.js';
 import TrendingView from '../../page-objects/Trending/TrendingView.js';
 import { TRENDING_API_MOCKS } from '../../api-mocking/mock-responses/trending-api-mocks.js';
 import { setupMockEvents } from '../../api-mocking/helpers/mockHelpers.js';
-import { remoteFeatureFlagTrendingTokensEnabled } from '../../api-mocking/mock-responses/feature-flags-mocks.js';
+import {
+  remoteFeatureFlagHeaderNavBar,
+  remoteFeatureFlagTrendingTokensEnabled,
+} from '../../api-mocking/mock-responses/feature-flags-mocks.js';
 import TabBarComponent from '../../page-objects/wallet/TabBarComponent.js';
 
 appiumTest.describe(SmokeWalletPlatform('Trending Search Smoke Test'), () => {
   const testSpecificMock = async (mockServer: Mockttp) => {
-    await setupRemoteFeatureFlagsMock(
-      mockServer,
-      remoteFeatureFlagTrendingTokensEnabled(),
-    );
+    await setupRemoteFeatureFlagsMock(mockServer, {
+      ...remoteFeatureFlagTrendingTokensEnabled(),
+      ...remoteFeatureFlagHeaderNavBar(),
+    });
 
     await setupMockEvents(mockServer, TRENDING_API_MOCKS);
   };

--- a/tests/smoke-appium/trending/trending-search.spec.ts
+++ b/tests/smoke-appium/trending/trending-search.spec.ts
@@ -51,10 +51,10 @@ appiumTest.describe(SmokeWalletPlatform('Trending Search Smoke Test'), () => {
           await TrendingView.tapSearchButton();
 
           await Assertions.expectElementToBeVisible(
-            TrendingView.searchCancelButton,
+            TrendingView.searchBackButton,
             {
               description:
-                'Search cancel button should be visible (search mode active)',
+                'Search back button should be visible (search mode active)',
             },
           );
 
@@ -65,13 +65,13 @@ appiumTest.describe(SmokeWalletPlatform('Trending Search Smoke Test'), () => {
           await TrendingView.verifySearchResultsListVisible();
 
           await Assertions.expectElementToBeVisible(
-            TrendingView.searchCancelButton,
+            TrendingView.searchBackButton,
             {
-              description: 'Cancel button should be visible',
+              description: 'Back button should be visible',
             },
           );
 
-          await TrendingView.tapSearchCancelButton();
+          await TrendingView.tapSearchBackButton();
 
           await Assertions.expectElementToBeVisible(TrendingView.searchButton, {
             description: 'Search button should be visible again',


### PR DESCRIPTION
## **Description**

Reworks the Explore search surface so search and the browser tab count are reachable from the Explore header. This is one of four PRs splitting the oversized `fix-tmcu-1277-floating-tab-navigation` [branch](https://github.com/MetaMask/metamask-mobile/pull/35432). All changes are behind a feature flag

**What changed**

- **`ExploreSearchBar` becomes a pressable affordance** rather than an inline text input, opening the full search screen on tap.
- **New `BrowserTabsButton`** surfaces the open browser tab count in the Explore header.
- **`ExploreSearchScreen` accepts an `entryPoint`**, so opens are attributed to the surface they came from.
- **`BrowserTab` returns to the home tabs** when reached from Explore search, instead of falling through to the Perps back behaviour.
- Appium page objects, locators and the `trending-search` spec updated for the new header.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/TMCU-1277

## **Manual testing steps**

```gherkin
Feature: Explore search header

  Scenario: user opens search from the Explore header
    Given user is on the Explore tab
    When user taps the search bar in the header
    Then the Explore search screen opens

  Scenario: user sees the open browser tab count
    Given user has one or more browser tabs open
    When user is on the Explore tab
    Then the header shows the number of open browser tabs

  Scenario: user returns from a site opened via search
    Given user opened a site from Explore search
    When user taps back
    Then the app returns to the home tabs
```

## **Screenshots/Recordings**

Feature Flag on:

https://github.com/user-attachments/assets/1379d020-b0d8-457d-9490-5fea03ddb2e4

Feature Flag off:

https://github.com/user-attachments/assets/6df963b2-a801-470b-b96a-5939e6e25596

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 803a8faa717b306549a46b2e099178980ac806f1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->