### PR TITLE
feat: serve limit-order quotes from SwapQuotesProvider

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -198,6 +198,7 @@ import { ALLOWED_CAPABILITIES as ADD_DEVICE_TO_WALLET_ROUTE_ALLOWED_CAPABILITIES
 import { ALLOWED_CAPABILITIES as CHOOSE_PASSWORD_ROUTE_ALLOWED_CAPABILITIES } from '../../Views/ChoosePassword/messenger';
 import { ALLOWED_CAPABILITIES as QR_TAB_SWITCHER_ROUTE_ALLOWED_CAPABILITIES } from '../../Views/QRTabSwitcher/messenger';
 import MoneyDeeplinkModal from '../../UI/Money/components/MoneyDeeplinkModal/MoneyDeeplinkModal';
+import { BridgeSessionProvider } from '../../UI/Bridge/hooks/useBridgeSession/BridgeSessionContext';
 
 const NativeStack = createNativeStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -1252,11 +1253,13 @@ const MainNavigator = () => {
         component={VbaVerifyIdentity}
         options={{ headerShown: false, ...slideFromRightNativeOptions }}
       />
-      <NativeStack.Screen
-        name={Routes.BRIDGE.ROOT}
-        component={BridgeScreenStack}
-        options={{ ...slideFromRightNativeOptions, gestureEnabled: false }}
-      />
+      <BridgeSessionProvider>
+        <NativeStack.Screen
+          name={Routes.BRIDGE.ROOT}
+          component={BridgeScreenStack}
+          options={{ ...slideFromRightNativeOptions, gestureEnabled: false }}
+        />
+      </BridgeSessionProvider>
       <NativeStack.Screen
         name={Routes.BRIDGE.MODALS.ROOT}
         component={BridgeModalStack}

--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -198,7 +198,6 @@ import { ALLOWED_CAPABILITIES as ADD_DEVICE_TO_WALLET_ROUTE_ALLOWED_CAPABILITIES
 import { ALLOWED_CAPABILITIES as CHOOSE_PASSWORD_ROUTE_ALLOWED_CAPABILITIES } from '../../Views/ChoosePassword/messenger';
 import { ALLOWED_CAPABILITIES as QR_TAB_SWITCHER_ROUTE_ALLOWED_CAPABILITIES } from '../../Views/QRTabSwitcher/messenger';
 import MoneyDeeplinkModal from '../../UI/Money/components/MoneyDeeplinkModal/MoneyDeeplinkModal';
-import { BridgeSessionProvider } from '../../UI/Bridge/hooks/useBridgeSession/BridgeSessionContext';
 
 const NativeStack = createNativeStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -1253,13 +1252,11 @@ const MainNavigator = () => {
         component={VbaVerifyIdentity}
         options={{ headerShown: false, ...slideFromRightNativeOptions }}
       />
-      <BridgeSessionProvider>
-        <NativeStack.Screen
-          name={Routes.BRIDGE.ROOT}
-          component={BridgeScreenStack}
-          options={{ ...slideFromRightNativeOptions, gestureEnabled: false }}
-        />
-      </BridgeSessionProvider>
+      <NativeStack.Screen
+        name={Routes.BRIDGE.ROOT}
+        component={BridgeScreenStack}
+        options={{ ...slideFromRightNativeOptions, gestureEnabled: false }}
+      />
       <NativeStack.Screen
         name={Routes.BRIDGE.MODALS.ROOT}
         component={BridgeModalStack}

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.test.tsx
@@ -12,7 +12,6 @@ import { useLimitOrderSwapInputs } from '../../../hooks/useLimitOrderSwapsInput'
 import { useSwapsLimitOrderPriceAdjust } from '../../../hooks/useSwapsLimitOrderPriceAdjust';
 import { useSwapsLimitOrderKeypad } from '../../../hooks/useSwapsLimitOrderKeypad';
 import { useHasMissingQuoteAndAssetsPriceData } from '../../../hooks/useHasMissingQuoteAndAssetsPriceData';
-import { useLatestBalance } from '../../../hooks/useLatestBalance';
 import useIsInsufficientBalance from '../../../hooks/useInsufficientBalance';
 import { useHasSufficientGas } from '../../../hooks/useHasSufficientGas';
 import {
@@ -48,14 +47,14 @@ jest.mock('../../../hooks/useBridgeQuoteData', () => ({
 
 jest.mock('../../../hooks/useBridgeSession', () => ({
   useBridgeSession: jest.fn().mockReturnValue({
-    selectedTab: "limit",
-    renderedTab: "limit",
+    selectedTab: 'limit',
+    renderedTab: 'limit',
     setSelectedTab: jest.fn(),
     setRenderedTab: jest.fn(),
-    latestSourceBalance: jest.fn().mockReturnValue({
+    latestSourceBalance: {
       displayBalance: '1.0',
       atomicBalance: undefined,
-    }),
+    },
   }),
 }));
 
@@ -65,14 +64,17 @@ jest.mock('../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => {
   );
 
   return {
-    BridgeQuoteDataProvider: ({ children }: { children: React.ReactNode }) =>
-      children,
     useBridgeQuoteDataContext: jest.fn(() => useBridgeQuoteDataMock()),
   };
 });
 
-jest.mock('../../../hooks/useLatestBalance', () => ({
-  useLatestBalance: jest.fn(),
+jest.mock('../../../hooks/useInsufficientBalance', () => ({
+  __esModule: true,
+  default: jest.fn(() => false),
+}));
+
+jest.mock('../../../hooks/useHasSufficientGas', () => ({
+  useHasSufficientGas: jest.fn(() => true),
 }));
 
 jest.mock('../../../hooks/useInsufficientBalance', () => ({
@@ -384,10 +386,6 @@ describe('BridgeLimitOrderView', () => {
     jest
       .mocked(useBridgeQuoteData as unknown as jest.Mock)
       .mockImplementation(() => mockUseBridgeQuoteData);
-    jest.mocked(useLatestBalance).mockReturnValue({
-      displayBalance: '1.0',
-      atomicBalance: undefined,
-    });
     jest
       .mocked(useLimitOrderSwapInputs)
       .mockImplementation(() => buildSwapInputsMock());

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.test.tsx
@@ -46,6 +46,19 @@ jest.mock('../../../hooks/useBridgeQuoteData', () => ({
   useBridgeQuoteData: jest.fn(),
 }));
 
+jest.mock('../../../hooks/useBridgeSession', () => ({
+  useBridgeSession: jest.fn().mockReturnValue({
+    selectedTab: "limit",
+    renderedTab: "limit",
+    setSelectedTab: jest.fn(),
+    setRenderedTab: jest.fn(),
+    latestSourceBalance: jest.fn().mockReturnValue({
+      displayBalance: '1.0',
+      atomicBalance: undefined,
+    }),
+  }),
+}));
+
 jest.mock('../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => {
   const { useBridgeQuoteData: useBridgeQuoteDataMock } = jest.requireMock(
     '../../../hooks/useBridgeQuoteData',

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
@@ -7,15 +7,10 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import type { AppNavigationProp } from '../../../../../../core/NavigationService/types';
 import Routes from '../../../../../../constants/navigation/Routes';
 import {
-  selectBridgeBalanceRefreshKey,
   selectSlippage,
-  selectSourceToken,
   setSlippage,
 } from '../../../../../../core/redux/slices/bridge';
-import {
-  BridgeQuoteDataProvider,
-  useBridgeQuoteDataContext,
-} from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import { useBridgeQuoteDataContext } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import type { TokenInputAreaRef } from '../../../components/TokenInputArea';
 import OrdersTabs from '../../../components/OrdersTabs';
 import {
@@ -61,6 +56,7 @@ import {
 } from '../../../utils/currencyUtils';
 import { formatAmountWithLocaleSeparators } from '../../../utils/formatAmountWithLocaleSeparators';
 import { strings } from '../../../../../../../locales/i18n';
+import { useBridgeSession } from '../../../hooks/useBridgeSession';
 
 const formatTokenAmountValue = (
   amount: string | undefined,
@@ -71,9 +67,7 @@ interface BridgeLimitOrderViewContentProps {
   latestSourceBalance: ReturnType<typeof useLatestBalance>;
 }
 
-const BridgeLimitOrderViewContent = ({
-  latestSourceBalance,
-}: BridgeLimitOrderViewContentProps) => {
+const BridgeLimitOrderViewContent = () => {
   const tw = useTailwind();
   const navigation = useNavigation<AppNavigationProp>();
   const dispatch = useDispatch();
@@ -90,6 +84,7 @@ const BridgeLimitOrderViewContent = ({
   const inputRef = useRef<TokenInputAreaRef>(null);
   const limitPriceInputRef = useRef<InputSectionRef>(null);
   const customPercentInputRef = useRef<ButtonPricePresetsSectionRef>(null);
+  const { latestSourceBalance } = useBridgeSession();
   const {
     destToken,
     destTokenAmount,
@@ -448,24 +443,4 @@ const BridgeLimitOrderViewContent = ({
   );
 };
 
-const BridgeLimitOrderView = () => {
-  const sourceToken = useSelector(selectSourceToken);
-  const balanceRefreshKey = useSelector(selectBridgeBalanceRefreshKey);
-  const latestSourceBalance = useLatestBalance({
-    address: sourceToken?.address,
-    decimals: sourceToken?.decimals,
-    chainId: sourceToken?.chainId,
-    balance: sourceToken?.balance,
-    refreshKey: balanceRefreshKey,
-  });
-
-  return (
-    <BridgeQuoteDataProvider
-      latestSourceAtomicBalance={latestSourceBalance?.atomicBalance}
-    >
-      <BridgeLimitOrderViewContent latestSourceBalance={latestSourceBalance} />
-    </BridgeQuoteDataProvider>
-  );
-};
-
-export default BridgeLimitOrderView;
+export default BridgeLimitOrderViewContent;

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
@@ -25,7 +25,6 @@ import {
 import { SwapsInputs } from '../../../components/SwapsInputs';
 import { SwapsKeypad } from '../../../components/SwapsKeypad';
 import { GaslessQuickPickOptions } from '../../../components/GaslessQuickPickOptions';
-import { useLatestBalance } from '../../../hooks/useLatestBalance';
 import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
 import { useLimitOrderSwapInputs } from '../../../hooks/useLimitOrderSwapsInput';
 import { LIMIT_MOCK_HISTORY_TAB } from './BridgeLimitOrderView.mockHistory';
@@ -63,10 +62,6 @@ const formatTokenAmountValue = (
   symbol: string | undefined,
 ) => (amount && symbol ? `${formatMinimumReceived(amount)} ${symbol}` : '--');
 
-interface BridgeLimitOrderViewContentProps {
-  latestSourceBalance: ReturnType<typeof useLatestBalance>;
-}
-
 const BridgeLimitOrderViewContent = () => {
   const tw = useTailwind();
   const navigation = useNavigation<AppNavigationProp>();
@@ -100,7 +95,7 @@ const BridgeLimitOrderViewContent = () => {
     sourceAmountInput,
     sourceToken,
     sourceAmount,
-  } = useLimitOrderSwapInputs({ latestSourceBalance });
+  } = useLimitOrderSwapInputs();
   const {
     commitCustomPercent,
     counterToken,

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeMarketView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeMarketView/index.tsx
@@ -35,7 +35,6 @@ import {
   selectBridgeViewMode,
   setBridgeViewMode,
   selectIsNonEvmNonEvmBridge,
-  selectBridgeBalanceRefreshKey,
   selectBridgeControllerState,
   selectQuoteStreamComplete,
   selectSlippage,
@@ -53,10 +52,7 @@ import Routes from '../../../../../../constants/navigation/Routes';
 import QuoteDetailsCard from '../../../components/QuoteDetailsCard';
 import QuoteDetailsCardSkeleton from '../../../components/QuoteDetailsCard/QuoteDetailsCardSkeleton';
 import { useBridgeQuoteRequest } from '../../../hooks/useBridgeQuoteRequest';
-import {
-  BridgeQuoteDataProvider,
-  useBridgeQuoteDataContext,
-} from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import { useBridgeQuoteDataContext } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import { createStyles } from './BridgeMarketView.styles';
 import { useInitialSourceToken } from '../../../hooks/useInitialSourceToken';
 import { useInitialDestToken } from '../../../hooks/useInitialDestToken';
@@ -131,16 +127,11 @@ import {
   showPostTradeNotificationSurface,
 } from '../../../utils/postTradeNotifications';
 import { useStockMarketHours } from '../../../hooks/useStockMarketHours';
+import { useBridgeSession } from '../../../hooks/useBridgeSession';
 
 const SCROLL_NEAR_BOTTOM_PX = 160;
 
-interface BridgeMarketViewContentProps {
-  latestSourceBalance: ReturnType<typeof useLatestBalance>;
-}
-
-const BridgeMarketViewContent = ({
-  latestSourceBalance,
-}: BridgeMarketViewContentProps) => {
+const BridgeMarketViewContent = () => {
   const [isNearBottom, setIsNearBottom] = useState(false);
 
   const { isStockMarketClosed } = useStockMarketHours();
@@ -276,6 +267,7 @@ const BridgeMarketViewContent = ({
 
   const hasDestinationPicker = isEvmNonEvmBridge || isNonEvmNonEvmBridge;
 
+  const { latestSourceBalance } = useBridgeSession();
   const updateQuoteParams = useBridgeQuoteRequest({
     latestSourceAtomicBalance: latestSourceBalance?.atomicBalance,
   });
@@ -725,24 +717,4 @@ const BridgeMarketViewContent = ({
   );
 };
 
-const BridgeMarketView = () => {
-  const sourceToken = useSelector(selectSourceToken);
-  const balanceRefreshKey = useSelector(selectBridgeBalanceRefreshKey);
-  const latestSourceBalance = useLatestBalance({
-    address: sourceToken?.address,
-    decimals: sourceToken?.decimals,
-    chainId: sourceToken?.chainId,
-    balance: sourceToken?.balance,
-    refreshKey: balanceRefreshKey,
-  });
-
-  return (
-    <BridgeQuoteDataProvider
-      latestSourceAtomicBalance={latestSourceBalance?.atomicBalance}
-    >
-      <BridgeMarketViewContent latestSourceBalance={latestSourceBalance} />
-    </BridgeQuoteDataProvider>
-  );
-};
-
-export default BridgeMarketView;
+export default BridgeMarketViewContent;

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeMarketView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeMarketView/index.tsx
@@ -20,7 +20,6 @@ import {
 import { useStyles } from '../../../../../../component-library/hooks';
 import { Box } from '@metamask/design-system-react-native';
 import { getNetworkImageSource } from '../../../../../../util/networks';
-import { useLatestBalance } from '../../../hooks/useLatestBalance';
 import {
   selectSourceAmount,
   selectSelectedDestChainId,

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
@@ -11,6 +11,9 @@ import {
   selectRecurringPriceRange,
   selectRecurringScheduleValidation,
   selectSourceToken,
+  selectRecurringEveryUnit,
+  setRecurringEveryUnit,
+  setRecurringPriceRange,
 } from '../../../../../../core/redux/slices/bridge';
 import { selectCurrentCurrency } from '../../../../../../selectors/currencyRateController';
 import type { TokenInputAreaRef } from '../../../components/TokenInputArea';
@@ -34,7 +37,6 @@ import {
   BridgeQuoteDataProvider,
   useBridgeQuoteDataContext,
 } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
-import { useLatestBalance } from '../../../hooks/useLatestBalance';
 import {
   formatPriceRangeBounds,
   isPriceRangeInCurrentCurrency,
@@ -46,18 +48,14 @@ import { useRecurringBuySwapInputs } from './useRecurringBuySwapInputs';
 import { createRecurringMockHistoryTab } from './BridgeRecurringBuyView.mockHistory';
 import { createRecurringMockOpenOrdersTab } from './BridgeRecurringBuyView.mockOpenOrders';
 import { BridgeRecurringBuyFooterView } from './BridgeRecurringBuyFooterView';
+import { useBridgeSession } from '../../../hooks/useBridgeSession';
 
-interface BridgeRecurringBuyViewContentProps {
-  latestSourceBalance: ReturnType<typeof useLatestBalance>;
-}
-
-const BridgeRecurringBuyViewContent = ({
-  latestSourceBalance,
-}: BridgeRecurringBuyViewContentProps) => {
+const BridgeRecurringBuyViewContent = () => {
   const tw = useTailwind();
   const navigation = useNavigation<AppNavigationProp>();
   const inputRef = useRef<TokenInputAreaRef>(null);
 
+  const { latestSourceBalance } = useBridgeSession();
   const {
     destToken,
     destTokenAmount,
@@ -271,26 +269,4 @@ const BridgeRecurringBuyViewContent = ({
   );
 };
 
-const BridgeRecurringBuyView = () => {
-  const sourceToken = useSelector(selectSourceToken);
-  const balanceRefreshKey = useSelector(selectBridgeBalanceRefreshKey);
-  const latestSourceBalance = useLatestBalance({
-    address: sourceToken?.address,
-    decimals: sourceToken?.decimals,
-    chainId: sourceToken?.chainId,
-    balance: sourceToken?.balance,
-    refreshKey: balanceRefreshKey,
-  });
-
-  return (
-    <BridgeQuoteDataProvider
-      latestSourceAtomicBalance={latestSourceBalance?.atomicBalance}
-    >
-      <BridgeRecurringBuyViewContent
-        latestSourceBalance={latestSourceBalance}
-      />
-    </BridgeQuoteDataProvider>
-  );
-};
-
-export default BridgeRecurringBuyView;
+export default BridgeRecurringBuyViewContent;

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.balanceFetch.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.balanceFetch.view.test.tsx
@@ -9,11 +9,14 @@ import {
 import Engine from '../../../../../core/Engine';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
+import { renderComponentViewScreen } from '../../../../../../tests/component-view/render';
 import {
-  renderComponentViewScreen,
-  renderScreenWithRoutes,
-} from '../../../../../../tests/component-view/render';
-import { renderBridgeView } from '../../../../../../tests/component-view/renderers/bridge';
+  renderBridgeView,
+  withBridgeSession,
+} from '../../../../../../tests/component-view/renderers/bridge';
+import { BridgeSessionProvider } from '../../hooks/useBridgeSession/BridgeSessionContext';
+import { SwapQuotesProvider } from '../../hooks/useSwapQuotes/SwapQuotesContext';
+import { BridgeQuoteDataProvider } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import { initialStateBridge } from '../../../../../../tests/component-view/presets/bridge';
 import { describeForPlatforms } from '../../../../../../tests/component-view/platform';
 import type { DeepPartial } from '../../../../../util/test/renderWithProvider';
@@ -36,10 +39,9 @@ import { BridgeViewSelectorsIDs } from './BridgeView.testIds';
 
 const BRIDGE_VIEW_NATIVE_SOURCE_FETCHES = 2;
 const QUOTE_MODAL_NATIVE_SOURCE_FETCHES = 1;
-const BRIDGE_VIEW_THEN_MODAL_NATIVE_SOURCE_FETCHES =
-  BRIDGE_VIEW_NATIVE_SOURCE_FETCHES + QUOTE_MODAL_NATIVE_SOURCE_FETCHES;
 
 const ModalStack = createNativeStackNavigator();
+const ScreensStack = createNativeStackNavigator();
 
 const BridgeModalsRoot = () => (
   <ModalStack.Navigator>
@@ -48,6 +50,25 @@ const BridgeModalsRoot = () => (
       component={TokenWarningModal}
     />
   </ModalStack.Navigator>
+);
+
+const BridgeViewWithTokenWarningModal = () => (
+  <BridgeSessionProvider>
+    <SwapQuotesProvider>
+      <BridgeQuoteDataProvider>
+        <ScreensStack.Navigator>
+          <ScreensStack.Screen
+            name={Routes.BRIDGE.BRIDGE_VIEW}
+            component={BridgeView}
+          />
+          <ScreensStack.Screen
+            name={Routes.BRIDGE.MODALS.ROOT}
+            component={BridgeModalsRoot}
+          />
+        </ScreensStack.Navigator>
+      </BridgeQuoteDataProvider>
+    </SwapQuotesProvider>
+  </BridgeSessionProvider>
 );
 
 const quotedBridgeControllerState = {
@@ -137,7 +158,7 @@ describeForPlatforms('Bridge native source balance fetches', () => {
     );
   });
 
-  it('fetches native source balance again when a quote modal opens over BridgeView', async () => {
+  it('does not fetch native source balance again when a quote modal opens over BridgeView', async () => {
     const state = initialStateBridge({ deterministicFiat: true })
       .withOverrides({
         bridge: {
@@ -158,15 +179,9 @@ describeForPlatforms('Bridge native source balance fetches', () => {
       } as unknown as DeepPartial<RootState>)
       .build();
 
-    const { findByTestId, findByText, getByTestId } = renderScreenWithRoutes(
-      BridgeView as unknown as React.ComponentType,
-      { name: Routes.BRIDGE.BRIDGE_VIEW },
-      [
-        {
-          name: Routes.BRIDGE.MODALS.ROOT,
-          Component: BridgeModalsRoot as unknown as React.ComponentType<object>,
-        },
-      ],
+    const { findByTestId, findByText, getByTestId } = renderComponentViewScreen(
+      BridgeViewWithTokenWarningModal,
+      { name: Routes.BRIDGE.ROOT },
       { state },
     );
 
@@ -187,7 +202,7 @@ describeForPlatforms('Bridge native source balance fetches', () => {
 
     await waitForEthGetBalanceCalls(
       ethGetBalance,
-      BRIDGE_VIEW_THEN_MODAL_NATIVE_SOURCE_FETCHES,
+      BRIDGE_VIEW_NATIVE_SOURCE_FETCHES,
     );
   });
 
@@ -225,7 +240,7 @@ describeForPlatforms('Bridge native source balance fetches', () => {
     'fetches native source balance once when $name opens',
     async ({ Component, routeName, params }) => {
       renderComponentViewScreen(
-        Component,
+        withBridgeSession(Component),
         { name: routeName },
         { state: createBridgeFlowState() },
         params,

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.balanceFetch.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.balanceFetch.view.test.tsx
@@ -14,8 +14,8 @@ import {
   renderBridgeView,
   withBridgeSession,
 } from '../../../../../../tests/component-view/renderers/bridge';
-import { BridgeSessionProvider } from '../../hooks/useBridgeSession/BridgeSessionContext';
-import { SwapQuotesProvider } from '../../hooks/useSwapQuotes/SwapQuotesContext';
+import { BridgeSessionProvider } from '../../providers/BridgeSessionProvider';
+import { SwapQuotesProvider } from '../../providers/SwapQuotesProvider';
 import { BridgeQuoteDataProvider } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import { initialStateBridge } from '../../../../../../tests/component-view/presets/bridge';
 import { describeForPlatforms } from '../../../../../../tests/component-view/platform';

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.constants.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.constants.ts
@@ -19,3 +19,9 @@ export const TAB_TO_FEATURE_ID = {
   [BridgeTabKey.Limit]: FeatureId.LIMIT_ORDER,
   [BridgeTabKey.Recurring]: FeatureId.RECURRING_BUY,
 };
+
+/**
+ * Feature IDs that have been migrated to use the SwapQuotesProvider
+ * To migrate a feature ID, add it to this list and replace the useBridgeQuoteRequest hook with useSwapQuotes.
+ */
+export const MIGRATED_FEATURE_IDS = [FeatureId.LIMIT_ORDER];

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.constants.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.constants.ts
@@ -1,3 +1,5 @@
+import { FeatureId } from '@metamask/bridge-controller';
+
 /**
  * Tabs rendered by the Bridge view. Values are used as stable keys, matched
  * against `TabsBar`'s filtered tab list by key rather than by index, since
@@ -9,3 +11,11 @@ export enum BridgeTabKey {
   Limit = 'limit',
   Recurring = 'recurring',
 }
+
+export const DEBOUNCE_WAIT = 300;
+
+export const TAB_TO_FEATURE_ID = {
+  [BridgeTabKey.Market]: FeatureId.UNIFIED_SWAP_BRIDGE,
+  [BridgeTabKey.Limit]: FeatureId.LIMIT_ORDER,
+  [BridgeTabKey.Recurring]: FeatureId.RECURRING_BUY,
+};

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -15,13 +15,12 @@ import {
   setSourceToken,
 } from '../../../../../core/redux/slices/bridge';
 import { Hex } from '@metamask/utils';
-import BridgeView from '.';
+import BridgeViewContent from '.';
 import type { BridgeRouteParams } from '../../hooks/useSwapBridgeNavigation';
 import { createBridgeTestState } from '../../testUtils';
 import { BridgeToken, BridgeViewMode, SecurityDataType } from '../../types';
 import {
   RequestStatus,
-  type QuoteResponse,
   MetaMetricsSwapsEventSource,
   QuoteStreamCompleteReason,
   TokenFeatureType,
@@ -47,6 +46,7 @@ import {
 import { useABTest } from '../../../../../hooks/useABTest';
 import { Button } from '@metamask/design-system-react-native';
 import { FEATURE_FLAG_NAME } from '../../../../../selectors/featureFlagController/rwa';
+import { BridgeSessionProvider } from '../../providers/BridgeSessionProvider';
 
 // Mock the account-tree-controller file that imports the problematic module
 jest.mock(
@@ -59,6 +59,14 @@ jest.mock(
     })),
   }),
 );
+
+jest.mock('../../hooks/useSwapQuotes', () => ({
+  useSwapQuotes: jest.fn(() => ({
+    debouncedUpdateQuoteParams: Object.assign(jest.fn(), { cancel: jest.fn() }),
+    destTokenAmount: undefined,
+    isLoading: false,
+  })),
+}));
 
 const mockState = {
   ...initialState,
@@ -408,6 +416,12 @@ jest.mock('../../hooks/useIsGasIncluded7702Supported/index.ts', () => ({
   useIsGasIncluded7702Supported: (chainId?: string) =>
     mockUseIsGasIncluded7702Supported(chainId),
 }));
+
+const BridgeView = () => (
+  <BridgeSessionProvider>
+    <BridgeViewContent />
+  </BridgeSessionProvider>
+);
 
 describe('BridgeView', () => {
   const token2Address = '0x0000000000000000000000000000000000000002' as Hex;

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   fireGestureHandler,
   getByGestureTestId,

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
@@ -1,6 +1,10 @@
 import '../../../../../../tests/component-view/mocks';
 import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
-import { renderBridgeView } from '../../../../../../tests/component-view/renderers/bridge';
+import {
+  BridgeViewWithSession as BridgeView,
+  renderBridgeView,
+  withBridgeSession,
+} from '../../../../../../tests/component-view/renderers/bridge';
 import { act, fireEvent, waitFor, within } from '@testing-library/react-native';
 import { strings } from '../../../../../../locales/i18n';
 import React from 'react';
@@ -11,7 +15,7 @@ import {
 } from '../../../../../../tests/component-view/render';
 import Routes from '../../../../../constants/navigation/Routes';
 import { initialStateBridge } from '../../../../../../tests/component-view/presets/bridge';
-import BridgeView from './index';
+import { QuoteSelectorView } from '../../components/QuoteSelectorView';
 import { describeForPlatforms } from '../../../../../../tests/component-view/platform';
 import { BridgeViewSelectorsIDs } from './BridgeView.testIds';
 import { BuildQuoteSelectors } from '../../../Ramp/Aggregator/Views/BuildQuote/BuildQuote.testIds';
@@ -828,6 +832,42 @@ describeForPlatforms('BridgeView', () => {
       (buttons[0] as unknown as { props: { isDisabled?: boolean } }).props
         .isDisabled,
     ).not.toBe(true);
+  });
+
+  it('opens quote selector from the market tab', async () => {
+    const now = Date.now();
+    const state = initialStateBridge({ deterministicFiat: true })
+      .withOverrides({
+        bridge: DEFAULT_BRIDGE,
+        engine: {
+          backgroundState: {
+            BridgeController: {
+              quotes: [mockQuoteWithMetadata],
+              recommendedQuote: mockQuoteWithMetadata,
+              quotesLastFetched: now,
+              quotesLoadingStatus: RequestStatus.FETCHED,
+              quoteFetchError: null,
+            },
+          },
+        },
+      } as unknown as DeepPartial<RootState>)
+      .build();
+
+    const { findByTestId, findByText } = renderScreenWithRoutes(
+      BridgeView,
+      { name: Routes.BRIDGE.BRIDGE_VIEW },
+      [
+        {
+          name: Routes.BRIDGE.QUOTE_SELECTOR_VIEW,
+          Component: withBridgeSession(QuoteSelectorView),
+        },
+      ],
+      { state },
+    );
+
+    fireEvent.press(await findByTestId('rate-arrow-button'));
+
+    expect(await findByText(strings('bridge.select_quote'))).toBeOnTheScreen();
   });
 
   it('stores custom slippage when user sets 5%', async () => {

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -1,10 +1,4 @@
-import React, {
-  startTransition,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, { startTransition, useCallback, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import { GestureDetector, Gesture } from 'react-native-gesture-handler';
@@ -42,18 +36,11 @@ import { BridgeViewSelectorsIDs } from './BridgeView.testIds';
 import BridgeMarketView from './BridgeMarketView';
 import BridgeLimitOrderView from './BridgeLimitOrderView';
 import BridgeRecurringBuyView from './BridgeRecurringBuyView';
+import { useBridgeSession } from '../../hooks/useBridgeSession';
 
 const BridgeView = () => {
-  // `selectedTab` drives the tabs bar and updates urgently so a press is
-  // acknowledged on the same frame. `renderedTab` swaps the content, which is
-  // expensive enough to drop frames, so it is deferred to a transition instead
-  // of holding up that feedback.
-  const [selectedTab, setSelectedTab] = useState<BridgeTabKey>(
-    BridgeTabKey.Market,
-  );
-  const [renderedTab, setRenderedTab] = useState<BridgeTabKey>(
-    BridgeTabKey.Market,
-  );
+  const { selectedTab, renderedTab, setSelectedTab, setRenderedTab } =
+    useBridgeSession();
   const navigation = useNavigation<AppNavigationProp>();
   const dispatch = useDispatch();
   const bridgeViewMode = useSelector(selectBridgeViewMode);

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -140,7 +140,7 @@ const BridgeView = () => {
       setSelectedTab(nextTab);
       startTransition(() => setRenderedTab(nextTab));
     },
-    [tabs],
+    [tabs, setRenderedTab, setSelectedTab],
   );
 
   const goToPreviousTab = useCallback(() => {
@@ -187,7 +187,7 @@ const BridgeView = () => {
       setSelectedTab(BridgeTabKey.Market);
       setRenderedTab(BridgeTabKey.Market);
     }
-  }, [tabs, renderedTab]);
+  }, [tabs, renderedTab, setRenderedTab, setSelectedTab]);
 
   // Stops any in-flight BridgeController quote polling, clears the amount
   // inputs and drops the destination token for the tab being left, whenever

--- a/app/components/UI/Bridge/components/LimitOrderDetails/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/index.test.tsx
@@ -17,7 +17,7 @@ import type { LimitOrderDetailsProps } from './types';
 /**
  * Unit fallback: LimitOrderDetails is a nested card, not a screen. Visibility
  * depends on quote context that component-view tests would need the full
- * BridgeQuoteDataProvider and quote fetch to drive.
+ * SwapQuotesProvider and quote fetch to drive.
  */
 jest.mock('../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => ({
   useBridgeQuoteDataContext: jest.fn(),

--- a/app/components/UI/Bridge/components/MissingPriceModal/MissingPriceModal.test.tsx
+++ b/app/components/UI/Bridge/components/MissingPriceModal/MissingPriceModal.test.tsx
@@ -3,9 +3,8 @@ import { fireEvent, waitFor } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { MissingPriceModal } from './index';
 import { useParams } from '../../../../../util/navigation/navUtils';
-import { useLatestBalance } from '../../hooks/useLatestBalance';
 import { useBridgeConfirm } from '../../hooks/useBridgeConfirm';
-import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
+import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import { useSelector } from 'react-redux';
 import { selectSourceToken } from '../../../../../core/redux/slices/bridge';
 import { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
@@ -53,16 +52,12 @@ jest.mock('../../../../../util/navigation/navUtils', () => ({
   useParams: jest.fn(),
 }));
 
-jest.mock('../../hooks/useLatestBalance', () => ({
-  useLatestBalance: jest.fn().mockReturnValue(undefined),
-}));
-
 jest.mock('../../hooks/useBridgeConfirm', () => ({
   useBridgeConfirm: jest.fn(),
 }));
 
-jest.mock('../../hooks/useBridgeQuoteData', () => ({
-  useBridgeQuoteData: jest.fn(),
+jest.mock('../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => ({
+  useBridgeQuoteDataContext: jest.fn(),
 }));
 
 jest.mock('react-redux', () => ({
@@ -76,14 +71,11 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 const mockUseParams = useParams as jest.MockedFunction<typeof useParams>;
-const mockUseLatestBalance = useLatestBalance as jest.MockedFunction<
-  typeof useLatestBalance
->;
 const mockUseBridgeConfirm = useBridgeConfirm as jest.MockedFunction<
   typeof useBridgeConfirm
 >;
-const mockUseBridgeQuoteData = useBridgeQuoteData as jest.MockedFunction<
-  typeof useBridgeQuoteData
+const mockUseBridgeQuoteData = useBridgeQuoteDataContext as jest.MockedFunction<
+  typeof useBridgeQuoteDataContext
 >;
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
@@ -109,10 +101,9 @@ describe('MissingPriceModal', () => {
     mockUseParams.mockReturnValue({
       location: MetaMetricsSwapsEventSource.MainView,
     });
-    mockUseLatestBalance.mockReturnValue(undefined);
     mockUseBridgeQuoteData.mockReturnValue({
       activeQuote: mockQuoteWithMetadata,
-    } as ReturnType<typeof useBridgeQuoteData>);
+    } as ReturnType<typeof useBridgeQuoteDataContext>);
     mockUseBridgeConfirm.mockReturnValue(mockConfirmBridge);
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectSourceToken) {

--- a/app/components/UI/Bridge/components/MissingPriceModal/index.tsx
+++ b/app/components/UI/Bridge/components/MissingPriceModal/index.tsx
@@ -1,14 +1,11 @@
 import React, { useCallback, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
 import { strings } from '../../../../../../locales/i18n';
 import { useParams } from '../../../../../util/navigation/navUtils';
-import { useLatestBalance } from '../../hooks/useLatestBalance';
 import { useBridgeConfirm } from '../../hooks/useBridgeConfirm';
-import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
-import { selectSourceToken } from '../../../../../core/redux/slices/bridge';
+import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import {
   BottomSheet,
   BottomSheetFooter,
@@ -35,15 +32,7 @@ export const MissingPriceModal = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const [loading, setLoading] = useState(false);
   const { location } = useParams<MissingPriceModalParams>();
-  const sourceToken = useSelector(selectSourceToken);
-  const tokenBalance = useLatestBalance({
-    address: sourceToken?.address,
-    decimals: sourceToken?.decimals,
-    chainId: sourceToken?.chainId,
-  });
-  const { activeQuote } = useBridgeQuoteData({
-    latestSourceAtomicBalance: tokenBalance?.atomicBalance,
-  });
+  const { activeQuote } = useBridgeQuoteDataContext();
 
   const confirmBridge = useBridgeConfirm({
     activeQuote,

--- a/app/components/UI/Bridge/components/PriceImpactModal/index.test.tsx
+++ b/app/components/UI/Bridge/components/PriceImpactModal/index.test.tsx
@@ -131,16 +131,12 @@ jest.mock('../../../../../util/navigation/navUtils', () => ({
   useParams: jest.fn(),
 }));
 
-jest.mock('../../hooks/useLatestBalance', () => ({
-  useLatestBalance: jest.fn(),
-}));
-
 jest.mock('../../hooks/useBridgeConfirm', () => ({
   useBridgeConfirm: jest.fn(),
 }));
 
-jest.mock('../../hooks/useBridgeQuoteData', () => ({
-  useBridgeQuoteData: jest.fn(),
+jest.mock('../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => ({
+  useBridgeQuoteDataContext: jest.fn(),
 }));
 
 jest.mock('../../hooks/usePriceImpactViewData', () => ({
@@ -149,23 +145,19 @@ jest.mock('../../hooks/usePriceImpactViewData', () => ({
 
 import { useSelector } from 'react-redux';
 import { useParams } from '../../../../../util/navigation/navUtils';
-import { useLatestBalance } from '../../hooks/useLatestBalance';
 import { useBridgeConfirm } from '../../hooks/useBridgeConfirm';
-import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
+import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import { usePriceImpactViewData } from '../../hooks/usePriceImpactViewData';
 import { PriceImpactHeader } from './PriceImpactHeader';
 import { PriceImpactDescription } from './PriceImpactDescription';
 import { PriceImpactFooter } from './PriceImpactFooter';
 
 const mockUseParams = useParams as jest.MockedFunction<typeof useParams>;
-const mockUseLatestBalance = useLatestBalance as jest.MockedFunction<
-  typeof useLatestBalance
->;
 const mockUseBridgeConfirm = useBridgeConfirm as jest.MockedFunction<
   typeof useBridgeConfirm
 >;
-const mockUseBridgeQuoteData = useBridgeQuoteData as jest.MockedFunction<
-  typeof useBridgeQuoteData
+const mockUseBridgeQuoteData = useBridgeQuoteDataContext as jest.MockedFunction<
+  typeof useBridgeQuoteDataContext
 >;
 const mockUsePriceImpactViewData =
   usePriceImpactViewData as jest.MockedFunction<typeof usePriceImpactViewData>;
@@ -207,11 +199,10 @@ describe('PriceImpactModal', () => {
   beforeEach(() => {
     mockUseSelector.mockReturnValue(undefined);
     mockUseParams.mockReturnValue(defaultParams);
-    mockUseLatestBalance.mockReturnValue(undefined);
     mockUseBridgeConfirm.mockReturnValue(mockConfirmBridge);
     mockUseBridgeQuoteData.mockReturnValue({
       formattedQuoteData: undefined,
-    } as ReturnType<typeof useBridgeQuoteData>);
+    } as ReturnType<typeof useBridgeQuoteDataContext>);
     mockUsePriceImpactViewData.mockReturnValue(
       defaultViewData as ReturnType<typeof usePriceImpactViewData>,
     );
@@ -284,7 +275,7 @@ describe('PriceImpactModal', () => {
     it('passes formattedPriceImpact to PriceImpactDescription when formattedQuoteData has it', () => {
       mockUseBridgeQuoteData.mockReturnValue({
         formattedQuoteData: { priceImpact: '5%' },
-      } as ReturnType<typeof useBridgeQuoteData>);
+      } as ReturnType<typeof useBridgeQuoteDataContext>);
 
       render(<PriceImpactModal />);
 
@@ -297,7 +288,7 @@ describe('PriceImpactModal', () => {
     it('passes undefined formattedPriceImpact to PriceImpactDescription when formattedQuoteData is absent', () => {
       mockUseBridgeQuoteData.mockReturnValue({
         formattedQuoteData: undefined,
-      } as ReturnType<typeof useBridgeQuoteData>);
+      } as ReturnType<typeof useBridgeQuoteDataContext>);
 
       render(<PriceImpactModal />);
 
@@ -310,7 +301,7 @@ describe('PriceImpactModal', () => {
     it('passes formattedPriceImpactFiat to PriceImpactDescription when formattedQuoteData has it', () => {
       mockUseBridgeQuoteData.mockReturnValue({
         formattedQuoteData: { priceImpact: '5%', priceImpactFiat: '$3.50' },
-      } as ReturnType<typeof useBridgeQuoteData>);
+      } as ReturnType<typeof useBridgeQuoteDataContext>);
 
       render(<PriceImpactModal />);
 
@@ -323,7 +314,7 @@ describe('PriceImpactModal', () => {
     it('passes undefined formattedPriceImpactFiat when formattedQuoteData is absent', () => {
       mockUseBridgeQuoteData.mockReturnValue({
         formattedQuoteData: undefined,
-      } as ReturnType<typeof useBridgeQuoteData>);
+      } as ReturnType<typeof useBridgeQuoteDataContext>);
 
       render(<PriceImpactModal />);
 
@@ -339,7 +330,7 @@ describe('PriceImpactModal', () => {
           quote: { priceData: { priceImpact: { amount: '0.96' } } },
         },
         formattedQuoteData: { priceImpact: '96%', priceImpactFiat: '$7.05' },
-      } as ReturnType<typeof useBridgeQuoteData>);
+      } as ReturnType<typeof useBridgeQuoteDataContext>);
 
       render(<PriceImpactModal />);
 
@@ -355,7 +346,7 @@ describe('PriceImpactModal', () => {
           quote: { priceData: { priceImpact: { amount: '0.05' } } },
         },
         formattedQuoteData: { priceImpact: '5%', priceImpactFiat: '$0.50' },
-      } as ReturnType<typeof useBridgeQuoteData>);
+      } as ReturnType<typeof useBridgeQuoteDataContext>);
 
       render(<PriceImpactModal />);
 
@@ -441,16 +432,6 @@ describe('PriceImpactModal', () => {
   });
 
   describe('hook wiring', () => {
-    it('passes token address, decimals, and chainId to useLatestBalance', () => {
-      render(<PriceImpactModal />);
-
-      expect(mockUseLatestBalance).toHaveBeenCalledWith({
-        address: mockToken.address,
-        decimals: mockToken.decimals,
-        chainId: mockToken.chainId,
-      });
-    });
-
     it('passes location to useBridgeConfirm', () => {
       render(<PriceImpactModal />);
 
@@ -467,7 +448,7 @@ describe('PriceImpactModal', () => {
           quote: { priceData: { priceImpact: { amount: '0.12' } } },
         },
         formattedQuoteData: { priceImpact: '12%' },
-      } as ReturnType<typeof useBridgeQuoteData>);
+      } as ReturnType<typeof useBridgeQuoteDataContext>);
 
       render(<PriceImpactModal />);
 
@@ -478,7 +459,7 @@ describe('PriceImpactModal', () => {
       mockUseBridgeQuoteData.mockReturnValue({
         activeQuote: undefined,
         formattedQuoteData: undefined,
-      } as ReturnType<typeof useBridgeQuoteData>);
+      } as ReturnType<typeof useBridgeQuoteDataContext>);
 
       render(<PriceImpactModal />);
 

--- a/app/components/UI/Bridge/components/PriceImpactModal/index.tsx
+++ b/app/components/UI/Bridge/components/PriceImpactModal/index.tsx
@@ -1,13 +1,12 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
-import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
+import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import { PriceImpactModalRouterParams } from './types';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { PriceImpactHeader } from './PriceImpactHeader';
 import { PriceImpactDescription } from './PriceImpactDescription';
 import { PriceImpactFooter } from './PriceImpactFooter';
-import { useLatestBalance } from '../../hooks/useLatestBalance';
 import { useBridgeConfirm } from '../../hooks/useBridgeConfirm';
 import { usePriceImpactViewData } from '../../hooks/usePriceImpactViewData';
 import {
@@ -25,17 +24,10 @@ export const PriceImpactModal = () => {
   const { goBack } = useNavigation<AppNavigationProp>();
   const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
   const [loading, setLoading] = useState(false);
-  const { type, token, location } = useParams<PriceImpactModalRouterParams>();
+  const { type, location } = useParams<PriceImpactModalRouterParams>();
   const sheetRef = useRef<BottomSheetRef>(null);
-  const tokenBalance = useLatestBalance({
-    address: token?.address,
-    decimals: token?.decimals,
-    chainId: token?.chainId,
-  });
 
-  const { formattedQuoteData, activeQuote } = useBridgeQuoteData({
-    latestSourceAtomicBalance: tokenBalance?.atomicBalance,
-  });
+  const { formattedQuoteData, activeQuote } = useBridgeQuoteDataContext();
   const confirmBridge = useBridgeConfirm({
     activeQuote,
     location,

--- a/app/components/UI/Bridge/components/QuoteSelectorView/index.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/index.test.tsx
@@ -22,13 +22,13 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 const mockUseBridgeQuoteData = jest.fn();
-jest.mock('../../hooks/useBridgeQuoteData', () => ({
-  useBridgeQuoteData: () => mockUseBridgeQuoteData(),
+jest.mock('../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => ({
+  useBridgeQuoteDataContext: () => mockUseBridgeQuoteData(),
 }));
 
-const mockUseLatestBalance = jest.fn();
-jest.mock('../../hooks/useLatestBalance', () => ({
-  useLatestBalance: (params: unknown) => mockUseLatestBalance(params),
+const mockUseBridgeSession = jest.fn();
+jest.mock('../../hooks/useBridgeSession', () => ({
+  useBridgeSession: () => mockUseBridgeSession(),
 }));
 
 const mockFormatFiat = jest.fn();
@@ -205,7 +205,9 @@ describe('QuoteSelectorView', () => {
       quoteFetchError: null,
       isExpired: false,
     });
-    mockUseLatestBalance.mockReturnValue(mockLatestBalance);
+    mockUseBridgeSession.mockReturnValue({
+      latestSourceBalance: mockLatestBalance,
+    });
     mockFormatFiat.mockReturnValue('$2,020.00');
     mockIsGaslessQuote.mockReturnValue(false);
     mockUseTrackAllQuotesSortedEvent.mockReturnValue(
@@ -324,33 +326,6 @@ describe('QuoteSelectorView', () => {
       const { getByTestId } = render(<QuoteSelectorView />);
 
       expect(getByTestId('quote-list')).toBeTruthy();
-    });
-  });
-
-  describe('useLatestBalance integration', () => {
-    it('calls useLatestBalance hook with correct parameters', () => {
-      render(<QuoteSelectorView />);
-
-      expect(mockUseLatestBalance).toHaveBeenCalledWith({
-        address: mockSourceToken.address,
-        decimals: mockSourceToken.decimals,
-        chainId: mockSourceToken.chainId,
-      });
-    });
-
-    it('uses latestBalance in quote data', () => {
-      mockUseBridgeQuoteData.mockReturnValue({
-        validQuotes: [mockQuote],
-        bestQuote: mockQuote,
-        isLoading: false,
-        blockaidError: null,
-        quoteFetchError: null,
-        isExpired: false,
-      });
-
-      render(<QuoteSelectorView />);
-
-      expect(mockUseLatestBalance).toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Bridge/components/QuoteSelectorView/index.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/index.tsx
@@ -17,15 +17,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
   selectDestToken,
   selectSelectedQuoteRequestId,
-  selectSourceToken,
   setSelectedQuoteRequestId,
 } from '../../../../../core/redux/slices/bridge';
-import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
+import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import { BigNumber } from 'bignumber.js';
 import { QuoteList } from './QuoteList';
 import { QuoteRowProps } from './QuoteRow';
 import { isGaslessQuote } from '../../utils/isGaslessQuote';
-import { useLatestBalance } from '../../hooks/useLatestBalance';
 import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
 import formatFiat from '../../../../../util/formatFiat';
 import { startCase } from 'lodash';
@@ -33,6 +31,7 @@ import { QUOTES_PLACEHOLDER_DATA } from './constants';
 import { useTrackAllQuotesSortedEvent } from '../../hooks/useTrackAllQuotesSortedEvent';
 import { fromTokenMinimalUnit } from '../../../../../util/number';
 import { sumAmounts } from '@metamask/bridge-controller';
+import { useBridgeSession } from '../../hooks/useBridgeSession';
 
 export const QuoteSelectorView = () => {
   const { styles } = useStyles(createStyles, {});
@@ -41,14 +40,9 @@ export const QuoteSelectorView = () => {
   const selectedQuoteRequestId = useSelector(selectSelectedQuoteRequestId);
   const currency = useSelector(selectCurrentCurrency);
   const { validQuotes, bestQuote, isLoading, blockaidError, quoteFetchError } =
-    useBridgeQuoteData();
-  const sourceToken = useSelector(selectSourceToken);
+    useBridgeQuoteDataContext();
+  const { latestSourceBalance } = useBridgeSession();
   const destToken = useSelector(selectDestToken);
-  const latestSourceBalance = useLatestBalance({
-    address: sourceToken?.address,
-    decimals: sourceToken?.decimals,
-    chainId: sourceToken?.chainId,
-  });
 
   const trackAllQuotesSortedEvent =
     useTrackAllQuotesSortedEvent(latestSourceBalance);

--- a/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.test.tsx
+++ b/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.test.tsx
@@ -8,7 +8,8 @@ import { Hex } from '@metamask/utils';
 import { mockUseBridgeQuoteData } from '../../_mocks_/useBridgeQuoteData.mock';
 import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
 import { BRIDGE_MM_FEE_RATE } from '@metamask/bridge-controller';
-import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
+import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import { useBridgeSession } from '../../hooks/useBridgeSession';
 import { useHasSufficientGas } from '../../hooks/useHasSufficientGas';
 import { createBridgeTestState } from '../../testUtils';
 import type { RootState } from '../../../../../reducers';
@@ -46,23 +47,16 @@ jest.mock('@metamask/design-system-react-native', () => {
   };
 });
 
-jest.mock('../../hooks/useBridgeQuoteData', () => ({
-  useBridgeQuoteData: jest
-    .fn()
-    .mockImplementation(() => mockUseBridgeQuoteData),
+jest.mock('../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => ({
+  useBridgeQuoteDataContext: jest.fn(),
 }));
-
-jest.mock('../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => {
-  const { useBridgeQuoteData: useQuotedData } = jest.requireMock(
-    '../../hooks/useBridgeQuoteData',
-  );
-  return {
-    useBridgeQuoteDataContext: jest.fn(() => useQuotedData()),
-  };
-});
 
 jest.mock('../../hooks/useHasSufficientGas', () => ({
   useHasSufficientGas: jest.fn(() => true),
+}));
+
+jest.mock('../../hooks/useBridgeSession', () => ({
+  useBridgeSession: jest.fn(),
 }));
 
 function buildState(
@@ -115,9 +109,11 @@ function renderSheet({
     | { displayBalance: string; atomicBalance: BigNumber }
     | undefined;
 } = {}) {
+  jest.mocked(useBridgeSession).mockReturnValue({
+    latestSourceBalance,
+  } as ReturnType<typeof useBridgeSession>);
   return renderWithProvider(
     <RecurringConfirmOrderSheet
-      latestSourceBalance={latestSourceBalance}
       onEditSlippagePress={onEditSlippagePress}
       goBack={goBack}
     />,
@@ -129,7 +125,7 @@ describe('RecurringConfirmOrderSheet', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest
-      .mocked(useBridgeQuoteData as unknown as jest.Mock)
+      .mocked(useBridgeQuoteDataContext as unknown as jest.Mock)
       .mockImplementation(() => ({
         ...mockUseBridgeQuoteData,
         destTokenAmount: '24.44',
@@ -194,7 +190,7 @@ describe('RecurringConfirmOrderSheet', () => {
     const repeat = 10;
 
     jest
-      .mocked(useBridgeQuoteData as unknown as jest.Mock)
+      .mocked(useBridgeQuoteDataContext as unknown as jest.Mock)
       .mockImplementation(() => ({
         ...mockUseBridgeQuoteData,
         destTokenAmount,
@@ -286,7 +282,7 @@ describe('RecurringConfirmOrderSheet', () => {
 
   it('shows skeletons for quote-dependent values while a quote is loading', () => {
     jest
-      .mocked(useBridgeQuoteData as unknown as jest.Mock)
+      .mocked(useBridgeQuoteDataContext as unknown as jest.Mock)
       .mockImplementation(() => ({
         ...mockUseBridgeQuoteData,
         isLoading: true,
@@ -332,7 +328,7 @@ describe('RecurringConfirmOrderSheet', () => {
 
   it('keeps paying, receiving, expiry, and slippage populated while a quote is loading', () => {
     jest
-      .mocked(useBridgeQuoteData as unknown as jest.Mock)
+      .mocked(useBridgeQuoteDataContext as unknown as jest.Mock)
       .mockImplementation(() => ({
         ...mockUseBridgeQuoteData,
         isLoading: true,
@@ -369,7 +365,7 @@ describe('RecurringConfirmOrderSheet', () => {
 
   it('shows placeholders for est receiving and network fee when there is no quote', () => {
     jest
-      .mocked(useBridgeQuoteData as unknown as jest.Mock)
+      .mocked(useBridgeQuoteDataContext as unknown as jest.Mock)
       .mockImplementation(() => ({
         ...mockUseBridgeQuoteData,
         isLoading: false,
@@ -422,7 +418,7 @@ describe('RecurringConfirmOrderSheet', () => {
 
   it('shows the discounted fee disclaimer when the quote has a promo discount', () => {
     jest
-      .mocked(useBridgeQuoteData as unknown as jest.Mock)
+      .mocked(useBridgeQuoteDataContext as unknown as jest.Mock)
       .mockImplementation(() => ({
         ...mockUseBridgeQuoteData,
         destTokenAmount: '24.44',
@@ -458,7 +454,7 @@ describe('RecurringConfirmOrderSheet', () => {
 
   it('shows the no MetaMask fee disclaimer when dest fee is zero', () => {
     jest
-      .mocked(useBridgeQuoteData as unknown as jest.Mock)
+      .mocked(useBridgeQuoteDataContext as unknown as jest.Mock)
       .mockImplementation(() => ({
         ...mockUseBridgeQuoteData,
         destTokenAmount: '24.44',

--- a/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.tsx
+++ b/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.tsx
@@ -51,6 +51,7 @@ import RewardsVipBadge from '../../../Rewards/components/RewardsVipBadge';
 import { RewardsDiscountBadge } from '../../../Rewards/components/RewardsDiscountBadge';
 import { RecurringConfirmOrderSheetSelectorsIDs } from './RecurringConfirmOrderSheet.testIds';
 import type { RecurringConfirmOrderSheetProps } from './RecurringConfirmOrderSheet.types';
+import { useBridgeSession } from '../../hooks/useBridgeSession';
 
 const QUOTE_VALUE_SKELETON_WIDTH = 72;
 const QUOTE_VALUE_SKELETON_HEIGHT = 20;
@@ -166,7 +167,6 @@ function formatTokenAmountValue(
 }
 
 const RecurringConfirmOrderSheet = ({
-  latestSourceBalance,
   onEditSlippagePress,
   goBack,
 }: RecurringConfirmOrderSheetProps) => {
@@ -178,6 +178,7 @@ const RecurringConfirmOrderSheet = ({
   const slippage = useSelector(selectSlippage);
   const { activeQuote, destTokenAmount, formattedQuoteData, isLoading } =
     useBridgeQuoteDataContext();
+  const { latestSourceBalance } = useBridgeSession();
   const hasInsufficientBalance = useIsInsufficientBalance({
     amount: sourceAmount,
     token: sourceToken,

--- a/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.types.ts
+++ b/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.types.ts
@@ -1,7 +1,4 @@
-import { useLatestBalance } from '../../hooks/useLatestBalance';
-
 export interface RecurringConfirmOrderSheetProps {
-  latestSourceBalance: ReturnType<typeof useLatestBalance>;
   onEditSlippagePress: () => void;
   goBack: () => void;
 }

--- a/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheetScreen.tsx
+++ b/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheetScreen.tsx
@@ -4,26 +4,16 @@ import { useSelector } from 'react-redux';
 import Routes from '../../../../../constants/navigation/Routes';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import {
-  selectBridgeBalanceRefreshKey,
   selectDestToken,
   selectSourceToken,
 } from '../../../../../core/redux/slices/bridge';
 import { BridgeQuoteDataProvider } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
-import { useLatestBalance } from '../../hooks/useLatestBalance';
 import RecurringConfirmOrderSheet from './RecurringConfirmOrderSheet';
 
 export const RecurringConfirmOrderSheetScreen = () => {
   const navigation = useNavigation<AppNavigationProp>();
   const sourceToken = useSelector(selectSourceToken);
   const destToken = useSelector(selectDestToken);
-  const balanceRefreshKey = useSelector(selectBridgeBalanceRefreshKey);
-  const latestSourceBalance = useLatestBalance({
-    address: sourceToken?.address,
-    decimals: sourceToken?.decimals,
-    chainId: sourceToken?.chainId,
-    balance: sourceToken?.balance,
-    refreshKey: balanceRefreshKey,
-  });
 
   const handleEditSlippagePress = useCallback(() => {
     navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
@@ -36,11 +26,8 @@ export const RecurringConfirmOrderSheetScreen = () => {
   }, [destToken?.chainId, navigation, sourceToken?.chainId]);
 
   return (
-    <BridgeQuoteDataProvider
-      latestSourceAtomicBalance={latestSourceBalance?.atomicBalance}
-    >
+    <BridgeQuoteDataProvider>
       <RecurringConfirmOrderSheet
-        latestSourceBalance={latestSourceBalance}
         onEditSlippagePress={handleEditSlippagePress}
         goBack={navigation.goBack}
       />

--- a/app/components/UI/Bridge/components/TokenWarningModal/TokenWarningModal.test.tsx
+++ b/app/components/UI/Bridge/components/TokenWarningModal/TokenWarningModal.test.tsx
@@ -31,16 +31,12 @@ jest.mock('../../../../../util/navigation/navUtils', () => ({
   useParams: jest.fn(),
 }));
 
-jest.mock('../../hooks/useLatestBalance', () => ({
-  useLatestBalance: jest.fn().mockReturnValue(undefined),
-}));
-
 jest.mock('../../hooks/useBridgeConfirm', () => ({
   useBridgeConfirm: jest.fn(),
 }));
 
-jest.mock('../../hooks/useBridgeQuoteData', () => ({
-  useBridgeQuoteData: jest.fn(),
+jest.mock('../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => ({
+  useBridgeQuoteDataContext: jest.fn(),
 }));
 
 jest.mock('react-redux', () => ({
@@ -59,9 +55,8 @@ jest.mock('../../../../../util/remoteFeatureFlag', () => ({
 }));
 
 import { useParams } from '../../../../../util/navigation/navUtils';
-import { useLatestBalance } from '../../hooks/useLatestBalance';
 import { useBridgeConfirm } from '../../hooks/useBridgeConfirm';
-import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
+import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import { useSelector } from 'react-redux';
 import {
   selectSourceToken,
@@ -72,14 +67,11 @@ import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { Hex } from '@metamask/utils';
 
 const mockUseParams = useParams as jest.MockedFunction<typeof useParams>;
-const mockUseLatestBalance = useLatestBalance as jest.MockedFunction<
-  typeof useLatestBalance
->;
 const mockUseBridgeConfirm = useBridgeConfirm as jest.MockedFunction<
   typeof useBridgeConfirm
 >;
-const mockUseBridgeQuoteData = useBridgeQuoteData as jest.MockedFunction<
-  typeof useBridgeQuoteData
+const mockUseBridgeQuoteData = useBridgeQuoteDataContext as jest.MockedFunction<
+  typeof useBridgeQuoteDataContext
 >;
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
@@ -113,7 +105,7 @@ const mockActiveQuote = {
   },
 } as unknown as QuoteResponse;
 
-const defaultBridgeQuoteData: ReturnType<typeof useBridgeQuoteData> = {
+const defaultBridgeQuoteData: ReturnType<typeof useBridgeQuoteDataContext> = {
   bestQuote: null,
   quoteFetchError: null,
   activeQuote: undefined,
@@ -160,7 +152,6 @@ describe('TokenWarningModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseParams.mockReturnValue(defaultWarningParams);
-    mockUseLatestBalance.mockReturnValue(undefined);
     mockUseBridgeConfirm.mockReturnValue(mockConfirmBridge);
     mockUseBridgeQuoteData.mockReturnValue({
       ...defaultBridgeQuoteData,
@@ -387,7 +378,7 @@ describe('TokenWarningModal', () => {
         activeQuote: {
           quote: { priceData: { priceImpact: undefined } },
         },
-      } as unknown as ReturnType<typeof useBridgeQuoteData>);
+      } as unknown as ReturnType<typeof useBridgeQuoteDataContext>);
 
       const { getByTestId } = renderModal();
       fireEvent.press(getByTestId('footer-secondary-button'));
@@ -408,7 +399,7 @@ describe('TokenWarningModal', () => {
         activeQuote: {
           quote: { priceData: undefined },
         },
-      } as unknown as ReturnType<typeof useBridgeQuoteData>);
+      } as unknown as ReturnType<typeof useBridgeQuoteDataContext>);
 
       const { getByTestId } = renderModal();
       fireEvent.press(getByTestId('footer-secondary-button'));
@@ -431,7 +422,7 @@ describe('TokenWarningModal', () => {
             priceData: { priceImpact: { amount: '0.25' } }, // exactly at threshold
           },
         },
-      } as unknown as ReturnType<typeof useBridgeQuoteData>);
+      } as unknown as ReturnType<typeof useBridgeQuoteDataContext>);
 
       const { getByTestId } = renderModal();
       fireEvent.press(getByTestId('footer-secondary-button'));
@@ -455,7 +446,7 @@ describe('TokenWarningModal', () => {
             priceData: { priceImpact: { amount: '0.90' } },
           },
         },
-      } as unknown as ReturnType<typeof useBridgeQuoteData>);
+      } as unknown as ReturnType<typeof useBridgeQuoteDataContext>);
 
       const { getByTestId } = renderModal();
       fireEvent.press(getByTestId('footer-secondary-button'));
@@ -481,7 +472,7 @@ describe('TokenWarningModal', () => {
             priceData: { priceImpact: { amount: '0.40' } },
           },
         },
-      } as unknown as ReturnType<typeof useBridgeQuoteData>);
+      } as unknown as ReturnType<typeof useBridgeQuoteDataContext>);
 
       const { getByTestId } = renderModal();
       fireEvent.press(getByTestId('footer-secondary-button'));

--- a/app/components/UI/Bridge/components/TokenWarningModal/index.tsx
+++ b/app/components/UI/Bridge/components/TokenWarningModal/index.tsx
@@ -11,9 +11,8 @@ import BottomSheet, {
 import { strings } from '../../../../../../locales/i18n';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { TokenWarningModalMode } from './constants';
-import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
+import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import { useBridgeConfirm } from '../../hooks/useBridgeConfirm';
-import { useLatestBalance } from '../../hooks/useLatestBalance';
 import {
   selectSourceToken,
   selectDestToken,
@@ -105,14 +104,7 @@ export const TokenWarningModal = () => {
   const destToken = useSelector(selectDestToken);
   const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
 
-  const tokenBalance = useLatestBalance({
-    address: sourceToken?.address,
-    decimals: sourceToken?.decimals,
-    chainId: sourceToken?.chainId,
-  });
-  const { activeQuote } = useBridgeQuoteData({
-    latestSourceAtomicBalance: tokenBalance?.atomicBalance,
-  });
+  const { activeQuote } = useBridgeQuoteDataContext();
 
   const confirmBridge = useBridgeConfirm({
     activeQuote,

--- a/app/components/UI/Bridge/hooks/useBridgeConfirm/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeConfirm/index.ts
@@ -1,5 +1,4 @@
 import { useDispatch, useSelector } from 'react-redux';
-import type { useBridgeQuoteData } from '../useBridgeQuoteData';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import {

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/BridgeQuoteDataContext.test.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/BridgeQuoteDataContext.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { BigNumber } from 'ethers';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import {
   BridgeQuoteDataProvider,
@@ -41,11 +40,11 @@ jest.mock('../../../../../util/notifications/methods/common', () => ({
   })),
 }));
 
-jest.mock('../../hooks/useSwapsFeatureId', () => ({
+jest.mock('../useSwapsFeatureId', () => ({
   useSwapsFeatureId: jest.fn(),
 }));
 
-jest.mock('../hooks/useBridgeSession', () => ({
+jest.mock('../useBridgeSession', () => ({
   useBridgeSession: jest.fn(),
 }));
 
@@ -70,4 +69,6 @@ runQuoteProviderCases({
       { state },
     ),
   renderWithoutProvider: () => renderWithProvider(<Consumer />),
+  featureId: FeatureId.UNIFIED_SWAP_BRIDGE,
+  quoteParams: {},
 });

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/BridgeQuoteDataContext.test.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/BridgeQuoteDataContext.test.tsx
@@ -6,6 +6,7 @@ import {
   useBridgeQuoteDataContext,
 } from './BridgeQuoteDataContext';
 import { runQuoteProviderCases } from './runQuoteProviderCases';
+import { FeatureId } from '@metamask/bridge-controller';
 
 jest.mock('../../../../../util/remoteFeatureFlag', () => ({
   hasMinimumRequiredVersion: jest.fn(() => true),
@@ -40,6 +41,14 @@ jest.mock('../../../../../util/notifications/methods/common', () => ({
   })),
 }));
 
+jest.mock('../../hooks/useSwapsFeatureId', () => ({
+  useSwapsFeatureId: jest.fn(),
+}));
+
+jest.mock('../hooks/useBridgeSession', () => ({
+  useBridgeSession: jest.fn(),
+}));
+
 const Consumer = () => {
   useBridgeQuoteDataContext();
   return null;
@@ -51,9 +60,7 @@ runQuoteProviderCases({
     'useBridgeQuoteDataContext must be used within BridgeQuoteDataProvider',
   renderProvider: (state) =>
     renderWithProvider(
-      <BridgeQuoteDataProvider
-        latestSourceAtomicBalance={BigNumber.from('1000000000')}
-      >
+      <BridgeQuoteDataProvider>
         <Consumer />
         <Consumer />
         <Consumer />

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/BridgeQuoteDataContext.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/BridgeQuoteDataContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext } from 'react';
 import { BigNumber as EthersBigNumber } from 'ethers';
 import { useBridgeQuoteData } from './index';
+import { useBridgeSession } from '../useBridgeSession';
 
 type BridgeQuoteDataContextValue = ReturnType<typeof useBridgeQuoteData>;
 
@@ -14,10 +15,10 @@ interface BridgeQuoteDataProviderProps {
 
 export function BridgeQuoteDataProvider({
   children,
-  latestSourceAtomicBalance,
 }: BridgeQuoteDataProviderProps) {
+  const { latestSourceBalance } = useBridgeSession();
   const value = useBridgeQuoteData({
-    latestSourceAtomicBalance,
+    latestSourceAtomicBalance: latestSourceBalance?.atomicBalance,
   });
 
   return (

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/BridgeQuoteDataContext.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/BridgeQuoteDataContext.tsx
@@ -1,6 +1,8 @@
 import React, { createContext, useContext } from 'react';
-import { BigNumber as EthersBigNumber } from 'ethers';
 import { useBridgeQuoteData } from './index';
+import { useSwapQuotes } from '../useSwapQuotes';
+import { useSwapsFeatureId } from '../useSwapsFeatureId';
+import { MIGRATED_FEATURE_IDS } from '../../Views/BridgeView/BridgeView.constants';
 import { useBridgeSession } from '../useBridgeSession';
 
 type BridgeQuoteDataContextValue = ReturnType<typeof useBridgeQuoteData>;
@@ -10,15 +12,16 @@ const BridgeQuoteDataContext =
 
 interface BridgeQuoteDataProviderProps {
   children: React.ReactNode;
-  latestSourceAtomicBalance?: EthersBigNumber;
 }
 
 export function BridgeQuoteDataProvider({
   children,
 }: BridgeQuoteDataProviderProps) {
+  const featureId = useSwapsFeatureId();
   const { latestSourceBalance } = useBridgeSession();
   const value = useBridgeQuoteData({
     latestSourceAtomicBalance: latestSourceBalance?.atomicBalance,
+    isActive: !MIGRATED_FEATURE_IDS.includes(featureId),
   });
 
   return (
@@ -29,11 +32,15 @@ export function BridgeQuoteDataProvider({
 }
 
 export function useBridgeQuoteDataContext(): BridgeQuoteDataContextValue {
-  const context = useContext(BridgeQuoteDataContext);
+  const combinedSwapQuoteData = useSwapQuotes();
+  const quoteDataContext = useContext(BridgeQuoteDataContext);
+
+  // Components shared by the Market, Limit and Recurring tabs use this hook so we need to check both contexts.
+  const context = combinedSwapQuoteData ?? quoteDataContext;
 
   if (!context) {
     throw new Error(
-      'useBridgeQuoteDataContext must be used within BridgeQuoteDataProvider',
+      'useBridgeQuoteDataContext must be used within BridgeQuoteDataProvider and SwapQuotesProvider',
     );
   }
 

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
@@ -45,6 +45,7 @@ interface UseBridgeQuoteDataParams {
 
 /**
  * Hook for getting bridge quote data without request logic
+ * @deprecated use useBridgeQuoteDataContext or useSwapQuotes instead
  */
 export const useBridgeQuoteData = ({
   latestSourceAtomicBalance,

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
@@ -39,17 +39,17 @@ import { parsePriceImpact } from '../../utils/getPriceImpactViewData';
 import { usePriceImpactFiat } from '../usePriceImpactFiat';
 import { parseCaipAssetType } from '@metamask/utils';
 
-interface UseBridgeQuoteDataParams {
-  latestSourceAtomicBalance?: EthersBigNumber;
-}
-
 /**
  * Hook for getting bridge quote data without request logic
  * @deprecated use useBridgeQuoteDataContext or useSwapQuotes instead
  */
 export const useBridgeQuoteData = ({
   latestSourceAtomicBalance,
-}: UseBridgeQuoteDataParams = {}) => {
+  isActive = true,
+}: {
+  latestSourceAtomicBalance?: EthersBigNumber;
+  isActive?: boolean;
+} = {}) => {
   const dispatch = useDispatch();
   const bridgeControllerState = useSelector(selectBridgeControllerState);
   const sourceToken = useSelector(selectSourceToken);
@@ -373,14 +373,16 @@ export const useBridgeQuoteData = ({
   }, [activeQuote, isSolanaSwap, isSolanaToNonSolana, validateBridgeTx]);
 
   useEffect(() => {
-    validateQuote();
-  }, [validateQuote]);
+    if (isActive) {
+      validateQuote();
+    }
+  }, [validateQuote, isActive]);
 
   useEffect(() => {
-    if (!manuallySelectedQuote) {
+    if (isActive && !manuallySelectedQuote) {
       dispatch(setSelectedQuoteRequestId(undefined));
     }
-  }, [manuallySelectedQuote, dispatch]);
+  }, [isActive, manuallySelectedQuote, dispatch]);
 
   const isActiveQuoteForCurrentTokenPair =
     isQuoteSourceTokenMatch && isQuoteDestTokenMatch;

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/runQuoteDataCases.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/runQuoteDataCases.ts
@@ -144,7 +144,10 @@ export const runQuoteDataCases = ({
 }: {
   name: string;
   mockDispatch: jest.Mock;
-  renderHook: (options?: { latestSourceAtomicBalance?: BigNumber }) => {
+  renderHook: (options?: {
+    latestSourceAtomicBalance?: BigNumber;
+    featureId: FeatureId;
+  }) => {
     result: { current: ReturnType<typeof useBridgeQuoteData> };
     rerender: (props?: unknown) => void;
     unmount: () => void;
@@ -152,11 +155,13 @@ export const runQuoteDataCases = ({
 }) => {
   const renderUseBridgeQuoteData = (
     overrides: QuoteDataState = {},
-    hookOptions?: { latestSourceAtomicBalance?: BigNumber },
+    hookOptions?: {
+      latestSourceAtomicBalance?: BigNumber;
+    },
   ) => {
     const { selectSourceAmountSpy } = applyQuoteDataState(overrides);
     return {
-      ...renderHook(hookOptions),
+      ...renderHook({ ...hookOptions, featureId }),
       selectSourceAmountSpy,
     };
   };

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/runQuoteDataCases.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/runQuoteDataCases.ts
@@ -23,6 +23,7 @@ import * as quoteUtils from '../../utils/quoteUtils';
 import { useBridgeQuoteData } from '.';
 import useValidateBridgeTx from '../../../../../util/bridge/hooks/useValidateBridgeTx';
 import useInsufficientBalance from '../useInsufficientBalance';
+import { useSwapsFeatureId } from '../useSwapsFeatureId';
 
 const defaultSelectBridgeQuotesResults: ReturnType<
   typeof bridgeSlice.selectBridgeQuotes
@@ -137,6 +138,9 @@ const mockUseValidateBridgeTx = useValidateBridgeTx as jest.MockedFunction<
 >;
 const mockValidateBridgeTx = jest.fn();
 const mockTrace = trace as jest.MockedFunction<typeof trace>;
+const mockUseSwapsFeatureId = useSwapsFeatureId as jest.MockedFunction<
+  typeof useSwapsFeatureId
+>;
 
 export const runQuoteDataCases = ({
   name,
@@ -210,6 +214,7 @@ export const runQuoteDataCases = ({
       mockUseValidateBridgeTx.mockReturnValue({
         validateBridgeTx: mockValidateBridgeTx,
       });
+      mockUseSwapsFeatureId.mockReturnValue(featureId);
     });
 
     afterEach(() => {

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/runQuoteDataCases.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/runQuoteDataCases.ts
@@ -3,6 +3,7 @@ import {
   RequestStatus,
   getNativeAssetForChainId,
   isSolanaChainId,
+  type FeatureId,
 } from '@metamask/bridge-controller';
 import { SolScope } from '@metamask/keyring-api';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
@@ -141,6 +142,7 @@ export const runQuoteDataCases = ({
   name,
   mockDispatch,
   renderHook,
+  featureId,
 }: {
   name: string;
   mockDispatch: jest.Mock;
@@ -152,6 +154,7 @@ export const runQuoteDataCases = ({
     rerender: (props?: unknown) => void;
     unmount: () => void;
   };
+  featureId: FeatureId;
 }) => {
   const renderUseBridgeQuoteData = (
     overrides: QuoteDataState = {},

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/runQuoteProviderCases.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/runQuoteProviderCases.ts
@@ -12,6 +12,10 @@ import useInsufficientBalance from '../useInsufficientBalance';
 import useValidateBridgeTx from '../../../../../util/bridge/hooks/useValidateBridgeTx';
 import { useSwapsFeatureId } from '../useSwapsFeatureId';
 import { FeatureId } from '@metamask/bridge-controller';
+import { useBridgeSession } from '../useBridgeSession';
+import type { buildGenericQuoteRequest } from '../useSwapQuotes/utils';
+import { BigNumber } from 'ethers';
+import { BridgeTabKey } from '../../Views/BridgeView/BridgeView.constants';
 
 const mockUseIsInsufficientBalance =
   useInsufficientBalance as jest.MockedFunction<typeof useInsufficientBalance>;
@@ -25,18 +29,24 @@ const mockUseValidateBridgeTx = useValidateBridgeTx as jest.MockedFunction<
 >;
 const mockValidateBridgeTx = jest.fn();
 
+const mockUseBridgeSession = useBridgeSession as jest.MockedFunction<
+  typeof useBridgeSession
+>;
+
 export const runQuoteProviderCases = ({
   name,
   missingProviderError,
   renderProvider,
   renderWithoutProvider,
   featureId,
+  quoteParams,
 }: {
   name: string;
   missingProviderError: string;
   renderProvider: (state: DeepPartial<RootState>) => void;
   renderWithoutProvider: () => void;
   featureId: FeatureId;
+  quoteParams: Parameters<typeof buildGenericQuoteRequest>[0]['quoteParams'];
 }) =>
   describe(name, () => {
     beforeEach(() => {
@@ -82,6 +92,17 @@ export const runQuoteProviderCases = ({
           refreshRate: 5000,
           maxRefreshCount: 10,
         }));
+      mockUseBridgeSession.mockReturnValue({
+        selectedTab: BridgeTabKey.Market,
+        renderedTab: BridgeTabKey.Market,
+        setSelectedTab: jest.fn(),
+        setRenderedTab: jest.fn(),
+        quoteParams,
+        latestSourceBalance: {
+          atomicBalance: BigNumber.from('1000000000'),
+          displayBalance: '123',
+        },
+      });
     });
 
     afterEach(() => {
@@ -118,7 +139,7 @@ export const runQuoteProviderCases = ({
       });
     });
 
-    it('throws when used outside BridgeQuoteDataProvider', () => {
+    it('throws when used outside its quote provider', () => {
       jest.spyOn(console, 'error').mockImplementation();
 
       const renderOutsideProvider = () => renderWithoutProvider();

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/runQuoteProviderCases.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/runQuoteProviderCases.ts
@@ -10,9 +10,15 @@ import type { RootState } from '../../../../../reducers';
 import type { DeepPartial } from '../../../../../util/test/renderWithProvider';
 import useInsufficientBalance from '../useInsufficientBalance';
 import useValidateBridgeTx from '../../../../../util/bridge/hooks/useValidateBridgeTx';
+import { useSwapsFeatureId } from '../useSwapsFeatureId';
+import { FeatureId } from '@metamask/bridge-controller';
 
 const mockUseIsInsufficientBalance =
   useInsufficientBalance as jest.MockedFunction<typeof useInsufficientBalance>;
+
+const mockUseSwapsFeatureId = useSwapsFeatureId as jest.MockedFunction<
+  typeof useSwapsFeatureId
+>;
 
 const mockUseValidateBridgeTx = useValidateBridgeTx as jest.MockedFunction<
   typeof useValidateBridgeTx
@@ -24,11 +30,13 @@ export const runQuoteProviderCases = ({
   missingProviderError,
   renderProvider,
   renderWithoutProvider,
+  featureId,
 }: {
   name: string;
   missingProviderError: string;
   renderProvider: (state: DeepPartial<RootState>) => void;
   renderWithoutProvider: () => void;
+  featureId: FeatureId;
 }) =>
   describe(name, () => {
     beforeEach(() => {
@@ -45,6 +53,7 @@ export const runQuoteProviderCases = ({
       mockUseValidateBridgeTx.mockReturnValue({
         validateBridgeTx: mockValidateBridgeTx,
       });
+      mockUseSwapsFeatureId.mockReturnValue(featureId);
       jest
         .spyOn(bridgeController, 'selectBridgeQuotes')
         .mockImplementation(() => ({

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
@@ -50,6 +50,10 @@ jest.mock('../../../../../util/notifications/methods/common', () => ({
   })),
 }));
 
+jest.mock('../useSwapsFeatureId', () => ({
+  useSwapsFeatureId: jest.fn(),
+}));
+
 runQuoteDataCases({
   name: 'useBridgeQuoteData',
   mockDispatch,

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-native';
 
 import { useBridgeQuoteData } from '.';
 import { runQuoteDataCases } from './runQuoteDataCases';
+import { FeatureId } from '@metamask/bridge-controller';
 
 const mockDispatch = jest.fn();
 
@@ -53,4 +54,5 @@ runQuoteDataCases({
   name: 'useBridgeQuoteData',
   mockDispatch,
   renderHook: (options) => renderHook(() => useBridgeQuoteData(options)),
+  featureId: FeatureId.UNIFIED_SWAP_BRIDGE,
 });

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/runQuoteRequestCases.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/runQuoteRequestCases.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from 'ethers';
 import { act } from '@testing-library/react-native';
 import {
+  FeatureId,
   formatAddressToCaipReference,
   isSolanaChainId,
 } from '@metamask/bridge-controller';
@@ -24,6 +25,7 @@ import {
   TraceOperation,
 } from '../../../../../util/trace';
 import { swapQuoteFetchTrace } from '../../utils/swapQuoteFetchTrace';
+import { useSwapsFeatureId } from '../useSwapsFeatureId';
 
 const spyUpdateBridgeQuoteRequestParams = jest.spyOn(
   Engine.context.BridgeController,
@@ -37,6 +39,10 @@ const mockUseIsInsufficientBalance =
 
 const mockUseLatestBalance = useLatestBalance as jest.MockedFunction<
   typeof useLatestBalance
+>;
+
+const mockUseSwapsFeatureId = useSwapsFeatureId as jest.MockedFunction<
+  typeof useSwapsFeatureId
 >;
 
 const mockUseInsufficientNativeReserveError =
@@ -83,12 +89,14 @@ export const runQuoteRequestCases = ({
   debounceMs,
   renderHook,
   name,
+  featureId,
 }: {
   debounceMs: number;
   renderHook: (options?: {
     latestSourceAtomicBalance?: BigNumber;
     quoteRequestIndex?: number;
     quoteRequestCount?: number;
+    featureId: FeatureId;
   }) => {
     result: {
       current: ((opts?: {
@@ -103,6 +111,7 @@ export const runQuoteRequestCases = ({
     unmount: () => void;
   };
   name: string;
+  featureId: FeatureId;
 }) => {
   /**
    * @deprecated only use to preserve coverage for old hooks
@@ -116,6 +125,7 @@ export const runQuoteRequestCases = ({
       walletAddress?: string;
       quoteRequestIndex?: number;
       quoteRequestCount?: number;
+      featureId: FeatureId;
     },
   ) => {
     const bridge = { ...mockBridgeReducerState, ...overrides };
@@ -162,6 +172,8 @@ export const runQuoteRequestCases = ({
         displayBalance: '10',
         atomicBalance: BigNumber.from('10000000000000000000'), // 10 ETH in wei
       });
+
+      mockUseSwapsFeatureId.mockReturnValue(featureId);
 
       mockUseIsInsufficientBalance.mockReturnValue(false);
       mockUseInsufficientNativeReserveError.mockReturnValue(undefined);
@@ -529,7 +541,7 @@ export const runQuoteRequestCases = ({
     it('skips update when wallet address is missing', async () => {
       const { result } = renderUseBridgeQuoteRequest(
         {},
-        { walletAddress: undefined },
+        { walletAddress: undefined, featureId: FeatureId.UNIFIED_SWAP_BRIDGE },
       );
 
       await act(async () => {
@@ -640,7 +652,12 @@ export const runQuoteRequestCases = ({
       async ({ overrides, omitWallet }) => {
         const { result } = renderUseBridgeQuoteRequest(
           overrides,
-          omitWallet ? { walletAddress: undefined } : undefined,
+          omitWallet
+            ? {
+                walletAddress: undefined,
+                featureId: FeatureId.UNIFIED_SWAP_BRIDGE,
+              }
+            : undefined,
         );
 
         await act(async () => {
@@ -1105,7 +1122,10 @@ export const runQuoteRequestCases = ({
 
         const testState = renderUseBridgeQuoteRequest(
           { sourceAmount: '5.5' },
-          { latestSourceAtomicBalance: overriddenAtomicBalance },
+          {
+            latestSourceAtomicBalance: overriddenAtomicBalance,
+            featureId: FeatureId.UNIFIED_SWAP_BRIDGE,
+          },
         );
 
         expect(mockUseLatestBalance).toHaveBeenCalledWith({});
@@ -1120,7 +1140,10 @@ export const runQuoteRequestCases = ({
       it('uses override path when latestSourceAtomicBalance key is provided as undefined', () => {
         const testState = renderUseBridgeQuoteRequest(
           { sourceAmount: '5.5' },
-          { latestSourceAtomicBalance: undefined },
+          {
+            latestSourceAtomicBalance: undefined,
+            featureId: FeatureId.UNIFIED_SWAP_BRIDGE,
+          },
         );
 
         expect(mockUseLatestBalance).toHaveBeenCalledWith({});

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
@@ -3,6 +3,7 @@ import { renderHook } from '@testing-library/react-native';
 import { DEBOUNCE_WAIT, useBridgeQuoteRequest } from './';
 import { mockContext, runQuoteRequestCases } from './runQuoteRequestCases';
 import type { DebounceSettings } from 'lodash';
+import { FeatureId } from '@metamask/bridge-controller';
 
 jest.mock('lodash', () => {
   const actual = jest.requireActual<typeof import('lodash')>('lodash');
@@ -59,8 +60,13 @@ jest.mock('../../../../../util/trace', () => ({
   endTrace: jest.fn(),
 }));
 
+jest.mock('../useSwapsFeatureId', () => ({
+  useSwapsFeatureId: jest.fn(),
+}));
+
 runQuoteRequestCases({
   name: 'useBridgeQuoteRequest',
   debounceMs: DEBOUNCE_WAIT,
   renderHook: (options) => renderHook(() => useBridgeQuoteRequest(options)),
+  featureId: FeatureId.UNIFIED_SWAP_BRIDGE,
 });

--- a/app/components/UI/Bridge/hooks/useBridgeSession/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeSession/index.ts
@@ -1,0 +1,15 @@
+import { useContext } from 'react';
+
+import { BridgeSessionContext } from '../../providers/BridgeSessionProvider';
+
+export const useBridgeSession = () => {
+  const context = useContext(BridgeSessionContext);
+
+  if (!context) {
+    throw new Error(
+      'useBridgeSession must be used within BridgeSessionProvider',
+    );
+  }
+
+  return context;
+};

--- a/app/components/UI/Bridge/hooks/useBridgeSession/useBridgeSession.test.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeSession/useBridgeSession.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { act, render, renderHook } from '@testing-library/react-native';
+
+import { BridgeTabKey } from '../../Views/BridgeView/BridgeView.constants';
+import { BridgeSessionProvider } from '../../providers/BridgeSessionProvider';
+import { useBridgeSession } from './index';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../useLatestBalance', () => ({
+  useLatestBalance: jest.fn(() => undefined),
+}));
+
+describe('useBridgeSession', () => {
+  it('throws when used outside BridgeSessionProvider', () => {
+    expect(() => renderHook(() => useBridgeSession())).toThrow(
+      'useBridgeSession must be used within BridgeSessionProvider',
+    );
+  });
+
+  it('defaults to Market and updates selectedTab and renderedTab independently', () => {
+    const { result } = renderHook(() => useBridgeSession(), {
+      wrapper: ({ children }) => (
+        <BridgeSessionProvider>{children}</BridgeSessionProvider>
+      ),
+    });
+
+    expect(result.current.selectedTab).toBe(BridgeTabKey.Market);
+    expect(result.current.renderedTab).toBe(BridgeTabKey.Market);
+
+    act(() => {
+      result.current.setSelectedTab(BridgeTabKey.Limit);
+    });
+
+    expect(result.current.selectedTab).toBe(BridgeTabKey.Limit);
+    expect(result.current.renderedTab).toBe(BridgeTabKey.Market);
+
+    act(() => {
+      result.current.setRenderedTab(BridgeTabKey.Limit);
+    });
+
+    expect(result.current.renderedTab).toBe(BridgeTabKey.Limit);
+  });
+
+  it('renders children', () => {
+    const { getByText } = render(
+      <BridgeSessionProvider>
+        <Text>hosted</Text>
+      </BridgeSessionProvider>,
+    );
+
+    expect(getByText('hosted')).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Bridge/hooks/useBridgeSession/useBridgeSession.test.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeSession/useBridgeSession.test.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
 import { Text } from 'react-native';
 import { act, render, renderHook } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import { FeatureId } from '@metamask/bridge-controller';
 
+import {
+  selectBridgeBalanceRefreshKey,
+  selectSourceToken,
+} from '../../../../../core/redux/slices/bridge';
 import { BridgeTabKey } from '../../Views/BridgeView/BridgeView.constants';
 import { BridgeSessionProvider } from '../../providers/BridgeSessionProvider';
+import { useLatestBalance } from '../useLatestBalance';
 import { useBridgeSession } from './index';
 
 jest.mock('react-redux', () => ({
@@ -14,7 +21,41 @@ jest.mock('../useLatestBalance', () => ({
   useLatestBalance: jest.fn(() => undefined),
 }));
 
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockUseLatestBalance = useLatestBalance as jest.MockedFunction<
+  typeof useLatestBalance
+>;
+
+const mockSourceToken = {
+  address: '0x1234',
+  decimals: 18,
+  chainId: '0x1' as const,
+  symbol: 'ETH',
+  balance: '1.5',
+};
+
+const mockLatestBalance = {
+  displayBalance: '1000',
+  atomicBalance: { toString: () => '1000000000000000000' },
+} as ReturnType<typeof useLatestBalance>;
+
+const mockSourceTokenSelectors = () => {
+  mockUseSelector.mockImplementation((selector) => {
+    if (selector === selectSourceToken) {
+      return mockSourceToken;
+    }
+    if (selector === selectBridgeBalanceRefreshKey) {
+      return 3;
+    }
+    return undefined;
+  });
+};
+
 describe('useBridgeSession', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('throws when used outside BridgeSessionProvider', () => {
     expect(() => renderHook(() => useBridgeSession())).toThrow(
       'useBridgeSession must be used within BridgeSessionProvider',
@@ -53,5 +94,46 @@ describe('useBridgeSession', () => {
     );
 
     expect(getByText('hosted')).toBeOnTheScreen();
+  });
+
+  describe('useLatestBalance', () => {
+    afterEach(() => {
+      mockUseLatestBalance.mockReturnValue(undefined);
+      mockUseSelector.mockReset();
+    });
+
+    it('calls useLatestBalance with source token fields and the rendered tab feature id', () => {
+      mockSourceTokenSelectors();
+
+      renderHook(() => useBridgeSession(), {
+        wrapper: ({ children }) => (
+          <BridgeSessionProvider>{children}</BridgeSessionProvider>
+        ),
+      });
+
+      expect(mockUseLatestBalance).toHaveBeenCalledWith(
+        {
+          address: mockSourceToken.address,
+          decimals: mockSourceToken.decimals,
+          chainId: mockSourceToken.chainId,
+          balance: mockSourceToken.balance,
+          refreshKey: 3,
+        },
+        FeatureId.UNIFIED_SWAP_BRIDGE,
+      );
+    });
+
+    it('exposes latestSourceBalance from useLatestBalance', () => {
+      mockSourceTokenSelectors();
+      mockUseLatestBalance.mockReturnValue(mockLatestBalance);
+
+      const { result } = renderHook(() => useBridgeSession(), {
+        wrapper: ({ children }) => (
+          <BridgeSessionProvider>{children}</BridgeSessionProvider>
+        ),
+      });
+
+      expect(result.current.latestSourceBalance).toBe(mockLatestBalance);
+    });
   });
 });

--- a/app/components/UI/Bridge/hooks/useHasSufficientGasEvenIfGasIncludedOrSponsored/index.ts
+++ b/app/components/UI/Bridge/hooks/useHasSufficientGasEvenIfGasIncludedOrSponsored/index.ts
@@ -3,17 +3,17 @@ import {
   formatChainIdToHex,
   isNonEvmChainId,
   sumAmounts,
+  type QuoteResponse,
 } from '@metamask/bridge-controller';
 import { useLatestBalance } from '../useLatestBalance';
 import { ethers } from 'ethers';
 import { CaipChainId, Hex } from '@metamask/utils';
-import { useBridgeQuoteData } from '../useBridgeQuoteData';
 import { getNativeSourceToken } from '../../utils/tokenUtils';
 import { BigNumber } from 'bignumber.js';
 import { isNumberValue } from '../../../../../util/number/bigint';
 
 interface Props {
-  quote: ReturnType<typeof useBridgeQuoteData>['activeQuote'];
+  quote?: QuoteResponse | null;
 }
 
 /**

--- a/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.ts
+++ b/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.ts
@@ -5,10 +5,10 @@ import {
   sumAmounts,
   isStellarChainId,
   isTronChainId,
+  type QuoteResponse,
 } from '@metamask/bridge-controller';
-import { useBridgeQuoteData } from '../useBridgeQuoteData';
 
-type ActiveQuote = ReturnType<typeof useBridgeQuoteData>['activeQuote'];
+type ActiveQuote = QuoteResponse | null | undefined;
 
 export const isQuoteNetworkFeeUnavailable = (
   activeQuote: ActiveQuote,

--- a/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
@@ -13,6 +13,7 @@ import {
   formatChainIdToCaip,
   isNativeAddress,
   isNonEvmChainId,
+  type FeatureId,
 } from '@metamask/bridge-controller';
 import {
   endTrace,
@@ -80,15 +81,19 @@ const getTokenIdentity = (token?: {
  * @param token.decimals - The token decimals.
  * @param token.chainId - The chain ID to be used for fetching the balance.
  * @param token.balance - The cached token balance as a non-atomic decimal string, e.g. "1.23456".
+ * @param featureId - The feature requesting the latest balance.
  * @returns An object containing the the balance as a non-atomic decimal string and the atomic balance as a BigNumber.
  */
-export const useLatestBalance = (token: {
-  address?: string;
-  decimals?: number;
-  chainId?: Hex | CaipChainId;
-  balance?: string;
-  refreshKey?: string | number;
-}) => {
+export const useLatestBalance = (
+  token: {
+    address?: string;
+    decimals?: number;
+    chainId?: Hex | CaipChainId;
+    balance?: string;
+    refreshKey?: string | number;
+  },
+  featureId?: FeatureId,
+) => {
   const [balance, setBalance] = useState<Balance | undefined>(undefined);
   const selectedAddress = useSelector(
     selectSelectedInternalAccountFormattedAddress,
@@ -230,7 +235,7 @@ export const useLatestBalance = (token: {
     }
 
     handleFetchEvmAtomicBalance();
-  }, [chainId, handleFetchEvmAtomicBalance, token.refreshKey]);
+  }, [chainId, handleFetchEvmAtomicBalance, token.refreshKey, featureId]);
 
   useEffect(() => {
     if (!chainId || !isCaipChainId(chainId) || !isNonEvmChainId(chainId)) {
@@ -238,7 +243,7 @@ export const useLatestBalance = (token: {
     }
 
     handleNonEvmAtomicBalance();
-  }, [chainId, handleNonEvmAtomicBalance, token.refreshKey]);
+  }, [chainId, handleNonEvmAtomicBalance, token.refreshKey, featureId]);
 
   const cachedBalance = useMemo(() => {
     const displayBalance = token.balance;

--- a/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.test.ts
@@ -30,15 +30,16 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 jest.mock('../useBridgeQuoteData/BridgeQuoteDataContext', () => ({
-  useBridgeQuoteDataContext: () => ({
-    destTokenAmount: undefined,
-    isLoading: false,
-  }),
+  useBridgeQuoteDataContext: () => ({}),
 }));
 
 const mockUpdateQuoteParams = Object.assign(jest.fn(), { cancel: jest.fn() });
-jest.mock('../useBridgeQuoteRequest', () => ({
-  useBridgeQuoteRequest: () => mockUpdateQuoteParams,
+jest.mock('../useSwapQuotes', () => ({
+  useSwapQuotes: () => ({
+    debouncedUpdateQuoteParams: mockUpdateQuoteParams,
+    destTokenAmount: undefined,
+    isLoading: false,
+  }),
 }));
 
 jest.mock('../useIsNetworkEnabled', () => ({
@@ -48,6 +49,12 @@ jest.mock('../useIsNetworkEnabled', () => ({
 let mockIsHardwareWallet = false;
 jest.mock('../useIsHardwareWalletForBridge', () => ({
   useIsHardwareWalletForBridge: () => mockIsHardwareWallet,
+}));
+
+jest.mock('../useBridgeSession', () => ({
+  useBridgeSession: () => ({
+    latestSourceBalance: undefined,
+  }),
 }));
 
 const mockSyncFiatAmountToTokenAmount = jest.fn();
@@ -115,9 +122,7 @@ const renderLimitOrderSwapInputsHook = (
     return undefined;
   });
 
-  return renderHook(() =>
-    useLimitOrderSwapInputs({ latestSourceBalance: undefined }),
-  );
+  return renderHook(() => useLimitOrderSwapInputs());
 };
 
 describe('useLimitOrderSwapInputs', () => {

--- a/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.test.ts
@@ -3,9 +3,6 @@ import type { CaipChainId } from '@metamask/utils';
 import { FeatureId } from '@metamask/bridge-controller';
 import { useLimitOrderSwapInputs } from '.';
 import {
-  selectDestToken,
-  selectSourceAmount,
-  selectSourceToken,
   setDestToken,
   setSourceAmount,
   setSourceToken,
@@ -16,6 +13,7 @@ import { getNativeSourceToken } from '../../utils/tokenUtils';
 import { createMockToken } from '../../testUtils/fixtures';
 import { TokenSelectorType, type BridgeToken } from '../../types';
 import Routes from '../../../../../constants/navigation/Routes';
+import { BridgeTabKey } from '../../Views/BridgeView/BridgeView.constants';
 
 const mockDispatch = jest.fn();
 
@@ -52,9 +50,7 @@ jest.mock('../useIsHardwareWalletForBridge', () => ({
 }));
 
 jest.mock('../useBridgeSession', () => ({
-  useBridgeSession: () => ({
-    latestSourceBalance: undefined,
-  }),
+  useBridgeSession: jest.fn(),
 }));
 
 const mockSyncFiatAmountToTokenAmount = jest.fn();
@@ -84,7 +80,12 @@ jest.mock('../useSwitchTokens', () => ({
 }));
 
 import { useSelector } from 'react-redux';
+import { useBridgeSession } from '../useBridgeSession';
+
 const mockUseSelector = useSelector as jest.Mock;
+const mockUseBridgeSession = useBridgeSession as jest.MockedFunction<
+  typeof useBridgeSession
+>;
 
 const ENABLED_CHAIN_IDS: CaipChainId[] = [
   'eip155:1',
@@ -104,15 +105,6 @@ const renderLimitOrderSwapInputsHook = (
   gasSponsoredChainIds: string[] = [],
 ) => {
   mockUseSelector.mockImplementation((selector: unknown) => {
-    if (selector === selectSourceToken) {
-      return selectorState.sourceToken;
-    }
-    if (selector === selectDestToken) {
-      return selectorState.destToken;
-    }
-    if (selector === selectSourceAmount) {
-      return selectorState.sourceAmount;
-    }
     if (selector === selectBridgeLimitOrderFeatureFlags) {
       return enabledChainIds ? { enabled: true, enabledChainIds } : undefined;
     }
@@ -120,6 +112,19 @@ const renderLimitOrderSwapInputsHook = (
       return (chainId: string) => gasSponsoredChainIds.includes(chainId);
     }
     return undefined;
+  });
+
+  mockUseBridgeSession.mockReturnValue({
+    selectedTab: BridgeTabKey.Limit,
+    renderedTab: BridgeTabKey.Limit,
+    setSelectedTab: jest.fn(),
+    setRenderedTab: jest.fn(),
+    latestSourceBalance: undefined,
+    quoteParams: {
+      srcToken: selectorState.sourceToken,
+      destToken: selectorState.destToken,
+      srcAmount: selectorState.sourceAmount,
+    },
   });
 
   return renderHook(() => useLimitOrderSwapInputs());

--- a/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.ts
+++ b/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.ts
@@ -6,9 +6,6 @@ import type { AppNavigationProp } from '../../../../../core/NavigationService/ty
 import Routes from '../../../../../constants/navigation/Routes';
 import type { RootState } from '../../../../../reducers';
 import {
-  selectDestToken,
-  selectSourceAmount,
-  selectSourceToken,
   setDestToken,
   setSourceAmount,
   setSourceAmountAsMax,
@@ -38,9 +35,6 @@ export const useLimitOrderSwapInputs = () => {
   );
   const enabledChainIds = limitOrderFeatureFlags?.enabledChainIds;
 
-  const sourceAmount = useSelector(selectSourceAmount);
-  const sourceToken = useSelector(selectSourceToken);
-  const destToken = useSelector(selectDestToken);
   const isFiatToggleEnabled = useSelector(
     (state: RootState) =>
       selectRemoteFeatureFlags(state).enableFiatToggle === true,
@@ -77,6 +71,11 @@ export const useLimitOrderSwapInputs = () => {
     },
     [dispatch],
   );
+
+  const {
+    latestSourceBalance,
+    quoteParams: { srcAmount: sourceAmount, srcToken: sourceToken, destToken },
+  } = useBridgeSession();
 
   const sourceAmountInput = useSourceAmountInput({
     isFiatToggleEnabled,
@@ -128,7 +127,6 @@ export const useLimitOrderSwapInputs = () => {
     };
   }, [hasValidBridgeInputs, updateQuoteParams]);
 
-  const { latestSourceBalance } = useBridgeSession();
   const handleSourceMaxPress = useCallback(() => {
     if (!latestSourceBalance?.displayBalance) {
       return;

--- a/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.ts
+++ b/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.ts
@@ -19,23 +19,17 @@ import { selectRemoteFeatureFlags } from '../../../../../selectors/featureFlagCo
 import { TokenSelectorType } from '../../types';
 import { MAX_INPUT_LENGTH } from '../../components/TokenInputArea';
 import { useBridgeQuoteDataContext } from '../useBridgeQuoteData/BridgeQuoteDataContext';
-import { useBridgeQuoteRequest } from '../useBridgeQuoteRequest';
 import { useIsHardwareWalletForBridge } from '../useIsHardwareWalletForBridge';
 import { useIsNetworkEnabled } from '../useIsNetworkEnabled';
 import { useIsNetworkGasSponsored } from '../useIsNetworkGasSponsored';
-import { useLatestBalance } from '../useLatestBalance';
 import { useSourceAmountInput } from '../useSourceAmountInput';
 import { useSwitchTokens } from '../useSwitchTokens';
 import { normalizeSourceAmountToMaxLength } from '../../utils/normalizeSourceAmountToMaxLength';
 import { getDefaultTokenPairForChains } from '../../utils/tokenUtils';
+import { useSwapQuotes } from '../useSwapQuotes';
+import { useBridgeSession } from '../useBridgeSession';
 
-interface UseLimitOrderSwapInputsOptions {
-  latestSourceBalance: ReturnType<typeof useLatestBalance>;
-}
-
-export const useLimitOrderSwapInputs = ({
-  latestSourceBalance,
-}: UseLimitOrderSwapInputsOptions) => {
+export const useLimitOrderSwapInputs = () => {
   const dispatch = useDispatch();
   const navigation = useNavigation<AppNavigationProp>();
 
@@ -106,14 +100,13 @@ export const useLimitOrderSwapInputs = ({
     sourceToken?.chainId === destToken?.chainId &&
     isSourceNetworkGasSponsored;
 
-  const updateQuoteParams = useBridgeQuoteRequest({
-    latestSourceAtomicBalance: latestSourceBalance?.atomicBalance,
-  });
+  const combinedSwapQuoteData = useSwapQuotes();
+  const updateQuoteParams = combinedSwapQuoteData?.debouncedUpdateQuoteParams;
 
   // A limit order can't be signed by a hardware wallet on any chain, so no
   // quote is ever requested for one. The inputs stay interactive and
   // `HardwareWalletUnsupportedBanner` explains why no quote appears. Gating
-  // here rather than in useBridgeQuoteRequest keeps hardware wallets working
+  // here rather than in useSwapQuotes keeps hardware wallets working
   // for Market orders, which share that hook but not this one.
   const isHardwareWallet = useIsHardwareWalletForBridge();
 
@@ -127,14 +120,15 @@ export const useLimitOrderSwapInputs = ({
     Boolean(destToken);
 
   useEffect(() => {
-    if (hasValidBridgeInputs) {
+    if (hasValidBridgeInputs && updateQuoteParams) {
       updateQuoteParams();
     }
     return () => {
-      updateQuoteParams.cancel();
+      updateQuoteParams?.cancel();
     };
   }, [hasValidBridgeInputs, updateQuoteParams]);
 
+  const { latestSourceBalance } = useBridgeSession();
   const handleSourceMaxPress = useCallback(() => {
     if (!latestSourceBalance?.displayBalance) {
       return;

--- a/app/components/UI/Bridge/hooks/useRewards/useRewards.ts
+++ b/app/components/UI/Bridge/hooks/useRewards/useRewards.ts
@@ -14,13 +14,16 @@ import {
 } from '../../../../../core/redux/slices/bridge';
 import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
 import { getFormattedAddressFromInternalAccount } from '../../../../../core/Multichain/utils';
-import { formatChainIdToCaip, sumAmounts } from '@metamask/bridge-controller';
+import {
+  formatChainIdToCaip,
+  sumAmounts,
+  type QuoteResponse,
+} from '@metamask/bridge-controller';
 import {
   toCaipAccountId,
   parseCaipChainId,
   type CaipAccountId,
 } from '@metamask/utils';
-import { useBridgeQuoteData } from '../useBridgeQuoteData';
 import Logger from '../../../../../util/Logger';
 import usePrevious from '../../../../hooks/usePrevious';
 import { InternalAccount } from '@metamask/keyring-internal-api';
@@ -60,7 +63,7 @@ export const getUsdPricePerToken = (
 };
 
 interface UseRewardsParams {
-  activeQuote: ReturnType<typeof useBridgeQuoteData>['activeQuote'];
+  activeQuote?: QuoteResponse | null;
   isQuoteLoading: boolean;
 }
 

--- a/app/components/UI/Bridge/hooks/useSwapQuotes/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapQuotes/index.ts
@@ -4,16 +4,23 @@ import {
   SwapQuotesContext,
   type SwapQuotesContextValue,
 } from '../../providers/SwapQuotesProvider';
+import { useSwapsFeatureId } from '../useSwapsFeatureId';
+import { MIGRATED_FEATURE_IDS } from '../../Views/BridgeView/BridgeView.constants';
 
 /**
  * Hook for updating the bridge-controller's quoteRequest state and returning quote data
  */
-export function useSwapQuotes(): SwapQuotesContextValue {
+export const useSwapQuotes = (): SwapQuotesContextValue | null => {
   const context = useContext(SwapQuotesContext);
+
+  const featureId = useSwapsFeatureId();
+  if (!MIGRATED_FEATURE_IDS.includes(featureId)) {
+    return null;
+  }
 
   if (!context) {
     throw new Error('useSwapQuotes must be used within SwapQuotesProvider');
   }
 
   return context;
-}
+};

--- a/app/components/UI/Bridge/hooks/useSwapQuotes/useSwapQuotes.test.tsx
+++ b/app/components/UI/Bridge/hooks/useSwapQuotes/useSwapQuotes.test.tsx
@@ -130,12 +130,14 @@ const Wrapper = ({
   children,
   quoteRequestIndex,
   quoteRequestCount,
+  featureId,
   ...options
 }: {
   children: React.ReactNode;
   latestSourceAtomicBalance?: BigNumber;
   quoteRequestIndex?: number;
   quoteRequestCount?: number;
+  featureId: FeatureId;
 }) => {
   const sourceAmount = useSelector(selectSourceAmount);
   const sourceToken = useSelector(selectSourceToken);
@@ -147,7 +149,7 @@ const Wrapper = ({
   return (
     <SwapQuotesProvider
       isActive
-      featureId={FeatureId.UNIFIED_SWAP_BRIDGE}
+      featureId={featureId}
       debounceWait={mockDebounceMs}
       quoteRequestIndex={quoteRequestIndex}
       quoteRequestCount={quoteRequestCount}
@@ -168,6 +170,10 @@ const Wrapper = ({
   );
 };
 
+jest.mock('../useSwapsFeatureId', () => ({
+  useSwapsFeatureId: jest.fn().mockReturnValue('limit_order'),
+}));
+
 describe('useSwapQuotes', () => {
   it('throws an error if used outside of SwapQuotesProvider', () => {
     expect(() => renderHook(() => useSwapQuotes())).toThrow(
@@ -180,14 +186,18 @@ runQuoteRequestCases({
   name: 'useQuoteRequest',
   debounceMs: mockDebounceMs,
   renderHook: (options) =>
+    // @ts-expect-error - this returns a defined update function
     renderHook(
       () => {
-        // @ts-expect-error - this returns a defined update function
-        const { debouncedUpdateQuoteParams } = useSwapQuotes();
-        return debouncedUpdateQuoteParams;
+        const value = useSwapQuotes();
+        return value?.debouncedUpdateQuoteParams;
       },
       {
-        wrapper: ({ children }) => <Wrapper {...options}>{children}</Wrapper>,
+        wrapper: ({ children }) => (
+          <Wrapper {...options} featureId={FeatureId.LIMIT_ORDER}>
+            {children}
+          </Wrapper>
+        ),
       },
     ),
   featureId: FeatureId.LIMIT_ORDER,
@@ -198,9 +208,13 @@ runQuoteDataCases({
   mockDispatch,
 
   renderHook: (options) =>
-    // @ts-expect-error - this returns a defined update function
+    // @ts-expect-error - this returns quote data
     renderHook(() => useSwapQuotes(), {
-      wrapper: ({ children }) => <Wrapper {...options}>{children}</Wrapper>,
+      wrapper: ({ children }) => (
+        <Wrapper {...options} featureId={FeatureId.LIMIT_ORDER}>
+          {children}
+        </Wrapper>
+      ),
     }),
   featureId: FeatureId.LIMIT_ORDER,
 });

--- a/app/components/UI/Bridge/hooks/useSwapQuotes/useSwapQuotes.test.tsx
+++ b/app/components/UI/Bridge/hooks/useSwapQuotes/useSwapQuotes.test.tsx
@@ -126,6 +126,18 @@ jest.mock('../../../../../selectors/currencyRateController', () => ({
   selectCurrentCurrency: () => 'USD',
 }));
 
+jest.mock('../useSwapsFeatureId', () => ({
+  useSwapsFeatureId: jest.fn().mockReturnValue('limit_order'),
+}));
+
+jest.mock('../useBridgeSession', () => ({
+  useBridgeSession: jest.fn(),
+}));
+
+const mockUseBridgeSession = useBridgeSession as jest.MockedFunction<
+  typeof useBridgeSession
+>;
+
 const mockDebounceMs = 300;
 
 const Wrapper = ({
@@ -172,18 +184,6 @@ const Wrapper = ({
 
   return <SwapQuotesProvider>{children}</SwapQuotesProvider>;
 };
-
-jest.mock('../useSwapsFeatureId', () => ({
-  useSwapsFeatureId: jest.fn().mockReturnValue('limit_order'),
-}));
-
-jest.mock('../useBridgeSession', () => ({
-  useBridgeSession: jest.fn(),
-}));
-
-const mockUseBridgeSession = useBridgeSession as jest.MockedFunction<
-  typeof useBridgeSession
->;
 
 describe('useSwapQuotes', () => {
   it('throws an error if used outside of SwapQuotesProvider', () => {

--- a/app/components/UI/Bridge/hooks/useSwapQuotes/useSwapQuotes.test.tsx
+++ b/app/components/UI/Bridge/hooks/useSwapQuotes/useSwapQuotes.test.tsx
@@ -182,6 +182,7 @@ runQuoteRequestCases({
   renderHook: (options) =>
     renderHook(
       () => {
+        // @ts-expect-error - this returns a defined update function
         const { debouncedUpdateQuoteParams } = useSwapQuotes();
         return debouncedUpdateQuoteParams;
       },
@@ -189,13 +190,17 @@ runQuoteRequestCases({
         wrapper: ({ children }) => <Wrapper {...options}>{children}</Wrapper>,
       },
     ),
+  featureId: FeatureId.LIMIT_ORDER,
 });
 
 runQuoteDataCases({
   name: 'useQuoteData',
   mockDispatch,
+
   renderHook: (options) =>
+    // @ts-expect-error - this returns a defined update function
     renderHook(() => useSwapQuotes(), {
       wrapper: ({ children }) => <Wrapper {...options}>{children}</Wrapper>,
     }),
+  featureId: FeatureId.LIMIT_ORDER,
 });

--- a/app/components/UI/Bridge/hooks/useSwapQuotes/useSwapQuotes.test.tsx
+++ b/app/components/UI/Bridge/hooks/useSwapQuotes/useSwapQuotes.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { SwapQuotesProvider } from '../../providers/SwapQuotesProvider';
 import { useSwapQuotes } from './index';
+import { useBridgeSession } from '../useBridgeSession';
 import {
   mockContext,
   runQuoteRequestCases,
 } from '../useBridgeQuoteRequest/runQuoteRequestCases';
 import { renderHook } from '@testing-library/react-native';
 import { FeatureId } from '@metamask/bridge-controller';
+import { BridgeTabKey } from '../../Views/BridgeView/BridgeView.constants';
 import { useSelector } from 'react-redux';
 import {
   selectDestAddress,
@@ -146,33 +148,42 @@ const Wrapper = ({
   const walletAddress = useSelector(selectSourceWalletAddress);
   const destAddress = useSelector(selectDestAddress);
 
-  return (
-    <SwapQuotesProvider
-      isActive
-      featureId={featureId}
-      debounceWait={mockDebounceMs}
-      quoteRequestIndex={quoteRequestIndex}
-      quoteRequestCount={quoteRequestCount}
-      quoteParams={{
-        srcAmount: sourceAmount,
-        srcToken: sourceToken,
-        destToken,
-        slippage,
-        walletAddress,
-        destWalletAddress: destAddress,
-      }}
-      {...('latestSourceAtomicBalance' in options
-        ? { latestSourceAtomicBalance: options.latestSourceAtomicBalance }
-        : {})}
-    >
-      {children}
-    </SwapQuotesProvider>
-  );
+  mockUseBridgeSession.mockReturnValue({
+    selectedTab: BridgeTabKey.Limit,
+    renderedTab: BridgeTabKey.Limit,
+    setSelectedTab: jest.fn(),
+    setRenderedTab: jest.fn(),
+    quoteParams: {
+      srcAmount: sourceAmount,
+      srcToken: sourceToken,
+      destToken,
+      slippage,
+      walletAddress,
+      destWalletAddress: destAddress,
+    },
+    latestSourceBalance:
+      'latestSourceAtomicBalance' in options
+        ? {
+            atomicBalance: options.latestSourceAtomicBalance,
+            displayBalance: '',
+          }
+        : undefined,
+  });
+
+  return <SwapQuotesProvider>{children}</SwapQuotesProvider>;
 };
 
 jest.mock('../useSwapsFeatureId', () => ({
   useSwapsFeatureId: jest.fn().mockReturnValue('limit_order'),
 }));
+
+jest.mock('../useBridgeSession', () => ({
+  useBridgeSession: jest.fn(),
+}));
+
+const mockUseBridgeSession = useBridgeSession as jest.MockedFunction<
+  typeof useBridgeSession
+>;
 
 describe('useSwapQuotes', () => {
   it('throws an error if used outside of SwapQuotesProvider', () => {
@@ -201,6 +212,8 @@ runQuoteRequestCases({
       },
     ),
   featureId: FeatureId.LIMIT_ORDER,
+  quoteParams: {},
+  debounceWait: mockDebounceMs,
 });
 
 runQuoteDataCases({

--- a/app/components/UI/Bridge/providers/BridgeSessionProvider/index.tsx
+++ b/app/components/UI/Bridge/providers/BridgeSessionProvider/index.tsx
@@ -1,0 +1,99 @@
+import React, { createContext, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import {
+  selectBridgeBalanceRefreshKey,
+  selectDestAddress,
+  selectDestToken,
+  selectSlippage,
+  selectSourceAmount,
+  selectSourceToken,
+} from '../../../../../core/redux/slices/bridge';
+import {
+  BridgeTabKey,
+  TAB_TO_FEATURE_ID,
+} from '../../Views/BridgeView/BridgeView.constants';
+import { useLatestBalance } from '../../hooks/useLatestBalance';
+import type { buildGenericQuoteRequest } from '../../hooks/useSwapQuotes/utils';
+import { selectSourceWalletAddress } from '../../../../../selectors/bridge';
+import { SwapsFeatureIdProvider } from '../SwapsFeatureIdProvider';
+
+export const BridgeSessionContext = createContext<{
+  selectedTab: BridgeTabKey;
+  renderedTab: BridgeTabKey;
+  setSelectedTab: (tab: BridgeTabKey) => void;
+  setRenderedTab: (tab: BridgeTabKey) => void;
+  latestSourceBalance: ReturnType<typeof useLatestBalance>;
+  quoteParams: Parameters<typeof buildGenericQuoteRequest>[0]['quoteParams'];
+} | null>(null);
+
+/**
+ * This context provides the current bridge session state, including the
+ * selected tab, rendered tab, latest source balance, and quote request parameters
+ */
+export const BridgeSessionProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  // `selectedTab` drives the tabs bar and updates urgently so a press is
+  // acknowledged on the same frame. `renderedTab` swaps the content, which is
+  // expensive enough to drop frames, so it is deferred to a transition instead
+  // of holding up that feedback.
+  const [selectedTab, setSelectedTab] = useState(BridgeTabKey.Market);
+  const [renderedTab, setRenderedTab] = useState(BridgeTabKey.Market);
+  const featureId = TAB_TO_FEATURE_ID[renderedTab];
+  const sourceToken = useSelector(selectSourceToken);
+  const balanceRefreshKey = useSelector(selectBridgeBalanceRefreshKey);
+  const latestSourceBalance = useLatestBalance({
+    address: sourceToken?.address,
+    decimals: sourceToken?.decimals,
+    chainId: sourceToken?.chainId,
+    balance: sourceToken?.balance,
+    refreshKey: balanceRefreshKey,
+  });
+
+  const destToken = useSelector(selectDestToken);
+  const sourceAmount = useSelector(selectSourceAmount);
+  const slippage = useSelector(selectSlippage);
+  const walletAddress = useSelector(selectSourceWalletAddress);
+  const destAddress = useSelector(selectDestAddress);
+  const quoteParams = useMemo(
+    (): Parameters<typeof buildGenericQuoteRequest>[0]['quoteParams'] => ({
+      srcToken: sourceToken,
+      destToken,
+      srcAmount: sourceAmount,
+      slippage,
+      walletAddress,
+      destWalletAddress: destAddress,
+    }),
+    [
+      sourceToken,
+      destToken,
+      sourceAmount,
+      slippage,
+      walletAddress,
+      destAddress,
+    ],
+  );
+
+  const value = useMemo(
+    () => ({
+      selectedTab,
+      renderedTab,
+      setSelectedTab,
+      setRenderedTab,
+      latestSourceBalance,
+      quoteParams,
+    }),
+    [selectedTab, renderedTab, latestSourceBalance, quoteParams],
+  );
+
+  return (
+    <BridgeSessionContext.Provider value={value}>
+      <SwapsFeatureIdProvider featureId={featureId}>
+        {children}
+      </SwapsFeatureIdProvider>
+    </BridgeSessionContext.Provider>
+  );
+};

--- a/app/components/UI/Bridge/providers/BridgeSessionProvider/index.tsx
+++ b/app/components/UI/Bridge/providers/BridgeSessionProvider/index.tsx
@@ -46,13 +46,16 @@ export const BridgeSessionProvider = ({
 
   const sourceToken = useSelector(selectSourceToken);
   const balanceRefreshKey = useSelector(selectBridgeBalanceRefreshKey);
-  const latestSourceBalance = useLatestBalance({
-    address: sourceToken?.address,
-    decimals: sourceToken?.decimals,
-    chainId: sourceToken?.chainId,
-    balance: sourceToken?.balance,
-    refreshKey: balanceRefreshKey,
-  });
+  const latestSourceBalance = useLatestBalance(
+    {
+      address: sourceToken?.address,
+      decimals: sourceToken?.decimals,
+      chainId: sourceToken?.chainId,
+      balance: sourceToken?.balance,
+      refreshKey: balanceRefreshKey,
+    },
+    featureId,
+  );
 
   const destToken = useSelector(selectDestToken);
   const sourceAmount = useSelector(selectSourceAmount);

--- a/app/components/UI/Bridge/providers/BridgeSessionProvider/index.tsx
+++ b/app/components/UI/Bridge/providers/BridgeSessionProvider/index.tsx
@@ -43,6 +43,7 @@ export const BridgeSessionProvider = ({
   const [selectedTab, setSelectedTab] = useState(BridgeTabKey.Market);
   const [renderedTab, setRenderedTab] = useState(BridgeTabKey.Market);
   const featureId = TAB_TO_FEATURE_ID[renderedTab];
+
   const sourceToken = useSelector(selectSourceToken);
   const balanceRefreshKey = useSelector(selectBridgeBalanceRefreshKey);
   const latestSourceBalance = useLatestBalance({

--- a/app/components/UI/Bridge/providers/SwapQuotesProvider/index.test.tsx
+++ b/app/components/UI/Bridge/providers/SwapQuotesProvider/index.test.tsx
@@ -67,6 +67,10 @@ jest.mock('../../hooks/useSwapsFeatureId', () => ({
   useSwapsFeatureId: jest.fn(),
 }));
 
+jest.mock('../../hooks/useBridgeSession', () => ({
+  useBridgeSession: jest.fn(),
+}));
+
 const Consumer = () => {
   useSwapQuotes();
   return null;
@@ -76,32 +80,28 @@ runQuoteProviderCases({
   name: 'SwapQuotesContext',
   missingProviderError: 'useSwapQuotes must be used within SwapQuotesProvider',
   featureId: FeatureId.LIMIT_ORDER,
+  quoteParams: {
+    srcAmount: '1000000000',
+    srcToken: {
+      chainId: '0x1',
+      address: '0x1',
+      decimals: 18,
+      symbol: 'USDC',
+      name: 'USDC',
+    },
+    destToken: {
+      chainId: '0x1',
+      address: '0x2',
+      decimals: 18,
+      symbol: 'USDC',
+      name: 'USDC',
+    },
+    walletAddress: '0x1',
+    destWalletAddress: '0x2',
+  },
   renderProvider: (state) =>
     renderWithProvider(
-      <SwapQuotesProvider
-        isActive
-        featureId={FeatureId.LIMIT_ORDER}
-        debounceWait={1000}
-        quoteParams={{
-          srcAmount: '1000000000',
-          srcToken: {
-            chainId: '0x1',
-            address: '0x1',
-            decimals: 18,
-            symbol: 'USDC',
-            name: 'USDC',
-          },
-          destToken: {
-            chainId: '0x1',
-            address: '0x2',
-            decimals: 18,
-            symbol: 'USDC',
-            name: 'USDC',
-          },
-          walletAddress: '0x1',
-          destWalletAddress: '0x2',
-        }}
-      >
+      <SwapQuotesProvider>
         <Consumer />
         <Consumer />
         <Consumer />

--- a/app/components/UI/Bridge/providers/SwapQuotesProvider/index.test.tsx
+++ b/app/components/UI/Bridge/providers/SwapQuotesProvider/index.test.tsx
@@ -63,6 +63,10 @@ jest.mock('../../../../../util/trace', () => ({
   endTrace: jest.fn(),
 }));
 
+jest.mock('../../hooks/useSwapsFeatureId', () => ({
+  useSwapsFeatureId: jest.fn(),
+}));
+
 const Consumer = () => {
   useSwapQuotes();
   return null;
@@ -71,11 +75,12 @@ const Consumer = () => {
 runQuoteProviderCases({
   name: 'SwapQuotesContext',
   missingProviderError: 'useSwapQuotes must be used within SwapQuotesProvider',
+  featureId: FeatureId.LIMIT_ORDER,
   renderProvider: (state) =>
     renderWithProvider(
       <SwapQuotesProvider
         isActive
-        featureId={FeatureId.UNIFIED_SWAP_BRIDGE}
+        featureId={FeatureId.LIMIT_ORDER}
         debounceWait={1000}
         quoteParams={{
           srcAmount: '1000000000',

--- a/app/components/UI/Bridge/providers/SwapQuotesProvider/index.tsx
+++ b/app/components/UI/Bridge/providers/SwapQuotesProvider/index.tsx
@@ -17,6 +17,12 @@ import useIsInsufficientBalance from '../../hooks/useInsufficientBalance';
 import { useInsufficientNativeReserveError } from '../../hooks/useInsufficientNativeReserveError';
 import { selectGasIncludedQuoteParams } from '../../../../../selectors/bridge';
 import { buildGenericQuoteRequest } from '../../hooks/useSwapQuotes/utils';
+import { useBridgeSession } from '../../hooks/useBridgeSession';
+import { useSwapsFeatureId } from '../../hooks/useSwapsFeatureId';
+import {
+  DEBOUNCE_WAIT,
+  MIGRATED_FEATURE_IDS,
+} from '../../Views/BridgeView/BridgeView.constants';
 
 export type SwapQuotesContextValue = ReturnType<typeof useQuoteRequest> &
   ReturnType<typeof useQuoteData>;
@@ -210,18 +216,22 @@ const useQuoteData = ({
   );
 };
 
-export function SwapQuotesProvider({
+export const SwapQuotesProvider = ({
   children,
-  ...params
-}: SwapQuotesProviderProps) {
-  const { quoteParams, latestSourceAtomicBalance } = params;
+}: {
+  children: React.ReactNode;
+}) => {
+  const { quoteParams, latestSourceBalance: latestSourceBalanceFromParent } =
+    useBridgeSession();
   // Presence (not truthiness): parent may pass undefined while its own
   // useLatestBalance is still loading. That must not start a second fetch.
-  const hasLatestSourceBalanceOverride = 'latestSourceAtomicBalance' in params;
+  const hasLatestSourceBalanceOverride = Boolean(latestSourceBalanceFromParent);
+  const featureId = useSwapsFeatureId();
 
+  const isActive = MIGRATED_FEATURE_IDS.includes(featureId);
   // Fetch balance here and pass it to the request/response hooks
   const latestSourceBalance = useLatestBalance(
-    hasLatestSourceBalanceOverride
+    hasLatestSourceBalanceOverride || !isActive
       ? {}
       : {
           address: quoteParams.srcToken?.address,
@@ -231,15 +241,20 @@ export function SwapQuotesProvider({
         },
   );
   const latestAtomicBalance = hasLatestSourceBalanceOverride
-    ? latestSourceAtomicBalance
+    ? latestSourceBalanceFromParent?.atomicBalance
     : latestSourceBalance?.atomicBalance;
   const resolvedParams = {
-    ...params,
+    quoteParams,
+    featureId,
     latestSourceAtomicBalance: latestAtomicBalance,
+    debounceWait: DEBOUNCE_WAIT,
   };
 
   const requestData = useQuoteRequest(resolvedParams);
-  const quoteData = useQuoteData(resolvedParams);
+  const quoteData = useQuoteData({
+    ...resolvedParams,
+    isActive,
+  });
 
   const value = useMemo(
     () => ({ ...requestData, ...quoteData }),
@@ -251,4 +266,4 @@ export function SwapQuotesProvider({
       {children}
     </SwapQuotesContext.Provider>
   );
-}
+};

--- a/app/components/UI/Bridge/routes.tsx
+++ b/app/components/UI/Bridge/routes.tsx
@@ -44,6 +44,8 @@ import type {
   BridgeScreensStackParamList,
 } from './types/navigation';
 import { BridgeSessionProvider } from './providers/BridgeSessionProvider';
+import { BridgeQuoteDataProvider } from './hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import { SwapQuotesProvider } from './providers/SwapQuotesProvider';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ScreenComponent = React.ComponentType<any>;
@@ -51,50 +53,57 @@ type ScreenComponent = React.ComponentType<any>;
 const Stack = createNativeStackNavigator<BridgeScreensStackParamList>();
 export const BridgeScreenStack = () => (
   <BridgeSessionProvider>
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
-      <Stack.Screen name={Routes.BRIDGE.BRIDGE_VIEW} component={BridgeView} />
-      <Stack.Screen
-        name={Routes.BRIDGE.TOKEN_SELECTOR}
-        component={BridgeTokenSelector}
-      />
-      <Stack.Screen
-        name={Routes.BRIDGE.BATCH_SELL_TOKEN_SELECT}
-        component={BatchSellTokenSelect}
-        options={{ title: '' }}
-      />
-      <Stack.Screen
-        name={Routes.BRIDGE.BATCH_SELL_REVIEW}
-        component={BatchSellReview}
-        options={{ title: '' }}
-      />
-      <Stack.Screen
-        name={Routes.BRIDGE.QUOTE_SELECTOR_VIEW}
-        component={QuoteSelectorView}
-      />
-      <Stack.Screen
-        name={Routes.BRIDGE.RECURRING_JOB_DETAILS}
-        component={RecurringJobDetailsView}
-        options={{ headerShown: false }}
-      />
-      <Stack.Screen
-        name={Routes.BRIDGE.HARDWARE_WALLETS_SWAPS}
-        component={HardwareWalletsSwaps}
-        options={{ headerShown: false }}
-      />
-      <Stack.Screen
-        name={Routes.BRIDGE.HW_QR_SCANNER}
-        component={HwQrScanner}
-        options={{ headerShown: false }}
-      />
-      <Stack.Screen
-        name={Routes.BRIDGE.MODALS.ROOT}
-        component={BridgeModalStack}
-        options={{
-          ...clearNativeStackNavigatorOptions,
-          ...transparentModalScreenOptions,
-        }}
-      />
-    </Stack.Navigator>
+    <SwapQuotesProvider>
+      <BridgeQuoteDataProvider>
+        <Stack.Navigator screenOptions={{ headerShown: false }}>
+          <Stack.Screen
+            name={Routes.BRIDGE.BRIDGE_VIEW}
+            component={BridgeView}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.TOKEN_SELECTOR}
+            component={BridgeTokenSelector}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.BATCH_SELL_TOKEN_SELECT}
+            component={BatchSellTokenSelect}
+            options={{ title: '' }}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.BATCH_SELL_REVIEW}
+            component={BatchSellReview}
+            options={{ title: '' }}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.QUOTE_SELECTOR_VIEW}
+            component={QuoteSelectorView}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.RECURRING_JOB_DETAILS}
+            component={RecurringJobDetailsView}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.HARDWARE_WALLETS_SWAPS}
+            component={HardwareWalletsSwaps}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.HW_QR_SCANNER}
+            component={HwQrScanner}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.MODALS.ROOT}
+            component={BridgeModalStack}
+            options={{
+              ...clearNativeStackNavigatorOptions,
+              ...transparentModalScreenOptions,
+            }}
+          />
+        </Stack.Navigator>
+      </BridgeQuoteDataProvider>
+    </SwapQuotesProvider>
   </BridgeSessionProvider>
 );
 

--- a/app/components/UI/Bridge/routes.tsx
+++ b/app/components/UI/Bridge/routes.tsx
@@ -47,68 +47,9 @@ import { BridgeSessionProvider } from './providers/BridgeSessionProvider';
 import { BridgeQuoteDataProvider } from './hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import { SwapQuotesProvider } from './providers/SwapQuotesProvider';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ScreenComponent = React.ComponentType<any>;
-
-const Stack = createNativeStackNavigator<BridgeScreensStackParamList>();
-export const BridgeScreenStack = () => (
-  <BridgeSessionProvider>
-    <SwapQuotesProvider>
-      <BridgeQuoteDataProvider>
-        <Stack.Navigator screenOptions={{ headerShown: false }}>
-          <Stack.Screen
-            name={Routes.BRIDGE.BRIDGE_VIEW}
-            component={BridgeView}
-          />
-          <Stack.Screen
-            name={Routes.BRIDGE.TOKEN_SELECTOR}
-            component={BridgeTokenSelector}
-          />
-          <Stack.Screen
-            name={Routes.BRIDGE.BATCH_SELL_TOKEN_SELECT}
-            component={BatchSellTokenSelect}
-            options={{ title: '' }}
-          />
-          <Stack.Screen
-            name={Routes.BRIDGE.BATCH_SELL_REVIEW}
-            component={BatchSellReview}
-            options={{ title: '' }}
-          />
-          <Stack.Screen
-            name={Routes.BRIDGE.QUOTE_SELECTOR_VIEW}
-            component={QuoteSelectorView}
-          />
-          <Stack.Screen
-            name={Routes.BRIDGE.RECURRING_JOB_DETAILS}
-            component={RecurringJobDetailsView}
-            options={{ headerShown: false }}
-          />
-          <Stack.Screen
-            name={Routes.BRIDGE.HARDWARE_WALLETS_SWAPS}
-            component={HardwareWalletsSwaps}
-            options={{ headerShown: false }}
-          />
-          <Stack.Screen
-            name={Routes.BRIDGE.HW_QR_SCANNER}
-            component={HwQrScanner}
-            options={{ headerShown: false }}
-          />
-          <Stack.Screen
-            name={Routes.BRIDGE.MODALS.ROOT}
-            component={BridgeModalStack}
-            options={{
-              ...clearNativeStackNavigatorOptions,
-              ...transparentModalScreenOptions,
-            }}
-          />
-        </Stack.Navigator>
-      </BridgeQuoteDataProvider>
-    </SwapQuotesProvider>
-  </BridgeSessionProvider>
-);
-
 const ModalStack =
   createNativeStackNavigator<BridgeModalsNavigationParamList>();
+
 export const BridgeModalStack = () => (
   <ModalStack.Navigator
     screenOptions={{
@@ -221,4 +162,64 @@ export const BridgeModalStack = () => (
       component={RecurringConfirmOrderSheetScreen}
     />
   </ModalStack.Navigator>
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ScreenComponent = React.ComponentType<any>;
+
+const Stack = createNativeStackNavigator<BridgeScreensStackParamList>();
+export const BridgeScreenStack = () => (
+  <BridgeSessionProvider>
+    <SwapQuotesProvider>
+      <BridgeQuoteDataProvider>
+        <Stack.Navigator screenOptions={{ headerShown: false }}>
+          <Stack.Screen
+            name={Routes.BRIDGE.BRIDGE_VIEW}
+            component={BridgeView}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.TOKEN_SELECTOR}
+            component={BridgeTokenSelector}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.BATCH_SELL_TOKEN_SELECT}
+            component={BatchSellTokenSelect}
+            options={{ title: '' }}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.BATCH_SELL_REVIEW}
+            component={BatchSellReview}
+            options={{ title: '' }}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.QUOTE_SELECTOR_VIEW}
+            component={QuoteSelectorView}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.RECURRING_JOB_DETAILS}
+            component={RecurringJobDetailsView}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.HARDWARE_WALLETS_SWAPS}
+            component={HardwareWalletsSwaps}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.HW_QR_SCANNER}
+            component={HwQrScanner}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name={Routes.BRIDGE.MODALS.ROOT}
+            component={BridgeModalStack}
+            options={{
+              ...clearNativeStackNavigatorOptions,
+              ...transparentModalScreenOptions,
+            }}
+          />
+        </Stack.Navigator>
+      </BridgeQuoteDataProvider>
+    </SwapQuotesProvider>
+  </BridgeSessionProvider>
 );

--- a/app/components/UI/Bridge/routes.tsx
+++ b/app/components/UI/Bridge/routes.tsx
@@ -84,6 +84,14 @@ export const BridgeScreenStack = () => (
       component={HwQrScanner}
       options={{ headerShown: false }}
     />
+    <Stack.Screen
+      name={Routes.BRIDGE.MODALS.ROOT}
+      component={BridgeModalStack}
+      options={{
+        ...clearNativeStackNavigatorOptions,
+        ...transparentModalScreenOptions,
+      }}
+    />
   </Stack.Navigator>
 );
 

--- a/app/components/UI/Bridge/routes.tsx
+++ b/app/components/UI/Bridge/routes.tsx
@@ -43,56 +43,59 @@ import type {
   BridgeModalsNavigationParamList,
   BridgeScreensStackParamList,
 } from './types/navigation';
+import { BridgeSessionProvider } from './providers/BridgeSessionProvider';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ScreenComponent = React.ComponentType<any>;
 
 const Stack = createNativeStackNavigator<BridgeScreensStackParamList>();
 export const BridgeScreenStack = () => (
-  <Stack.Navigator screenOptions={{ headerShown: false }}>
-    <Stack.Screen name={Routes.BRIDGE.BRIDGE_VIEW} component={BridgeView} />
-    <Stack.Screen
-      name={Routes.BRIDGE.TOKEN_SELECTOR}
-      component={BridgeTokenSelector}
-    />
-    <Stack.Screen
-      name={Routes.BRIDGE.BATCH_SELL_TOKEN_SELECT}
-      component={BatchSellTokenSelect}
-      options={{ title: '' }}
-    />
-    <Stack.Screen
-      name={Routes.BRIDGE.BATCH_SELL_REVIEW}
-      component={BatchSellReview}
-      options={{ title: '' }}
-    />
-    <Stack.Screen
-      name={Routes.BRIDGE.QUOTE_SELECTOR_VIEW}
-      component={QuoteSelectorView}
-    />
-    <Stack.Screen
-      name={Routes.BRIDGE.RECURRING_JOB_DETAILS}
-      component={RecurringJobDetailsView}
-      options={{ headerShown: false }}
-    />
-    <Stack.Screen
-      name={Routes.BRIDGE.HARDWARE_WALLETS_SWAPS}
-      component={HardwareWalletsSwaps}
-      options={{ headerShown: false }}
-    />
-    <Stack.Screen
-      name={Routes.BRIDGE.HW_QR_SCANNER}
-      component={HwQrScanner}
-      options={{ headerShown: false }}
-    />
-    <Stack.Screen
-      name={Routes.BRIDGE.MODALS.ROOT}
-      component={BridgeModalStack}
-      options={{
-        ...clearNativeStackNavigatorOptions,
-        ...transparentModalScreenOptions,
-      }}
-    />
-  </Stack.Navigator>
+  <BridgeSessionProvider>
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name={Routes.BRIDGE.BRIDGE_VIEW} component={BridgeView} />
+      <Stack.Screen
+        name={Routes.BRIDGE.TOKEN_SELECTOR}
+        component={BridgeTokenSelector}
+      />
+      <Stack.Screen
+        name={Routes.BRIDGE.BATCH_SELL_TOKEN_SELECT}
+        component={BatchSellTokenSelect}
+        options={{ title: '' }}
+      />
+      <Stack.Screen
+        name={Routes.BRIDGE.BATCH_SELL_REVIEW}
+        component={BatchSellReview}
+        options={{ title: '' }}
+      />
+      <Stack.Screen
+        name={Routes.BRIDGE.QUOTE_SELECTOR_VIEW}
+        component={QuoteSelectorView}
+      />
+      <Stack.Screen
+        name={Routes.BRIDGE.RECURRING_JOB_DETAILS}
+        component={RecurringJobDetailsView}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={Routes.BRIDGE.HARDWARE_WALLETS_SWAPS}
+        component={HardwareWalletsSwaps}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={Routes.BRIDGE.HW_QR_SCANNER}
+        component={HwQrScanner}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={Routes.BRIDGE.MODALS.ROOT}
+        component={BridgeModalStack}
+        options={{
+          ...clearNativeStackNavigatorOptions,
+          ...transparentModalScreenOptions,
+        }}
+      />
+    </Stack.Navigator>
+  </BridgeSessionProvider>
 );
 
 const ModalStack =

--- a/app/components/UI/Bridge/types/navigation.ts
+++ b/app/components/UI/Bridge/types/navigation.ts
@@ -39,6 +39,9 @@ export type BridgeScreensStackParamList = {
   RecurringJobDetails: RecurringJobDetailsRouteParams;
   HardwareWalletsSwaps: HardwareWalletsSwapsRouteParams | undefined;
   HwQrScanner: HwQrScannerRouteParams | undefined;
+  BridgeModals:
+    | NavigatorScreenParams<BridgeModalsNavigationParamList>
+    | undefined;
 };
 
 /**

--- a/tests/component-view/renderers/bridge.tsx
+++ b/tests/component-view/renderers/bridge.tsx
@@ -89,7 +89,7 @@ export function renderBridgeViewWithModals(
   const state = builder.build();
 
   return renderScreenWithRoutes(
-    BridgeView as unknown as React.ComponentType,
+    BridgeViewWithSession as unknown as React.ComponentType,
     { name: Routes.BRIDGE.BRIDGE_VIEW },
     [
       {
@@ -112,7 +112,7 @@ export function renderBridgeViewWithRecurringJobDetails(
   const state = builder.build();
 
   return renderScreenWithRoutes(
-    BridgeView as unknown as React.ComponentType,
+    BridgeViewWithSession as unknown as React.ComponentType,
     { name: Routes.BRIDGE.BRIDGE_VIEW },
     [
       {

--- a/tests/component-view/renderers/bridge.tsx
+++ b/tests/component-view/renderers/bridge.tsx
@@ -38,6 +38,7 @@ export const withBridgeSession = (Component: React.ComponentType) =>
   };
 
 export const BridgeViewWithSession = withBridgeSession(BridgeView);
+
 interface RenderBridgeViewOptions {
   overrides?: DeepPartial<RootState>;
   deterministicFiat?: boolean;
@@ -71,7 +72,8 @@ export function renderBridgeView(
   const state = builder.build();
 
   return renderComponentViewScreen(
-    BridgeViewWithSession as unknown as React.ComponentType,    { name: Routes.BRIDGE.BRIDGE_VIEW },
+    BridgeViewWithSession as unknown as React.ComponentType,
+    { name: Routes.BRIDGE.BRIDGE_VIEW },
     { state },
   );
 }

--- a/tests/component-view/renderers/bridge.tsx
+++ b/tests/component-view/renderers/bridge.tsx
@@ -20,7 +20,24 @@ import BlockExplorersModal from '../../../app/components/UI/Bridge/components/Tr
 import { initialStateBridge } from '../presets/bridge';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Transaction } from '@metamask/keyring-api';
+import { BridgeSessionProvider } from '../../../app/components/UI/Bridge/providers/BridgeSessionProvider';
+import { SwapQuotesProvider } from '../../../app/components/UI/Bridge/providers/SwapQuotesProvider';
+import { BridgeQuoteDataProvider } from '../../../app/components/UI/Bridge/hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 
+export const withBridgeSession = (Component: React.ComponentType) =>
+  function BridgeViewWithSession() {
+    return (
+      <BridgeSessionProvider>
+        <SwapQuotesProvider>
+          <BridgeQuoteDataProvider>
+            <Component />
+          </BridgeQuoteDataProvider>
+        </SwapQuotesProvider>
+      </BridgeSessionProvider>
+    );
+  };
+
+export const BridgeViewWithSession = withBridgeSession(BridgeView);
 interface RenderBridgeViewOptions {
   overrides?: DeepPartial<RootState>;
   deterministicFiat?: boolean;
@@ -54,8 +71,7 @@ export function renderBridgeView(
   const state = builder.build();
 
   return renderComponentViewScreen(
-    BridgeView as unknown as React.ComponentType,
-    { name: Routes.BRIDGE.BRIDGE_VIEW },
+    BridgeViewWithSession as unknown as React.ComponentType,    { name: Routes.BRIDGE.BRIDGE_VIEW },
     { state },
   );
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This change replaces `BridgeLimitOrderView`'s quote request/data provider with `SwapQuotesProvider`

Added
- Wrap each bridge view in `FeatureIdProvider` and call `useSwapFeatureId` to retrieve active FeatureId
- One BridgeSessionProvider owns tab state and the source-token balance for the whole Bridge stack (screens + modals), so tabs and quote modals no longer each call useLatestBalance

Changed
- Use the SwapQuotesProvider in the Limit view
  - define a list of "migrated" features
  - return early in `useSwapQuotes` if the active featureId is not on the list
  - useBridgeQuoteDataContext prefers useSwapQuotes() when the tab is migrated (LIMIT_ORDER); Market / Recurring stay on BridgeQuoteDataProvider.
  - wrap Limit view in `SwapQuotesProvider`

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: limit order quotes from session providers

  Scenario: source token survives Limit to Market
    Given the user is on Bridge with a source token selected
    When the user switches to Limit then back to Market
    Then the source token is still selected

  Scenario: Limit still quotes
    Given the user is on the Limit tab with a valid pair and amount
    Then a limit quote is shown and confirm stays available

  Scenario: Market quote selector still opens
    Given the Market tab has a fetched quote
    When the user opens the quote selector
    Then the select quote screen is shown

  Scenario: quote warning modals still confirm
    Given a Price Impact, Token Warning, or Missing Price modal is open over Bridge
    Then confirm still uses the session quote and does not refetch source balance on its own
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
