### PR TITLE
fix(predict): harden claim gas-station preflight

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -4400,7 +4400,39 @@ describe('PredictController', () => {
             disableHook: true,
             disableSequential: true,
             gasFeeToken: MATIC_CONTRACTS_V2.collateral,
-            skipInitialGasEstimate: true,
+          }),
+        );
+      });
+    });
+
+    it('omits gasFeeToken when account walletType is deposit-wallet', async () => {
+      const mockBatchId = 'claim-batch-deposit-wallet';
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.getAccountState.mockResolvedValue({
+          address: '0xDepositWalletAddress' as `0x${string}`,
+          isDeployed: true,
+          walletType: 'deposit-wallet' as const,
+        });
+        mockPolymarketProvider.getPositions = jest.fn().mockResolvedValue([
+          {
+            marketId: 'test-market',
+            outcomeId: 'test-outcome',
+            balance: '100',
+          },
+        ]);
+        mockPolymarketProvider.prepareClaim = jest
+          .fn()
+          .mockResolvedValue(mockClaim);
+        (addTransactionBatch as jest.Mock).mockResolvedValue({
+          batchId: mockBatchId,
+        });
+        await controller.getPositions({ claimable: true });
+
+        await controller.claimWithConfirmation({});
+
+        expect(addTransactionBatch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            gasFeeToken: undefined,
           }),
         );
       });

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -2537,6 +2537,16 @@ export class PredictController extends BaseController<
         );
       }
 
+      const accountState = await provider.getAccountState({
+        ownerAddress: signer.address,
+      });
+
+      const isDepositWallet = accountState.walletType === 'deposit-wallet';
+
+      const gasFeeToken = isDepositWallet
+        ? undefined
+        : (MATIC_CONTRACTS_V2.collateral as Hex);
+
       // Add transaction batch - can fail if transaction submission fails
       const batchId = await this.submitPredictTransactionBatch({
         params: {
@@ -2546,9 +2556,7 @@ export class PredictController extends BaseController<
           networkClientId,
           disableHook: true,
           disableSequential: true,
-          skipInitialGasEstimate: true,
-          // Temporarily breaking abstraction, can instead be abstracted via provider.
-          gasFeeToken: MATIC_CONTRACTS_V2.collateral as Hex,
+          gasFeeToken,
           transactions,
         },
         missingBatchIdError:

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -1,6 +1,7 @@
 import {
   CHAIN_IDS,
   TransactionType,
+  type GasFeeToken,
   type TransactionMeta,
 } from '@metamask/transaction-controller';
 import { SignTypedDataVersion } from '@metamask/keyring-controller';
@@ -2075,17 +2076,37 @@ describe('PolymarketProvider', () => {
     expect(transactionMeta.txParams.nonce).toBeUndefined();
   });
 
-  it('passes through Safe claims before signing', async () => {
+  it('passes through Safe claims before signing when gas fee tokens are pending', async () => {
     const result = await createProvider().beforeSignClaim({
       transactionMeta: {
         id: 'claim-tx',
         txParams: { from: signer.address },
+        selectedGasFeeToken: MATIC_CONTRACTS_V2.collateral,
+        isGasFeeTokenIgnoredIfBalance: true,
       } as TransactionMeta,
       signer,
       positions: [createClaimPosition()],
     });
 
     expect(result).toBeUndefined();
+  });
+
+  it('throws for Safe claims when the selected gas fee token is unavailable', async () => {
+    await expect(
+      createProvider().beforeSignClaim({
+        transactionMeta: {
+          id: 'claim-tx',
+          txParams: { from: signer.address },
+          selectedGasFeeToken: MATIC_CONTRACTS_V2.collateral,
+          isGasFeeTokenIgnoredIfBalance: true,
+          gasFeeTokens: [] as GasFeeToken[],
+        } as TransactionMeta,
+        signer,
+        positions: [createClaimPosition()],
+      }),
+    ).rejects.toThrow(
+      'Insufficient POL and pUSD to pay network fees for this claim',
+    );
   });
 
   it('passes through Safe claim publishing', async () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -2115,8 +2115,10 @@ describe('PolymarketProvider', () => {
         selectedGasFeeToken: MATIC_CONTRACTS_V2.collateral,
         isGasFeeTokenIgnoredIfBalance: true,
         gasFeeTokens: [
-          { tokenAddress: '0x1111111111111111111111111111111111111111' },
-        ] as GasFeeToken[],
+          {
+            tokenAddress: '0x1111111111111111111111111111111111111111',
+          },
+        ] as unknown as GasFeeToken[],
       } as TransactionMeta,
       signer,
       positions: [createClaimPosition()],

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -2091,22 +2091,38 @@ describe('PolymarketProvider', () => {
     expect(result).toBeUndefined();
   });
 
-  it('throws for Safe claims when the selected gas fee token is unavailable', async () => {
-    await expect(
-      createProvider().beforeSignClaim({
-        transactionMeta: {
-          id: 'claim-tx',
-          txParams: { from: signer.address },
-          selectedGasFeeToken: MATIC_CONTRACTS_V2.collateral,
-          isGasFeeTokenIgnoredIfBalance: true,
-          gasFeeTokens: [] as GasFeeToken[],
-        } as TransactionMeta,
-        signer,
-        positions: [createClaimPosition()],
-      }),
-    ).rejects.toThrow(
-      'Insufficient POL and pUSD to pay network fees for this claim',
-    );
+  it('passes through Safe claims when the selected gas fee token is missing from gasFeeTokens', async () => {
+    const result = await createProvider().beforeSignClaim({
+      transactionMeta: {
+        id: 'claim-tx',
+        txParams: { from: signer.address },
+        selectedGasFeeToken: MATIC_CONTRACTS_V2.collateral,
+        isGasFeeTokenIgnoredIfBalance: true,
+        gasFeeTokens: [] as GasFeeToken[],
+      } as TransactionMeta,
+      signer,
+      positions: [createClaimPosition()],
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('passes through Safe claims when gasFeeTokens does not include the selected token', async () => {
+    const result = await createProvider().beforeSignClaim({
+      transactionMeta: {
+        id: 'claim-tx',
+        txParams: { from: signer.address },
+        selectedGasFeeToken: MATIC_CONTRACTS_V2.collateral,
+        isGasFeeTokenIgnoredIfBalance: true,
+        gasFeeTokens: [
+          { tokenAddress: '0x1111111111111111111111111111111111111111' },
+        ] as GasFeeToken[],
+      } as TransactionMeta,
+      signer,
+      positions: [createClaimPosition()],
+    });
+
+    expect(result).toBeUndefined();
   });
 
   it('passes through Safe claim publishing', async () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -2342,27 +2342,46 @@ export class PolymarketProvider implements PredictProvider {
       ownerAddress: signer.address,
     });
 
-    if (accountState.walletType !== 'deposit-wallet') {
-      return undefined;
+    if (accountState.walletType === 'deposit-wallet') {
+      DevLogger.log('PolymarketProvider: Deposit wallet claim beforeSign', {
+        operation: 'deposit_wallet_claim_before_sign',
+        walletType: 'deposit-wallet',
+        signerAddress: signer.address,
+        depositWalletAddress: accountState.address,
+        transactionId: transactionMeta.id,
+        positionCount: positions.length,
+      });
+
+      return {
+        updateTransaction: (transaction: TransactionMeta) => {
+          transaction.isExternalSign = true;
+          transaction.selectedGasFeeToken = undefined;
+          transaction.isGasFeeTokenIgnoredIfBalance = false;
+          delete transaction.txParams.nonce;
+        },
+      };
     }
 
-    DevLogger.log('PolymarketProvider: Deposit wallet claim beforeSign', {
-      operation: 'deposit_wallet_claim_before_sign',
-      walletType: 'deposit-wallet',
-      signerAddress: signer.address,
-      depositWalletAddress: accountState.address,
-      transactionId: transactionMeta.id,
-      positionCount: positions.length,
-    });
+    const { gasFeeTokens, isGasFeeTokenIgnoredIfBalance, selectedGasFeeToken } =
+      transactionMeta;
 
-    return {
-      updateTransaction: (transaction: TransactionMeta) => {
-        transaction.isExternalSign = true;
-        transaction.selectedGasFeeToken = undefined;
-        transaction.isGasFeeTokenIgnoredIfBalance = false;
-        delete transaction.txParams.nonce;
-      },
-    };
+    const isSelectedGasFeeTokenUnavailable =
+      Boolean(selectedGasFeeToken) &&
+      Boolean(isGasFeeTokenIgnoredIfBalance) &&
+      gasFeeTokens !== undefined &&
+      !gasFeeTokens.some(
+        (token) =>
+          token.tokenAddress.toLowerCase() ===
+          selectedGasFeeToken?.toLowerCase(),
+      );
+
+    if (isSelectedGasFeeTokenUnavailable) {
+      throw new Error(
+        'Insufficient POL and pUSD to pay network fees for this claim',
+      );
+    }
+
+    return undefined;
   }
 
   public async publishClaim({

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -2362,25 +2362,9 @@ export class PolymarketProvider implements PredictProvider {
       };
     }
 
-    const { gasFeeTokens, isGasFeeTokenIgnoredIfBalance, selectedGasFeeToken } =
-      transactionMeta;
-
-    const isSelectedGasFeeTokenUnavailable =
-      Boolean(selectedGasFeeToken) &&
-      Boolean(isGasFeeTokenIgnoredIfBalance) &&
-      gasFeeTokens !== undefined &&
-      !gasFeeTokens.some(
-        (token) =>
-          token.tokenAddress.toLowerCase() ===
-          selectedGasFeeToken?.toLowerCase(),
-      );
-
-    if (isSelectedGasFeeTokenUnavailable) {
-      throw new Error(
-        'Insufficient POL and pUSD to pay network fees for this claim',
-      );
-    }
-
+    // Safe claims keep `isGasFeeTokenIgnoredIfBalance`, so native POL can pay
+    // when Sentinel returns an empty or mismatched `gasFeeTokens` list.
+    // Transaction-controller preflight rejects only when native is also short.
     return undefined;
   }
 

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -62,6 +62,7 @@ export const useInsufficientBalanceAlert = ({
       transactionMetadata;
 
     const isGasFeeTokensEmpty = gasFeeTokens?.length === 0;
+    const { isGasFeeTokenIgnoredIfBalance } = transactionMetadata;
 
     // Check if gasless check has completed (regardless of result)
     const isGaslessCheckComplete = !isGaslessCheckPending;
@@ -83,7 +84,10 @@ export const useInsufficientBalanceAlert = ({
     const hasNoGasFeeTokenSelected =
       ignoreGasFeeToken ||
       !selectedGasFeeToken ||
-      (excludeNativeTokenForFee && isGasFeeTokensEmpty);
+      (excludeNativeTokenForFee && isGasFeeTokensEmpty) ||
+      (isGasFeeTokenIgnoredIfBalance &&
+        isGasFeeTokensEmpty &&
+        Boolean(selectedGasFeeToken));
 
     // Gasless check is complete AND one of:
     //  - Gasless is NOT supported (native currency needed for gas)

--- a/app/components/Views/confirmations/hooks/gas/useIsGaslessLoading.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useIsGaslessLoading.test.ts
@@ -128,7 +128,7 @@ describe('useIsGaslessLoading', () => {
     expect(result.isGaslessLoading).toBe(false);
   });
 
-  it('returns false if gas fee tokens is an empty array', async () => {
+  it('returns true if gas fee tokens is an empty array', async () => {
     const result = await runHook({
       simulationEnabled: true,
       gaslessSupported: true,
@@ -136,7 +136,7 @@ describe('useIsGaslessLoading', () => {
       gasFeeTokens: [],
     });
 
-    expect(result.isGaslessLoading).toBe(false);
+    expect(result.isGaslessLoading).toBe(true);
   });
 
   it('returns false if gas fee tokens are present and dont match selectedGasFeeToken (non-reg)', async () => {

--- a/app/components/Views/confirmations/hooks/gas/useIsGaslessLoading.ts
+++ b/app/components/Views/confirmations/hooks/gas/useIsGaslessLoading.ts
@@ -49,11 +49,16 @@ export function useIsGaslessLoading() {
   const hasNoNativeTokenAvailable =
     excludeNativeTokenForFee || hasInsufficientBalance;
 
+  const isGasFeeTokensPending = gasFeeTokens === undefined;
+  const isGasFeeTokensEmpty =
+    gasFeeTokens !== undefined && gasFeeTokens.length === 0;
+
   const isGaslessLoading = Boolean(
     isSimulationEnabled &&
       hasNoNativeTokenAvailable &&
       (isGaslessSupportedPending || isGaslessSupportedFinished) &&
-      (!gasFeeTokens ||
+      (isGasFeeTokensPending ||
+        (!excludeNativeTokenForFee && isGasFeeTokensEmpty) ||
         (excludeNativeTokenForFee &&
           hasWrongSelectedGasFeeToken({ gasFeeTokens, selectedGasFeeToken }))),
   );

--- a/package.json
+++ b/package.json
@@ -401,7 +401,7 @@
     "@metamask/subscription-controller": "^8.0.1",
     "@metamask/superstruct": "^3.2.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
-    "@metamask/transaction-controller": "^69.7.0",
+    "@metamask/transaction-controller": "^69.8.1",
     "@metamask/transaction-pay-controller": "^27.1.1",
     "@metamask/tron-wallet-snap": "^3.2.0",
     "@metamask/utils": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39828,7 +39828,7 @@ __metadata:
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/tooling-insight": "npm:^1.0.1"
-    "@metamask/transaction-controller": "npm:^69.7.0"
+    "@metamask/transaction-controller": "npm:^69.8.1"
     "@metamask/transaction-pay-controller": "npm:^27.1.1"
     "@metamask/tron-wallet-snap": "npm:^3.2.0"
     "@metamask/utils": "npm:^11.11.0"


### PR DESCRIPTION
## **Description**

Predict claim can fail on Polygon Safe wallets when a pUSD gas fee token is pre-selected but Sentinel returns an empty `gasFeeTokens` list and native POL is insufficient. Users see a generic confirmation failure (`Gas fee token not found and insufficient native balance` / `intrinsic gas too low: gas 0`).

This PR hardens the mobile-side claim flow:

1. **`PredictController.claimWithConfirmation`** — align batch submission with withdraw: gate `gasFeeToken` on wallet type (omit for deposit-wallet), and remove `skipInitialGasEstimate` so gas estimates complete before confirm.
2. **`PolymarketProvider.beforeSignClaim`** — for Safe wallets, fail early with a clear error when simulation has finished and the selected gas fee token is unavailable.
3. **`useIsGaslessLoading`** — treat an empty `gasFeeTokens` array as unavailable (not “done loading”) when native balance is insufficient, so confirm stays disabled.
4. **`useInsufficientBalanceAlert`** — show the blocking insufficient-balance alert for forced gas-fee-token flows (`isGasFeeTokenIgnoredIfBalance`) when no gas-station tokens are available.
5. **`@metamask/transaction-controller`** — bump to `^69.8.1` for the companion core gas fee token preflight.

Companion core fix: [MetaMask/core#10071](https://github.com/MetaMask/core/pull/10071) (transaction-controller gas fee token preflight).

## **Changelog**

CHANGELOG entry: Fixed Predict claim failures for users with insufficient POL when gas-station fee tokens are unavailable

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/CONF-1725

## **Manual testing steps**

```gherkin
Feature: Predict claim gas-station preflight

  Scenario: Safe wallet with insufficient POL and unavailable pUSD gas token
    Given a Polygon Predict Safe wallet with claimable positions
    And the EOA has low POL and insufficient pUSD for gas-station fees
    When the user opens Predict claim confirmation
    Then confirm remains disabled or a blocking insufficient-balance alert is shown
    And submitting does not produce a generic gas-station failure at sign time

  Scenario: Deposit-wallet claim
    Given a deposit-wallet Predict account with claimable positions
    When the user claims winnings
    Then the claim batch omits gasFeeToken and uses the relayer path
```

## **Screenshots/Recordings**

N/A — preflight/confirmation gating change; manual verification on iOS/Android simulator recommended.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gas-fee gating and claim batch params on a funds-related flow; mis-gating could block valid claims or allow bad submits, mitigated by tests and the controller bump.
> 
> **Overview**
> Fixes Predict **claim** failures on Polygon when a pUSD gas fee token is pre-selected but Sentinel returns no `gasFeeTokens` and native POL is too low—users previously hit opaque sign-time errors.
> 
> **Claim submission** (`PredictController`): drops `skipInitialGasEstimate` so gas estimates finish before confirm, and only sets `gasFeeToken` to pUSD collateral for non–deposit-wallet accounts (deposit-wallet batches omit it for the relayer path).
> 
> **Signing** (`PolymarketProvider.beforeSignClaim`): deposit-wallet claims still strip gas-fee-token metadata and mark external sign; **Safe** claims no longer get that override and pass through with `isGasFeeTokenIgnoredIfBalance`, relying on core preflight when gas-station tokens are missing.
> 
> **Confirmation UI**: `useIsGaslessLoading` treats an **empty** `gasFeeTokens` list as still loading when native balance is insufficient (keeps confirm disabled). `useInsufficientBalanceAlert` surfaces a blocking alert for the same forced gas-token scenario when simulation completes with no station tokens.
> 
> Bumps `@metamask/transaction-controller` to **^69.8.1** for companion gas-fee-token preflight in core.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e13ce95adfa2491f4808bbb63e86c01a608c122. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->