### PR TITLE
fix(perps): fix BTC Perps volume denomination

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -46,6 +46,8 @@ export const PerpsOHLCVBarSelectorsIDs = {
   CONTAINER: 'perps-ohlcv-bar',
   VALUES_ROW: 'perps-ohlcv-bar-values-row',
   LABELS_ROW: 'perps-ohlcv-bar-labels-row',
+  OPEN_VALUE: 'perps-ohlcv-bar-open-value',
+  VOLUME_VALUE: 'perps-ohlcv-bar-volume-value',
 };
 
 // ========================================

--- a/app/components/UI/Perps/components/PerpsOHLCVBar/PerpsOHLCVBar.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOHLCVBar/PerpsOHLCVBar.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react-native';
 import PerpsOHLCVBar from './PerpsOHLCVBar';
 import {
   formatPerpsFiat,
-  formatVolume,
+  formatCoinVolume,
   PRICE_RANGES_UNIVERSAL,
 } from '../../utils/formatUtils';
 import { PerpsOHLCVBarSelectorsIDs } from '../../Perps.testIds';
@@ -23,7 +23,7 @@ jest.mock('../../../../../component-library/hooks', () => ({
 
 jest.mock('../../utils/formatUtils', () => ({
   formatPerpsFiat: jest.fn(),
-  formatVolume: jest.fn(),
+  formatCoinVolume: jest.fn(),
   PRICE_RANGES_UNIVERSAL: [],
 }));
 
@@ -31,14 +31,14 @@ describe('PerpsOHLCVBar', () => {
   const mockFormatPerpsFiat = formatPerpsFiat as jest.MockedFunction<
     typeof formatPerpsFiat
   >;
-  const mockFormatVolume = formatVolume as jest.MockedFunction<
-    typeof formatVolume
+  const mockFormatCoinVolume = formatCoinVolume as jest.MockedFunction<
+    typeof formatCoinVolume
   >;
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockFormatPerpsFiat.mockReturnValue('$1000.00');
-    mockFormatVolume.mockReturnValue('1.2M');
+    mockFormatCoinVolume.mockReturnValue('1.2M');
   });
 
   afterEach(() => {
@@ -121,7 +121,7 @@ describe('PerpsOHLCVBar', () => {
       });
     });
 
-    it('calls formatVolume when volume is provided', () => {
+    it('calls formatCoinVolume when volume is provided', () => {
       render(
         <PerpsOHLCVBar
           open="1000.00"
@@ -133,10 +133,10 @@ describe('PerpsOHLCVBar', () => {
         />,
       );
 
-      expect(mockFormatVolume).toHaveBeenCalledWith('1234567.89');
+      expect(mockFormatCoinVolume).toHaveBeenCalledWith('1234567.89');
     });
 
-    it('does not call formatVolume when volume is not provided', () => {
+    it('does not call formatCoinVolume when volume is not provided', () => {
       render(
         <PerpsOHLCVBar
           open="1000.00"
@@ -147,7 +147,26 @@ describe('PerpsOHLCVBar', () => {
         />,
       );
 
-      expect(mockFormatVolume).not.toHaveBeenCalled();
+      expect(mockFormatCoinVolume).not.toHaveBeenCalled();
+    });
+
+    it('renders coin volume without a USD prefix', () => {
+      mockFormatCoinVolume.mockReturnValue('0.33');
+
+      const { getByTestId } = render(
+        <PerpsOHLCVBar
+          open="77479"
+          high="77662"
+          low="77413"
+          close="77595"
+          volume="0.33"
+          testID={PerpsOHLCVBarSelectorsIDs.CONTAINER}
+        />,
+      );
+
+      expect(
+        getByTestId(PerpsOHLCVBarSelectorsIDs.VOLUME_VALUE),
+      ).toHaveTextContent('0.33');
     });
   });
 
@@ -181,7 +200,7 @@ describe('PerpsOHLCVBar', () => {
 
       expect(getByTestId(PerpsOHLCVBarSelectorsIDs.CONTAINER)).toBeDefined();
       expect(mockFormatPerpsFiat).toHaveBeenCalledTimes(4);
-      expect(mockFormatVolume).toHaveBeenCalledWith('999999999999');
+      expect(mockFormatCoinVolume).toHaveBeenCalledWith('999999999999');
     });
 
     it('handles high decimal precision', () => {

--- a/app/components/UI/Perps/components/PerpsOHLCVBar/PerpsOHLCVBar.tsx
+++ b/app/components/UI/Perps/components/PerpsOHLCVBar/PerpsOHLCVBar.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { View } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import {
@@ -10,6 +10,7 @@ import { createStyles } from './PerpsOHLCVBar.styles';
 import type { PerpsOHLCVBarProps } from './PerpsOHLCVBar.types';
 import { strings } from '../../../../../../locales/i18n';
 import { Text, TextColor } from '@metamask/design-system-react-native';
+import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 
 /**
  * PerpsOHLCVBar Component
@@ -80,6 +81,18 @@ const PerpsOHLCVBar: React.FC<PerpsOHLCVBarProps> = ({
       volume: formattedVolume,
     };
   }, [open, high, low, close, volume]);
+
+  useEffect(() => {
+    if (formattedValues.volume && formattedValues.volume.includes('$')) {
+      DevLogger.log(
+        '[PR-TAT-3867] BUG_MARKER: HLOCV volume formatted as USD while candle volume is coin-denominated',
+        {
+          formattedVolume: formattedValues.volume,
+          rawVolume: volume,
+        },
+      );
+    }
+  }, [formattedValues.volume, volume]);
 
   return (
     <View style={styles.container} testID={testID}>

--- a/app/components/UI/Perps/components/PerpsOHLCVBar/PerpsOHLCVBar.tsx
+++ b/app/components/UI/Perps/components/PerpsOHLCVBar/PerpsOHLCVBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import {
@@ -10,7 +10,6 @@ import { createStyles } from './PerpsOHLCVBar.styles';
 import type { PerpsOHLCVBarProps } from './PerpsOHLCVBar.types';
 import { strings } from '../../../../../../locales/i18n';
 import { Text, TextColor } from '@metamask/design-system-react-native';
-import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 import { PerpsOHLCVBarSelectorsIDs } from '../../Perps.testIds';
 
 /**
@@ -82,18 +81,6 @@ const PerpsOHLCVBar: React.FC<PerpsOHLCVBarProps> = ({
       volume: formattedVolume,
     };
   }, [open, high, low, close, volume]);
-
-  useEffect(() => {
-    if (formattedValues.volume && formattedValues.volume.includes('$')) {
-      DevLogger.log(
-        '[PR-TAT-3867] BUG_MARKER: HLOCV volume formatted as USD while candle volume is coin-denominated',
-        {
-          formattedVolume: formattedValues.volume,
-          rawVolume: volume,
-        },
-      );
-    }
-  }, [formattedValues.volume, volume]);
 
   return (
     <View style={styles.container} testID={testID}>

--- a/app/components/UI/Perps/components/PerpsOHLCVBar/PerpsOHLCVBar.tsx
+++ b/app/components/UI/Perps/components/PerpsOHLCVBar/PerpsOHLCVBar.tsx
@@ -11,6 +11,7 @@ import type { PerpsOHLCVBarProps } from './PerpsOHLCVBar.types';
 import { strings } from '../../../../../../locales/i18n';
 import { Text, TextColor } from '@metamask/design-system-react-native';
 import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
+import { PerpsOHLCVBarSelectorsIDs } from '../../Perps.testIds';
 
 /**
  * PerpsOHLCVBar Component
@@ -105,6 +106,11 @@ const PerpsOHLCVBar: React.FC<PerpsOHLCVBarProps> = ({
             numberOfLines={1}
             adjustsFontSizeToFit
             minimumFontScale={0.7}
+            testID={
+              testID
+                ? `${testID}-open-value`
+                : PerpsOHLCVBarSelectorsIDs.OPEN_VALUE
+            }
           >
             {formattedValues.open}
           </Text>
@@ -150,6 +156,11 @@ const PerpsOHLCVBar: React.FC<PerpsOHLCVBarProps> = ({
               numberOfLines={1}
               adjustsFontSizeToFit
               minimumFontScale={0.7}
+              testID={
+                testID
+                  ? `${testID}-volume-value`
+                  : PerpsOHLCVBarSelectorsIDs.VOLUME_VALUE
+              }
             >
               {formattedValues.volume}
             </Text>

--- a/app/components/UI/Perps/components/PerpsOHLCVBar/PerpsOHLCVBar.tsx
+++ b/app/components/UI/Perps/components/PerpsOHLCVBar/PerpsOHLCVBar.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import {
   formatPerpsFiat,
-  formatVolume,
+  formatCoinVolume,
   PRICE_RANGES_UNIVERSAL,
 } from '../../utils/formatUtils';
 import { createStyles } from './PerpsOHLCVBar.styles';
@@ -70,8 +70,8 @@ const PerpsOHLCVBar: React.FC<PerpsOHLCVBarProps> = ({
       stripTrailingZeros: true,
     });
 
-    // Format volume with K/M/B/T suffixes (if provided)
-    const formattedVolume = volume ? formatVolume(volume) : null;
+    // Candle volume is base-asset size (coins), not USD.
+    const formattedVolume = volume ? formatCoinVolume(volume) : null;
 
     return {
       open: formattedOpen,

--- a/app/components/UI/Perps/utils/formatUtils.test.ts
+++ b/app/components/UI/Perps/utils/formatUtils.test.ts
@@ -9,6 +9,7 @@ import {
   formatPercentage,
   formatLargeNumber,
   formatVolume,
+  formatCoinVolume,
   formatPositionSize,
   formatLeverage,
   parseCurrencyString,
@@ -802,6 +803,32 @@ describe('formatUtils', () => {
       expect(formatVolume(1000000000000)).toBe('$1.00T');
       expect(formatVolume(2500000000000)).toBe('$2.50T');
       expect(formatVolume(2500000000000, 0)).toBe('$3T');
+    });
+  });
+
+  describe('formatCoinVolume', () => {
+    it('formats candle volume without a USD prefix', () => {
+      const volume = 0.33;
+
+      const result = formatCoinVolume(volume);
+
+      expect(result).toBe('0.33');
+    });
+
+    it('keeps magnitude suffixes without a dollar sign', () => {
+      const volume = 123456;
+
+      const result = formatCoinVolume(volume);
+
+      expect(result).toBe('123K');
+    });
+
+    it('keeps the minus sign in front of negative coin volume', () => {
+      const volume = -1000000;
+
+      const result = formatCoinVolume(volume);
+
+      expect(result).toBe('-1.00M');
     });
   });
 

--- a/app/components/UI/Perps/utils/formatUtils.ts
+++ b/app/components/UI/Perps/utils/formatUtils.ts
@@ -347,6 +347,19 @@ export const formatVolume = (
 };
 
 /**
+ * Formats coin (base-asset) volume with the same magnitude suffixes as
+ * {@link formatVolume}, without a fiat `$` prefix.
+ * Candle volume from Hyperliquid is denominated in coins, not USD.
+ *
+ * @example formatCoinVolume(0.33) => "0.33"
+ * @example formatCoinVolume(123456) => "123K"
+ */
+export const formatCoinVolume = (
+  volume: string | number,
+  decimals?: number,
+): string => formatVolume(volume, decimals).replace('$', '');
+
+/**
  * Formats leverage value with 'x' suffix
  * @param leverage - Raw leverage multiplier value
  * @returns Format: "X.Xx" (1 decimal place with 'x' suffix)


### PR DESCRIPTION
## **Description**

Pressing a Perps candle shows HLOCV Volume with a `$` prefix even though Hyperliquid candle volume is base-asset size (BTC coins, not USD). A 5k BTC candle read as `$5K`.

This formats that volume with `formatCoinVolume`, which keeps K/M/B/T suffixes and drops the fiat prefix. Open, Close, High, and Low stay USD.

## **Changelog**

CHANGELOG entry: Fixed Perps chart candle volume showing as USD instead of coin size

## **Related issues**

Fixes: [TAT-3867](https://consensyssoftware.atlassian.net/browse/TAT-3867)

## **Manual testing steps**

```gherkin
Feature: Perps chart HLOCV volume denomination

  Scenario: user inspects BTC candle volume
    Given the wallet is unlocked
    And Perps is open on the BTC-USD market

    When user opens the fullscreen chart
    And user presses a candle
    Then Volume is shown without a $ prefix
    And Open, Close, High, and Low remain USD prices
```

## **Screenshots/Recordings**

Volume column is the delta: $0.33 before, 1.30 after (no USD prefix). OHLC prices stay in USD.

<table>
<tr><td colspan="2"><strong>HLOCV Volume: $0.33 (USD prefix, bug) vs 1.30 (coin size, fix). Open/High/Low/Close stay USD.</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35572/before-evidence-ac1-hlocv-closeup.png?sha=aec502b1cf2c1e57" alt="before" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35572/after-ac1-hlocv-closeup.png?sha=869673699aae7a0c" alt="after" width="320" /></td>
</tr>
</table>

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "BTC Perps HLOCV volume is coin-denominated",
  "description": "Opens BTC market details, selects a candle, and proves HLOCV Volume is not USD-prefixed while Open remains a USD price.",
  "workflow": {
    "entry": "setup-unlock",
    "nodes": {
      "setup-unlock": {
        "action": "metamask.wallet.ensure_unlocked",
        "intent": "Unlock the fixture wallet so Perps is reachable",
        "next": "setup-start"
      },
      "setup-start": {
        "action": "metamask.perps.start_state",
        "intent": "Reach an unlocked Perps session for the Bitcoin market",
        "market": "BTC",
        "network": "testnet",
        "page": "market_details",
        "next": "setup-navigate-market"
      },
      "setup-navigate-market": {
        "action": "ui.navigate",
        "page": "perps-market",
        "market": "BTC",
        "timeout_ms": 45000,
        "intent": "Open the Bitcoin perpetual market details screen",
        "next": "setup-wait-market"
      },
      "setup-wait-market": {
        "action": "ui.wait_for",
        "test_id": "perps-market-details-view",
        "expected": "visible",
        "timeout_ms": 45000,
        "intent": "Confirm the Bitcoin perpetual market screen is visible",
        "next": "setup-open-fullscreen"
      },
      "setup-open-fullscreen": {
        "action": "ui.press",
        "test_id": "perps-market-details-fullscreen-chart-button",
        "intent": "Open the fullscreen Bitcoin chart so a candle can be selected",
        "next": "setup-wait-fullscreen"
      },
      "setup-wait-fullscreen": {
        "action": "ui.wait_for",
        "test_id": "perps-chart-fullscreen-close-button",
        "expected": "visible",
        "timeout_ms": 15000,
        "intent": "Confirm the fullscreen Bitcoin chart is on screen",
        "next": "setup-wait-chart-ready"
      },
      "setup-wait-chart-ready": {
        "action": "ui.wait_for",
        "test_id": "advanced-chart-skeleton",
        "expected": "absent",
        "timeout_ms": 20000,
        "intent": "Confirm the Bitcoin candles have finished loading before selecting one",
        "next": "ac1-tap-chart"
      },
      "ac1-tap-chart": {
        "action": "command",
        "cmd": "idb ui tap --udid 6DB37F77-5F8F-4E8C-B6B3-8FD1AAD75EA3 --api hid --duration 0.8 200 420",
        "intent": "Select a Bitcoin candle so the HLOCV volume row appears",
        "next": "ac1-wait-ohlcv"
      },
      "ac1-wait-ohlcv": {
        "action": "ui.wait_for",
        "test_id": "fullscreen-chart-ohlcv-bar",
        "expected": "present",
        "timeout_ms": 10000,
        "intent": "Confirm the candle open high low close volume row is on screen",
        "next": "ac1-wait-volume"
      },
      "ac1-wait-volume": {
        "action": "ui.wait_for",
        "test_id": "fullscreen-chart-ohlcv-bar-volume-value",
        "expected": "present",
        "timeout_ms": 8000,
        "intent": "Confirm the selected candle volume value is visible",
        "next": "ac1-assert-volume-not-usd"
      },
      "ac1-assert-volume-not-usd": {
        "action": "ui.wait_for",
        "test_id": "fullscreen-chart-ohlcv-bar-volume-value",
        "text": "$",
        "text_match": "contains",
        "expected": "absent",
        "timeout_ms": 5000,
        "intent": "Confirm the selected candle volume is not shown as a USD amount",
        "next": "ac1-screenshot-volume"
      },
      "ac1-screenshot-volume": {
        "action": "ui.screenshot",
        "label": "AC1: HLOCV Volume is coin-denominated",
        "intent": "Preserve the HLOCV volume value without a USD prefix",
        "next": "ac2-wait-open-usd"
      },
      "ac2-wait-open-usd": {
        "action": "ui.wait_for",
        "test_id": "fullscreen-chart-ohlcv-bar-open-value",
        "text": "$",
        "text_match": "contains",
        "expected": "present",
        "timeout_ms": 8000,
        "intent": "Confirm the selected candle open price remains a USD amount",
        "next": "ac2-screenshot-prices"
      },
      "ac2-screenshot-prices": {
        "action": "ui.screenshot",
        "label": "AC2: HLOCV Open Close High Low remain USD",
        "intent": "Preserve the HLOCV open price still shown as USD",
        "next": "done"
      },
      "done": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
  setup-unlock[setup-unlock: unlock wallet]
  setup-start[setup-start: Perps BTC session]
  setup-navigate-market[setup-navigate-market: BTC market details]
  setup-wait-market[setup-wait-market: market view visible]
  setup-open-fullscreen[setup-open-fullscreen: open fullscreen chart]
  setup-wait-fullscreen[setup-wait-fullscreen: fullscreen close control]
  setup-wait-chart-ready[setup-wait-chart-ready: candles loaded]
  ac1-tap-chart[ac1-tap-chart: select candle]
  ac1-wait-ohlcv[ac1-wait-ohlcv: HLOCV bar present]
  ac1-wait-volume[ac1-wait-volume: volume value present]
  ac1-assert-volume-not-usd[ac1-assert-volume-not-usd: volume has no $]
  ac1-screenshot-volume[ac1-screenshot-volume: capture volume]
  ac2-wait-open-usd[ac2-wait-open-usd: open price still $]
  ac2-screenshot-prices[ac2-screenshot-prices: capture prices]
  done[done]

  setup-unlock --> setup-start --> setup-navigate-market --> setup-wait-market
  setup-wait-market --> setup-open-fullscreen --> setup-wait-fullscreen --> setup-wait-chart-ready
  setup-wait-chart-ready --> ac1-tap-chart --> ac1-wait-ohlcv --> ac1-wait-volume
  ac1-wait-volume --> ac1-assert-volume-not-usd --> ac1-screenshot-volume
  ac1-screenshot-volume --> ac2-wait-open-usd --> ac2-screenshot-prices --> done
```

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TAT-3867]: https://consensyssoftware.atlassian.net/browse/TAT-3867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display-format change on the OHLCV bar with new formatter and tests; no auth, payments, or trading logic touched.
> 
> **Overview**
> Fixes **mislabeled candle volume** on the Perps chart HLOCV bar: Hyperliquid reports volume in **base asset (e.g. BTC)**, but the UI formatted it with `formatVolume`, which adds a **`$` prefix** like a USD notional.
> 
> **`PerpsOHLCVBar`** now formats volume with new **`formatCoinVolume`** (same K/M/B/T scaling as `formatVolume`, minus the dollar sign). **Open, high, low, and close** still use **`formatPerpsFiat`**.
> 
> Adds **`formatCoinVolume`** in `formatUtils` and unit/component tests. **E2E selectors** `OPEN_VALUE` and `VOLUME_VALUE` (and dynamic `*-open-value` / `*-volume-value` testIDs on the bar) support automation that asserts volume has no `$` while open still does.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9596b341d7a3226eae6331c5f5dd71a6b8ee26a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->