### PR TITLE
refactor: co-locate Keypad and AssetElement testIDs (MMQA-1390)

### DIFF
--- a/app/components/Base/Keypad/Keypad.testIds.ts
+++ b/app/components/Base/Keypad/Keypad.testIds.ts
@@ -1,0 +1,16 @@
+export const KeypadTestIds = {
+  KEY_0: 'keypad-key-0',
+  KEY_1: 'keypad-key-1',
+  KEY_2: 'keypad-key-2',
+  KEY_3: 'keypad-key-3',
+  KEY_4: 'keypad-key-4',
+  KEY_5: 'keypad-key-5',
+  KEY_6: 'keypad-key-6',
+  KEY_7: 'keypad-key-7',
+  KEY_8: 'keypad-key-8',
+  KEY_9: 'keypad-key-9',
+  KEY_DOT: 'keypad-key-dot',
+  DELETE_BUTTON: 'keypad-delete-button',
+} as const;
+
+export type KeypadTestIdsType = typeof KeypadTestIds;

--- a/app/components/Base/Keypad/index.tsx
+++ b/app/components/Base/Keypad/index.tsx
@@ -7,6 +7,7 @@ import Keypad, {
 } from './components';
 import { Keys } from './constants';
 import useCurrency from './useCurrency';
+import { KeypadTestIds } from './Keypad.testIds';
 import { colors } from '../../../styles/common';
 
 const styles = StyleSheet.create({
@@ -132,52 +133,82 @@ function KeypadComponent({
   return (
     <Keypad {...props}>
       <Keypad.Row>
-        <Keypad.Button testID="keypad-key-1" onPress={handleKeypadPress1}>
+        <Keypad.Button
+          testID={KeypadTestIds.KEY_1}
+          onPress={handleKeypadPress1}
+        >
           1
         </Keypad.Button>
-        <Keypad.Button testID="keypad-key-2" onPress={handleKeypadPress2}>
+        <Keypad.Button
+          testID={KeypadTestIds.KEY_2}
+          onPress={handleKeypadPress2}
+        >
           2
         </Keypad.Button>
-        <Keypad.Button testID="keypad-key-3" onPress={handleKeypadPress3}>
+        <Keypad.Button
+          testID={KeypadTestIds.KEY_3}
+          onPress={handleKeypadPress3}
+        >
           3
         </Keypad.Button>
       </Keypad.Row>
       <Keypad.Row>
-        <Keypad.Button testID="keypad-key-4" onPress={handleKeypadPress4}>
+        <Keypad.Button
+          testID={KeypadTestIds.KEY_4}
+          onPress={handleKeypadPress4}
+        >
           4
         </Keypad.Button>
-        <Keypad.Button testID="keypad-key-5" onPress={handleKeypadPress5}>
+        <Keypad.Button
+          testID={KeypadTestIds.KEY_5}
+          onPress={handleKeypadPress5}
+        >
           5
         </Keypad.Button>
-        <Keypad.Button testID="keypad-key-6" onPress={handleKeypadPress6}>
+        <Keypad.Button
+          testID={KeypadTestIds.KEY_6}
+          onPress={handleKeypadPress6}
+        >
           6
         </Keypad.Button>
       </Keypad.Row>
       <Keypad.Row>
-        <Keypad.Button testID="keypad-key-7" onPress={handleKeypadPress7}>
+        <Keypad.Button
+          testID={KeypadTestIds.KEY_7}
+          onPress={handleKeypadPress7}
+        >
           7
         </Keypad.Button>
-        <Keypad.Button testID="keypad-key-8" onPress={handleKeypadPress8}>
+        <Keypad.Button
+          testID={KeypadTestIds.KEY_8}
+          onPress={handleKeypadPress8}
+        >
           8
         </Keypad.Button>
-        <Keypad.Button testID="keypad-key-9" onPress={handleKeypadPress9}>
+        <Keypad.Button
+          testID={KeypadTestIds.KEY_9}
+          onPress={handleKeypadPress9}
+        >
           9
         </Keypad.Button>
       </Keypad.Row>
       <Keypad.Row>
         <Keypad.Button
-          testID="keypad-key-dot"
+          testID={KeypadTestIds.KEY_DOT}
           onPress={handleKeypadPressPeriod}
           style={styles.periodButton}
           {...periodButtonProps}
         >
           {decimalSeparator}
         </Keypad.Button>
-        <Keypad.Button testID="keypad-key-0" onPress={handleKeypadPress0}>
+        <Keypad.Button
+          testID={KeypadTestIds.KEY_0}
+          onPress={handleKeypadPress0}
+        >
           0
         </Keypad.Button>
         <Keypad.DeleteButton
-          testID="keypad-delete-button"
+          testID={KeypadTestIds.DELETE_BUTTON}
           onPress={handleKeypadPressBack}
           onLongPress={handleKeypadLongPressBack}
           delayLongPress={500}

--- a/app/components/UI/AssetElement/AssetElement.testIds.ts
+++ b/app/components/UI/AssetElement/AssetElement.testIds.ts
@@ -1,0 +1,7 @@
+export const getAssetTestId = (token: string): string => `asset-${token}`;
+
+const STAKED_ETHEREUM_SYMBOL = 'ETH';
+
+export const WalletAssetSelectorsIDs = {
+  STAKED_ETHEREUM: getAssetTestId(STAKED_ETHEREUM_SYMBOL),
+} as const;

--- a/app/components/UI/AssetElement/index.test.tsx
+++ b/app/components/UI/AssetElement/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import AssetElement from './';
-import { getAssetTestId } from '../../../../tests/selectors/Wallet/WalletView.selectors';
+import { getAssetTestId } from './AssetElement.testIds';
 import {
   BALANCE_TEST_ID,
   SECONDARY_BALANCE_BUTTON_TEST_ID,

--- a/app/components/UI/AssetElement/index.tsx
+++ b/app/components/UI/AssetElement/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../../component-library/components/Texts/Text';
 import SkeletonText from '../Ramp/Aggregator/components/SkeletonText';
 import { TokenI } from '../Tokens/types';
-import { getAssetTestId } from '../../../../tests/selectors/Wallet/WalletView.selectors';
+import { getAssetTestId } from './AssetElement.testIds';
 import SensitiveText, {
   SensitiveTextLength,
 } from '../../../component-library/components/Texts/SensitiveText';

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -1386,6 +1386,13 @@ describe('BridgeTokenSelector', () => {
       );
       const initialMountCount = mockFlashListMount.mock.calls.length;
       const { FlatList } = jest.requireActual('react-native');
+      const flushAnimationFrame = async () => {
+        await act(async () => {
+          await new Promise<void>((resolve) => {
+            requestAnimationFrame(() => resolve());
+          });
+        });
+      };
 
       await act(async () => {
         UNSAFE_getByType(FlatList).props.onScroll({
@@ -1397,19 +1404,21 @@ describe('BridgeTokenSelector', () => {
         });
       });
 
+      // Flush rAF after each chain change so the scroll reset effect does not
+      // race (cleanup can cancel a pending frame when presses are back-to-back).
       await act(async () => {
         fireEvent.press(getByTestId('select-eth-network'));
       });
+      await flushAnimationFrame();
       await act(async () => {
         fireEvent.press(getByTestId('select-all-networks'));
       });
+      await flushAnimationFrame();
 
-      await waitFor(() => {
-        expect(mockFlashListScrollToIndex).toHaveBeenCalledTimes(1);
-        expect(mockFlashListScrollToIndex).toHaveBeenCalledWith({
-          index: 0,
-          animated: false,
-        });
+      expect(mockFlashListScrollToIndex).toHaveBeenCalledTimes(2);
+      expect(mockFlashListScrollToIndex).toHaveBeenLastCalledWith({
+        index: 0,
+        animated: false,
       });
       expect(mockFlashListMount).toHaveBeenCalledTimes(initialMountCount);
       expect(mockFlashListUnmount).not.toHaveBeenCalled();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Part of [MMQA-1390](https://consensyssoftware.atlassian.net/browse/MMQA-1390) (hardcoded selector audit).

Moves shared `Keypad` and `AssetElement` / `getAssetTestId` helpers into app co-located `*.testIds.ts` so stacked owner PRs can import them without depending on `tests/selectors` ID maps.

This is the foundation PR for the MMQA-1390 split stack.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
Refs: MMQA-1390

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — internal testID co-location only; string values unchanged. Covered by `AssetElement` unit tests.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MMQA-1390]: https://consensyssoftware.atlassian.net/browse/MMQA-1390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-ID refactor only; runtime testID strings are unchanged. The Bridge change is test-only.
> 
> **Overview**
> Part of the MMQA-1390 hardcoded-selector audit: **Keypad** and **AssetElement** test IDs now live next to the components instead of inline strings or `tests/selectors`.
> 
> Adds `Keypad.testIds.ts` and wires `Keypad` buttons/delete control through `KeypadTestIds` (same string values as before). Adds `AssetElement.testIds.ts` with `getAssetTestId` and `WalletAssetSelectorsIDs`, and points `AssetElement` plus its unit tests at that module rather than `WalletView.selectors`.
> 
> Also stabilizes **BridgeTokenSelector** chain-selection coverage by flushing `requestAnimationFrame` after back-to-back network presses and asserting **two** `scrollToIndex` resets (one per chain change), avoiding a race with the scroll-reset effect cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40a5b5e89661cef9e8e9105c4f2e387707a48c56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->