### PR TITLE
test: ai-analyzer MetaMask skills integration (ai-analyzer#46)

### DIFF
--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -31,12 +31,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      # https://github.com/MetaMask/ai-analyzer/releases
+      # Integration test: MetaMask/ai-analyzer#46 (feat/metamask-skills-plumbing)
       - name: Checkout AI Analyzer
         uses: actions/checkout@v6
         with:
           repository: MetaMask/ai-analyzer
-          ref: 68870b76360431110ae00b27a0072d3011e6238c
+          ref: feat/metamask-skills-plumbing
           path: .ai-analyzer-action
           token: ${{ secrets.AI_ANALYZER_TOKEN }}
 
@@ -44,6 +44,8 @@ jobs:
         uses: ./.ai-analyzer-action
         with:
           mode: pr-risk-analysis
+          include-metamask-skills: auto
+          target-repo: metamask-mobile
           add-comment: false
           add-label: true
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Integration test: MetaMask/ai-analyzer#46 (feat/metamask-skills-plumbing)
+      # Integration test: MetaMask/ai-analyzer#46 @ feat/metamask-skills-plumbing (npm-only skills, no vendored/)
       - name: Checkout AI Analyzer
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
Integration test PR for [MetaMask/ai-analyzer#46](https://github.com/MetaMask/ai-analyzer/pull/46) (`feat/metamask-skills-plumbing`).

Pins `ai-pr-risk-analysis.yml` to checkout `MetaMask/ai-analyzer@feat/metamask-skills-plumbing` instead of the pinned release SHA, and passes:
- `include-metamask-skills: auto`
- `target-repo: metamask-mobile`

## What to verify in CI
- [ ] **AI PR risk analysis** job completes successfully
- [ ] Logs show MetaMask skills discovered (mms-* count > 0)
- [ ] Logs show file-based skill recommendations for this PR
- [ ] Analysis quality reflects loaded team conventions (optional: Langfuse trace shows `load_skill` calls)

## Do not merge
This is a throwaway integration test branch. Close after validating ai-analyzer#46.

## Test plan
- [ ] Open PR triggers `AI PR risk analysis` workflow
- [ ] Review workflow logs for skills catalog + recommendations
- [ ] Compare risk output vs baseline if needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CI workflow inputs and the external analyzer ref change; no app runtime or security-sensitive code paths are touched.
> 
> **Overview**
> **Temporary CI wiring** to exercise [MetaMask/ai-analyzer#46](https://github.com/MetaMask/ai-analyzer/pull/46) from `metamask-mobile`.
> 
> The **AI PR risk analysis** workflow now checks out `MetaMask/ai-analyzer` at branch `feat/metamask-skills-plumbing` instead of the previous release SHA, and passes **`include-metamask-skills: auto`** and **`target-repo: metamask-mobile`** into the analyzer action so PR runs can load npm-based MetaMask skills and team conventions. The checkout step comment documents that this is an integration test (not intended to merge).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a5a88d14c99210a2e246b97455e4cde97016db0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->