### PR TITLE
fix(ci): rewrite build number in repacked RC artifact filenames

### DIFF
--- a/.github/workflows/build-rc-repack.yml
+++ b/.github/workflows/build-rc-repack.yml
@@ -187,14 +187,8 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ inputs.donor_run_id }}
 
-      # The donor's filename still carries the donor build's number
-      # (scripts/rename-artifacts.js baked it in as ...-<buildNumber>.<ext>), but the
-      # artifact this job publishes carries the NEW build number patched in below by
-      # repack-build-version.sh. Without this rewrite the filename would silently lie
-      # about the build number burnt into the binary — see the incident this fixed,
-      # where every repack sharing a donor kept the donor's filename forever. Only the
-      # trailing build-number segment is rewritten; the rest (environment/build
-      # type/version) is unaffected by a repack and stays exactly as the donor named it.
+      # Rewrite the donor filename's trailing build-number segment to this build's
+      # number, so it doesn't lie about the version patched into the binary below.
       - name: Locate donor artifact
         id: donor
         env:

--- a/.github/workflows/build-rc-repack.yml
+++ b/.github/workflows/build-rc-repack.yml
@@ -187,13 +187,20 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ inputs.donor_run_id }}
 
-      # The output keeps the donor's filename so the published artifact is
-      # indistinguishable from a native build's for anything downstream.
+      # The donor's filename still carries the donor build's number
+      # (scripts/rename-artifacts.js baked it in as ...-<buildNumber>.<ext>), but the
+      # artifact this job publishes carries the NEW build number patched in below by
+      # repack-build-version.sh. Without this rewrite the filename would silently lie
+      # about the build number burnt into the binary — see the incident this fixed,
+      # where every repack sharing a donor kept the donor's filename forever. Only the
+      # trailing build-number segment is rewritten; the rest (environment/build
+      # type/version) is unaffected by a repack and stays exactly as the donor named it.
       - name: Locate donor artifact
         id: donor
         env:
           PLATFORM: ${{ inputs.platform }}
           DONOR_RUN_ID: ${{ inputs.donor_run_id }}
+          BUILD_NUMBER: ${{ inputs.build_number }}
         run: |
           set -euo pipefail
           EXT=$([ "$PLATFORM" = "ios" ] && echo ipa || echo apk)
@@ -203,13 +210,18 @@ jobs:
             exit 1
           fi
           NAME=$(basename "$FILE")
+          OUT_NAME=$(printf '%s' "$NAME" | sed -E "s/-[0-9]+\.${EXT}\$/-${BUILD_NUMBER}.${EXT}/")
+          if [ "$OUT_NAME" = "$NAME" ] && [ "${NAME%-${BUILD_NUMBER}.$EXT}" = "$NAME" ]; then
+            echo "::warning::Donor filename '$NAME' does not end in -<build number>.$EXT; keeping it as is."
+          fi
           mkdir -p repacked
           {
             echo "path=$PWD/$FILE"
-            echo "name=$NAME"
-            echo "output=$PWD/repacked/$NAME"
+            echo "name=$OUT_NAME"
+            echo "output=$PWD/repacked/$OUT_NAME"
           } >> "$GITHUB_OUTPUT"
           echo "Donor artifact: $FILE ($(du -h "$FILE" | cut -f1)) from run $DONOR_RUN_ID"
+          echo "Repacked artifact will be named: $OUT_NAME (build number $BUILD_NUMBER)"
 
       - name: Read release version
         id: version

--- a/.github/workflows/build-rc-repack.yml
+++ b/.github/workflows/build-rc-repack.yml
@@ -205,7 +205,7 @@ jobs:
           fi
           NAME=$(basename "$FILE")
           OUT_NAME=$(printf '%s' "$NAME" | sed -E "s/-[0-9]+\.${EXT}\$/-${BUILD_NUMBER}.${EXT}/")
-          if [ "$OUT_NAME" = "$NAME" ] && [ "${NAME%-${BUILD_NUMBER}.$EXT}" = "$NAME" ]; then
+          if [ "$OUT_NAME" = "$NAME" ] && [ "${NAME%-"${BUILD_NUMBER}"."${EXT}"}" = "$NAME" ]; then
             echo "::warning::Donor filename '$NAME' does not end in -<build number>.$EXT; keeping it as is."
           fi
           mkdir -p repacked


### PR DESCRIPTION
## **Description**

Repacked RC artifacts (from the `repack-rc-enabled` fast path in [build-rc-auto.yml](https://github.com/MetaMask/metamask-mobile/blob/main/.github/workflows/build-rc-auto.yml)) reuse a signed IPA/APK from an earlier native RC build on the same release branch and swap in a fresh JS bundle. The **binary** gets its build number patched correctly via `scripts/repack-build-version.sh` (and this is asserted by `android-verify`/`ios-verify`), but the **filename** of the published artifact was copied verbatim from the donor build — e.g. `metamask-rc-main-8.10.0-6672.apk` — because the `Locate donor artifact` step in `build-rc-repack.yml` just did `output=$PWD/repacked/$(basename "$FILE")`.

The native path names artifacts via `scripts/rename-artifacts.js` as `metamask-{environment}-{buildType}-{version}-{buildNumber}`, reading the build number out of `build.gradle`/`project.pbxproj` after `set-build-version.sh` has run — a step the repack path never runs. Every repacked build sharing the same donor therefore kept shipping under the donor's old filename forever, even though the number inside the installed app was correct and different each time. See [run 33530951226](https://github.com/MetaMask/metamask-mobile/actions/runs/33530951226) for an example.

This PR rewrites only the trailing `-<build number>.<ext>` segment of the donor's filename to the new build number being patched in, so the published artifact name matches what the native path would have produced. If a donor filename doesn't end in `-<digits>.<ext>` (unexpected shape), a `::warning::` is emitted and the name is left as-is instead of failing the build.

No downstream consumer parses the filename — `upload-to-testflight.yml` and `nightly-build.yml` glob by extension, and the donor-reuse lookup/artifact purge key off the artifact *name* (`android-apk-main-rc` / `ios-ipa-main-rc`), not the file inside — so this change is scoped entirely to the `Locate donor artifact` step.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Auto RC repack build

  Scenario: Repacked RC artifact filename reflects the new build number
    Given a release branch's PR has the "repack-rc-enabled" label
    And an earlier auto RC run on that branch has a fingerprint-matching donor artifact
    When a new commit is pushed to the release branch
    Then the "Repack Android RC Build" / "Repack iOS RC Build" job runs the repack fast path
    And the published "android-apk-main-rc" / "ios-ipa-main-rc" artifact filename ends in
      "-<new build number>.apk" / "-<new build number>.ipa"
    And that build number matches the versionCode/CFBundleVersion reported by
      "aapt2 dump badging" / "plutil -extract CFBundleVersion" on the artifact
    And it matches the build number posted in the RC PR comment
```

## **Screenshots/Recordings**

### **Before**

N/A — this is a CI workflow change; no UI.

### **After**

N/A — this is a CI workflow change; no UI.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)