### PR TITLE
fix(onboarding): end Password Login Attempt before biometric upgrade

### DIFF
--- a/app/components/Views/OAuthRehydration/index.test.tsx
+++ b/app/components/Views/OAuthRehydration/index.test.tsx
@@ -1429,6 +1429,59 @@ describe('OAuthRehydration', () => {
         mockReplace.mock.invocationCallOrder[0],
       );
     });
+
+    it('ends Password Login Attempt before post-unlock biometric upgrade', async () => {
+      const journeyCtx = { traceId: 'journey' };
+      const passwordAttemptCtx = { traceId: 'password-attempt' };
+
+      mockRoute.mockReturnValue({
+        params: {
+          locked: false,
+          oauthLoginSuccess: true,
+        },
+      });
+      (getTraceContextMock as jest.Mock).mockImplementation(
+        (req: { name: string }) => {
+          if (req.name === 'OnboardingJourneyOverall') return journeyCtx;
+          return undefined;
+        },
+      );
+      (traceMock as jest.Mock).mockImplementation(
+        (config: { name?: string }, fn?: () => Promise<void>) => {
+          if (fn) {
+            return fn();
+          }
+          if (config?.name === 'OnboardingPasswordLoginAttempt') {
+            return passwordAttemptCtx;
+          }
+          return undefined;
+        },
+      );
+
+      const { getByTestId } = renderWithProvider(<OAuthRehydration />);
+      await enterPasswordAndSubmit(getByTestId);
+
+      await waitFor(() => {
+        expect(endTraceMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'OnboardingPasswordLoginAttempt',
+          }),
+        );
+        expect(mockRequestBiometricsAccessControlForIOS).toHaveBeenCalled();
+      });
+
+      const endTraceJestMock = endTraceMock as jest.Mock;
+      const passwordEndIndex = endTraceJestMock.mock.calls.findIndex(
+        ([request]: [{ name?: string }]) =>
+          request?.name === 'OnboardingPasswordLoginAttempt',
+      );
+      expect(passwordEndIndex).toBeGreaterThanOrEqual(0);
+      expect(
+        endTraceJestMock.mock.invocationCallOrder[passwordEndIndex],
+      ).toBeLessThan(
+        mockRequestBiometricsAccessControlForIOS.mock.invocationCallOrder[0],
+      );
+    });
   });
 
   describe('Component lifecycle', () => {

--- a/app/components/Views/OAuthRehydration/index.tsx
+++ b/app/components/Views/OAuthRehydration/index.tsx
@@ -611,21 +611,18 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
             password,
             authPreference: authData,
             onBeforeNavigate: async () => {
-              await upgradeKeychainAuthAfterSuccessfulUnlock();
-              // End the onboarding-journey spans with success BEFORE unlockWallet
-              // navigates to home. Navigation resets the stack and unmounts the
-              // Onboarding screen, whose cleanup ends OnboardingJourneyOverall with
-              // success:false. unlockWallet awaits onBeforeNavigate prior to that
-              // navigation, so ending the spans here guarantees the success value is
-              // recorded first and the later unmount cleanup (and the no-longer-needed
-              // post-return endTrace calls) safely no-op — otherwise a completed social
-              // login would be misrecorded as abandoned.
+              // End unlock/journey spans before the biometric keychain upgrade so
+              // human biometric wait is excluded from Password Login Attempt (and
+              // parent journey) duration. Still must finish before unlockWallet
+              // navigates home: navigation unmounts Onboarding, whose cleanup would
+              // otherwise end OnboardingJourneyOverall with success:false.
               if (passwordLoginAttemptTraceCtxRef.current) {
                 endTrace({ name: TraceName.OnboardingPasswordLoginAttempt });
                 passwordLoginAttemptTraceCtxRef.current = null;
               }
               endTrace({ name: TraceName.OnboardingExistingSocialLogin });
               endTrace({ name: TraceName.OnboardingJourneyOverall });
+              await upgradeKeychainAuthAfterSuccessfulUnlock();
             },
             // Nest OnboardingFetchSrps under Password Login Attempt when present.
             parentContext: passwordLoginAttemptCtx ?? journeyCtx,


### PR DESCRIPTION
## **Description**

**Before:** After a successful social rehydrate unlock, `Onboarding - Password Login Attempt` (and its parent journey spans) stayed open through `upgradeKeychainAuthAfterSuccessfulUnlock`, so human biometric wait inflated span duration. That wait was also historically counted in `onboarding.machine.ms` until #34912 removed Password Login from the whitelist.

**After:** Those spans end before the biometric keychain upgrade, and still before home navigation, so Password Login Attempt covers unlock work (including Fetch SRPs) without biometric think-time.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TO-1001

## **Manual testing steps**

```gherkin
Feature: Social rehydrate unlock tracing

  Scenario: Existing Google user unlocks with password then biometrics
    Given the user is on OAuth rehydration after Google login
    And metrics consent is enabled
    When the user submits a correct password
    And the device biometric prompt is shown
    Then unlock completes and the wallet home opens
    And Sentry records Onboarding - Password Login Attempt ending before the biometric prompt wait
```

## **Screenshots/Recordings**

### **Before**

N/A — tracing-only change

### **After**

N/A — tracing-only change

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).


## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
