### PR TITLE
feat: UI improvements on limit order details card

### DIFF
--- a/app/components/UI/Bridge/components/LimitOrderDetails/ExpirationRow/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/ExpirationRow/index.tsx
@@ -28,8 +28,9 @@ const ExpirationRow: React.FC<ExpirationRowProps> = ({
     variant={KeyValueRowVariant.Summary}
     keyLabel={strings('bridge.limit.expires')}
     keyTextProps={{
-      variant: TextVariant.BodySm,
+      variant: TextVariant.BodyMd,
       color: TextColor.TextAlternative,
+      fontWeight: FontWeight.Regular,
     }}
     value={
       <TouchableOpacity
@@ -45,9 +46,8 @@ const ExpirationRow: React.FC<ExpirationRowProps> = ({
           gap={1}
         >
           <Text
-            variant={TextVariant.BodySm}
-            fontWeight={FontWeight.Medium}
-            color={TextColor.TextDefault}
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
             testID={ExpirationRowSelectorsIDs.VALUE}
           >
             {value}
@@ -56,6 +56,7 @@ const ExpirationRow: React.FC<ExpirationRowProps> = ({
             name={IconName.ArrowRight}
             size={IconSize.Sm}
             color={IconColor.IconAlternative}
+            twClassName="mt-1"
           />
         </Box>
       </TouchableOpacity>

--- a/app/components/UI/Bridge/components/LimitOrderDetails/NetworkFeeRow/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/NetworkFeeRow/index.tsx
@@ -55,6 +55,7 @@ const NetworkFeeRow: React.FC<NetworkFeeRowProps> = ({
     <BadgeWrapper
       testID={NetworkFeeRowSelectorsIDs.AVATAR}
       position={BadgeWrapperPosition.BottomRight}
+      twClassName="mt-1"
       badge={
         <Box
           twClassName="overflow-hidden border-2 border-background-default bg-default rounded-[2px]"
@@ -95,10 +96,10 @@ const NetworkFeeRow: React.FC<NetworkFeeRowProps> = ({
       >
         {feeTokenAvatar}
         <Text
-          variant={TextVariant.BodySm}
-          fontWeight={FontWeight.Medium}
-          color={TextColor.TextDefault}
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
           testID={NetworkFeeRowSelectorsIDs.VALUE}
+          fontWeight={FontWeight.Regular}
         >
           {amount}
         </Text>
@@ -113,8 +114,9 @@ const NetworkFeeRow: React.FC<NetworkFeeRowProps> = ({
       variant={KeyValueRowVariant.Summary}
       keyLabel={strings('bridge.limit.est_network_fee')}
       keyTextProps={{
-        variant: TextVariant.BodySm,
+        variant: TextVariant.BodyMd,
         color: TextColor.TextAlternative,
+        fontWeight: FontWeight.Regular,
       }}
       valueStartAccessory={onPress ? undefined : feeTokenAvatar}
       value={value}
@@ -122,9 +124,10 @@ const NetworkFeeRow: React.FC<NetworkFeeRowProps> = ({
         onPress
           ? undefined
           : {
-              variant: TextVariant.BodySm,
-              color: TextColor.TextDefault,
+              variant: TextVariant.BodyMd,
+              color: TextColor.TextAlternative,
               testID: NetworkFeeRowSelectorsIDs.VALUE,
+              fontWeight: FontWeight.Regular,
             }
       }
       twClassName="h-8"

--- a/app/components/UI/Bridge/components/LimitOrderDetails/PriceRow/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/PriceRow/index.tsx
@@ -28,8 +28,9 @@ const PriceRow: React.FC<PriceRowProps> = ({
     variant={KeyValueRowVariant.Summary}
     keyLabel={strings('bridge.slippage')}
     keyTextProps={{
-      variant: TextVariant.BodySm,
+      variant: TextVariant.BodyMd,
       color: TextColor.TextAlternative,
+      fontWeight: FontWeight.Regular,
     }}
     value={
       <TouchableOpacity
@@ -45,9 +46,8 @@ const PriceRow: React.FC<PriceRowProps> = ({
           gap={1}
         >
           <Text
-            variant={TextVariant.BodySm}
-            fontWeight={FontWeight.Medium}
-            color={TextColor.TextDefault}
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
             testID={PriceRowSelectorsIDs.VALUE}
           >
             {value}
@@ -56,6 +56,7 @@ const PriceRow: React.FC<PriceRowProps> = ({
             name={IconName.Edit}
             size={IconSize.Sm}
             color={IconColor.IconAlternative}
+            twClassName="-mt-0.5"
           />
         </Box>
       </TouchableOpacity>

--- a/app/components/UI/Bridge/components/LimitOrderDetails/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderDetails/index.tsx
@@ -42,7 +42,7 @@ const LimitOrderDetails: React.FC<LimitOrderDetailsProps> = ({
   }
 
   return (
-    <Box testID={testID} twClassName="w-full py-3 gap-3">
+    <Box testID={testID} twClassName="w-full pt-3 gap-3">
       <ExpirationRow value={expiration} onPress={onExpirationPress} />
       <PriceRow value={slippage} onPress={onPricePress} />
       <NetworkFeeRow


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

UI improvements on limit order details card

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: UI improvements on limit order details card

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-5002

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Bridge UI changes with no logic, data, or navigation impact.
> 
> **Overview**
> Updates the **limit order details** summary rows (expiration, slippage/price, and estimated network fee) to match revised design tokens: labels and values move from `BodySm` to **`BodyMd`**, use **`TextAlternative`** with **regular** weight instead of medium/default emphasis, and icons/avatars get small Tailwind nudges for vertical alignment.
> 
> The parent **`LimitOrderDetails`** container drops bottom padding (`py-3` → **`pt-3`**) so spacing below the card is tighter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6c01d28dc17b4b6b2f094b2afe67a4e163797a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->