### PR TITLE
feat(notifications): harden Chase notification delivery

### DIFF
--- a/app/components/UI/Perps/providers/PerpsAlwaysOnProvider.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsAlwaysOnProvider.test.tsx
@@ -428,10 +428,9 @@ describe('PerpsAlwaysOnProvider', () => {
       id: 'perps-chase-max-distance-chase-max-distance',
       title: 'Chase max distance reached',
       body: 'Your ETH Chase order reached its max distance and is now resting as a limit order.',
-      data: {
-        notification_id: 'perps-chase-max-distance-chase-max-distance',
-      },
+      throwOnError: true,
     });
+    expect(mockDisplayNotification.mock.calls[0][0]).not.toHaveProperty('data');
     expect(mockDisplayNotification.mock.calls[0][0]).not.toHaveProperty(
       'pressActionId',
     );
@@ -1631,6 +1630,7 @@ describe('PerpsAlwaysOnProvider', () => {
           notification_type: 'chase_backgrounded',
         },
         title: 'Chase became a limit order',
+        throwOnError: true,
       }),
     );
     expect(mockDisplayNotification.mock.calls[0][0]).not.toHaveProperty(

--- a/app/components/UI/Perps/providers/PerpsAlwaysOnProvider.tsx
+++ b/app/components/UI/Perps/providers/PerpsAlwaysOnProvider.tsx
@@ -374,6 +374,7 @@ export const PerpsAlwaysOnProvider: React.FC<{ children: React.ReactNode }> = ({
             notification_type:
               PERPS_EVENT_VALUE.NOTIFICATION_TYPE.CHASE_BACKGROUNDED,
           },
+          throwOnError: true,
         });
         notificationOrders.forEach((order) => {
           const notifiedHandles = notifiedBackgroundedChaseHandlesRef.current;
@@ -444,16 +445,15 @@ export const PerpsAlwaysOnProvider: React.FC<{ children: React.ReactNode }> = ({
         ) {
           return;
         }
-        const notificationId = `perps-chase-max-distance-${event.handle}`;
         await NotificationsService.displayNotification({
-          id: notificationId,
+          id: `perps-chase-max-distance-${event.handle}`,
           title: strings('perps.order.chase.max_distance_reached_title'),
           body: strings('perps.order.chase.max_distance_reached_notification', {
             symbol: event.symbol,
           }),
-          data: { notification_id: notificationId },
           // Controller v15 has no max-distance notification enum, so
           // notification_type is omitted and tap attribution is unavailable.
+          throwOnError: true,
         });
         const notifiedHandles = notifiedMaxDistanceChaseHandlesRef.current;
         notifiedHandles.add(event.handle);

--- a/app/core/Engine/controllers/notifications/push-utils.test.ts
+++ b/app/core/Engine/controllers/notifications/push-utils.test.ts
@@ -148,6 +148,21 @@ describe('createSubscribeToPushNotifications', () => {
     });
   });
 
+  it('displays notifications without an invalid data field', async () => {
+    const handler = await getForegroundHandler();
+    const payload = createRemoteMessage();
+
+    await handler(payload);
+
+    expect(mockDisplay).toHaveBeenCalledWith({
+      pressActionId: PressActionId.OPEN_NOTIFICATIONS_VIEW,
+      id: undefined,
+      title: 'You received ETH',
+      body: '0.05 ETH',
+    });
+    expect(mockDisplay.mock.calls[0][0]).not.toHaveProperty('data');
+  });
+
   it('does not display notifications without a title', async () => {
     const handler = await getForegroundHandler();
     const payload = {

--- a/app/core/Engine/controllers/notifications/push-utils.ts
+++ b/app/core/Engine/controllers/notifications/push-utils.ts
@@ -47,7 +47,7 @@ export const createSubscribeToPushNotifications = () => async () =>
       id: data?.notification_id,
       title,
       body,
-      data,
+      ...(data === undefined ? {} : { data }),
     });
   });
 

--- a/app/util/notifications/pushNotificationDeeplink.test.ts
+++ b/app/util/notifications/pushNotificationDeeplink.test.ts
@@ -28,6 +28,19 @@ describe('extractPushNotificationData', () => {
     expect(result).toStrictEqual(notificationData);
   });
 
+  it('extracts Chase notification attribution from serialized Notifee data', () => {
+    const notificationData = {
+      notification_id: 'perps-chase-backgrounded-chase-1',
+      notification_type: 'chase_backgrounded',
+    };
+
+    const result = extractPushNotificationData({
+      dataStr: JSON.stringify(notificationData),
+    });
+
+    expect(result).toStrictEqual(notificationData);
+  });
+
   it('returns the wrapper for malformed serialized data', () => {
     const data = { dataStr: '{not-json' };
 

--- a/app/util/notifications/services/NotificationService.test.ts
+++ b/app/util/notifications/services/NotificationService.test.ts
@@ -19,6 +19,7 @@ import NotificationService, {
 } from './NotificationService';
 import { markPushNotificationOsPromptRequested } from '../../../actions/onboarding';
 import { store } from '../../../store';
+import { PressActionId } from '../types';
 
 jest.mock('@notifee/react-native', () => ({
   getNotificationSettings: jest.fn(),
@@ -72,6 +73,7 @@ jest.mock('../../../store', () => ({
 }));
 jest.mock('../../../util/Logger', () => ({
   error: jest.fn(),
+  log: jest.fn(),
 }));
 
 describe('NotificationsService - getBlockedNotifications', () => {
@@ -552,6 +554,40 @@ describe('NotificationService - displayNotification', () => {
     );
     const displayCall = mocks.mockNotifeeDisplayNotification.mock.calls[0][0];
     expect(displayCall.android).not.toHaveProperty('largeIcon');
+    expect(displayCall.android?.pressAction?.id).toBe(PressActionId.OPEN_HOME);
+  });
+
+  it('omits Notifee data when notification data is undefined', async () => {
+    const mocks = arrangeMocks();
+
+    await NotificationService.displayNotification({ title: 'Test Title' });
+
+    expect(mocks.mockNotifeeDisplayNotification).toHaveBeenCalledWith(
+      expect.not.objectContaining({ data: expect.anything() }),
+    );
+  });
+
+  it('keeps display failures non-throwing by default', async () => {
+    const error = new Error('display failed');
+    jest.mocked(notifee.displayNotification).mockRejectedValueOnce(error);
+
+    const result = NotificationService.displayNotification({
+      title: 'Test Title',
+    });
+
+    await expect(result).resolves.toBeUndefined();
+  });
+
+  it('propagates display failures when requested', async () => {
+    const error = new Error('display failed');
+    jest.mocked(notifee.displayNotification).mockRejectedValueOnce(error);
+
+    const result = NotificationService.displayNotification({
+      title: 'Test Title',
+      throwOnError: true,
+    });
+
+    await expect(result).rejects.toThrow('display failed');
   });
 });
 

--- a/app/util/notifications/services/NotificationService.ts
+++ b/app/util/notifications/services/NotificationService.ts
@@ -266,6 +266,7 @@ class NotificationsService {
     body,
     data,
     id,
+    throwOnError = false,
   }: {
     channelId?: ChannelId;
     pressActionId?: PressActionId;
@@ -273,6 +274,7 @@ class NotificationsService {
     body?: string;
     data?: unknown;
     id?: string;
+    throwOnError?: boolean;
   }): Promise<void> => {
     try {
       const channel = notificationChannels.find((c) => c.id === channelId);
@@ -285,7 +287,9 @@ class NotificationsService {
         title,
         body,
         // Notifee can only store and handle data strings
-        data: { dataStr: JSON.stringify(data) },
+        ...(data === undefined
+          ? {}
+          : { data: { dataStr: JSON.stringify(data) } }),
         android: {
           // Omit largeIcon — same fox as smallIcon caused a duplicate on Android.
           smallIcon: 'ic_notification_small',
@@ -311,6 +315,9 @@ class NotificationsService {
       });
     } catch (error) {
       Logger.log('Error displaying notification ', error);
+      if (throwOnError) {
+        throw error;
+      }
     }
   };
 }


### PR DESCRIPTION
## **Description**

Restores the shared notification hardening that was split out of #35277 (now merged).

Three related problems in notification plumbing:

1. **Display failures were always swallowed.** `NotificationsService.displayNotification`
   caught every error and logged it. Chase notifications rely on a failure surfacing so the
   Perps provider's retry logic can run, so the method now takes an optional `throwOnError`
   flag (default `false`, preserving existing behaviour for every other caller). The Chase
   backgrounded and max-distance notifications opt in.
2. **Notifee received an invalid `data` payload when there was none.** `JSON.stringify(undefined)`
   returns `undefined`, so `{ dataStr: JSON.stringify(data) }` was handing Notifee an invalid
   field whenever a notification had no data. `data` is now attached only when a payload
   exists, in both `NotificationService.displayNotification` and the foreground FCM handler
   in `push-utils.ts`.
3. **Max-distance alerts carried unusable attribution.** Controller v15 has no max-distance
   notification enum, so `notification_type` cannot be set and tap attribution is unavailable.
   The `data` object is dropped entirely rather than sending a half-populated one. Backgrounded
   Chase notifications keep their attribution fields, which `extractPushNotificationData`
   parses back from the serialized `dataStr`.

Unit coverage added for missing data, error propagation in both modes, and Chase deeplink
attribution round-tripping through the serialized Notifee payload.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #35277

## **Manual testing steps**

```gherkin
Feature: Chase local notification reliability

  Scenario: A Chase notification cannot be displayed
    Given Chase notification delivery is enabled
    When the native notification service rejects the display request
    Then the error propagates so the Perps provider can retry the notification

  Scenario: A non-Chase notification cannot be displayed
    Given a caller that does not opt into throwOnError
    When the native notification service rejects the display request
    Then the error is logged and swallowed as before

  Scenario: Notification data is absent
    Given a foreground notification has no data payload
    When it is displayed through Notifee
    Then no invalid serialized data field is sent

  Scenario: A backgrounded Chase notification is tapped
    Given a Chase notification carrying serialized attribution data
    When the notification is tapped
    Then the notification_id and notification_type are parsed back correctly
```

## **Screenshots/Recordings**

N/A — this change is notification plumbing and unit-test coverage. There is no UI surface
to capture: the behaviour is error propagation and payload shape, both covered by the unit
tests listed above.

### **Before**

N/A — no UI change.

### **After**

N/A — no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared notification display behavior (payload shape and optional error propagation); default remains non-throwing, but Chase lifecycle depends on the new opt-in path for retries.
> 
> **Overview**
> Hardens local notification plumbing so Perps Chase alerts can retry on failure and Notifee never receives invalid payloads.
> 
> **`NotificationsService.displayNotification`** now accepts optional **`throwOnError`** (default **`false`**, so existing callers still swallow errors). Chase **backgrounded** and **max-distance** paths in **`PerpsAlwaysOnProvider`** opt in so display failures surface to the provider’s retry logic. When **`data`** is absent, the Notifee **`data`** / **`dataStr`** field is omitted instead of passing **`JSON.stringify(undefined)`**; the foreground FCM handler in **`push-utils.ts`** uses the same conditional **`data`** spread.
> 
> **Max-distance** Chase notifications no longer send a **`data`** payload at all (controller v15 has no attribution enum); **backgrounded** Chase notifications still include **`notification_id`** and **`notification_type`** for tap deeplink parsing.
> 
> Unit tests cover missing **`data`**, default vs **`throwOnError`** error propagation, FCM foreground display without **`data`**, and Chase attribution round-trip through serialized Notifee **`dataStr`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 672ed4f07236de38d24e2fb926163216c5e87091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

