### PR TITLE
refactor(swaps): co-locate Bridge testIDs (MMQA-1390)

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.testIds.ts
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.testIds.ts
@@ -1,0 +1,8 @@
+export const BridgeTokenSelectorTestIds = {
+  SEARCH_INPUT: 'bridge-token-search-input',
+  TOKEN_LIST: 'bridge-token-list',
+  BACK_BUTTON: 'bridge-token-selector-back-button',
+  EMPTY_STATE: 'bridge-token-selector-empty-state',
+} as const;
+
+export type BridgeTokenSelectorTestIdsType = typeof BridgeTokenSelectorTestIds;

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -64,6 +64,7 @@ import NoSearchResultsDark from '../../../../../images/predictions-no-search-res
 import { SkeletonItem } from '../SkeletonItem';
 import { TabEmptyState } from '../../../../../component-library/components-temp/TabEmptyState';
 import { TokenSelectorItem } from '../TokenSelectorItem';
+import { BridgeTokenSelectorTestIds } from './BridgeTokenSelector.testIds';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import { type BridgeToken, TokenSelectorType } from '../../types';
 import { usePopularTokens } from '../../hooks/usePopularTokens';
@@ -184,7 +185,7 @@ const BridgeTokenSelectorSearchEmptyState = React.memo(
     NoSearchResultsIcon,
   }: BridgeTokenSelectorSearchEmptyStateProps) => (
     <TabEmptyState
-      testID="bridge-token-selector-empty-state"
+      testID={BridgeTokenSelectorTestIds.EMPTY_STATE}
       icon={<NoSearchResultsIcon width={72} height={78} />}
       description={strings('bridge.no_tokens_found')}
       descriptionProps={{
@@ -992,13 +993,16 @@ export const BridgeTokenSelector: React.FC = () => {
         title={strings('bridge.select_token')}
         onBack={() => navigation.goBack()}
         includesTopInset
+        backButtonProps={{
+          testID: BridgeTokenSelectorTestIds.BACK_BUTTON,
+        }}
       />
       <Box twClassName="px-4 pb-3">
         <TextFieldSearch
           value={searchString}
           onChangeText={handleSearchTextChange}
           placeholder={strings('swaps.search_token')}
-          testID="bridge-token-search-input"
+          testID={BridgeTokenSelectorTestIds.SEARCH_INPUT}
           autoComplete="off"
           autoCorrect={false}
           autoCapitalize="none"
@@ -1027,7 +1031,7 @@ export const BridgeTokenSelector: React.FC = () => {
       ) : (
         <FlashList
           ref={flatListRef}
-          testID="bridge-token-list"
+          testID={BridgeTokenSelectorTestIds.TOKEN_LIST}
           style={styles.tokensList}
           contentContainerStyle={styles.tokensListContainer}
           data={displayData}

--- a/app/components/UI/Bridge/components/InputStepper/InputStepper.testIds.ts
+++ b/app/components/UI/Bridge/components/InputStepper/InputStepper.testIds.ts
@@ -1,0 +1,11 @@
+export const InputStepperTestIds = {
+  MINUS_BUTTON: 'input-stepper-minus-button',
+  PLUS_BUTTON: 'input-stepper-plus-button',
+  INPUT: 'input-stepper-input',
+  POST_VALUE: 'input-stepper-post-value',
+  DESCRIPTION_ROW: 'input-stepper-description-row',
+  DESCRIPTION_ICON: 'input-stepper-description-icon',
+  DESCRIPTION_MESSAGE: 'input-text-description-message',
+} as const;
+
+export type InputStepperTestIdsType = typeof InputStepperTestIds;

--- a/app/components/UI/Bridge/components/InputStepper/InputStepperDescriptionRow.tsx
+++ b/app/components/UI/Bridge/components/InputStepper/InputStepperDescriptionRow.tsx
@@ -8,6 +8,7 @@ import {
 } from '@metamask/design-system-react-native';
 import { inputStepperDescriptionRow } from './styles';
 import { InputStepperProps } from './types';
+import { InputStepperTestIds } from './InputStepper.testIds';
 
 interface InputStepperDescriptionRowProps {
   description: InputStepperProps['description'];
@@ -23,12 +24,12 @@ export const InputStepperDescriptionRow = ({
   return (
     <View
       style={inputStepperDescriptionRow.descriptionRow}
-      testID="input-stepper-description-row"
+      testID={InputStepperTestIds.DESCRIPTION_ROW}
     >
       {description.icon && (
         <View style={inputStepperDescriptionRow.iconWrapper}>
           <Icon
-            testID="input-stepper-description-icon"
+            testID={InputStepperTestIds.DESCRIPTION_ICON}
             name={description.icon.name}
             size={description.icon.size}
             color={description.icon.color}
@@ -41,7 +42,7 @@ export const InputStepperDescriptionRow = ({
           color={description.color}
           variant={TextVariant.BodySm}
           fontWeight={FontWeight.Medium}
-          testID="input-text-description-message"
+          testID={InputStepperTestIds.DESCRIPTION_MESSAGE}
         >
           {description.message}
         </Text>

--- a/app/components/UI/Bridge/components/InputStepper/index.tsx
+++ b/app/components/UI/Bridge/components/InputStepper/index.tsx
@@ -15,6 +15,7 @@ import { inputStepperStyles } from './styles';
 import { calculateInputFontSize } from '../../utils/calculateInputFontSize';
 import { InputStepperProps } from './types';
 import { InputStepperDescriptionRow } from './InputStepperDescriptionRow';
+import { InputStepperTestIds } from './InputStepper.testIds';
 import { formatAmountWithLocaleSeparators } from '../../utils/formatAmountWithLocaleSeparators';
 
 export const InputStepper = ({
@@ -52,7 +53,7 @@ export const InputStepper = ({
           onPressOut={() => setMinusPressed(false)}
           onPress={onDecrease}
           isDisabled={parseFloat(value) <= minAmount}
-          testID="input-stepper-minus-button"
+          testID={InputStepperTestIds.MINUS_BUTTON}
         />
         <View style={styles.inputRow}>
           <View>
@@ -63,7 +64,7 @@ export const InputStepper = ({
               placeholder={placeholder}
               value={displayedAmount}
               style={styles.input}
-              testID="input-stepper-input"
+              testID={InputStepperTestIds.INPUT}
               // Slippage controls selection so keypad edits can target the
               // displayed caret position instead of always appending.
               selection={selection}
@@ -71,7 +72,7 @@ export const InputStepper = ({
             />
           </View>
           {postValue && (
-            <View testID="input-stepper-post-value">
+            <View testID={InputStepperTestIds.POST_VALUE}>
               <Text style={styles.input}>{postValue}</Text>
             </View>
           )}
@@ -86,7 +87,7 @@ export const InputStepper = ({
           onPressOut={() => setPlusPressed(false)}
           onPress={onIncrease}
           isDisabled={parseFloat(value) >= maxAmount}
-          testID="input-stepper-plus-button"
+          testID={InputStepperTestIds.PLUS_BUTTON}
         />
       </View>
       <InputStepperDescriptionRow description={description} />

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.testIds.ts
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.testIds.ts
@@ -1,0 +1,9 @@
+export const QuoteDetailsCardTestIds = {
+  RATE_ARROW_BUTTON: 'rate-arrow-button',
+  EDIT_SLIPPAGE_BUTTON: 'edit-slippage-button',
+  PRICE_IMPACT_INFO_BUTTON: 'price-impact-info-button',
+  BRIDGE_REWARDS_ROW: 'bridge-rewards-row',
+  BRIDGE_ADD_REWARDS_ACCOUNT: 'bridge-add-rewards-account',
+} as const;
+
+export type QuoteDetailsCardTestIdsType = typeof QuoteDetailsCardTestIds;

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -37,6 +37,7 @@ import RewardsAnimations, {
 import AddRewardsAccount from '../../../Rewards/components/AddRewardsAccount/AddRewardsAccount';
 import QuoteCountdownTimer from '../QuoteCountdownTimer';
 import QuoteDetailsRecipientKeyValueRow from '../QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow';
+import { QuoteDetailsCardTestIds } from './QuoteDetailsCard.testIds';
 import { toSentenceCase } from '../../../../../util/string';
 import TagColored, {
   TagColor,
@@ -196,7 +197,7 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
           <TouchableOpacity
             style={tw`flex-1 items-end`}
             onPress={handleRatePress}
-            testID="rate-arrow-button"
+            testID={QuoteDetailsCardTestIds.RATE_ARROW_BUTTON}
             activeOpacity={0.6}
           >
             <Box
@@ -329,7 +330,7 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
               <TouchableOpacity
                 onPress={handleSlippagePress}
                 activeOpacity={0.6}
-                testID="edit-slippage-button"
+                testID={QuoteDetailsCardTestIds.EDIT_SLIPPAGE_BUTTON}
                 style={styles.slippageButton}
               >
                 <Text
@@ -389,7 +390,7 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
             value={{
               label: (
                 <TouchableOpacity
-                  testID="price-impact-info-button"
+                  testID={QuoteDetailsCardTestIds.PRICE_IMPACT_INFO_BUTTON}
                   onPress={handlePriceImpactPress}
                   activeOpacity={priceImpactIsSafe ? 1 : 0.6}
                 >
@@ -423,7 +424,7 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
 
         {/* Estimated Points */}
         {shouldShowRewardsRow && (
-          <Box testID="bridge-rewards-row">
+          <Box testID={QuoteDetailsCardTestIds.BRIDGE_REWARDS_ROW}>
             <KeyValueRow
               field={{
                 label: {
@@ -459,7 +460,9 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
                       />
                     ) : rewardsAccountScope ? (
                       <AddRewardsAccount
-                        testID="bridge-add-rewards-account"
+                        testID={
+                          QuoteDetailsCardTestIds.BRIDGE_ADD_REWARDS_ACCOUNT
+                        }
                         account={rewardsAccountScope}
                       />
                     ) : (

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -8,7 +8,7 @@ import {
   TextStyle,
 } from 'react-native';
 import { strings } from '../../../../../locales/i18n';
-import { getAssetTestId } from '../../../../../tests/selectors/Wallet/WalletView.selectors';
+import { getAssetTestId } from '../../AssetElement/AssetElement.testIds';
 import TagBase, {
   TagSeverity,
   TagShape,

--- a/tests/page-objects/swaps/QuoteView.ts
+++ b/tests/page-objects/swaps/QuoteView.ts
@@ -6,12 +6,15 @@ import {
   sleep,
   type AppiumElement,
 } from '../../framework';
-import { getAssetTestId } from '../../selectors/Wallet/WalletView.selectors';
+import { getAssetTestId } from '../../../app/components/UI/AssetElement/AssetElement.testIds';
 import {
-  QuoteViewSelectorIDs,
   QuoteViewSelectorText,
   getChainIdForNetwork,
 } from '../../selectors/Bridge/QuoteView.selectors';
+import { BridgeViewSelectorsIDs } from '../../../app/components/UI/Bridge/Views/BridgeView/BridgeView.testIds';
+import { BridgeTokenSelectorTestIds } from '../../../app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.testIds';
+import { QuoteDetailsCardTestIds } from '../../../app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.testIds';
+import { KeypadTestIds } from '../../../app/components/Base/Keypad/Keypad.testIds';
 
 const TIMEOUT = {
   SWAP_SCREEN_VISIBLE: 10000,
@@ -29,38 +32,40 @@ class QuoteView {
   }
 
   get confirmBridge(): Promise<AppiumElement> {
-    return Matchers.getElementByID(QuoteViewSelectorIDs.CONFIRM_BUTTON);
+    return Matchers.getElementByID(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
   }
 
   get confirmSwap(): Promise<AppiumElement> {
-    return Matchers.getElementByID(QuoteViewSelectorIDs.CONFIRM_BUTTON);
+    return Matchers.getElementByID(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
   }
 
   get sourceTokenArea(): Promise<AppiumElement> {
-    return Matchers.getElementByID(QuoteViewSelectorIDs.SOURCE_TOKEN_AREA);
+    return Matchers.getElementByID(BridgeViewSelectorsIDs.SOURCE_TOKEN_AREA);
   }
 
   get amountInput(): Promise<AppiumElement> {
-    return Matchers.getElementByID(QuoteViewSelectorIDs.SOURCE_TOKEN_INPUT);
+    return Matchers.getElementByID(BridgeViewSelectorsIDs.SOURCE_TOKEN_INPUT);
   }
 
   get destinationTokenArea(): Promise<AppiumElement> {
-    return Matchers.getElementByID(QuoteViewSelectorIDs.DESTINATION_TOKEN_AREA);
+    return Matchers.getElementByID(
+      BridgeViewSelectorsIDs.DESTINATION_TOKEN_AREA,
+    );
   }
 
   get destinationTokenInput(): Promise<AppiumElement> {
     return Matchers.getElementByID(
-      QuoteViewSelectorIDs.DESTINATION_TOKEN_INPUT,
+      BridgeViewSelectorsIDs.DESTINATION_TOKEN_INPUT,
     );
   }
 
   get searchToken(): Promise<AppiumElement> {
     if (PlatformDetector.isIOS()) {
       return Matchers.getElementByNativeXPath(
-        `//*[@name='${QuoteViewSelectorIDs.TOKEN_SEARCH_INPUT}' or @name='textfieldsearch' or contains(@label,'Enter token name') or contains(@name,'Enter token name')]`,
+        `//*[@name='${BridgeTokenSelectorTestIds.SEARCH_INPUT}' or @name='textfieldsearch' or contains(@label,'Enter token name') or contains(@name,'Enter token name')]`,
       );
     }
-    return Matchers.getElementByID(QuoteViewSelectorIDs.TOKEN_SEARCH_INPUT);
+    return Matchers.getElementByID(BridgeTokenSelectorTestIds.SEARCH_INPUT);
   }
 
   get seeAllButton(): Promise<AppiumElement> {
@@ -68,7 +73,7 @@ class QuoteView {
   }
 
   get backButton(): Promise<AppiumElement> {
-    return Matchers.getElementByID(QuoteViewSelectorIDs.BACK_BUTTON);
+    return Matchers.getElementByID(BridgeTokenSelectorTestIds.BACK_BUTTON);
   }
 
   get moreNetworksButton(): Promise<AppiumElement> {
@@ -80,23 +85,23 @@ class QuoteView {
   }
 
   get bridgeViewScroll(): Promise<AppiumElement> {
-    return Matchers.getElementByID(QuoteViewSelectorIDs.BRIDGE_VIEW_SCROLL);
+    return Matchers.getElementByID(BridgeViewSelectorsIDs.BRIDGE_VIEW_SCROLL);
   }
 
   /** Fee disclaimer (e.g. "Includes 0.875% MetaMask fee") - used for isQuoteDisplayed. */
   get feeDisclaimerLabel(): Promise<AppiumElement> {
     return Matchers.getElementByID(
-      QuoteViewSelectorIDs.PRICE_IMPACT_INFO_BUTTON,
+      QuoteDetailsCardTestIds.PRICE_IMPACT_INFO_BUTTON,
     );
   }
 
   get keypadDeleteButton(): Promise<AppiumElement> {
     if (PlatformDetector.isIOS()) {
       return Matchers.getElementByNativeXPath(
-        `//*[contains(@name,'${QuoteViewSelectorIDs.KEYPAD_DELETE_BUTTON}')]`,
+        `//*[contains(@name,'${KeypadTestIds.DELETE_BUTTON}')]`,
       );
     }
-    return Matchers.getElementByID(QuoteViewSelectorIDs.KEYPAD_DELETE_BUTTON);
+    return Matchers.getElementByID(KeypadTestIds.DELETE_BUTTON);
   }
 
   get maxLink(): Promise<AppiumElement> {
@@ -178,7 +183,7 @@ class QuoteView {
           // (matches prior AppiumGestures.scrollIntoView direction: 'up').
           await Gestures.scrollToElement(
             tokenElement,
-            Matchers.scrollContainer(QuoteViewSelectorIDs.TOKEN_LIST),
+            Matchers.scrollContainer(BridgeTokenSelectorTestIds.TOKEN_LIST),
             {
               direction: 'down',
               elemDescription: `Scroll to token symbol ${symbol}`,
@@ -440,7 +445,7 @@ class QuoteView {
     const timeout = 60000;
     const message = QuoteViewSelectorText.RWA_GEO_RESTRICTED_MESSAGE;
     const banner = Matchers.getElementByID(
-      QuoteViewSelectorIDs.NO_QUOTES_BANNER,
+      BridgeViewSelectorsIDs.NO_QUOTES_BANNER,
     );
 
     await Assertions.expectElementToBeVisible(banner, {

--- a/tests/page-objects/swaps/SlippageModal.ts
+++ b/tests/page-objects/swaps/SlippageModal.ts
@@ -1,16 +1,16 @@
 import Matchers from '../../framework/Matchers';
 import Gestures from '../../framework/Gestures';
 import Assertions from '../../framework/Assertions';
-import {
-  SlippageModalSelectorIDs,
-  SlippageModalSelectorText,
-} from '../../selectors/Bridge/SlippageModal.selectors';
+import { SlippageModalSelectorText } from '../../selectors/Bridge/SlippageModal.selectors';
+import { QuoteDetailsCardTestIds } from '../../../app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.testIds';
+import { InputStepperTestIds } from '../../../app/components/UI/Bridge/components/InputStepper/InputStepper.testIds';
+import { KeypadTestIds } from '../../../app/components/Base/Keypad/Keypad.testIds';
 import { type AppiumElement } from '../../framework';
 
 class SlippageModal {
   get editSlippageButton(): Promise<AppiumElement> {
     return Matchers.getElementByID(
-      SlippageModalSelectorIDs.EDIT_SLIPPAGE_BUTTON,
+      QuoteDetailsCardTestIds.EDIT_SLIPPAGE_BUTTON,
     );
   }
 
@@ -23,15 +23,11 @@ class SlippageModal {
   }
 
   get inputStepperInput(): Promise<AppiumElement> {
-    return Matchers.getElementByID(
-      SlippageModalSelectorIDs.INPUT_STEPPER_INPUT,
-    );
+    return Matchers.getElementByID(InputStepperTestIds.INPUT);
   }
 
   get keypadDeleteButton(): Promise<AppiumElement> {
-    return Matchers.getElementByID(
-      SlippageModalSelectorIDs.KEYPAD_DELETE_BUTTON,
-    );
+    return Matchers.getElementByID(KeypadTestIds.DELETE_BUTTON);
   }
 
   /**

--- a/tests/selectors/Bridge/QuoteView.selectors.ts
+++ b/tests/selectors/Bridge/QuoteView.selectors.ts
@@ -40,21 +40,3 @@ export const NETWORK_TO_CHAIN_ID: Record<string, string> = {
 export function getChainIdForNetwork(network: string): string {
   return NETWORK_TO_CHAIN_ID[network] ?? '0x1';
 }
-
-export const QuoteViewSelectorIDs = {
-  TOKEN_SEARCH_INPUT: 'bridge-token-search-input',
-  TOKEN_LIST: 'bridge-token-list',
-  EXPAND_QUOTE_DETAILS: 'expand-quote-details',
-  SOURCE_TOKEN_AREA: 'source-token-area',
-  DESTINATION_TOKEN_AREA: 'dest-token-area',
-  SOURCE_TOKEN_INPUT: 'source-token-area-input',
-  DESTINATION_TOKEN_INPUT: 'dest-token-area-input',
-  SOURCE_TOKEN_SELECTOR: 'select-source-token-selector',
-  CONFIRM_BUTTON: 'bridge-confirm-button',
-  BRIDGE_VIEW_SCROLL: 'bridge-view-scroll',
-  NO_QUOTES_BANNER: 'bridge-no-quotes',
-  FEE_DISCLAIMER: 'bridge-fee-disclaimer',
-  KEYPAD_DELETE_BUTTON: 'keypad-delete-button',
-  BACK_BUTTON: 'button-icon',
-  PRICE_IMPACT_INFO_BUTTON: 'price-impact-info-button',
-};

--- a/tests/selectors/Bridge/SlippageModal.selectors.ts
+++ b/tests/selectors/Bridge/SlippageModal.selectors.ts
@@ -1,13 +1,5 @@
 import enContent from '../../../locales/languages/en.json';
 
-export const SlippageModalSelectorIDs = {
-  EDIT_SLIPPAGE_BUTTON: 'edit-slippage-button',
-  INPUT_STEPPER_MINUS_BUTTON: 'input-stepper-minus-button',
-  INPUT_STEPPER_PLUS_BUTTON: 'input-stepper-plus-button',
-  INPUT_STEPPER_INPUT: 'input-stepper-input',
-  KEYPAD_DELETE_BUTTON: 'keypad-delete-button',
-};
-
 export const SlippageModalSelectorText = {
   CUSTOM: enContent.bridge.custom,
   CONFIRM: enContent.bridge.confirm,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Part of [MMQA-1390](https://consensyssoftware.atlassian.net/browse/MMQA-1390) (hardcoded selector audit).

Adds Bridge `QuoteDetailsCard` / `InputStepper` / `BridgeTokenSelector` co-located `*.testIds.ts`, wires components to those IDs, removes native ID maps from `tests/selectors/Bridge/*`, and updates Quote/Slippage page objects to import from app testIDs.

**Stack:** base = `fix/mmqa-1390-foundation-testids` ([#35576](https://github.com/MetaMask/metamask-mobile/pull/35576)).

**Reviewers:** `@swaps-engineers` · `@metamask-qa-team`

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
Refs: MMQA-1390

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — testID co-location / selector cleanup only; ID string values unchanged aside from intentional Bridge back-button ID. Prefer unit tests for QuoteDetailsCard / InputStepper.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MMQA-1390]: https://consensyssoftware.atlassian.net/browse/MMQA-1390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TestID and import-path refactor only; runtime behavior unchanged aside from the token-selector back-button testID, which E2E already targets via the new constant.
> 
> **Overview**
> Part of the MMQA-1390 hardcoded-selector audit: **Bridge UI testIDs now live next to their components** instead of in `tests/selectors/Bridge/*`.
> 
> New `*.testIds.ts` files for **BridgeTokenSelector**, **InputStepper**, and **QuoteDetailsCard** centralize accessibility IDs; those components (and **InputStepperDescriptionRow**) reference the constants instead of inline strings. **BridgeTokenSelector** also sets an explicit back-button testID via `HeaderStandard` **`backButtonProps`** (`bridge-token-selector-back-button`, replacing the generic header icon id used in old selectors).
> 
> **TokenSelectorItem** now imports **`getAssetTestId`** from **`AssetElement.testIds`**. E2E **QuoteView** and **SlippageModal** page objects import co-located app testIDs (plus **`BridgeView.testIds`** and **`KeypadTestIds`** from the foundation stack). **`QuoteViewSelectorIDs`** and **`SlippageModalSelectorIDs`** are removed; locale-based text selectors remain under `tests/selectors/Bridge/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6884e72490acff3e04cdad292ace0dbc4677f15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->