### PR TITLE
fix(perps): performance issue: Deposit button delay and token list lag in Perps flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Made Perps Add funds open the deposit confirmation immediately instead of waiting for transaction prep
+
 ## [8.9.1]
 
 ### Fixed

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -1822,17 +1822,26 @@ describe('PerpsMarketDetailsView', () => {
       const addFundsButton = getByTestId(
         PerpsMarketDetailsViewSelectorsIDs.ADD_FUNDS_BUTTON,
       );
-      await act(async () => {
-        fireEvent.press(addFundsButton);
-      });
+      jest.useFakeTimers();
+      try {
+        await act(async () => {
+          fireEvent.press(addFundsButton);
+        });
 
-      await waitFor(() => {
         expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
           loader: 'customAmount',
           stack: 'Perps',
         });
+        expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
+
+        await act(async () => {
+          jest.runAllTimers();
+        });
+
         expect(mockDepositWithConfirmation).toHaveBeenCalled();
-      });
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('handles depositWithConfirmation rejection without throwing', async () => {

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -243,6 +243,7 @@ const mockGoBack = jest.fn();
 const mockCanGoBack = jest.fn();
 const mockReset = jest.fn();
 const mockGetState = jest.fn();
+const mockAddListener = jest.fn(() => jest.fn());
 const mockSetPerpsMode = jest.fn();
 // Mutable active mode surfaced by the mocked usePerpsMode hook.
 let mockPerpsModeValue = 'lite';
@@ -306,6 +307,7 @@ jest.mock('@react-navigation/native', () => {
       canGoBack: mockCanGoBack,
       setOptions: jest.fn(),
       getState: mockGetState,
+      addListener: mockAddListener,
       reset: mockReset,
     }),
     useRoute: () => ({
@@ -1826,6 +1828,7 @@ describe('PerpsMarketDetailsView', () => {
 
       await waitFor(() => {
         expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
+          loader: 'customAmount',
           stack: 'Perps',
         });
         expect(mockDepositWithConfirmation).toHaveBeenCalled();

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -56,6 +56,7 @@ import { Skeleton } from '../../../../../component-library/components-temp/Skele
 import { useStyles } from '../../../../../component-library/hooks';
 import Routes from '../../../../../constants/navigation/Routes';
 import Logger from '../../../../../util/Logger';
+import { ImpactMoment, playImpact } from '../../../../../util/haptics';
 import { isNotificationsFeatureEnabled } from '../../../../../util/notifications';
 import { trace, TraceName, TraceOperation } from '../../../../../util/trace';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
@@ -118,8 +119,13 @@ import {
   usePerpsMarketAboutTracking,
 } from '../../hooks';
 import { usePerpsMarketHeaderActions } from '../../hooks/usePerpsMarketHeaderActions';
+import { ConfirmationLoader } from '../../../../Views/confirmations/components/confirm/confirm-component';
 import { useConfirmNavigation } from '../../../../Views/confirmations/hooks/useConfirmNavigation';
 import { useDefaultPayWithTokenWhenNoPerpsBalance } from '../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance';
+import {
+  createDepositConfirmationGuard,
+  type DepositConfirmationNavigation,
+} from '../../utils/depositConfirmationGuard';
 import {
   usePerpsLiveAccount,
   usePerpsLiveOrders,
@@ -365,6 +371,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
   // This prevents stale closure issues where the captured position is outdated
   // Initialized to null, will be updated via useEffect when existingPosition is available
   const currentPositionRef = useRef<Position | null>(null);
+  const confirmationGuardCancelRef = useRef<(() => void) | null>(null);
   const scrollViewRef = useRef<Animated.ScrollView>(null);
 
   const isEligible = useSelector(selectPerpsEligibility);
@@ -690,7 +697,16 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
     (spendableBalance >= PERPS_MIN_BALANCE_THRESHOLD ||
       defaultPayTokenWhenNoPerpsBalance !== null);
 
-  const handleAddFunds = useCallback(async () => {
+  const clearConfirmationGuard = useCallback(() => {
+    confirmationGuardCancelRef.current?.();
+    confirmationGuardCancelRef.current = null;
+  }, []);
+
+  useEffect(() => clearConfirmationGuard, [clearConfirmationGuard]);
+
+  const handleAddFunds = useCallback(() => {
+    playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
+
     if (!isEligible) {
       track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
         [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
@@ -702,10 +718,34 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
       return;
     }
     try {
-      navigateToConfirmation({ stack: Routes.PERPS.ROOT });
-      await withPendingTransactionActiveAbTests(transactionActiveAbTests, () =>
-        depositWithConfirmation(),
+      navigateToConfirmation({
+        loader: ConfirmationLoader.CustomAmount,
+        stack: Routes.PERPS.ROOT,
+      });
+      clearConfirmationGuard();
+      const confirmationGuard = createDepositConfirmationGuard(
+        navigation as unknown as DepositConfirmationNavigation,
       );
+      confirmationGuardCancelRef.current = confirmationGuard.cancel;
+      setTimeout(() => {
+        withPendingTransactionActiveAbTests(transactionActiveAbTests, () =>
+          depositWithConfirmation(),
+        )
+          .then(() => {
+            confirmationGuard.cancel();
+            confirmationGuardCancelRef.current = null;
+          })
+          .catch((err) => {
+            confirmationGuard.onDepositFailed();
+            confirmationGuardCancelRef.current = null;
+            Logger.error(
+              ensureError(err, 'PerpsMarketDetailsView.handleAddFunds'),
+              {
+                tags: { feature: PERPS_CONSTANTS.FeatureName },
+              },
+            );
+          });
+      }, 0);
     } catch (err) {
       Logger.error(ensureError(err, 'PerpsMarketDetailsView.handleAddFunds'), {
         tags: { feature: PERPS_CONSTANTS.FeatureName },
@@ -714,9 +754,11 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
   }, [
     isEligible,
     track,
+    navigation,
     navigateToConfirmation,
     depositWithConfirmation,
     transactionActiveAbTests,
+    clearConfirmationGuard,
   ]);
 
   // Keep current position ref in sync for callbacks stored in route params

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -119,7 +119,7 @@ import {
   usePerpsMarketAboutTracking,
 } from '../../hooks';
 import { usePerpsMarketHeaderActions } from '../../hooks/usePerpsMarketHeaderActions';
-import { ConfirmationLoader } from '../../../../Views/confirmations/components/confirm/confirm-component';
+import type { ConfirmationLoader } from '../../../../Views/confirmations/components/confirm/confirm-component';
 import { useConfirmNavigation } from '../../../../Views/confirmations/hooks/useConfirmNavigation';
 import { useDefaultPayWithTokenWhenNoPerpsBalance } from '../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance';
 import {
@@ -721,7 +721,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
     }
     try {
       navigateToConfirmation({
-        loader: ConfirmationLoader.CustomAmount,
+        loader: 'customAmount' as ConfirmationLoader,
         stack: Routes.PERPS.ROOT,
       });
       if (!depositPrepSessionRef.current) {

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -742,7 +742,6 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
             depositPrepSessionRef.current = null;
           },
           onFailure: (err) => {
-            depositPrepSessionRef.current = null;
             Logger.error(
               ensureError(err, 'PerpsMarketDetailsView.handleAddFunds'),
               {

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -124,7 +124,9 @@ import { useConfirmNavigation } from '../../../../Views/confirmations/hooks/useC
 import { useDefaultPayWithTokenWhenNoPerpsBalance } from '../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance';
 import {
   createDepositConfirmationGuard,
+  createDepositPrepSession,
   type DepositConfirmationNavigation,
+  type DepositPrepSession,
 } from '../../utils/depositConfirmationGuard';
 import {
   usePerpsLiveAccount,
@@ -371,7 +373,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
   // This prevents stale closure issues where the captured position is outdated
   // Initialized to null, will be updated via useEffect when existingPosition is available
   const currentPositionRef = useRef<Position | null>(null);
-  const confirmationGuardCancelRef = useRef<(() => void) | null>(null);
+  const depositPrepSessionRef = useRef<DepositPrepSession | null>(null);
   const scrollViewRef = useRef<Animated.ScrollView>(null);
 
   const isEligible = useSelector(selectPerpsEligibility);
@@ -697,12 +699,12 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
     (spendableBalance >= PERPS_MIN_BALANCE_THRESHOLD ||
       defaultPayTokenWhenNoPerpsBalance !== null);
 
-  const clearConfirmationGuard = useCallback(() => {
-    confirmationGuardCancelRef.current?.();
-    confirmationGuardCancelRef.current = null;
+  const clearDepositPrepSession = useCallback(() => {
+    depositPrepSessionRef.current?.dispose();
+    depositPrepSessionRef.current = null;
   }, []);
 
-  useEffect(() => clearConfirmationGuard, [clearConfirmationGuard]);
+  useEffect(() => clearDepositPrepSession, [clearDepositPrepSession]);
 
   const handleAddFunds = useCallback(() => {
     playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
@@ -722,30 +724,34 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
         loader: ConfirmationLoader.CustomAmount,
         stack: Routes.PERPS.ROOT,
       });
-      clearConfirmationGuard();
-      const confirmationGuard = createDepositConfirmationGuard(
-        navigation as unknown as DepositConfirmationNavigation,
+      if (!depositPrepSessionRef.current) {
+        depositPrepSessionRef.current = createDepositPrepSession();
+      }
+      depositPrepSessionRef.current.attachGuard(
+        createDepositConfirmationGuard(
+          navigation as unknown as DepositConfirmationNavigation,
+        ),
       );
-      confirmationGuardCancelRef.current = confirmationGuard.cancel;
-      setTimeout(() => {
-        withPendingTransactionActiveAbTests(transactionActiveAbTests, () =>
-          depositWithConfirmation(),
-        )
-          .then(() => {
-            confirmationGuard.cancel();
-            confirmationGuardCancelRef.current = null;
-          })
-          .catch((err) => {
-            confirmationGuard.onDepositFailed();
-            confirmationGuardCancelRef.current = null;
+      depositPrepSessionRef.current.ensureScheduled(
+        () =>
+          withPendingTransactionActiveAbTests(transactionActiveAbTests, () =>
+            depositWithConfirmation(),
+          ),
+        {
+          onSuccess: () => {
+            depositPrepSessionRef.current = null;
+          },
+          onFailure: (err) => {
+            depositPrepSessionRef.current = null;
             Logger.error(
               ensureError(err, 'PerpsMarketDetailsView.handleAddFunds'),
               {
                 tags: { feature: PERPS_CONSTANTS.FeatureName },
               },
             );
-          });
-      }, 0);
+          },
+        },
+      );
     } catch (err) {
       Logger.error(ensureError(err, 'PerpsMarketDetailsView.handleAddFunds'), {
         tags: { feature: PERPS_CONSTANTS.FeatureName },
@@ -758,7 +764,6 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
     navigateToConfirmation,
     depositWithConfirmation,
     transactionActiveAbTests,
-    clearConfirmationGuard,
   ]);
 
   // Keep current position ref in sync for callbacks stored in route params

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
@@ -1,6 +1,8 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
+import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
+import { playImpact, ImpactMoment } from '../../../../util/haptics';
 import { usePerpsHomeActions } from './usePerpsHomeActions';
 import { usePerpsTrading } from './usePerpsTrading';
 import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
@@ -15,7 +17,21 @@ import {
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(() => ({
     navigate: jest.fn(),
+    goBack: jest.fn(),
+    getState: jest.fn(() => ({
+      index: 1,
+      routes: [
+        { name: 'PerpsMarketListView' },
+        { name: 'RedesignedConfirmations' },
+      ],
+    })),
+    addListener: jest.fn(() => jest.fn()),
   })),
+}));
+
+jest.mock('../../../../util/haptics', () => ({
+  playImpact: jest.fn().mockResolvedValue(undefined),
+  ImpactMoment: { PrimaryCTA: 'primaryCta' },
 }));
 
 jest.mock('react-redux', () => ({
@@ -72,6 +88,15 @@ jest.mock('../../Compliance', () => ({
 describe('usePerpsHomeActions', () => {
   const mockNavigation = {
     navigate: jest.fn(),
+    goBack: jest.fn(),
+    getState: jest.fn(() => ({
+      index: 1,
+      routes: [
+        { name: 'PerpsMarketListView' },
+        { name: 'RedesignedConfirmations' },
+      ],
+    })),
+    addListener: jest.fn(() => jest.fn()),
   };
 
   const mockDepositWithConfirmation = jest
@@ -140,6 +165,12 @@ describe('usePerpsHomeActions', () => {
   });
 
   describe('handleAddFunds - eligible user', () => {
+    afterEach(async () => {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    });
+
     it('navigates to confirmation and initiates deposit', async () => {
       const { result } = renderHook(() => usePerpsHomeActions());
 
@@ -147,10 +178,40 @@ describe('usePerpsHomeActions', () => {
         await result.current.handleAddFunds();
       });
 
+      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
       expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
+        loader: ConfirmationLoader.CustomAmount,
         stack: Routes.PERPS.ROOT,
       });
-      expect(mockDepositWithConfirmation).toHaveBeenCalledTimes(1);
+
+      await waitFor(() => {
+        expect(mockDepositWithConfirmation).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('navigates to confirmation without waiting for deposit prep', async () => {
+      let resolveDeposit: () => void = () => undefined;
+      mockDepositWithConfirmation.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveDeposit = resolve;
+        }),
+      );
+
+      const { result } = renderHook(() => usePerpsHomeActions());
+
+      await act(async () => {
+        result.current.handleAddFunds();
+      });
+
+      expect(mockNavigateToConfirmation).toHaveBeenCalledTimes(1);
+
+      await waitFor(() => {
+        expect(mockDepositWithConfirmation).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        resolveDeposit();
+      });
     });
 
     it('triggers onAddFundsSuccess callback', async () => {
@@ -182,18 +243,25 @@ describe('usePerpsHomeActions', () => {
 
     it('handles deposit error during add funds', async () => {
       const depositError = new Error('Deposit failed');
-      mockDepositWithConfirmation.mockRejectedValueOnce(depositError);
+      mockDepositWithConfirmation.mockImplementationOnce(() =>
+        Promise.reject(depositError),
+      );
 
       const onError = jest.fn();
       const { result } = renderHook(() => usePerpsHomeActions({ onError }));
 
       await act(async () => {
-        await result.current.handleAddFunds();
+        result.current.handleAddFunds();
       });
 
       await waitFor(() => {
-        expect(result.current.error).toEqual(depositError);
+        expect(mockDepositWithConfirmation).toHaveBeenCalledTimes(1);
+      });
+
+      await waitFor(() => {
         expect(onError).toHaveBeenCalledWith(depositError, 'deposit');
+        expect(result.current.error).toEqual(depositError);
+        expect(mockNavigation.goBack).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
@@ -190,6 +190,7 @@ describe('usePerpsHomeActions', () => {
     });
 
     it('navigates to confirmation without waiting for deposit prep', async () => {
+      jest.useFakeTimers();
       let resolveDeposit: () => void = () => undefined;
       mockDepositWithConfirmation.mockReturnValue(
         new Promise<void>((resolve) => {
@@ -199,19 +200,26 @@ describe('usePerpsHomeActions', () => {
 
       const { result } = renderHook(() => usePerpsHomeActions());
 
-      await act(async () => {
-        result.current.handleAddFunds();
-      });
+      try {
+        await act(async () => {
+          await result.current.handleAddFunds();
+        });
 
-      expect(mockNavigateToConfirmation).toHaveBeenCalledTimes(1);
+        expect(mockNavigateToConfirmation).toHaveBeenCalledTimes(1);
+        expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
 
-      await waitFor(() => {
+        await act(async () => {
+          jest.runAllTimers();
+        });
+
         expect(mockDepositWithConfirmation).toHaveBeenCalledTimes(1);
-      });
 
-      await act(async () => {
-        resolveDeposit();
-      });
+        await act(async () => {
+          resolveDeposit();
+        });
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('triggers onAddFundsSuccess callback', async () => {

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
@@ -169,21 +169,28 @@ describe('usePerpsHomeActions', () => {
 
   describe('handleAddFunds - eligible user', () => {
     it('navigates to confirmation and initiates deposit', async () => {
-      const { result } = renderHook(() => usePerpsHomeActions());
+      jest.useFakeTimers();
+      try {
+        const { result } = renderHook(() => usePerpsHomeActions());
 
-      await act(async () => {
-        await result.current.handleAddFunds();
-      });
+        await act(async () => {
+          await result.current.handleAddFunds();
+        });
 
-      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
-      expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
-        loader: ConfirmationLoader.CustomAmount,
-        stack: Routes.PERPS.ROOT,
-      });
+        expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
+        expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
+          loader: ConfirmationLoader.CustomAmount,
+          stack: Routes.PERPS.ROOT,
+        });
 
-      await waitFor(() => {
+        await act(async () => {
+          await jest.runAllTimersAsync();
+        });
+
         expect(mockDepositWithConfirmation).toHaveBeenCalledTimes(1);
-      });
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     describe('deferred deposit prep', () => {
@@ -602,20 +609,27 @@ describe('usePerpsHomeActions', () => {
 
   describe('error handling with non-Error objects', () => {
     it('converts string error to Error object', async () => {
-      mockDepositWithConfirmation.mockRejectedValueOnce('String error');
+      jest.useFakeTimers();
+      try {
+        mockDepositWithConfirmation.mockRejectedValueOnce('String error');
 
-      const onError = jest.fn();
-      const { result } = renderHook(() => usePerpsHomeActions({ onError }));
+        const onError = jest.fn();
+        const { result } = renderHook(() => usePerpsHomeActions({ onError }));
 
-      await act(async () => {
-        await result.current.handleAddFunds();
-      });
+        await act(async () => {
+          await result.current.handleAddFunds();
+        });
 
-      await waitFor(() => {
+        await act(async () => {
+          await jest.runAllTimersAsync();
+        });
+
         expect(result.current.error).toBeInstanceOf(Error);
         expect(result.current.error?.message).toBe('String error');
         expect(onError).toHaveBeenCalledWith(expect.any(Error), 'deposit');
-      });
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
@@ -105,8 +105,11 @@ describe('usePerpsHomeActions', () => {
   const mockNavigateToConfirmation = jest.fn();
 
   beforeEach(() => {
+    jest.useRealTimers();
     jest.clearAllMocks();
     mockTrack.mockClear();
+    mockDepositWithConfirmation.mockReset();
+    mockDepositWithConfirmation.mockResolvedValue(undefined);
     mockWithdrawWithConfirmation.mockResolvedValue(undefined);
     mockComplianceGate.mockImplementation((action: () => Promise<unknown>) =>
       action(),
@@ -165,12 +168,6 @@ describe('usePerpsHomeActions', () => {
   });
 
   describe('handleAddFunds - eligible user', () => {
-    afterEach(async () => {
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-    });
-
     it('navigates to confirmation and initiates deposit', async () => {
       const { result } = renderHook(() => usePerpsHomeActions());
 
@@ -189,18 +186,26 @@ describe('usePerpsHomeActions', () => {
       });
     });
 
-    it('navigates to confirmation without waiting for deposit prep', async () => {
-      jest.useFakeTimers();
-      let resolveDeposit: () => void = () => undefined;
-      mockDepositWithConfirmation.mockReturnValue(
-        new Promise<void>((resolve) => {
-          resolveDeposit = resolve;
-        }),
-      );
+    describe('deferred deposit prep', () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
+      });
 
-      const { result } = renderHook(() => usePerpsHomeActions());
+      afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+      });
 
-      try {
+      it('navigates to confirmation without waiting for deposit prep', async () => {
+        let resolveDeposit: () => void = () => undefined;
+        mockDepositWithConfirmation.mockReturnValue(
+          new Promise<void>((resolve) => {
+            resolveDeposit = resolve;
+          }),
+        );
+
+        const { result } = renderHook(() => usePerpsHomeActions());
+
         await act(async () => {
           await result.current.handleAddFunds();
         });
@@ -217,56 +222,98 @@ describe('usePerpsHomeActions', () => {
         await act(async () => {
           resolveDeposit();
         });
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    it('triggers onAddFundsSuccess callback', async () => {
-      const onAddFundsSuccess = jest.fn();
-      const { result } = renderHook(() =>
-        usePerpsHomeActions({ onAddFundsSuccess }),
-      );
-
-      await act(async () => {
-        await result.current.handleAddFunds();
       });
 
-      await waitFor(() => {
-        expect(onAddFundsSuccess).toHaveBeenCalledTimes(1);
-      });
-    });
+      it('starts deposit prep once when add funds is tapped twice', async () => {
+        const { result } = renderHook(() => usePerpsHomeActions());
 
-    it('resets isProcessing to false after operation completes', async () => {
-      const { result } = renderHook(() => usePerpsHomeActions());
+        await act(async () => {
+          await result.current.handleAddFunds();
+          await result.current.handleAddFunds();
+        });
 
-      await act(async () => {
-        await result.current.handleAddFunds();
-      });
+        await act(async () => {
+          jest.runAllTimers();
+        });
 
-      await waitFor(() => {
-        expect(result.current.isProcessing).toBe(false);
-      });
-    });
-
-    it('handles deposit error during add funds', async () => {
-      const depositError = new Error('Deposit failed');
-      mockDepositWithConfirmation.mockImplementationOnce(() =>
-        Promise.reject(depositError),
-      );
-
-      const onError = jest.fn();
-      const { result } = renderHook(() => usePerpsHomeActions({ onError }));
-
-      await act(async () => {
-        result.current.handleAddFunds();
-      });
-
-      await waitFor(() => {
+        expect(mockNavigateToConfirmation).toHaveBeenCalledTimes(2);
         expect(mockDepositWithConfirmation).toHaveBeenCalledTimes(1);
       });
 
-      await waitFor(() => {
+      it('dismisses the latest confirmation when the first prep fails after a second tap', async () => {
+        let rejectDeposit: (error: Error) => void = () => undefined;
+        mockDepositWithConfirmation.mockImplementation(
+          () =>
+            new Promise<void>((_resolve, reject) => {
+              rejectDeposit = reject;
+            }),
+        );
+
+        const { result } = renderHook(() => usePerpsHomeActions());
+
+        await act(async () => {
+          await result.current.handleAddFunds();
+        });
+        await act(async () => {
+          jest.runAllTimers();
+        });
+        await act(async () => {
+          await result.current.handleAddFunds();
+        });
+        await act(async () => {
+          rejectDeposit(new Error('stale prep failed'));
+        });
+
+        expect(mockDepositWithConfirmation).toHaveBeenCalledTimes(1);
+        expect(mockNavigation.goBack).toHaveBeenCalledTimes(1);
+      });
+
+      it('triggers onAddFundsSuccess callback', async () => {
+        const onAddFundsSuccess = jest.fn();
+        const { result } = renderHook(() =>
+          usePerpsHomeActions({ onAddFundsSuccess }),
+        );
+
+        await act(async () => {
+          await result.current.handleAddFunds();
+        });
+        await act(async () => {
+          await jest.runAllTimersAsync();
+        });
+
+        expect(onAddFundsSuccess).toHaveBeenCalledTimes(1);
+      });
+
+      it('resets isProcessing to false after operation completes', async () => {
+        const { result } = renderHook(() => usePerpsHomeActions());
+
+        await act(async () => {
+          await result.current.handleAddFunds();
+        });
+        await act(async () => {
+          await jest.runAllTimersAsync();
+        });
+
+        expect(result.current.isProcessing).toBe(false);
+      });
+
+      it('handles deposit error during add funds', async () => {
+        const depositError = new Error('Deposit failed');
+        mockDepositWithConfirmation.mockImplementationOnce(() =>
+          Promise.reject(depositError),
+        );
+
+        const onError = jest.fn();
+        const { result } = renderHook(() => usePerpsHomeActions({ onError }));
+
+        await act(async () => {
+          result.current.handleAddFunds();
+        });
+        await act(async () => {
+          await jest.runAllTimersAsync();
+        });
+
+        expect(mockDepositWithConfirmation).toHaveBeenCalledTimes(1);
         expect(onError).toHaveBeenCalledWith(depositError, 'deposit');
         expect(result.current.error).toEqual(depositError);
         expect(mockNavigation.goBack).toHaveBeenCalledTimes(1);

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
@@ -9,7 +9,7 @@ import { ImpactMoment, playImpact } from '../../../../util/haptics';
 import Routes from '../../../../constants/navigation/Routes';
 import { selectPerpsEligibility } from '../selectors/perpsController';
 import { usePerpsTrading } from './usePerpsTrading';
-import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
+import type { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
 import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
 import {
   PERPS_CONSTANTS,
@@ -150,7 +150,7 @@ export const usePerpsHomeActions = (
       DevLogger.log('[usePerpsHomeActions] Starting add funds flow');
 
       navigateToConfirmation({
-        loader: ConfirmationLoader.CustomAmount,
+        loader: 'customAmount' as ConfirmationLoader,
         stack: Routes.PERPS.ROOT,
       });
 

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
@@ -1,13 +1,15 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../core/NavigationService/types';
 
 import { useSelector } from 'react-redux';
 import Logger from '../../../../util/Logger';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import { ImpactMoment, playImpact } from '../../../../util/haptics';
 import Routes from '../../../../constants/navigation/Routes';
 import { selectPerpsEligibility } from '../selectors/perpsController';
 import { usePerpsTrading } from './usePerpsTrading';
+import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
 import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
 import {
   PERPS_CONSTANTS,
@@ -22,6 +24,10 @@ import { RootState } from '../../../../reducers';
 import { usePerpsWithdrawConfirmation } from './usePerpsWithdrawConfirmation';
 import { useComplianceGate } from '../../Compliance';
 import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
+import {
+  createDepositConfirmationGuard,
+  type DepositConfirmationNavigation,
+} from '../utils/depositConfirmationGuard';
 
 export type PerpsHomeActionType = 'deposit' | 'withdraw';
 
@@ -64,7 +70,7 @@ export interface UsePerpsHomeActionsReturn {
  * Handles:
  * - Eligibility checks and modal display
  * - Network validation (Arbitrum)
- * - Add funds flow with confirmation navigation
+ * - Add funds flow: haptic + skeleton immediately, then fire-and-forget deposit prep
  * - Withdraw navigation
  * - Error handling with Sentry tracking
  * - Loading state management
@@ -94,6 +100,14 @@ export const usePerpsHomeActions = (
 
   const { onAddFundsSuccess, onWithdrawSuccess, onError, buttonLocation } =
     options || {};
+  const confirmationGuardCancelRef = useRef<(() => void) | null>(null);
+
+  const clearConfirmationGuard = useCallback(() => {
+    confirmationGuardCancelRef.current?.();
+    confirmationGuardCancelRef.current = null;
+  }, []);
+
+  useEffect(() => clearConfirmationGuard, [clearConfirmationGuard]);
 
   const showEligibilityModal = useCallback(
     (source: string) => {
@@ -110,74 +124,84 @@ export const usePerpsHomeActions = (
     [track],
   );
 
-  const handleAddFunds = useCallback(
-    () =>
-      gate(async () => {
-        track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
-          [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
-            PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
-          [PERPS_EVENT_PROPERTY.BUTTON_CLICKED]:
-            PERPS_EVENT_VALUE.BUTTON_CLICKED.DEPOSIT,
-          [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
-            buttonLocation || PERPS_EVENT_VALUE.BUTTON_LOCATION.PERPS_HOME,
-        });
+  const handleAddFunds = useCallback(() => {
+    playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
 
-        if (!isEligible) {
-          DevLogger.log('[usePerpsHomeActions] User not eligible for deposit');
-          showEligibilityModal(PERPS_EVENT_VALUE.SOURCE.DEPOSIT_BUTTON);
-          return;
-        }
+    return gate(async () => {
+      track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
+        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+          PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+        [PERPS_EVENT_PROPERTY.BUTTON_CLICKED]:
+          PERPS_EVENT_VALUE.BUTTON_CLICKED.DEPOSIT,
+        [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
+          buttonLocation || PERPS_EVENT_VALUE.BUTTON_LOCATION.PERPS_HOME,
+      });
 
-        setIsProcessing(true);
-        setError(null);
+      if (!isEligible) {
+        DevLogger.log('[usePerpsHomeActions] User not eligible for deposit');
+        showEligibilityModal(PERPS_EVENT_VALUE.SOURCE.DEPOSIT_BUTTON);
+        return;
+      }
 
-        DevLogger.log('[usePerpsHomeActions] Starting add funds flow');
+      setError(null);
 
-        try {
-          navigateToConfirmation({ stack: Routes.PERPS.ROOT });
+      DevLogger.log('[usePerpsHomeActions] Starting add funds flow');
 
-          // Wait for deposit confirmation to complete before calling success callback
-          await depositWithConfirmation();
+      navigateToConfirmation({
+        loader: ConfirmationLoader.CustomAmount,
+        stack: Routes.PERPS.ROOT,
+      });
 
-          DevLogger.log(
-            '[usePerpsHomeActions] Add funds flow completed successfully',
-          );
+      clearConfirmationGuard();
+      const confirmationGuard = createDepositConfirmationGuard(
+        navigation as unknown as DepositConfirmationNavigation,
+      );
+      confirmationGuardCancelRef.current = confirmationGuard.cancel;
 
-          if (onAddFundsSuccess) {
-            onAddFundsSuccess();
-          }
-        } catch (err) {
-          const errorObj = ensureError(
-            err,
-            'usePerpsHomeActions.handleAddFunds',
-          );
-          setError(errorObj);
+      // Yield so the confirmation skeleton can paint before deposit prep.
+      setTimeout(() => {
+        depositWithConfirmation()
+          .then(() => {
+            DevLogger.log(
+              '[usePerpsHomeActions] Add funds flow completed successfully',
+            );
+            confirmationGuard.cancel();
+            confirmationGuardCancelRef.current = null;
+            onAddFundsSuccess?.();
+          })
+          .catch((err) => {
+            confirmationGuard.onDepositFailed();
+            confirmationGuardCancelRef.current = null;
 
-          Logger.error(errorObj, {
-            tags: {
-              feature: PERPS_CONSTANTS.FeatureName,
-            },
+            const errorObj = ensureError(
+              err,
+              'usePerpsHomeActions.handleAddFunds',
+            );
+            setError(errorObj);
+
+            Logger.error(errorObj, {
+              tags: {
+                feature: PERPS_CONSTANTS.FeatureName,
+              },
+            });
+
+            onError?.(errorObj, 'deposit');
           });
-
-          if (onError) {
-            onError(errorObj, 'deposit');
-          }
-        } finally {
-          setIsProcessing(false);
-        }
-      }),
-    [
-      gate,
-      isEligible,
-      navigateToConfirmation,
-      depositWithConfirmation,
-      onAddFundsSuccess,
-      onError,
-      track,
-      buttonLocation,
-      showEligibilityModal,
-    ],
-  );
+      }, 0);
+    });
+  }, [
+    gate,
+    isEligible,
+    navigation,
+    navigateToConfirmation,
+    depositWithConfirmation,
+    clearConfirmationGuard,
+    onAddFundsSuccess,
+    onError,
+    track,
+    buttonLocation,
+    showEligibilityModal,
+  ]);
 
   const handleWithdraw = useCallback(async () => {
     // Track withdrawal button click with geo-block status for monitoring (TAT-2337)

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
@@ -132,9 +132,6 @@ export const usePerpsHomeActions = (
         setError(null);
 
         DevLogger.log('[usePerpsHomeActions] Starting add funds flow');
-        DevLogger.log(
-          '[PR-TAT-3772] BUG_MARKER: deposit tap blocked by setIsProcessing and await depositWithConfirmation',
-        );
 
         try {
           navigateToConfirmation({ stack: Routes.PERPS.ROOT });

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
@@ -26,7 +26,9 @@ import { useComplianceGate } from '../../Compliance';
 import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
 import {
   createDepositConfirmationGuard,
+  createDepositPrepSession,
   type DepositConfirmationNavigation,
+  type DepositPrepSession,
 } from '../utils/depositConfirmationGuard';
 
 export type PerpsHomeActionType = 'deposit' | 'withdraw';
@@ -100,14 +102,14 @@ export const usePerpsHomeActions = (
 
   const { onAddFundsSuccess, onWithdrawSuccess, onError, buttonLocation } =
     options || {};
-  const confirmationGuardCancelRef = useRef<(() => void) | null>(null);
+  const depositPrepSessionRef = useRef<DepositPrepSession | null>(null);
 
-  const clearConfirmationGuard = useCallback(() => {
-    confirmationGuardCancelRef.current?.();
-    confirmationGuardCancelRef.current = null;
+  const clearDepositPrepSession = useCallback(() => {
+    depositPrepSessionRef.current?.dispose();
+    depositPrepSessionRef.current = null;
   }, []);
 
-  useEffect(() => clearConfirmationGuard, [clearConfirmationGuard]);
+  useEffect(() => clearDepositPrepSession, [clearDepositPrepSession]);
 
   const showEligibilityModal = useCallback(
     (source: string) => {
@@ -152,26 +154,28 @@ export const usePerpsHomeActions = (
         stack: Routes.PERPS.ROOT,
       });
 
-      clearConfirmationGuard();
-      const confirmationGuard = createDepositConfirmationGuard(
-        navigation as unknown as DepositConfirmationNavigation,
+      if (!depositPrepSessionRef.current) {
+        depositPrepSessionRef.current = createDepositPrepSession();
+      }
+      depositPrepSessionRef.current.attachGuard(
+        createDepositConfirmationGuard(
+          navigation as unknown as DepositConfirmationNavigation,
+        ),
       );
-      confirmationGuardCancelRef.current = confirmationGuard.cancel;
-
       // Yield so the confirmation skeleton can paint before deposit prep.
-      setTimeout(() => {
-        depositWithConfirmation()
-          .then(() => {
+      // A second tap reuses this session so stale prep cannot clear the new guard.
+      depositPrepSessionRef.current.ensureScheduled(
+        () => depositWithConfirmation(),
+        {
+          onSuccess: () => {
             DevLogger.log(
               '[usePerpsHomeActions] Add funds flow completed successfully',
             );
-            confirmationGuard.cancel();
-            confirmationGuardCancelRef.current = null;
+            depositPrepSessionRef.current = null;
             onAddFundsSuccess?.();
-          })
-          .catch((err) => {
-            confirmationGuard.onDepositFailed();
-            confirmationGuardCancelRef.current = null;
+          },
+          onFailure: (err) => {
+            depositPrepSessionRef.current = null;
 
             const errorObj = ensureError(
               err,
@@ -186,8 +190,9 @@ export const usePerpsHomeActions = (
             });
 
             onError?.(errorObj, 'deposit');
-          });
-      }, 0);
+          },
+        },
+      );
     });
   }, [
     gate,
@@ -195,7 +200,6 @@ export const usePerpsHomeActions = (
     navigation,
     navigateToConfirmation,
     depositWithConfirmation,
-    clearConfirmationGuard,
     onAddFundsSuccess,
     onError,
     track,

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
@@ -132,6 +132,9 @@ export const usePerpsHomeActions = (
         setError(null);
 
         DevLogger.log('[usePerpsHomeActions] Starting add funds flow');
+        DevLogger.log(
+          '[PR-TAT-3772] BUG_MARKER: deposit tap blocked by setIsProcessing and await depositWithConfirmation',
+        );
 
         try {
           navigateToConfirmation({ stack: Routes.PERPS.ROOT });

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
@@ -175,8 +175,6 @@ export const usePerpsHomeActions = (
             onAddFundsSuccess?.();
           },
           onFailure: (err) => {
-            depositPrepSessionRef.current = null;
-
             const errorObj = ensureError(
               err,
               'usePerpsHomeActions.handleAddFunds',

--- a/app/components/UI/Perps/utils/depositConfirmationGuard.test.ts
+++ b/app/components/UI/Perps/utils/depositConfirmationGuard.test.ts
@@ -1,0 +1,121 @@
+import Routes from '../../../../constants/navigation/Routes';
+import {
+  createDepositConfirmationGuard,
+  getFocusedRouteName,
+  isRedesignedConfirmationFocused,
+  type NestedNavigationState,
+} from './depositConfirmationGuard';
+
+const CONFIRMATION_ROUTE =
+  Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS;
+
+const createState = (
+  focusedName: string,
+  nested?: NestedNavigationState,
+): NestedNavigationState => ({
+  index: 1,
+  routes: [
+    { name: Routes.PERPS.PERPS_HOME },
+    { name: focusedName, ...(nested ? { state: nested } : {}) },
+  ],
+});
+
+const createNavigation = (initialState: NestedNavigationState) => {
+  let state = initialState;
+  const listeners = new Set<() => void>();
+
+  return {
+    getState: jest.fn(() => state),
+    goBack: jest.fn(),
+    addListener: jest.fn((_event: 'state', callback: () => void) => {
+      listeners.add(callback);
+      return () => {
+        listeners.delete(callback);
+      };
+    }),
+    emitState: (nextState: NestedNavigationState) => {
+      state = nextState;
+      listeners.forEach((listener) => listener());
+    },
+  };
+};
+
+describe('getFocusedRouteName', () => {
+  it('returns undefined for empty state', () => {
+    expect(getFocusedRouteName(undefined)).toBeUndefined();
+    expect(getFocusedRouteName({ index: 0, routes: [] })).toBeUndefined();
+  });
+
+  it('returns the focused leaf route name from nested stacks', () => {
+    const state = createState(Routes.PERPS.ROOT, {
+      index: 0,
+      routes: [{ name: CONFIRMATION_ROUTE }],
+    });
+
+    expect(getFocusedRouteName(state)).toBe(CONFIRMATION_ROUTE);
+  });
+});
+
+describe('isRedesignedConfirmationFocused', () => {
+  it('returns true when a confirmation route is focused', () => {
+    const navigation = createNavigation(createState(CONFIRMATION_ROUTE));
+
+    expect(isRedesignedConfirmationFocused(navigation)).toBe(true);
+  });
+
+  it('returns false when Perps is focused', () => {
+    const navigation = createNavigation(
+      createState(Routes.PERPS.MARKET_DETAILS),
+    );
+
+    expect(isRedesignedConfirmationFocused(navigation)).toBe(false);
+  });
+});
+
+describe('createDepositConfirmationGuard', () => {
+  it('goes back when deposit fails while confirmation is focused', () => {
+    const navigation = createNavigation(createState(CONFIRMATION_ROUTE));
+    const guard = createDepositConfirmationGuard(navigation);
+
+    guard.onDepositFailed();
+
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not go back when the user already left confirmation', () => {
+    const navigation = createNavigation(createState(CONFIRMATION_ROUTE));
+    const guard = createDepositConfirmationGuard(navigation);
+
+    navigation.emitState(createState(Routes.PERPS.MARKET_DETAILS));
+    guard.onDepositFailed();
+
+    expect(navigation.goBack).not.toHaveBeenCalled();
+  });
+
+  it('goes back once confirmation appears after deferred navigation', () => {
+    const navigation = createNavigation(
+      createState(Routes.PERPS.MARKET_DETAILS),
+    );
+    const guard = createDepositConfirmationGuard(navigation);
+
+    guard.onDepositFailed();
+    expect(navigation.goBack).not.toHaveBeenCalled();
+
+    navigation.emitState(createState(CONFIRMATION_ROUTE));
+
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not go back for a later confirmation after cancel', () => {
+    const navigation = createNavigation(
+      createState(Routes.PERPS.MARKET_DETAILS),
+    );
+    const guard = createDepositConfirmationGuard(navigation);
+
+    guard.onDepositFailed();
+    guard.cancel();
+    navigation.emitState(createState(CONFIRMATION_ROUTE));
+
+    expect(navigation.goBack).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Perps/utils/depositConfirmationGuard.test.ts
+++ b/app/components/UI/Perps/utils/depositConfirmationGuard.test.ts
@@ -130,6 +130,29 @@ describe('createDepositConfirmationGuard', () => {
 
     expect(navigation.goBack).not.toHaveBeenCalled();
   });
+
+  it('keeps watching when Pay With opens on top of confirmation', () => {
+    const navigation = createNavigation(createState(CONFIRMATION_ROUTE));
+    const guard = createDepositConfirmationGuard(navigation);
+
+    navigation.emitState(
+      createState(Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET),
+    );
+    guard.onDepositFailed();
+
+    expect(navigation.goBack).toHaveBeenCalledTimes(2);
+  });
+
+  it('dismisses Pay With and confirmation when prep fails while the sheet is focused', () => {
+    const navigation = createNavigation(
+      createState(Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET),
+    );
+    const guard = createDepositConfirmationGuard(navigation);
+
+    guard.onDepositFailed();
+
+    expect(navigation.goBack).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('createDepositPrepSession', () => {
@@ -266,6 +289,35 @@ describe('createDepositPrepSession', () => {
     await Promise.resolve();
 
     expect(onFailure).not.toHaveBeenCalled();
+    expect(navigation.goBack).not.toHaveBeenCalled();
+  });
+
+  it('cancels a waiting dismiss listener on dispose after prep fails', async () => {
+    const navigation = createNavigation(
+      createState(Routes.PERPS.MARKET_DETAILS),
+    );
+    const session = createDepositPrepSession();
+    let rejectRun: (error: Error) => void = () => undefined;
+    const run = jest.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectRun = reject;
+        }),
+    );
+
+    session.attachGuard(createDepositConfirmationGuard(navigation));
+    session.ensureScheduled(run, {
+      onSuccess: jest.fn(),
+      onFailure: jest.fn(),
+    });
+    await jest.runAllTimersAsync();
+    rejectRun(new Error('prep failed'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    session.dispose();
+    navigation.emitState(createState(CONFIRMATION_ROUTE));
+
     expect(navigation.goBack).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Perps/utils/depositConfirmationGuard.test.ts
+++ b/app/components/UI/Perps/utils/depositConfirmationGuard.test.ts
@@ -1,6 +1,7 @@
 import Routes from '../../../../constants/navigation/Routes';
 import {
   createDepositConfirmationGuard,
+  createDepositPrepSession,
   getFocusedRouteName,
   isRedesignedConfirmationFocused,
   type NestedNavigationState,
@@ -127,6 +128,144 @@ describe('createDepositConfirmationGuard', () => {
     guard.cancel();
     navigation.emitState(createState(CONFIRMATION_ROUTE));
 
+    expect(navigation.goBack).not.toHaveBeenCalled();
+  });
+});
+
+describe('createDepositPrepSession', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('runs deposit prep once when scheduled twice before the timeout fires', async () => {
+    const session = createDepositPrepSession();
+    const firstRun = jest.fn().mockResolvedValue(undefined);
+    const secondRun = jest.fn().mockResolvedValue(undefined);
+    const firstSuccess = jest.fn();
+    const secondSuccess = jest.fn();
+
+    session.ensureScheduled(firstRun, {
+      onSuccess: firstSuccess,
+      onFailure: jest.fn(),
+    });
+    session.ensureScheduled(secondRun, {
+      onSuccess: secondSuccess,
+      onFailure: jest.fn(),
+    });
+
+    await jest.runAllTimersAsync();
+
+    expect(firstRun).toHaveBeenCalledTimes(1);
+    expect(secondRun).not.toHaveBeenCalled();
+    expect(firstSuccess).not.toHaveBeenCalled();
+    expect(secondSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start a second prep while the first is in flight', async () => {
+    const session = createDepositPrepSession();
+    let resolveFirst: () => void = () => undefined;
+    const firstRun = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+    const secondRun = jest.fn().mockResolvedValue(undefined);
+
+    session.ensureScheduled(firstRun, {
+      onSuccess: jest.fn(),
+      onFailure: jest.fn(),
+    });
+    await jest.runAllTimersAsync();
+
+    session.ensureScheduled(secondRun, {
+      onSuccess: jest.fn(),
+      onFailure: jest.fn(),
+    });
+    await jest.runAllTimersAsync();
+    resolveFirst();
+    await Promise.resolve();
+
+    expect(firstRun).toHaveBeenCalledTimes(1);
+    expect(secondRun).not.toHaveBeenCalled();
+  });
+
+  it('dismisses the latest attached confirmation when a superseded tap fails', async () => {
+    const firstNavigation = createNavigation(createState(CONFIRMATION_ROUTE));
+    const secondNavigation = createNavigation(createState(CONFIRMATION_ROUTE));
+    const session = createDepositPrepSession();
+    let rejectFirst: (error: Error) => void = () => undefined;
+    const firstRun = jest.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectFirst = reject;
+        }),
+    );
+
+    session.attachGuard(createDepositConfirmationGuard(firstNavigation));
+    session.ensureScheduled(firstRun, {
+      onSuccess: jest.fn(),
+      onFailure: jest.fn(),
+    });
+    await jest.runAllTimersAsync();
+
+    session.attachGuard(createDepositConfirmationGuard(secondNavigation));
+    session.ensureScheduled(jest.fn().mockResolvedValue(undefined), {
+      onSuccess: jest.fn(),
+      onFailure: jest.fn(),
+    });
+
+    rejectFirst(new Error('stale prep failed'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(firstNavigation.goBack).not.toHaveBeenCalled();
+    expect(secondNavigation.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run prep or settle after dispose', async () => {
+    const navigation = createNavigation(createState(CONFIRMATION_ROUTE));
+    const session = createDepositPrepSession();
+    const run = jest.fn().mockResolvedValue(undefined);
+    const onSuccess = jest.fn();
+    const onFailure = jest.fn();
+
+    session.attachGuard(createDepositConfirmationGuard(navigation));
+    session.ensureScheduled(run, { onSuccess, onFailure });
+    session.dispose();
+    await jest.runAllTimersAsync();
+
+    expect(run).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(navigation.goBack).not.toHaveBeenCalled();
+  });
+
+  it('ignores in-flight settlement after dispose', async () => {
+    const navigation = createNavigation(createState(CONFIRMATION_ROUTE));
+    const session = createDepositPrepSession();
+    let rejectRun: (error: Error) => void = () => undefined;
+    const run = jest.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectRun = reject;
+        }),
+    );
+    const onFailure = jest.fn();
+
+    session.attachGuard(createDepositConfirmationGuard(navigation));
+    session.ensureScheduled(run, { onSuccess: jest.fn(), onFailure });
+    await jest.runAllTimersAsync();
+    session.dispose();
+    rejectRun(new Error('prep failed after unmount'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onFailure).not.toHaveBeenCalled();
     expect(navigation.goBack).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Perps/utils/depositConfirmationGuard.test.ts
+++ b/app/components/UI/Perps/utils/depositConfirmationGuard.test.ts
@@ -106,6 +106,17 @@ describe('createDepositConfirmationGuard', () => {
     expect(navigation.goBack).toHaveBeenCalledTimes(1);
   });
 
+  it('does not go back for a later confirmation after the original loses focus', () => {
+    const navigation = createNavigation(createState(CONFIRMATION_ROUTE));
+    const guard = createDepositConfirmationGuard(navigation);
+
+    navigation.emitState(createState(Routes.PERPS.MARKET_DETAILS));
+    navigation.emitState(createState(CONFIRMATION_ROUTE));
+    guard.onDepositFailed();
+
+    expect(navigation.goBack).not.toHaveBeenCalled();
+  });
+
   it('does not go back for a later confirmation after cancel', () => {
     const navigation = createNavigation(
       createState(Routes.PERPS.MARKET_DETAILS),

--- a/app/components/UI/Perps/utils/depositConfirmationGuard.ts
+++ b/app/components/UI/Perps/utils/depositConfirmationGuard.ts
@@ -83,6 +83,10 @@ export function createDepositConfirmationGuard(
 
     const focused = isRedesignedConfirmationFocused(navigation);
     if (!focused) {
+      if (presented) {
+        cancelled = true;
+        unsubscribe();
+      }
       return;
     }
 

--- a/app/components/UI/Perps/utils/depositConfirmationGuard.ts
+++ b/app/components/UI/Perps/utils/depositConfirmationGuard.ts
@@ -1,0 +1,126 @@
+import Routes from '../../../../constants/navigation/Routes';
+
+const CONFIRMATION_ROUTE_NAMES: ReadonlySet<string> = new Set([
+  Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
+  Routes.FULL_SCREEN_CONFIRMATIONS.NO_HEADER,
+]);
+
+export interface NestedNavigationState {
+  index: number;
+  routes: { name: string; state?: NestedNavigationState }[];
+}
+
+export interface DepositConfirmationNavigation {
+  getState: () => NestedNavigationState | undefined;
+  goBack: () => void;
+  addListener: (event: 'state', callback: () => void) => () => void;
+}
+
+export interface DepositConfirmationGuard {
+  /**
+   * Dismiss confirmation if it is focused, or once it appears if navigation
+   * was deferred. No-ops when the user already left confirmation.
+   */
+  onDepositFailed: () => void;
+  /** Stop watching navigation. Call on success or unmount. */
+  cancel: () => void;
+}
+
+/**
+ * Returns the focused leaf route name from a (possibly nested) navigation state.
+ *
+ * @param state - React Navigation state, including nested stack state.
+ * @returns The focused route name, or undefined when state is empty.
+ */
+export function getFocusedRouteName(
+  state: NestedNavigationState | undefined,
+): string | undefined {
+  if (!state?.routes?.length) {
+    return undefined;
+  }
+
+  const route = state.routes[state.index];
+  if (route.state) {
+    return getFocusedRouteName(route.state) ?? route.name;
+  }
+
+  return route.name;
+}
+
+/**
+ * Whether the redesigned confirmation screen is the focused route.
+ *
+ * @param navigation - Navigation object exposing `getState`.
+ * @returns True when a confirmation route is focused.
+ */
+export function isRedesignedConfirmationFocused(
+  navigation: Pick<DepositConfirmationNavigation, 'getState'>,
+): boolean {
+  const focused = getFocusedRouteName(navigation.getState());
+  return focused !== undefined && CONFIRMATION_ROUTE_NAMES.has(focused);
+}
+
+/**
+ * Guards `goBack` after fire-and-forget deposit prep so we only dismiss the
+ * confirmation we opened — not Perps, and not a confirmation the user already
+ * closed. If `useConfirmNavigation` deferred the push, we wait until it
+ * appears and then dismiss it.
+ *
+ * @param navigation - Navigation object with state, goBack, and state listener.
+ * @returns Guard with `onDepositFailed` and `cancel`.
+ */
+export function createDepositConfirmationGuard(
+  navigation: DepositConfirmationNavigation,
+): DepositConfirmationGuard {
+  let cancelled = false;
+  let presented = isRedesignedConfirmationFocused(navigation);
+  let dismissWhenShown = false;
+
+  const unsubscribe = navigation.addListener('state', () => {
+    if (cancelled) {
+      return;
+    }
+
+    const focused = isRedesignedConfirmationFocused(navigation);
+    if (!focused) {
+      return;
+    }
+
+    presented = true;
+    if (dismissWhenShown) {
+      cancelled = true;
+      unsubscribe();
+      navigation.goBack();
+    }
+  });
+
+  return {
+    onDepositFailed: () => {
+      if (cancelled) {
+        return;
+      }
+
+      if (isRedesignedConfirmationFocused(navigation)) {
+        cancelled = true;
+        unsubscribe();
+        navigation.goBack();
+        return;
+      }
+
+      if (presented) {
+        cancelled = true;
+        unsubscribe();
+        return;
+      }
+
+      dismissWhenShown = true;
+    },
+    cancel: () => {
+      if (cancelled) {
+        return;
+      }
+      cancelled = true;
+      unsubscribe();
+    },
+  };
+}

--- a/app/components/UI/Perps/utils/depositConfirmationGuard.ts
+++ b/app/components/UI/Perps/utils/depositConfirmationGuard.ts
@@ -128,3 +128,104 @@ export function createDepositConfirmationGuard(
     },
   };
 }
+
+export interface DepositPrepSessionHandlers {
+  onSuccess: () => void;
+  onFailure: (error: unknown) => void;
+}
+
+export interface DepositPrepSession {
+  /** Swap the confirmation guard; in-flight prep settles against the latest one. */
+  attachGuard: (nextGuard: DepositConfirmationGuard) => void;
+  /**
+   * Start deposit prep if none is pending or in flight. Later calls keep the
+   * first `run` and only refresh settlement handlers.
+   */
+  ensureScheduled: (
+    run: () => Promise<unknown>,
+    handlers: DepositPrepSessionHandlers,
+  ) => void;
+  /** Cancel a pending timeout, ignore in-flight settlement, and cancel the guard. */
+  dispose: () => void;
+}
+
+/**
+ * Owns the fire-and-forget deposit timeout so a second Add funds tap cannot
+ * start another prep or let a stale settlement clear the latest guard.
+ *
+ * @returns Session that attaches guards, schedules one prep, and disposes on unmount.
+ */
+export function createDepositPrepSession(): DepositPrepSession {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let inFlight = false;
+  let disposed = false;
+  let guard: DepositConfirmationGuard | null = null;
+  let handlers: DepositPrepSessionHandlers | null = null;
+
+  const attachGuard = (nextGuard: DepositConfirmationGuard) => {
+    if (disposed) {
+      nextGuard.cancel();
+      return;
+    }
+
+    guard?.cancel();
+    guard = nextGuard;
+  };
+
+  const ensureScheduled = (
+    run: () => Promise<unknown>,
+    nextHandlers: DepositPrepSessionHandlers,
+  ) => {
+    if (disposed) {
+      return;
+    }
+
+    handlers = nextHandlers;
+
+    if (timeoutId !== null || inFlight) {
+      return;
+    }
+
+    timeoutId = setTimeout(() => {
+      timeoutId = null;
+      if (disposed) {
+        return;
+      }
+
+      inFlight = true;
+      run()
+        .then(() => {
+          inFlight = false;
+          if (disposed) {
+            return;
+          }
+          guard?.cancel();
+          guard = null;
+          handlers?.onSuccess();
+        })
+        .catch((error: unknown) => {
+          inFlight = false;
+          if (disposed) {
+            return;
+          }
+          guard?.onDepositFailed();
+          guard = null;
+          handlers?.onFailure(error);
+        });
+    }, 0);
+  };
+
+  const dispose = () => {
+    disposed = true;
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+    inFlight = false;
+    guard?.cancel();
+    guard = null;
+    handlers = null;
+  };
+
+  return { attachGuard, ensureScheduled, dispose };
+}

--- a/app/components/UI/Perps/utils/depositConfirmationGuard.ts
+++ b/app/components/UI/Perps/utils/depositConfirmationGuard.ts
@@ -5,6 +5,12 @@ const CONFIRMATION_ROUTE_NAMES: ReadonlySet<string> = new Set([
   Routes.FULL_SCREEN_CONFIRMATIONS.NO_HEADER,
 ]);
 
+const PAY_WITH_ROUTE_NAMES: ReadonlySet<string> = new Set([
+  Routes.CONFIRMATION_PAY_WITH_MODAL,
+  Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET,
+  Routes.CONFIRMATION_PAY_WITH_NETWORK_MODAL,
+]);
+
 export interface NestedNavigationState {
   index: number;
   routes: { name: string; state?: NestedNavigationState }[];
@@ -61,6 +67,38 @@ export function isRedesignedConfirmationFocused(
 }
 
 /**
+ * Whether the deposit confirmation flow is focused, including Pay With sheets
+ * stacked on top of the redesigned confirmation.
+ *
+ * @param navigation - Navigation object exposing `getState`.
+ * @returns True when confirmation or a Pay With route is focused.
+ */
+export function isDepositConfirmationFlowFocused(
+  navigation: Pick<DepositConfirmationNavigation, 'getState'>,
+): boolean {
+  const focused = getFocusedRouteName(navigation.getState());
+  return (
+    focused !== undefined &&
+    (CONFIRMATION_ROUTE_NAMES.has(focused) || PAY_WITH_ROUTE_NAMES.has(focused))
+  );
+}
+
+/**
+ * Dismiss Pay With if it is covering confirmation, then dismiss confirmation.
+ *
+ * @param navigation - Navigation object exposing `getState` and `goBack`.
+ */
+export function dismissDepositConfirmation(
+  navigation: DepositConfirmationNavigation,
+): void {
+  const focused = getFocusedRouteName(navigation.getState());
+  if (focused !== undefined && PAY_WITH_ROUTE_NAMES.has(focused)) {
+    navigation.goBack();
+  }
+  navigation.goBack();
+}
+
+/**
  * Guards `goBack` after fire-and-forget deposit prep so we only dismiss the
  * confirmation we opened — not Perps, and not a confirmation the user already
  * closed. If `useConfirmNavigation` deferred the push, we wait until it
@@ -73,7 +111,7 @@ export function createDepositConfirmationGuard(
   navigation: DepositConfirmationNavigation,
 ): DepositConfirmationGuard {
   let cancelled = false;
-  let presented = isRedesignedConfirmationFocused(navigation);
+  let presented = isDepositConfirmationFlowFocused(navigation);
   let dismissWhenShown = false;
 
   const unsubscribe = navigation.addListener('state', () => {
@@ -81,8 +119,7 @@ export function createDepositConfirmationGuard(
       return;
     }
 
-    const focused = isRedesignedConfirmationFocused(navigation);
-    if (!focused) {
+    if (!isDepositConfirmationFlowFocused(navigation)) {
       if (presented) {
         cancelled = true;
         unsubscribe();
@@ -94,7 +131,7 @@ export function createDepositConfirmationGuard(
     if (dismissWhenShown) {
       cancelled = true;
       unsubscribe();
-      navigation.goBack();
+      dismissDepositConfirmation(navigation);
     }
   });
 
@@ -104,10 +141,10 @@ export function createDepositConfirmationGuard(
         return;
       }
 
-      if (isRedesignedConfirmationFocused(navigation)) {
+      if (isDepositConfirmationFlowFocused(navigation)) {
         cancelled = true;
         unsubscribe();
-        navigation.goBack();
+        dismissDepositConfirmation(navigation);
         return;
       }
 
@@ -208,8 +245,9 @@ export function createDepositPrepSession(): DepositPrepSession {
           if (disposed) {
             return;
           }
+          // Keep the guard so a waiting dismissWhenShown listener can be
+          // cancelled on dispose or replaced on the next tap.
           guard?.onDepositFailed();
-          guard = null;
           handlers?.onFailure(error);
         });
     }, 0);


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Tapping Add funds in Perps felt stuck because the tap handler awaited `depositWithConfirmation()` (Arbitrum ensure + unapproved tx simulation) and called `setIsProcessing(true)`, which re-rendered the live Perps tree on the same tick as navigation.

Predict already navigates to a Custom Amount confirmation skeleton first and prepares the transaction afterward. Perps home and market details now match that:

- Play a Primary CTA haptic immediately on tap
- Navigate to the confirmation loader without awaiting deposit prep
- Fire-and-forget `depositWithConfirmation()`; dismiss confirmation only if prep fails while it is still focused. The guard cancels if that confirmation loses focus so a later sheet is not popped.
- Yield one turn with `setTimeout(0)` so the skeleton can paint before prep work

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Made Perps Add funds open the deposit confirmation immediately instead of waiting for transaction prep

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [TAT-3772](https://consensyssoftware.atlassian.net/browse/TAT-3772)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps deposit tap responsiveness

  Scenario: user taps Add funds on Perps home
    Given the wallet is unlocked on the Trading account
    And Perps home shows the Add funds button

    When user taps Add funds
    Then the deposit amount screen appears without waiting for tx prep
    And Pay with shows a selected token

  Scenario: user opens Pay with
    Given the deposit amount screen is visible

    When user taps Pay with
    Then the Pay with sheet lists a crypto asset and Other assets
```

## **Screenshots/Recordings**

Re-validation after rebase onto origin/main and Bugbot Pay With / abandoned-guard fixes: Add funds opens the amount screen immediately; Pay with lists ETH and Other assets.

<table>
<tr><td colspan="2"><strong>Perps Add funds opens the deposit amount screen with Pay with</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35573/recipe-runs/inherited-7c0c5927-dfc9-40e0-a1ab-864e5e4e43a2/recipe-runs/inherited-ddaa2a89-e25d-406d-a793-597a44688ba4/before-evidence-ac1-deposit-confirmation.png?sha=8bd9f11d8a4c20a8" alt="before" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35573/recipe-run/screenshots/evidence-ac1-deposit-confirmation.png?sha=8f6a114cc4fc53d6" alt="after" width="320" /></td>
</tr>
<tr><td colspan="2"><strong>Pay with sheet lists ETH and other assets</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35573/recipe-runs/inherited-7c0c5927-dfc9-40e0-a1ab-864e5e4e43a2/recipe-runs/inherited-ddaa2a89-e25d-406d-a793-597a44688ba4/before-evidence-ac2-pay-with-list.png?sha=c2c119a263a0bb66" alt="before" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35573/recipe-run/screenshots/evidence-ac2-pay-with-list.png?sha=36f2e59f587ce18c" alt="after" width="320" /></td>
</tr>
</table>

**Video**
<table>
<tr><td align="center" width="50%"><em>Before</em><br/><a href="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35573/recipe-runs/inherited-7c0c5927-dfc9-40e0-a1ab-864e5e4e43a2/recipe-runs/inherited-ddaa2a89-e25d-406d-a793-597a44688ba4/before.mp4?sha=e74a2bf89d208009">recipe-runs/inherited-7c0c5927-dfc9-40e0-a1ab-864e5e4e43a2/recipe-runs/inherited-ddaa2a89-e25d-406d-a793-597a44688ba4/before.mp4</a></td>
<td align="center" width="50%"><em>After</em><br/><a href="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35573/recipe-runs/inherited-7c0c5927-dfc9-40e0-a1ab-864e5e4e43a2/recipe-runs/inherited-ddaa2a89-e25d-406d-a793-597a44688ba4/after.mp4?sha=bce5208ff504eada">recipe-runs/inherited-7c0c5927-dfc9-40e0-a1ab-864e5e4e43a2/recipe-runs/inherited-ddaa2a89-e25d-406d-a793-597a44688ba4/after.mp4</a></td></tr>
</table>

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "Perps deposit tap is responsive and Pay With tokens load",
  "description": "Unlocks the Trading fixture account, opens Perps home, taps Add funds, and proves confirmation plus the Pay With token sheet appear without the pre-fix multi-second stall. Setup follows the perps.smoke unlock and Perps navigation pattern.",
  "workflow": {
    "entry": "setup-unlock",
    "nodes": {
      "setup-unlock": {
        "action": "metamask.wallet.ensure_unlocked",
        "intent": "Unlock the fixture wallet before opening Perps",
        "stable_unlocked_ms": 0,
        "unlock_timeout_ms": 60000,
        "target_timeout_ms": 60000,
        "next": "setup-account"
      },
      "setup-account": {
        "action": "metamask.wallet.select_account",
        "intent": "Select the funded Trading account for the deposit flow",
        "name": "Trading",
        "next": "setup-open-perps"
      },
      "setup-open-perps": {
        "action": "ui.navigate",
        "intent": "Open the Perps home screen where deposit is triggered",
        "page": "perps",
        "timeout_ms": 30000,
        "next": "gate-wait-heading"
      },
      "gate-wait-heading": {
        "action": "ui.wait_for",
        "intent": "Confirm Perps home has finished rendering its title",
        "test_id": "perps-home-heading-provider-badge",
        "expected": "present",
        "timeout_ms": 20000,
        "next": "gate-wait-deposit"
      },
      "gate-wait-deposit": {
        "action": "ui.wait_for",
        "intent": "Confirm the deposit CTA is on screen before using it",
        "test_id": "perps-market-add-funds-button",
        "expected": "present",
        "timeout_ms": 20000,
        "next": "ac1-press-deposit"
      },
      "ac1-press-deposit": {
        "action": "ui.press",
        "intent": "Begin the Perps deposit confirmation from home",
        "test_id": "perps-market-add-funds-button",
        "timeout_ms": 8000,
        "next": "ac1-wait-confirmation"
      },
      "ac1-wait-confirmation": {
        "action": "ui.wait_for",
        "intent": "Confirm the deposit amount screen appeared without a multi-second stall",
        "test_id": "custom-amount-input",
        "expected": "present",
        "timeout_ms": 4000,
        "next": "ac1-wait-pay-with"
      },
      "ac1-wait-pay-with": {
        "action": "ui.wait_for",
        "intent": "Confirm Pay With is mounted on the deposit confirmation",
        "test_id": "pay-with",
        "expected": "present",
        "timeout_ms": 8000,
        "next": "ac1-screenshot-confirmation"
      },
      "ac1-screenshot-confirmation": {
        "action": "ui.screenshot",
        "intent": "Record the deposit confirmation after a responsive Add funds tap",
        "label": "AC1: deposit confirmation after Add funds",
        "next": "ac2-press-pay-with"
      },
      "ac2-press-pay-with": {
        "action": "ui.press",
        "intent": "Show every token that can fund this Perps deposit",
        "test_id": "pay-with",
        "timeout_ms": 10000,
        "next": "ac2-wait-token-sheet"
      },
      "ac2-wait-token-sheet": {
        "action": "ui.wait_for",
        "intent": "Confirm the Pay With token sheet listed a crypto asset",
        "test_id": "pay-with-crypto-section-preferred-token-row",
        "expected": "present",
        "timeout_ms": 4000,
        "next": "ac2-screenshot-token-list"
      },
      "ac2-screenshot-token-list": {
        "action": "ui.screenshot",
        "intent": "Record the Pay With token sheet after first open",
        "label": "AC2: Pay With token sheet",
        "next": "done"
      },
      "done": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
  setup-unlock[setup-unlock] --> setup-account[setup-account]
  setup-account --> setup-open-perps[setup-open-perps]
  setup-open-perps --> gate-wait-heading[gate-wait-heading]
  gate-wait-heading --> gate-wait-deposit[gate-wait-deposit]
  gate-wait-deposit --> ac1-press-deposit[ac1-press-deposit]
  ac1-press-deposit --> ac1-wait-confirmation[ac1-wait-confirmation]
  ac1-wait-confirmation --> ac1-wait-pay-with[ac1-wait-pay-with]
  ac1-wait-pay-with --> ac1-screenshot-confirmation[ac1-screenshot-confirmation]
  ac1-screenshot-confirmation --> ac2-press-pay-with[ac2-press-pay-with]
  ac2-press-pay-with --> ac2-wait-token-sheet[ac2-wait-token-sheet]
  ac2-wait-token-sheet --> ac2-screenshot-token-list[ac2-screenshot-token-list]
  ac2-screenshot-token-list --> done[done]
```

</details>

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TAT-3772]: https://consensyssoftware.atlassian.net/browse/TAT-3772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deposit navigation timing and stack dismissal logic for a funds flow; regressions could strand users on a blank confirmation or pop the wrong screen, though behavior is heavily unit-tested.
> 
> **Overview**
> **Perps Add funds** on home and market details no longer blocks on `depositWithConfirmation()` before navigation. The tap plays a primary haptic, pushes the redesigned confirmation with the **`customAmount`** loader right away, and defers Arbitrum/tx prep to the next tick via a shared **`depositConfirmationGuard`** session.
> 
> That utility adds **`createDepositPrepSession`** (single in-flight prep, refreshed handlers on repeat taps) and **`createDepositConfirmationGuard`** (dismiss confirmation—and Pay With if stacked—only when prep fails while that flow is still focused; no-op if the user already left). Sessions dispose on unmount.
> 
> Home **`usePerpsHomeActions`** stops toggling **`isProcessing`** for deposits during this path; failures still surface through **`onError`** and guarded **`goBack`**. Tests cover deferred prep, double-tap, stale failure after a second tap, and navigation edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 998aa49925b15b82442204db64c0958cd0fe0f22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

