### PR TITLE
feat: implement real time price tracking in limit orders

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
@@ -101,7 +101,6 @@ const BridgeLimitOrderViewContent = ({
     value,
   } = useSwapsLimitOrderPriceAdjust({
     destToken,
-    destTokenAmount,
     sourceToken,
   });
   const {

--- a/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.test.ts
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { useTokenFiatRate } from '../useTokenFiatRate';
 import { createMockToken } from '../../testUtils/fixtures';
 import { LimitOrderExecutionType } from '../../constants/limitOrders';
+import { getSwapsLimitOrderPriceMarketComparison } from '../../utils/limitOrders/getSwapsLimitOrderPriceMarketComparison';
 import { useSwapsLimitOrderPriceAdjust } from './index';
 
 jest.mock('react-redux', () => ({
@@ -13,8 +14,18 @@ jest.mock('../useTokenFiatRate', () => ({
   useTokenFiatRate: jest.fn(),
 }));
 
+jest.mock('../../utils/limitOrders/getSwapsLimitOrderPriceMarketComparison');
+
 const mockUseSelector = jest.mocked(useSelector);
 const mockUseTokenFiatRate = jest.mocked(useTokenFiatRate);
+const mockGetSwapsLimitOrderPriceMarketComparison = jest.mocked(
+  getSwapsLimitOrderPriceMarketComparison,
+);
+const actualGetSwapsLimitOrderPriceMarketComparison = jest.requireActual<{
+  getSwapsLimitOrderPriceMarketComparison: typeof getSwapsLimitOrderPriceMarketComparison;
+}>(
+  '../../utils/limitOrders/getSwapsLimitOrderPriceMarketComparison',
+).getSwapsLimitOrderPriceMarketComparison;
 
 const sourceToken = createMockToken({
   address: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
@@ -49,14 +60,12 @@ function mockFiatRates({
 function renderPriceAdjustHook(
   overrides: {
     destToken?: typeof destToken;
-    destTokenAmount?: string | undefined;
     sourceToken?: typeof sourceToken;
   } = {},
 ) {
   return renderHook((props) => useSwapsLimitOrderPriceAdjust(props), {
     initialProps: {
       destToken: overrides.destToken ?? destToken,
-      destTokenAmount: overrides.destTokenAmount ?? '1.5',
       sourceToken: overrides.sourceToken ?? sourceToken,
     },
   });
@@ -67,9 +76,12 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
     jest.clearAllMocks();
     mockUseSelector.mockReturnValue('usd');
     mockFiatRates();
+    mockGetSwapsLimitOrderPriceMarketComparison.mockImplementation(
+      actualGetSwapsLimitOrderPriceMarketComparison,
+    );
   });
 
-  it('starts in buy mode with market price seeded from the quoted token fiat rate', () => {
+  it('starts in buy mode with market price seeded from the quoted token fiat rate, with no source amount entered', () => {
     const { result } = renderPriceAdjustHook();
 
     expect(result.current.executionType).toBe(LimitOrderExecutionType.BUY);
@@ -88,7 +100,6 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
     mockUseTokenFiatRate.mockImplementation(() => 1);
 
     const { result } = renderPriceAdjustHook({
-      destTokenAmount: '10',
       sourceToken: usdt,
     });
 
@@ -110,9 +121,10 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
       result.current.handleLimitPriceChange('2');
     });
 
+    mockFiatRates({ destRate: 1.2 });
+
     rerender({
       destToken,
-      destTokenAmount: '2.0',
       sourceToken,
     });
 
@@ -120,9 +132,7 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
   });
 
   it('applies market preset on handleMarketPress', () => {
-    const { result } = renderPriceAdjustHook({
-      destTokenAmount: undefined,
-    });
+    const { result } = renderPriceAdjustHook();
 
     act(() => {
       result.current.handleMarketPress();
@@ -142,9 +152,7 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
   });
 
   it('applies negative percent preset in buy mode', () => {
-    const { result } = renderPriceAdjustHook({
-      destTokenAmount: undefined,
-    });
+    const { result } = renderPriceAdjustHook();
 
     act(() => {
       result.current.handlePercentPress(5);
@@ -154,9 +162,7 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
   });
 
   it('applies positive percent preset in sell mode', () => {
-    const { result } = renderPriceAdjustHook({
-      destTokenAmount: undefined,
-    });
+    const { result } = renderPriceAdjustHook();
 
     act(() => {
       result.current.onQuoteUnitPress?.();
@@ -172,9 +178,7 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
   });
 
   it('commits a valid custom percent into the limit price', () => {
-    const { result } = renderPriceAdjustHook({
-      destTokenAmount: undefined,
-    });
+    const { result } = renderPriceAdjustHook();
 
     act(() => {
       result.current.handleCustomPress();
@@ -190,9 +194,7 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
   });
 
   it('exits custom mode without changing the limit price when custom percent is empty', () => {
-    const { result } = renderPriceAdjustHook({
-      destTokenAmount: undefined,
-    });
+    const { result } = renderPriceAdjustHook();
 
     act(() => {
       result.current.handleLimitPriceChange('3');
@@ -209,10 +211,8 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
     expect(result.current.customValue).toBe('');
   });
 
-  it('exits custom mode without changing the limit price when custom percent is zero', () => {
-    const { result } = renderPriceAdjustHook({
-      destTokenAmount: undefined,
-    });
+  it('commits a zero custom percent as the market price', () => {
+    const { result } = renderPriceAdjustHook();
 
     act(() => {
       result.current.handleLimitPriceChange('3');
@@ -224,9 +224,9 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
       result.current.commitCustomPercent();
     });
 
-    expect(result.current.limitPrice).toBe('3');
-    expect(result.current.isCustomActive).toBe(false);
-    expect(result.current.customValue).toBe('');
+    expect(result.current.limitPrice).toBe('1');
+    expect(result.current.isCustomActive).toBe(true);
+    expect(result.current.customValue).toBe('0');
   });
 
   it('toggles fiat mode when both token fiat rates are available', () => {
@@ -259,21 +259,45 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
     expect(result.current.secondaryValue).toBe('$0.95');
   });
 
-  it('keeps counter-token denomination after destTokenAmount updates', () => {
-    const { result, rerender } = renderPriceAdjustHook();
+  it('seeds the new pair market price when the selected assets change', () => {
+    const dai = createMockToken({
+      address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+      symbol: 'DAI',
+      decimals: 18,
+    });
+    mockUseTokenFiatRate.mockImplementation((token) => {
+      if (token?.symbol === 'ETH') {
+        return 2000;
+      }
+      if (token?.symbol === 'DAI') {
+        return 1;
+      }
+      return undefined;
+    });
 
-    act(() => {
-      result.current.onAmountTypeTogglePress?.();
+    const { result, rerender } = renderPriceAdjustHook({
+      destToken: dai,
+    });
+
+    expect(result.current.limitPrice).toBe('1');
+
+    const usdc = destToken;
+    mockUseTokenFiatRate.mockImplementation((token) => {
+      if (token?.symbol === 'ETH') {
+        return 2000;
+      }
+      if (token?.symbol === 'USDC') {
+        return 1.5;
+      }
+      return undefined;
     });
 
     rerender({
-      destToken,
-      destTokenAmount: '2.0',
+      destToken: usdc,
       sourceToken,
     });
 
-    expect(result.current.isLimitFiatMode).toBe(false);
-    expect(result.current.limitPrice).toBe('0.0005');
+    expect(result.current.limitPrice).toBe('1.5');
   });
 
   it('keeps counter-token denomination after quoted fiat rate updates', () => {
@@ -287,7 +311,6 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
 
     rerender({
       destToken,
-      destTokenAmount: '1.5',
       sourceToken,
     });
 
@@ -302,6 +325,151 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
     expect(result.current.onAmountTypeTogglePress).toBeUndefined();
   });
 
+  describe('live market tracking', () => {
+    it('suppresses market comparison while tracking market, even if the raw comparison would show one', () => {
+      // Simulates the one-render lag right after a market data update, where
+      // limitPrice hasn't resynced yet and the raw comparison would report a
+      // false divergence. isTrackingMarket must suppress it unconditionally.
+      mockGetSwapsLimitOrderPriceMarketComparison.mockReturnValue({
+        label: 'stale comparison',
+        isNegative: true,
+      });
+
+      const { result } = renderPriceAdjustHook();
+
+      expect(result.current.marketComparison).toBeUndefined();
+    });
+
+    it('surfaces the market comparison once tracking market stops', () => {
+      mockGetSwapsLimitOrderPriceMarketComparison.mockReturnValue({
+        label: 'real comparison',
+        isNegative: true,
+      });
+
+      const { result } = renderPriceAdjustHook();
+
+      act(() => {
+        result.current.handleLimitPriceChange('2');
+      });
+
+      expect(result.current.marketComparison).toEqual({
+        label: 'real comparison',
+        isNegative: true,
+      });
+    });
+
+    it('follows the market rate while the price sits at market', () => {
+      const { result, rerender } = renderPriceAdjustHook();
+
+      expect(result.current.limitPrice).toBe('1');
+
+      mockFiatRates({ destRate: 1.2 });
+      rerender({ destToken, sourceToken });
+
+      expect(result.current.limitPrice).toBe('1.2');
+    });
+
+    it('stops following the market after a percent preset, and resumes after the market preset', () => {
+      const { result, rerender } = renderPriceAdjustHook();
+
+      act(() => {
+        result.current.handlePercentPress(5);
+      });
+
+      expect(result.current.limitPrice).toBe('0.95');
+
+      mockFiatRates({ destRate: 1.2 });
+      rerender({ destToken, sourceToken });
+
+      expect(result.current.limitPrice).toBe('0.95');
+
+      act(() => {
+        result.current.handleMarketPress();
+      });
+
+      expect(result.current.limitPrice).toBe('1.2');
+
+      mockFiatRates({ destRate: 1.5 });
+      rerender({ destToken, sourceToken });
+
+      expect(result.current.limitPrice).toBe('1.5');
+    });
+
+    it('follows the market after a zero custom percent is committed', () => {
+      const { result, rerender } = renderPriceAdjustHook();
+
+      act(() => {
+        result.current.handleCustomPress();
+        result.current.handleCustomValueChange('0');
+      });
+
+      act(() => {
+        result.current.commitCustomPercent();
+      });
+
+      mockFiatRates({ destRate: 1.2 });
+      rerender({ destToken, sourceToken });
+
+      expect(result.current.limitPrice).toBe('1.2');
+      expect(result.current.isCustomActive).toBe(true);
+    });
+
+    it('stops following the market after a non-zero custom percent is committed', () => {
+      const { result, rerender } = renderPriceAdjustHook();
+
+      act(() => {
+        result.current.handleCustomPress();
+        result.current.handleCustomValueChange('5');
+      });
+
+      act(() => {
+        result.current.commitCustomPercent();
+      });
+
+      expect(result.current.limitPrice).toBe('0.95');
+
+      mockFiatRates({ destRate: 1.2 });
+      rerender({ destToken, sourceToken });
+
+      expect(result.current.limitPrice).toBe('0.95');
+    });
+
+    it('stops following the market after the denomination is toggled', () => {
+      const { result, rerender } = renderPriceAdjustHook();
+
+      act(() => {
+        result.current.onAmountTypeTogglePress?.();
+      });
+
+      expect(result.current.limitPrice).toBe('0.0005');
+
+      mockFiatRates({ destRate: 1.2 });
+      rerender({ destToken, sourceToken });
+
+      expect(result.current.limitPrice).toBe('0.0005');
+    });
+
+    it('follows the market in counter-token denomination after the market preset', () => {
+      const { result, rerender } = renderPriceAdjustHook();
+
+      act(() => {
+        result.current.onAmountTypeTogglePress?.();
+      });
+
+      act(() => {
+        result.current.handleMarketPress();
+      });
+
+      expect(result.current.isLimitFiatMode).toBe(false);
+      expect(result.current.limitPrice).toBe('0.0005');
+
+      mockFiatRates({ destRate: 2 });
+      rerender({ destToken, sourceToken });
+
+      expect(result.current.limitPrice).toBe('0.001');
+    });
+  });
+
   it('resets price fields when the token pair changes', () => {
     const { result, rerender } = renderPriceAdjustHook();
 
@@ -311,7 +479,6 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
 
     rerender({
       destToken,
-      destTokenAmount: '1.5',
       sourceToken: {
         ...sourceToken,
         address: '0x0000000000000000000000000000000000000001',

--- a/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.test.ts
@@ -470,6 +470,28 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
     });
   });
 
+  it('seeds the market price for a new pair sharing the same quoted fiat rate and counter decimals', () => {
+    const usdt = createMockToken({
+      address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+      symbol: 'USDT',
+      decimals: 6,
+    });
+    mockUseTokenFiatRate.mockImplementation((token) =>
+      token?.symbol === 'ETH' ? 2000 : 1,
+    );
+
+    const { result, rerender } = renderPriceAdjustHook();
+
+    expect(result.current.limitPrice).toBe('1');
+
+    rerender({
+      destToken: usdt,
+      sourceToken,
+    });
+
+    expect(result.current.limitPrice).toBe('1');
+  });
+
   it('resets price fields when the token pair changes', () => {
     const { result, rerender } = renderPriceAdjustHook();
 

--- a/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.ts
@@ -5,10 +5,7 @@ import { selectCurrentCurrency } from '../../../../../selectors/currencyRateCont
 import { useTokenFiatRate } from '../useTokenFiatRate';
 import type { BridgeToken } from '../../types';
 import { formatTokenInputAmountFromFiat } from '../../utils/sourceAmountInputMode';
-import {
-  formatLimitOrderFiatPrice,
-  formatLimitOrderFiatPriceFromTokenAmount,
-} from '../../utils/limitOrders/formatLimitOrderFiatPrice';
+import { formatLimitOrderFiatPriceFromTokenAmount } from '../../utils/limitOrders/formatLimitOrderFiatPrice';
 import { getSwapsLimitOrderPriceFromMarketPercent } from '../../utils/limitOrders/getSwapsLimitOrderPriceFromMarketPercent';
 import { getSwapsLimitOrderPriceMarketComparison } from '../../utils/limitOrders/getSwapsLimitOrderPriceMarketComparison';
 import { getSwapsLimitOrderSecondaryValue } from '../../utils/limitOrders/getSwapsLimitOrderSecondaryValue';
@@ -20,13 +17,11 @@ import { LimitOrderExecutionType } from '../../constants/limitOrders';
 
 interface Params {
   destToken: BridgeToken | undefined;
-  destTokenAmount: string | undefined;
   sourceToken: BridgeToken | undefined;
 }
 
 export const useSwapsLimitOrderPriceAdjust = ({
   destToken,
-  destTokenAmount,
   sourceToken,
 }: Params) => {
   const currentCurrency = useSelector(selectCurrentCurrency);
@@ -36,9 +31,9 @@ export const useSwapsLimitOrderPriceAdjust = ({
   );
   const {
     customValue,
-    hasUserEditedLimitPrice,
     isCustomActive,
     isLimitFiatMode,
+    isTrackingMarket,
     limitPrice,
     executionType,
   } = state;
@@ -71,6 +66,7 @@ export const useSwapsLimitOrderPriceAdjust = ({
     dispatch({
       type: 'applyPreset',
       limitPrice: getLimitPriceFromSignedPercent(0),
+      isTrackingMarket: true,
     });
   }, [getLimitPriceFromSignedPercent]);
 
@@ -79,6 +75,7 @@ export const useSwapsLimitOrderPriceAdjust = ({
       dispatch({
         type: 'applyPreset',
         limitPrice: getLimitPriceFromSignedPercent(isSell ? percent : -percent),
+        isTrackingMarket: false,
       });
     },
     [getLimitPriceFromSignedPercent, isSell],
@@ -98,7 +95,7 @@ export const useSwapsLimitOrderPriceAdjust = ({
     }
 
     const magnitude = new BigNumber(customValue ?? '');
-    if (!magnitude.isFinite() || magnitude.lte(0)) {
+    if (!magnitude.isFinite() || magnitude.isNegative()) {
       dispatch({ type: 'exitCustom' });
       return;
     }
@@ -110,7 +107,12 @@ export const useSwapsLimitOrderPriceAdjust = ({
       return;
     }
 
-    dispatch({ type: 'setLimitPrice', limitPrice: nextLimitPrice });
+    // A 0% offset is market, so the price keeps following the live rate.
+    dispatch({
+      type: 'commitCustomPercent',
+      limitPrice: nextLimitPrice,
+      isTrackingMarket: magnitude.isZero(),
+    });
   }, [customValue, getLimitPriceFromSignedPercent, isCustomActive, isSell]);
 
   useEffect(() => {
@@ -122,16 +124,15 @@ export const useSwapsLimitOrderPriceAdjust = ({
     sourceToken?.chainId,
   ]);
 
+  // Keeps the limit price on the live market rate for as long as it sits at
+  // market, so it refreshes with every market data update instead of only
+  // being seeded once.
   useEffect(() => {
-    if (hasUserEditedLimitPrice || !destTokenAmount) {
+    if (!isTrackingMarket) {
       return;
     }
 
-    if (!quotedFiatRate || quotedFiatRate <= 0) {
-      return;
-    }
-
-    const nextLimitPrice = formatLimitOrderFiatPrice(quotedFiatRate);
+    const nextLimitPrice = getLimitPriceFromSignedPercent(0);
     if (nextLimitPrice === undefined) {
       return;
     }
@@ -141,10 +142,9 @@ export const useSwapsLimitOrderPriceAdjust = ({
       limitPrice: nextLimitPrice,
     });
   }, [
-    destTokenAmount,
     executionType, // flipSide clears limitPrice even when quotedFiatRate is unchanged
-    hasUserEditedLimitPrice,
-    quotedFiatRate,
+    getLimitPriceFromSignedPercent,
+    isTrackingMarket,
   ]);
 
   const canToggleLimitPrice = Boolean(
@@ -193,12 +193,14 @@ export const useSwapsLimitOrderPriceAdjust = ({
   const limitFiat = isLimitFiatMode
     ? limitPrice
     : formatLimitOrderFiatPriceFromTokenAmount(limitPrice, counterFiatRate);
-  const marketComparison = getSwapsLimitOrderPriceMarketComparison({
-    limitFiat,
-    marketFiat: quotedFiatRate,
-    executionType,
-    threshold: 0,
-  });
+  const marketComparison = isTrackingMarket
+    ? undefined
+    : getSwapsLimitOrderPriceMarketComparison({
+        limitFiat,
+        marketFiat: quotedFiatRate,
+        executionType,
+        threshold: 0,
+      });
 
   return {
     commitCustomPercent,

--- a/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.ts
@@ -142,9 +142,13 @@ export const useSwapsLimitOrderPriceAdjust = ({
       limitPrice: nextLimitPrice,
     });
   }, [
+    destToken?.address,
+    destToken?.chainId,
     executionType, // flipSide clears limitPrice even when quotedFiatRate is unchanged
     getLimitPriceFromSignedPercent,
     isTrackingMarket,
+    sourceToken?.address,
+    sourceToken?.chainId,
   ]);
 
   const canToggleLimitPrice = Boolean(

--- a/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.test.ts
+++ b/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.test.ts
@@ -9,7 +9,7 @@ const modifiedState: LimitOrderPriceAdjustState = {
   executionType: LimitOrderExecutionType.SELL,
   limitPrice: '120',
   isLimitFiatMode: false,
-  hasUserEditedLimitPrice: true,
+  isTrackingMarket: false,
   isCustomActive: true,
   customValue: '8',
 };
@@ -20,14 +20,14 @@ describe('limitOrderPriceAdjustReducer', () => {
       executionType: LimitOrderExecutionType.BUY,
       limitPrice: undefined,
       isLimitFiatMode: true,
-      hasUserEditedLimitPrice: false,
+      isTrackingMarket: true,
       isCustomActive: false,
       customValue: undefined,
     });
   });
 
   describe('setLimitPrice', () => {
-    it('stores the limit price and marks the limit price as user edited', () => {
+    it('stores the limit price and stops market tracking', () => {
       const result = limitOrderPriceAdjustReducer(
         initialLimitOrderPriceAdjustState,
         { type: 'setLimitPrice', limitPrice: '95' },
@@ -36,7 +36,7 @@ describe('limitOrderPriceAdjustReducer', () => {
       expect(result).toEqual({
         ...initialLimitOrderPriceAdjustState,
         limitPrice: '95',
-        hasUserEditedLimitPrice: true,
+        isTrackingMarket: false,
       });
     });
   });
@@ -46,12 +46,29 @@ describe('limitOrderPriceAdjustReducer', () => {
       const result = limitOrderPriceAdjustReducer(modifiedState, {
         type: 'applyPreset',
         limitPrice: '110',
+        isTrackingMarket: false,
       });
 
       expect(result).toEqual({
         ...modifiedState,
         limitPrice: '110',
-        hasUserEditedLimitPrice: true,
+        isTrackingMarket: false,
+        isCustomActive: false,
+        customValue: undefined,
+      });
+    });
+
+    it('resumes market tracking for a market preset', () => {
+      const result = limitOrderPriceAdjustReducer(modifiedState, {
+        type: 'applyPreset',
+        limitPrice: '100',
+        isTrackingMarket: true,
+      });
+
+      expect(result).toEqual({
+        ...modifiedState,
+        limitPrice: '100',
+        isTrackingMarket: true,
         isCustomActive: false,
         customValue: undefined,
       });
@@ -60,6 +77,7 @@ describe('limitOrderPriceAdjustReducer', () => {
     it('clears custom mode without changing limit price when preset value is omitted', () => {
       const result = limitOrderPriceAdjustReducer(modifiedState, {
         type: 'applyPreset',
+        isTrackingMarket: false,
       });
 
       expect(result).toEqual({
@@ -70,8 +88,40 @@ describe('limitOrderPriceAdjustReducer', () => {
     });
   });
 
+  describe('commitCustomPercent', () => {
+    it('stores the limit price and keeps custom mode active', () => {
+      const result = limitOrderPriceAdjustReducer(modifiedState, {
+        type: 'commitCustomPercent',
+        limitPrice: '130',
+        isTrackingMarket: false,
+      });
+
+      expect(result).toEqual({
+        ...modifiedState,
+        limitPrice: '130',
+        isTrackingMarket: false,
+        isCustomActive: true,
+        customValue: '8',
+      });
+    });
+
+    it('resumes market tracking when the committed percent is market', () => {
+      const result = limitOrderPriceAdjustReducer(modifiedState, {
+        type: 'commitCustomPercent',
+        limitPrice: '100',
+        isTrackingMarket: true,
+      });
+
+      expect(result).toEqual({
+        ...modifiedState,
+        limitPrice: '100',
+        isTrackingMarket: true,
+      });
+    });
+  });
+
   describe('seedFromMarket', () => {
-    it('seeds market price without marking user edits or changing denomination', () => {
+    it('seeds market price without changing tracking or denomination', () => {
       const result = limitOrderPriceAdjustReducer(modifiedState, {
         type: 'seedFromMarket',
         limitPrice: '100',
@@ -81,6 +131,15 @@ describe('limitOrderPriceAdjustReducer', () => {
         ...modifiedState,
         limitPrice: '100',
       });
+    });
+
+    it('returns the same state when the seeded price is unchanged', () => {
+      const result = limitOrderPriceAdjustReducer(modifiedState, {
+        type: 'seedFromMarket',
+        limitPrice: modifiedState.limitPrice as string,
+      });
+
+      expect(result).toBe(modifiedState);
     });
   });
 
@@ -127,7 +186,7 @@ describe('limitOrderPriceAdjustReducer', () => {
   });
 
   describe('toggleFiatMode', () => {
-    it('toggles fiat mode, stores the converted limit price, and marks the limit price as user edited', () => {
+    it('toggles fiat mode, stores the converted limit price, and stops market tracking', () => {
       const result = limitOrderPriceAdjustReducer(
         {
           ...initialLimitOrderPriceAdjustState,
@@ -140,7 +199,7 @@ describe('limitOrderPriceAdjustReducer', () => {
         ...initialLimitOrderPriceAdjustState,
         isLimitFiatMode: false,
         limitPrice: '0.05',
-        hasUserEditedLimitPrice: true,
+        isTrackingMarket: false,
       });
     });
 
@@ -174,7 +233,7 @@ describe('limitOrderPriceAdjustReducer', () => {
         executionType: LimitOrderExecutionType.BUY,
         limitPrice: undefined,
         isLimitFiatMode: true,
-        hasUserEditedLimitPrice: false,
+        isTrackingMarket: true,
         isCustomActive: false,
         customValue: undefined,
       });
@@ -193,7 +252,7 @@ describe('limitOrderPriceAdjustReducer', () => {
         executionType: LimitOrderExecutionType.SELL,
         limitPrice: undefined,
         isLimitFiatMode: true,
-        hasUserEditedLimitPrice: false,
+        isTrackingMarket: true,
         isCustomActive: false,
         customValue: undefined,
       });
@@ -210,7 +269,7 @@ describe('limitOrderPriceAdjustReducer', () => {
         executionType: LimitOrderExecutionType.SELL,
         limitPrice: undefined,
         isLimitFiatMode: true,
-        hasUserEditedLimitPrice: false,
+        isTrackingMarket: true,
         isCustomActive: false,
         customValue: undefined,
       });

--- a/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.ts
+++ b/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.ts
@@ -3,7 +3,7 @@ import { LimitOrderExecutionType } from '../constants/limitOrders';
 export interface LimitOrderPriceAdjustState {
   limitPrice: string | undefined;
   isLimitFiatMode: boolean;
-  hasUserEditedLimitPrice: boolean;
+  isTrackingMarket: boolean;
   executionType: LimitOrderExecutionType;
   isCustomActive: boolean;
   customValue: string | undefined;
@@ -11,7 +11,12 @@ export interface LimitOrderPriceAdjustState {
 
 export type LimitOrderPriceAdjustAction =
   | { type: 'setLimitPrice'; limitPrice: string | undefined }
-  | { type: 'applyPreset'; limitPrice?: string }
+  | { type: 'applyPreset'; limitPrice?: string; isTrackingMarket: boolean }
+  | {
+      type: 'commitCustomPercent';
+      limitPrice: string;
+      isTrackingMarket: boolean;
+    }
   | { type: 'seedFromMarket'; limitPrice: string }
   | { type: 'enterCustom' }
   | { type: 'exitCustom' }
@@ -26,7 +31,7 @@ export type LimitOrderPriceAdjustAction =
 const PRICE_FIELDS_RESET = {
   limitPrice: undefined,
   isLimitFiatMode: true,
-  hasUserEditedLimitPrice: false,
+  isTrackingMarket: true,
   isCustomActive: false,
   customValue: undefined,
 } as const satisfies Omit<LimitOrderPriceAdjustState, 'executionType'>;
@@ -44,7 +49,7 @@ export const limitOrderPriceAdjustReducer = (
     case 'setLimitPrice':
       return {
         ...state,
-        hasUserEditedLimitPrice: true,
+        isTrackingMarket: false,
         limitPrice: action.limitPrice,
       };
     case 'applyPreset':
@@ -52,18 +57,25 @@ export const limitOrderPriceAdjustReducer = (
         ...state,
         isCustomActive: false,
         customValue: undefined,
+        isTrackingMarket: action.isTrackingMarket,
         ...(action.limitPrice !== undefined
-          ? {
-              hasUserEditedLimitPrice: true,
-              limitPrice: action.limitPrice,
-            }
+          ? { limitPrice: action.limitPrice }
           : {}),
       };
-    case 'seedFromMarket':
+    case 'commitCustomPercent':
       return {
         ...state,
+        isTrackingMarket: action.isTrackingMarket,
         limitPrice: action.limitPrice,
       };
+    case 'seedFromMarket':
+      // A market refresh that rounds to the same string is not a state change.
+      return state.limitPrice === action.limitPrice
+        ? state
+        : {
+            ...state,
+            limitPrice: action.limitPrice,
+          };
     case 'enterCustom':
       return {
         ...state,
@@ -83,7 +95,7 @@ export const limitOrderPriceAdjustReducer = (
     case 'toggleFiatMode':
       return {
         ...state,
-        hasUserEditedLimitPrice: true,
+        isTrackingMarket: false,
         isLimitFiatMode: !state.isLimitFiatMode,
         limitPrice: action.convertLimitPrice(state.limitPrice),
       };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

implement real time price tracking in limit orders

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: implement real time price tracking in limit orders

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4997

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes limit-order pricing UX and state machine behavior; wrong tracking flags could show stale prices or misleading market comparisons, though coverage is extensive.
> 
> **Overview**
> Limit order price adjustment now **tracks the live market** by default instead of only seeding once when a destination amount is entered.
> 
> **`useSwapsLimitOrderPriceAdjust`** drops the **`destTokenAmount`** input and replaces **`hasUserEditedLimitPrice`** with **`isTrackingMarket`**. While tracking is on, fiat rate updates re-apply the market price via **`seedFromMarket`**; market comparison UI is hidden to avoid false “off market” flashes during resync. **Market** and **0% custom** presets resume tracking; manual edits, percent presets, and fiat/counter denomination toggles stop it. **`commitCustomPercent`** treats zero as market (still in custom mode) instead of exiting custom.
> 
> The **limit order price adjust reducer** wires **`isTrackingMarket`** through presets, **`commitCustomPercent`**, and resets; **`seedFromMarket`** no-ops when the formatted price string is unchanged.
> 
> **`BridgeLimitOrderView`** no longer passes **`destTokenAmount`** into the hook. Tests add a **live market tracking** suite and mock market comparison where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 203a5f7d615f950696c71589196145cc2472bd3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->