### PR TITLE
fix(permissions): use MMDS buttons on connect summary screens

### DIFF
--- a/app/components/UI/PermissionsSummary/MaliciousDappIndicators.test.tsx
+++ b/app/components/UI/PermissionsSummary/MaliciousDappIndicators.test.tsx
@@ -2,15 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import {
   MaliciousDappUrlIcon,
-  DangerConnectButtonContent,
+  getConnectButtonContent,
 } from './MaliciousDappIndicators';
-
-jest.mock('../../../util/theme', () => {
-  const { mockTheme } = jest.requireActual('../../../util/theme');
-  return {
-    useTheme: jest.fn(() => mockTheme),
-  };
-});
 
 describe('MaliciousDappIndicators', () => {
   describe('MaliciousDappUrlIcon', () => {
@@ -21,24 +14,17 @@ describe('MaliciousDappIndicators', () => {
     });
   });
 
-  describe('DangerConnectButtonContent', () => {
-    it('renders the Connect label', () => {
-      const { getByText } = render(<DangerConnectButtonContent />);
-      expect(getByText('Connect')).toBeDefined();
+  describe('getConnectButtonContent', () => {
+    it('returns the Connect label for a standard connection', () => {
+      expect(getConnectButtonContent(false, false)).toBe('Connect');
     });
 
-    it('renders a Danger icon alongside the label', () => {
-      const { toJSON } = render(<DangerConnectButtonContent />);
-      const tree = JSON.stringify(toJSON());
-      expect(tree).toContain('Danger');
-      expect(tree).toContain('Connect');
+    it('returns the Confirm label for a network switch', () => {
+      expect(getConnectButtonContent(false, true)).toBe('Confirm');
     });
 
-    it('renders with a row layout', () => {
-      const { toJSON } = render(<DangerConnectButtonContent />);
-      const root = toJSON();
-      const node = Array.isArray(root) ? root[0] : root;
-      expect(node?.props?.style?.flexDirection).toBe('row');
+    it('returns the Connect label for a malicious dapp connection', () => {
+      expect(getConnectButtonContent(true, false)).toBe('Connect');
     });
   });
 });

--- a/app/components/UI/PermissionsSummary/MaliciousDappIndicators.tsx
+++ b/app/components/UI/PermissionsSummary/MaliciousDappIndicators.tsx
@@ -1,28 +1,16 @@
 import React from 'react';
-import { StyleSheet, Text as RNText, View } from 'react-native';
+import { StyleSheet } from 'react-native';
 import Icon, {
   IconColor,
   IconName,
   IconSize,
 } from '../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../locales/i18n';
-import { useTheme } from '../../../util/theme';
 
 const styles = StyleSheet.create({
   urlIcon: {
     marginTop: 2,
     alignSelf: 'center',
-  },
-  buttonContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 4,
-  },
-  buttonText: {
-    fontSize: 14,
-    fontFamily: 'Geist-SemiBold',
-    textAlign: 'center',
   },
 });
 
@@ -40,37 +28,13 @@ export const MaliciousDappUrlIcon = () => (
 );
 
 /**
- * Content for the red "Connect" button on Step 1 of the malicious-dapp
- * warning flow.  Renders a danger triangle to the left of the "Connect" label.
- */
-export const DangerConnectButtonContent = () => {
-  const { colors } = useTheme();
-
-  return (
-    <View style={styles.buttonContent}>
-      <Icon
-        name={IconName.Danger}
-        size={IconSize.Sm}
-        color={IconColor.Inverse}
-      />
-      <RNText style={[styles.buttonText, { color: colors.primary.inverse }]}>
-        {strings('accounts.connect')}
-      </RNText>
-    </View>
-  );
-};
-
-/**
  * Returns the appropriate label for the confirm/connect button based on
- * whether the dApp is malicious and whether this is a network switch.
+ * whether this is a network switch.
  */
 export const getConnectButtonContent = (
-  isMaliciousDapp: boolean,
+  _isMaliciousDapp: boolean,
   isNetworkSwitch: boolean,
-): React.ReactNode => {
-  if (isMaliciousDapp && !isNetworkSwitch) {
-    return <DangerConnectButtonContent />;
-  }
+): string => {
   if (isNetworkSwitch) {
     return strings('confirmation_modal.confirm_cta');
   }

--- a/app/components/UI/PermissionsSummary/PermissionsSummary.styles.ts
+++ b/app/components/UI/PermissionsSummary/PermissionsSummary.styles.ts
@@ -52,18 +52,10 @@ const createStyles = (params: {
     actionButtonsContainer: {
       flex: 0,
       flexDirection: 'row',
+      gap: 16,
       marginTop: 8,
       paddingHorizontal: 16,
       marginBottom: Platform.OS === 'android' ? 16 : 0,
-    },
-    buttonPositioning: {
-      flex: 1,
-    },
-    cancelButton: {
-      marginRight: 8,
-    },
-    confirmButton: {
-      marginLeft: 8,
     },
     networkPermissionRequestInfoCard: {
       marginHorizontal: 24,

--- a/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
+++ b/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
@@ -5,7 +5,6 @@ import ScrollableTabView from '@tommasini/react-native-scrollable-tab-view';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import { NON_EVM_TESTNET_IDS } from '@metamask/multichain-network-controller';
-import StyledButton from '../StyledButton';
 import { strings } from '../../../../locales/i18n';
 import { useTheme } from '../../../util/theme';
 import { CommonSelectorsIDs } from '../../../util/Common.testIds';
@@ -693,29 +692,34 @@ const PermissionsSummary = ({
           )}
           {showActionButtons && !isNonDappNetworkSwitch && (
             <View style={styles.actionButtonsContainer}>
-              <StyledButton
-                type={'cancel'}
+              <Button
+                variant={ButtonVariant.Secondary}
                 onPress={cancel}
-                containerStyle={[styles.buttonPositioning, styles.cancelButton]}
+                size={ButtonSize.Lg}
+                twClassName="flex-1"
                 testID={CommonSelectorsIDs.CANCEL_BUTTON}
               >
                 {strings('permissions.cancel')}
-              </StyledButton>
-              <StyledButton
-                type={isMaliciousDapp ? 'danger' : 'confirm'}
+              </Button>
+              <Button
+                variant={ButtonVariant.Primary}
                 onPress={confirm}
-                disabled={
+                isDanger={isMaliciousDapp && !isNetworkSwitch}
+                startIconName={
+                  isMaliciousDapp && !isNetworkSwitch
+                    ? IconName.Danger
+                    : undefined
+                }
+                isDisabled={
                   !isNetworkSwitch &&
                   (accountAddresses.length === 0 || networkAvatars.length === 0)
                 }
-                containerStyle={[
-                  styles.buttonPositioning,
-                  styles.confirmButton,
-                ]}
+                size={ButtonSize.Lg}
+                twClassName="flex-1"
                 testID={CommonSelectorsIDs.CONNECT_BUTTON}
               >
                 {getConnectButtonContent(isMaliciousDapp, isNetworkSwitch)}
-              </StyledButton>
+              </Button>
             </View>
           )}
           {isNonDappNetworkSwitch && (

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.styles.ts
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.styles.ts
@@ -41,7 +41,6 @@ const createStyles = (params: { theme: Theme }) => {
     actionButtonsContainer: {
       flex: 0,
       flexDirection: 'row',
-      gap: 16,
       marginTop: 8,
       paddingHorizontal: 16,
       marginBottom: Platform.OS === 'android' ? 16 : 0,

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.styles.ts
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.styles.ts
@@ -41,18 +41,10 @@ const createStyles = (params: { theme: Theme }) => {
     actionButtonsContainer: {
       flex: 0,
       flexDirection: 'row',
+      gap: 16,
       marginTop: 8,
       paddingHorizontal: 16,
       marginBottom: Platform.OS === 'android' ? 16 : 0,
-    },
-    buttonPositioning: {
-      flex: 1,
-    },
-    cancelButton: {
-      marginRight: 8,
-    },
-    confirmButton: {
-      marginLeft: 8,
     },
     networkPermissionRequestInfoCard: {
       marginHorizontal: 24,

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
@@ -653,7 +653,7 @@ const MultichainPermissionsSummary = ({
                 variant={ButtonVariant.Secondary}
                 onPress={cancel}
                 size={ButtonBaseSize.Lg}
-                twClassName="flex-1"
+                twClassName="mr-4 flex-1"
                 testID={CommonSelectorsIDs.CANCEL_BUTTON}
               >
                 {strings('permissions.cancel')}

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
@@ -5,7 +5,6 @@ import ScrollableTabView from '@tommasini/react-native-scrollable-tab-view';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../core/NavigationService/types';
 import { navigateWithDetails } from '../../../../util/navigation/navUtils';
-import StyledButton from '../../../UI/StyledButton';
 import { strings } from '../../../../../locales/i18n';
 import { useTheme } from '../../../../util/theme';
 import { CommonSelectorsIDs } from '../../../../util/Common.testIds';
@@ -650,30 +649,35 @@ const MultichainPermissionsSummary = ({
           )}
           {showActionButtons && !isNonDappNetworkSwitch && (
             <View style={styles.actionButtonsContainer}>
-              <StyledButton
-                type={'cancel'}
+              <Button
+                variant={ButtonVariant.Secondary}
                 onPress={cancel}
-                containerStyle={[styles.buttonPositioning, styles.cancelButton]}
+                size={ButtonBaseSize.Lg}
+                twClassName="flex-1"
                 testID={CommonSelectorsIDs.CANCEL_BUTTON}
               >
                 {strings('permissions.cancel')}
-              </StyledButton>
-              <StyledButton
-                type={isMaliciousDapp ? 'danger' : 'confirm'}
+              </Button>
+              <Button
+                variant={ButtonVariant.Primary}
                 onPress={confirm}
-                disabled={
+                isDanger={isMaliciousDapp && !isNetworkSwitch}
+                startIconName={
+                  isMaliciousDapp && !isNetworkSwitch
+                    ? DesignSystemIconName.Danger
+                    : undefined
+                }
+                isDisabled={
                   !isNetworkSwitch &&
                   (selectedAccountGroupIds.length === 0 ||
                     networkAvatars.length === 0)
                 }
-                containerStyle={[
-                  styles.buttonPositioning,
-                  styles.confirmButton,
-                ]}
+                size={ButtonBaseSize.Lg}
+                twClassName="flex-1"
                 testID={CommonSelectorsIDs.CONNECT_BUTTON}
               >
                 {getConnectButtonContent(isMaliciousDapp, isNetworkSwitch)}
-              </StyledButton>
+              </Button>
             </View>
           )}
           {isNonDappNetworkSwitch && (


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Cancel/Connect on the dapp permissions summary screens still used deprecated `StyledButton`, which rendered the legacy blue primary CTA and looked inconsistent with the rest of the app’s monochromatic MMDS buttons.

This PR replaces those CTAs with `@metamask/design-system-react-native` `Button` (`Secondary` for Cancel, `Primary` for Connect) in both `PermissionsSummary` and `MultichainPermissionsSummary`. Malicious-dapp Connect now uses `isDanger` + `startIconName` instead of custom button content. Button spacing uses container `gap` and `twClassName="flex-1"`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated Cancel and Connect buttons on website connection screens to use MetaMask design system styling

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Permissions connect action buttons

  Background:
    Given I am logged into MetaMask Mobile with at least one account

  Scenario: Connect buttons use MMDS primary/secondary styling
    Given I open the in-app browser
    And I navigate to a dapp that requests connection
    When the "Connect this website with MetaMask" sheet appears
    Then the Cancel button uses the MMDS secondary (outlined) style
    And the Connect button uses the MMDS primary (monochromatic) style

  Scenario: Connect and Cancel still work
    Given the permissions connect sheet is visible with an account and network selected
    When I tap Cancel
    Then the sheet dismisses without connecting
    When I reopen the connect sheet and tap Connect
    Then the dapp is connected successfully
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/eae13c11-e55e-4fc3-b3d8-bbdbcd5f0889




### **After**


https://github.com/user-attachments/assets/21caa33c-3fc5-40c7-944d-7a85e5384f76



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)