### PR TITLE
feat(subscriptions): replace benefits list with member pricing on trades

### DIFF
--- a/app/components/Views/ProHub/ProHub.constants.ts
+++ b/app/components/Views/ProHub/ProHub.constants.ts
@@ -22,3 +22,19 @@ export const MOCK_NEXT_PAYMENT: ProHubNextPayment = {
   amount: '$49.99',
   date: 'Jul 20, 2027',
 };
+
+export type TradeAllowanceKind = 'currency' | 'count';
+
+export interface TradeAllowanceItem {
+  id: 'swaps' | 'perps' | 'predict';
+  used: number;
+  allowance: number;
+  kind: TradeAllowanceKind;
+}
+
+// TODO: replace with real API data once the membership endpoint is available.
+export const MOCK_TRADE_ALLOWANCES: TradeAllowanceItem[] = [
+  { id: 'swaps', used: 310, allowance: 500, kind: 'currency' },
+  { id: 'perps', used: 240, allowance: 1000, kind: 'currency' },
+  { id: 'predict', used: 0, allowance: 1, kind: 'count' },
+];

--- a/app/components/Views/ProHub/ProHub.test.tsx
+++ b/app/components/Views/ProHub/ProHub.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import ProHub from './ProHub';
 import { ProHubTestIds } from './ProHub.testIds';
-import { MOCK_NEXT_PAYMENT, MOCK_PRO_HUB_STATS } from './ProHub.constants';
-import { BENEFITS, BenefitRowTestIds } from '../shared/pro';
+import { MOCK_NEXT_PAYMENT, MOCK_PRO_HUB_STATS, MOCK_TRADE_ALLOWANCES } from './ProHub.constants';
+import { MemberPricingOnTradesTestIds } from './components/MemberPricingOnTrades';
 import { strings } from '../../../../locales/i18n';
 import Routes from '../../../constants/navigation/Routes';
 
@@ -128,14 +128,28 @@ describe('ProHub', () => {
       );
     });
 
-    it('renders all benefit rows with correct titles', () => {
+    it('renders member pricing section title and all trade rows', () => {
       const { getByTestId } = renderProHub();
 
-      BENEFITS.forEach((benefit) => {
-        const row = getByTestId(BenefitRowTestIds.ROW(benefit.id));
+      const section = getByTestId(MemberPricingOnTradesTestIds.SECTION);
+      const title = getByTestId(MemberPricingOnTradesTestIds.TITLE);
+
+      expect(section).toBeOnTheScreen();
+      expect(title).toHaveTextContent(
+        strings('pro_hub.member_pricing.title'),
+      );
+
+      MOCK_TRADE_ALLOWANCES.forEach((item) => {
+        const row = getByTestId(MemberPricingOnTradesTestIds.ROW(item.id));
+        const progress = getByTestId(
+          MemberPricingOnTradesTestIds.PROGRESS(item.id),
+        );
 
         expect(row).toBeOnTheScreen();
-        expect(row).toHaveTextContent(toRegex(strings(benefit.title)));
+        expect(progress).toBeOnTheScreen();
+        expect(row).toHaveTextContent(
+          toRegex(strings(`pro_hub.member_pricing.${item.id}.label`)),
+        );
       });
     });
 
@@ -222,14 +236,6 @@ describe('ProHub', () => {
       const { getByTestId } = renderProHub();
 
       fireEvent.press(getByTestId(ProHubTestIds.SAVED_CARD));
-
-      expect(mockNavigate).not.toHaveBeenCalled();
-    });
-
-    it('does not navigate when a benefit row is pressed', () => {
-      const { getByTestId } = renderProHub();
-
-      fireEvent.press(getByTestId(BenefitRowTestIds.ROW(BENEFITS[0].id)));
 
       expect(mockNavigate).not.toHaveBeenCalled();
     });

--- a/app/components/Views/ProHub/ProHub.test.tsx
+++ b/app/components/Views/ProHub/ProHub.test.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import ProHub from './ProHub';
 import { ProHubTestIds } from './ProHub.testIds';
-import { MOCK_NEXT_PAYMENT, MOCK_PRO_HUB_STATS, MOCK_TRADE_ALLOWANCES } from './ProHub.constants';
+import {
+  MOCK_NEXT_PAYMENT,
+  MOCK_PRO_HUB_STATS,
+  MOCK_TRADE_ALLOWANCES,
+} from './ProHub.constants';
 import { MemberPricingOnTradesTestIds } from './components/MemberPricingOnTrades';
 import { strings } from '../../../../locales/i18n';
 import Routes from '../../../constants/navigation/Routes';
@@ -135,9 +139,7 @@ describe('ProHub', () => {
       const title = getByTestId(MemberPricingOnTradesTestIds.TITLE);
 
       expect(section).toBeOnTheScreen();
-      expect(title).toHaveTextContent(
-        strings('pro_hub.member_pricing.title'),
-      );
+      expect(title).toHaveTextContent(strings('pro_hub.member_pricing.title'));
 
       MOCK_TRADE_ALLOWANCES.forEach((item) => {
         const row = getByTestId(MemberPricingOnTradesTestIds.ROW(item.id));

--- a/app/components/Views/ProHub/ProHub.testIds.ts
+++ b/app/components/Views/ProHub/ProHub.testIds.ts
@@ -10,7 +10,6 @@ export const ProHubTestIds = {
   PHYSICAL_CARD_TITLE: 'pro-hub-physical-card-title',
   PHYSICAL_CARD_DESCRIPTION: 'pro-hub-physical-card-description',
   GET_CARD_BUTTON: 'pro-hub-get-card-button',
-  BENEFITS_SECTION: 'pro-hub-benefits-section',
   MEMBERSHIP_SECTION: 'pro-hub-membership-section',
   NEXT_PAYMENT_TEXT: 'pro-hub-next-payment-text',
   MANAGE_BUTTON: 'pro-hub-manage-button',

--- a/app/components/Views/ProHub/ProHub.tsx
+++ b/app/components/Views/ProHub/ProHub.tsx
@@ -28,7 +28,7 @@ import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import { ProHubTestIds } from './ProHub.testIds';
 import { MOCK_NEXT_PAYMENT, MOCK_PRO_HUB_STATS } from './ProHub.constants';
 import PhysicalCardPreview from './components/PhysicalCardPreview';
-import { BENEFITS, BenefitRow } from '../shared/pro';
+import MemberPricingOnTrades from './components/MemberPricingOnTrades';
 
 interface StatCardProps {
   iconName: IconName;
@@ -204,18 +204,7 @@ const ProHub = () => {
 
         <SectionDivider marginVertical={6} />
 
-        <Box testID={ProHubTestIds.BENEFITS_SECTION}>
-          <Text
-            variant={TextVariant.HeadingMd}
-            fontWeight={FontWeight.Bold}
-            color={TextColor.TextDefault}
-          >
-            {strings('pro_hub.your_benefits')}
-          </Text>
-          {BENEFITS.map((item) => (
-            <BenefitRow key={item.id} item={item} showArrow={false} />
-          ))}
-        </Box>
+        <MemberPricingOnTrades />
 
         <SectionDivider marginVertical={6} />
 

--- a/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.test.tsx
+++ b/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.test.tsx
@@ -37,9 +37,7 @@ describe('MemberPricingOnTrades', () => {
 
     const title = getByTestId(MemberPricingOnTradesTestIds.TITLE);
 
-    expect(title).toHaveTextContent(
-      strings('pro_hub.member_pricing.title'),
-    );
+    expect(title).toHaveTextContent(strings('pro_hub.member_pricing.title'));
   });
 
   it('renders a row and progress bar for each mock trade allowance', () => {

--- a/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.test.tsx
+++ b/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import MemberPricingOnTrades from './MemberPricingOnTrades';
+import TradeAllowanceRow from './TradeAllowanceRow';
+import { MemberPricingOnTradesTestIds } from './MemberPricingOnTrades.testIds';
+import {
+  MOCK_TRADE_ALLOWANCES,
+  type TradeAllowanceItem,
+} from '../../ProHub.constants';
+import { strings } from '../../../../../../locales/i18n';
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({
+    style: (..._args: unknown[]) => ({}),
+  }),
+}));
+
+const renderMemberPricingOnTrades = () => render(<MemberPricingOnTrades />);
+
+const renderTradeAllowanceRow = (item: TradeAllowanceItem) =>
+  render(<TradeAllowanceRow item={item} />);
+
+const toRegex = (s: string) =>
+  new RegExp(s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+
+const getFlattenedStyle = (style: unknown) => {
+  if (Array.isArray(style)) {
+    return Object.assign({}, ...style.filter(Boolean));
+  }
+
+  return style;
+};
+
+describe('MemberPricingOnTrades', () => {
+  it('renders the section title from i18n', () => {
+    const { getByTestId } = renderMemberPricingOnTrades();
+
+    const title = getByTestId(MemberPricingOnTradesTestIds.TITLE);
+
+    expect(title).toHaveTextContent(
+      strings('pro_hub.member_pricing.title'),
+    );
+  });
+
+  it('renders a row and progress bar for each mock trade allowance', () => {
+    const { getByTestId } = renderMemberPricingOnTrades();
+
+    MOCK_TRADE_ALLOWANCES.forEach((item) => {
+      const row = getByTestId(MemberPricingOnTradesTestIds.ROW(item.id));
+      const progress = getByTestId(
+        MemberPricingOnTradesTestIds.PROGRESS(item.id),
+      );
+
+      expect(row).toBeOnTheScreen();
+      expect(progress).toBeOnTheScreen();
+      expect(row).toHaveTextContent(
+        toRegex(strings(`pro_hub.member_pricing.${item.id}.label`)),
+      );
+    });
+  });
+});
+
+describe('TradeAllowanceRow', () => {
+  it('renders swaps usage as formatted currency values', () => {
+    const swapsItem = MOCK_TRADE_ALLOWANCES.find((item) => item.id === 'swaps');
+
+    if (!swapsItem) {
+      throw new Error('swaps mock item not found');
+    }
+
+    const { getByTestId } = renderTradeAllowanceRow(swapsItem);
+
+    const row = getByTestId(MemberPricingOnTradesTestIds.ROW('swaps'));
+
+    expect(row).toHaveTextContent(toRegex('$310'));
+    expect(row).toHaveTextContent(toRegex('$500'));
+  });
+
+  it('renders predict usage as a count value', () => {
+    const predictItem = MOCK_TRADE_ALLOWANCES.find(
+      (item) => item.id === 'predict',
+    );
+
+    if (!predictItem) {
+      throw new Error('predict mock item not found');
+    }
+
+    const { getByTestId } = renderTradeAllowanceRow(predictItem);
+
+    const row = getByTestId(MemberPricingOnTradesTestIds.ROW('predict'));
+
+    expect(row).toHaveTextContent(toRegex('0'));
+    expect(row).toHaveTextContent(toRegex('1 trade'));
+  });
+
+  it('sets progress fill width to 62% for swaps usage of 310 of 500', () => {
+    const swapsItem = MOCK_TRADE_ALLOWANCES.find((item) => item.id === 'swaps');
+
+    if (!swapsItem) {
+      throw new Error('swaps mock item not found');
+    }
+
+    const { getByTestId } = renderTradeAllowanceRow(swapsItem);
+
+    const fill = getByTestId(
+      MemberPricingOnTradesTestIds.PROGRESS_FILL('swaps'),
+    );
+
+    expect(getFlattenedStyle(fill.props.style)).toEqual(
+      expect.objectContaining({ width: '62%' }),
+    );
+  });
+
+  it('clamps progress fill width to 100% when used exceeds allowance', () => {
+    const overAllowanceItem: TradeAllowanceItem = {
+      id: 'swaps',
+      used: 600,
+      allowance: 500,
+      kind: 'currency',
+    };
+
+    const { getByTestId } = renderTradeAllowanceRow(overAllowanceItem);
+
+    const fill = getByTestId(
+      MemberPricingOnTradesTestIds.PROGRESS_FILL('swaps'),
+    );
+
+    expect(getFlattenedStyle(fill.props.style)).toEqual(
+      expect.objectContaining({ width: '100%' }),
+    );
+  });
+});

--- a/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.test.tsx
+++ b/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.test.tsx
@@ -109,6 +109,49 @@ describe('TradeAllowanceRow', () => {
     );
   });
 
+  it('rounds fractional progress fill width to a whole percent', () => {
+    const fractionalItem: TradeAllowanceItem = {
+      id: 'swaps',
+      used: 1,
+      allowance: 3,
+      kind: 'currency',
+    };
+
+    const { getByTestId } = renderTradeAllowanceRow(fractionalItem);
+
+    const fill = getByTestId(
+      MemberPricingOnTradesTestIds.PROGRESS_FILL('swaps'),
+    );
+
+    expect(getFlattenedStyle(fill.props.style)).toEqual(
+      expect.objectContaining({ width: '33%' }),
+    );
+  });
+
+  it('exposes progressbar accessibility props on the allowance track', () => {
+    const swapsItem = MOCK_TRADE_ALLOWANCES.find((item) => item.id === 'swaps');
+
+    if (!swapsItem) {
+      throw new Error('swaps mock item not found');
+    }
+
+    const { getByTestId } = renderTradeAllowanceRow(swapsItem);
+
+    const progress = getByTestId(
+      MemberPricingOnTradesTestIds.PROGRESS('swaps'),
+    );
+
+    expect(progress.props.accessibilityRole).toBe('progressbar');
+    expect(progress.props.accessibilityLabel).toBe(
+      strings('pro_hub.member_pricing.swaps.label'),
+    );
+    expect(progress.props.accessibilityValue).toEqual({
+      min: 0,
+      max: 500,
+      now: 310,
+    });
+  });
+
   it('clamps progress fill width to 100% when used exceeds allowance', () => {
     const overAllowanceItem: TradeAllowanceItem = {
       id: 'swaps',
@@ -122,9 +165,17 @@ describe('TradeAllowanceRow', () => {
     const fill = getByTestId(
       MemberPricingOnTradesTestIds.PROGRESS_FILL('swaps'),
     );
+    const progress = getByTestId(
+      MemberPricingOnTradesTestIds.PROGRESS('swaps'),
+    );
 
     expect(getFlattenedStyle(fill.props.style)).toEqual(
       expect.objectContaining({ width: '100%' }),
     );
+    expect(progress.props.accessibilityValue).toEqual({
+      min: 0,
+      max: 500,
+      now: 500,
+    });
   });
 });

--- a/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.testIds.ts
+++ b/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.testIds.ts
@@ -1,0 +1,11 @@
+import type { TradeAllowanceItem } from '../../ProHub.constants';
+
+export const MemberPricingOnTradesTestIds = {
+  SECTION: 'pro-hub-member-pricing-section',
+  TITLE: 'pro-hub-member-pricing-title',
+  ROW: (id: TradeAllowanceItem['id']) => `pro-hub-member-pricing-row-${id}`,
+  PROGRESS: (id: TradeAllowanceItem['id']) =>
+    `pro-hub-member-pricing-progress-${id}`,
+  PROGRESS_FILL: (id: TradeAllowanceItem['id']) =>
+    `pro-hub-member-pricing-progress-fill-${id}`,
+} as const;

--- a/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.tsx
+++ b/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.tsx
@@ -12,10 +12,7 @@ import { MemberPricingOnTradesTestIds } from './MemberPricingOnTrades.testIds';
 import TradeAllowanceRow from './TradeAllowanceRow';
 
 const MemberPricingOnTrades = () => (
-  <Box
-    twClassName="gap-y-6"
-    testID={MemberPricingOnTradesTestIds.SECTION}
-  >
+  <Box twClassName="gap-y-6" testID={MemberPricingOnTradesTestIds.SECTION}>
     <Text
       variant={TextVariant.HeadingMd}
       fontWeight={FontWeight.Bold}

--- a/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.tsx
+++ b/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {
+  Box,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { MOCK_TRADE_ALLOWANCES } from '../../ProHub.constants';
+import { MemberPricingOnTradesTestIds } from './MemberPricingOnTrades.testIds';
+import TradeAllowanceRow from './TradeAllowanceRow';
+
+const MemberPricingOnTrades = () => (
+  <Box
+    twClassName="gap-y-6"
+    testID={MemberPricingOnTradesTestIds.SECTION}
+  >
+    <Text
+      variant={TextVariant.HeadingMd}
+      fontWeight={FontWeight.Bold}
+      color={TextColor.TextDefault}
+      testID={MemberPricingOnTradesTestIds.TITLE}
+    >
+      {strings('pro_hub.member_pricing.title')}
+    </Text>
+
+    <Box twClassName="gap-y-6">
+      {MOCK_TRADE_ALLOWANCES.map((item) => (
+        <TradeAllowanceRow key={item.id} item={item} />
+      ))}
+    </Box>
+  </Box>
+);
+
+export default MemberPricingOnTrades;

--- a/app/components/Views/ProHub/components/MemberPricingOnTrades/TradeAllowanceRow.tsx
+++ b/app/components/Views/ProHub/components/MemberPricingOnTrades/TradeAllowanceRow.tsx
@@ -52,9 +52,13 @@ const calculateProgress = (item: TradeAllowanceItem): number => {
 };
 
 const TradeAllowanceRow = ({ item }: TradeAllowanceRowProps) => {
-  const progress = useMemo(() => calculateProgress(item), [item]);
+  const progressPercent = useMemo(
+    () => Math.round(calculateProgress(item) * 100),
+    [item],
+  );
   const labelKey = `pro_hub.member_pricing.${item.id}.label`;
   const footnoteKey = `pro_hub.member_pricing.${item.id}.footnote`;
+  const label = strings(labelKey);
 
   return (
     <Box
@@ -68,7 +72,7 @@ const TradeAllowanceRow = ({ item }: TradeAllowanceRowProps) => {
           justifyContent={BoxJustifyContent.Between}
         >
           <Text variant={TextVariant.BodyLg} color={TextColor.TextDefault}>
-            {strings(labelKey)}
+            {label}
           </Text>
           <Box flexDirection={BoxFlexDirection.Row}>
             <Text
@@ -90,10 +94,18 @@ const TradeAllowanceRow = ({ item }: TradeAllowanceRowProps) => {
         <Box
           twClassName="h-2 rounded-full bg-muted overflow-hidden"
           testID={MemberPricingOnTradesTestIds.PROGRESS(item.id)}
+          accessible
+          accessibilityRole="progressbar"
+          accessibilityLabel={label}
+          accessibilityValue={{
+            min: 0,
+            max: item.allowance,
+            now: Math.min(item.used, item.allowance),
+          }}
         >
           <Box
             twClassName="h-full rounded-full bg-icon-default"
-            style={{ width: `${progress * 100}%` }}
+            style={{ width: `${progressPercent}%` }}
             testID={MemberPricingOnTradesTestIds.PROGRESS_FILL(item.id)}
           />
         </Box>

--- a/app/components/Views/ProHub/components/MemberPricingOnTrades/TradeAllowanceRow.tsx
+++ b/app/components/Views/ProHub/components/MemberPricingOnTrades/TradeAllowanceRow.tsx
@@ -1,0 +1,109 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import type { TradeAllowanceItem } from '../../ProHub.constants';
+import { MemberPricingOnTradesTestIds } from './MemberPricingOnTrades.testIds';
+
+interface TradeAllowanceRowProps {
+  item: TradeAllowanceItem;
+}
+
+const formatCurrencyAmount = (amount: number): string =>
+  strings('pro_hub.member_pricing.allowance_currency', {
+    amount: amount.toLocaleString('en-US'),
+  });
+
+const formatAllowanceValue = (item: TradeAllowanceItem): string => {
+  if (item.kind === 'currency') {
+    return formatCurrencyAmount(item.allowance);
+  }
+
+  const countKey =
+    item.allowance === 1
+      ? 'pro_hub.member_pricing.allowance_count_one'
+      : 'pro_hub.member_pricing.allowance_count_other';
+
+  return strings(countKey, { count: item.allowance });
+};
+
+const formatUsedValue = (item: TradeAllowanceItem): string => {
+  if (item.kind === 'currency') {
+    return formatCurrencyAmount(item.used);
+  }
+
+  return String(item.used);
+};
+
+const calculateProgress = (item: TradeAllowanceItem): number => {
+  if (item.allowance <= 0) {
+    return 0;
+  }
+
+  return Math.min(item.used / item.allowance, 1);
+};
+
+const TradeAllowanceRow = ({ item }: TradeAllowanceRowProps) => {
+  const progress = useMemo(() => calculateProgress(item), [item]);
+  const labelKey = `pro_hub.member_pricing.${item.id}.label`;
+  const footnoteKey = `pro_hub.member_pricing.${item.id}.footnote`;
+
+  return (
+    <Box
+      twClassName="gap-y-3"
+      testID={MemberPricingOnTradesTestIds.ROW(item.id)}
+    >
+      <Box twClassName="gap-y-2">
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Between}
+        >
+          <Text variant={TextVariant.BodyLg} color={TextColor.TextDefault}>
+            {strings(labelKey)}
+          </Text>
+          <Box flexDirection={BoxFlexDirection.Row}>
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextDefault}
+            >
+              {formatUsedValue(item)}
+            </Text>
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+            >
+              {` / ${formatAllowanceValue(item)}`}
+            </Text>
+          </Box>
+        </Box>
+
+        <Box
+          twClassName="h-2 rounded-full bg-muted overflow-hidden"
+          testID={MemberPricingOnTradesTestIds.PROGRESS(item.id)}
+        >
+          <Box
+            twClassName="h-full rounded-full bg-icon-default"
+            style={{ width: `${progress * 100}%` }}
+            testID={MemberPricingOnTradesTestIds.PROGRESS_FILL(item.id)}
+          />
+        </Box>
+      </Box>
+
+      <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
+        {strings(footnoteKey)}
+      </Text>
+    </Box>
+  );
+};
+
+export default TradeAllowanceRow;

--- a/app/components/Views/ProHub/components/MemberPricingOnTrades/index.ts
+++ b/app/components/Views/ProHub/components/MemberPricingOnTrades/index.ts
@@ -1,0 +1,2 @@
+export { default } from './MemberPricingOnTrades';
+export { MemberPricingOnTradesTestIds } from './MemberPricingOnTrades.testIds';

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -11286,8 +11286,25 @@
     "manage_plan": "Manage plan",
     "earned_with_pro": "Earned with Pro",
     "saved_with_pro": "Saved with Pro",
-    "your_benefits": "Your benefits",
     "next_payment": "Your next payment of {{amount}} is coming up {{date}}.",
+    "member_pricing": {
+      "title": "Member pricing on trades",
+      "allowance_currency": "${{amount}}",
+      "allowance_count_one": "{{count}} trade",
+      "allowance_count_other": "{{count}} trades",
+      "swaps": {
+        "label": "Swaps",
+        "footnote": "Allowance resets monthly. Fees apply above $500."
+      },
+      "perps": {
+        "label": "Perps",
+        "footnote": "Allowance resets monthly. Fees apply above $1,000."
+      },
+      "predict": {
+        "label": "Predict",
+        "footnote": "One prediction trade per month. Unused trades don't roll over."
+      }
+    },
     "physical_card": {
       "title": "Get your physical card.",
       "description": "Get 3% mUSD back at 150M+ merchants when you spend with MetaMask Card.",


### PR DESCRIPTION
## **Description**

Replaces the Pro Hub "Your benefits" checklist with a new **Member pricing on trades** section that shows monthly usage against allowance for Swaps, Perps, and Predict. Each row displays current usage, a progress bar, and explanatory footnote copy matching the updated design.

This is mock-data UI for now (consistent with other Pro Hub sections) and will be wired to real membership API data in a follow-up.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A

## **Manual testing steps**

```gherkin
Feature: Pro Hub member pricing on trades

  Scenario: user views member pricing allowances on Pro Hub
    Given the user is a Pro member with access to Pro Hub

    When user navigates to Pro Hub
    Then the "Member pricing on trades" section is visible
    And Swaps, Perps, and Predict rows each show usage vs allowance
    And each row displays a progress bar and footnote text
```

Additional verification:
- [x] `yarn jest app/components/Views/ProHub/ProHub.test.tsx`
- [x] `yarn jest app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.test.tsx`

## **Screenshots/Recordings**

_Replace Benefits section with Member pricing_

### **Before**

Pro Hub displayed a static "Your benefits" checklist of six benefit rows.

<img width="464" height="1022" alt="Screenshot 2026-09-02 at 11 35 08 AM" src="https://github.com/user-attachments/assets/ffb40824-72e5-47b2-86cd-382f1e14fad3" />


### **After**

Pro Hub displays three trade allowance rows (Swaps, Perps, Predict) with usage amounts, progress bars, and footnotes.

<img width="485" height="1012" alt="Screenshot 2026-09-02 at 11 19 26 AM" src="https://github.com/user-attachments/assets/b1fd264c-aa42-44e3-9839-c0fc3b0f16fc" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pro Hub UI and mock membership display only; no payment, auth, or live API wiring in this change.
> 
> **Overview**
> Pro Hub **replaces** the static “Your benefits” checklist with a **Member pricing on trades** block driven by mock `MOCK_TRADE_ALLOWANCES` (Swaps, Perps, Predict). Each row shows used vs allowance (currency or trade count), a progress bar with clamping/rounding, footnote copy, and progressbar accessibility.
> 
> `ProHub` now renders `MemberPricingOnTrades` instead of shared `BenefitRow`/`BENEFITS`; `pro_hub.your_benefits` is removed and new `pro_hub.member_pricing.*` strings are added. Tests cover the new section in `ProHub.test.tsx` and dedicated `MemberPricingOnTrades` unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecb78495d92b5cbbad5c655397d1acc5c6ac9bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->