### PR TITLE
build(typescript): use bundler module resolution

### DIFF
--- a/app/components/UI/Card/components/CardTransactionDetailsContent/CardTransactionDetailsContent.tsx
+++ b/app/components/UI/Card/components/CardTransactionDetailsContent/CardTransactionDetailsContent.tsx
@@ -14,8 +14,8 @@ import {
   TextButton,
   TextColor,
   TextVariant,
+  type ImageOrSvgSrc,
 } from '@metamask/design-system-react-native';
-import type { ImageOrSvgSrc } from '@metamask/design-system-react-native/dist/components/temp-components/ImageOrSvg/ImageOrSvg.types.d.cts';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { ButtonIconSizes } from '../../../../../component-library/components/Buttons/ButtonIcon';
 import { IconColor } from '../../../../../component-library/components/Icons/Icon';

--- a/app/components/UI/Perps/integration/orderLifecycleFlow.integration.test.ts
+++ b/app/components/UI/Perps/integration/orderLifecycleFlow.integration.test.ts
@@ -32,7 +32,6 @@ import {
 import { HyperliquidError } from '@nktkas/hyperliquid';
 // Mobile's current Node resolver cannot read this package export, while Jest
 // and Metro resolve the SDK's declared `./api/exchange` entrypoint.
-// @ts-expect-error The subpath is exported by @nktkas/hyperliquid.
 import { ApiRequestError } from '@nktkas/hyperliquid/api/exchange';
 
 import { usePerpsTrading } from '../hooks/usePerpsTrading';

--- a/app/components/UI/Stake/components/PoolStakingLearnMoreModal/index.tsx
+++ b/app/components/UI/Stake/components/PoolStakingLearnMoreModal/index.tsx
@@ -25,7 +25,7 @@ import {
   formatPercent,
   PercentageOutputFormat,
 } from '../../utils/value';
-import { Hex } from 'viem/_types/types/misc';
+import { Hex } from 'viem';
 import { getDecimalChainId } from '../../../../../util/networks';
 import { endTrace, trace, TraceName } from '../../../../../util/trace';
 import { EARN_EXPERIENCES } from '../../../Earn/constants/experiences';

--- a/app/components/Views/ConnectQRHardware/index.test.tsx
+++ b/app/components/Views/ConnectQRHardware/index.test.tsx
@@ -206,6 +206,8 @@ const mockLegacyQrKeyring = new LegacyQrKeyring({
   bridge: mockQrKeyringBridge,
 });
 const mockQrKeyring = new QrKeyring({
+  // @ts-expect-error: Property '#private' in type 'QrKeyring' refers to a
+  // different member that cannot be accessed from within type 'QrKeyring'.
   legacyKeyring: mockLegacyQrKeyring,
   entropySource: 'test-entropy-source',
 });

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -471,7 +471,6 @@ import {
   ControllerGetStateAction,
   ControllerStateChangeEvent,
 } from '@metamask/base-controller';
-import type { NFTDetectionControllerState } from '@metamask/assets-controllers/dist/NftDetectionController.cjs';
 import {
   ProfileMetricsController,
   ProfileMetricsControllerActions,
@@ -487,12 +486,12 @@ import {
 
 type NftDetectionControllerActions = ControllerGetStateAction<
   'NftDetectionController',
-  NFTDetectionControllerState
+  NftDetectionController['state']
 >;
 
 type NftDetectionControllerEvents = ControllerStateChangeEvent<
   'NftDetectionController',
-  NFTDetectionControllerState
+  NftDetectionController['state']
 >;
 import {
   TransactionPayController,

--- a/app/core/Engine/wallet-init/keyrings.test.ts
+++ b/app/core/Engine/wallet-init/keyrings.test.ts
@@ -115,6 +115,8 @@ describe('wallet-init/keyrings', () => {
         mnemonic: 'test test test test test test test test test test test ball',
       });
       const hdKeyring = new HdKeyringV2({
+        // @ts-expect-error: Property '#private' in type 'HdKeyring' refers to a
+        // different member that cannot be accessed from within type 'HdKeyring'.
         legacyKeyring: legacyHd,
         entropySource: 'entropy-1',
       });
@@ -163,6 +165,8 @@ describe('wallet-init/keyrings', () => {
     it('MoneyKeyring getMnemonic closure throws if the HD keyring has no mnemonic', async () => {
       const messenger = getRootMessenger();
       const emptyHd = new HdKeyringV2({
+        // @ts-expect-error: Two different types with this name exist, but they
+        // are unrelated.
         legacyKeyring: new LegacyHdKeyring(),
         entropySource: 'entropy-1',
       });

--- a/app/core/Ledger/Ledger.test.ts
+++ b/app/core/Ledger/Ledger.test.ts
@@ -125,6 +125,8 @@ describe('Ledger core', () => {
     jest.resetAllMocks();
 
     ledgerKeyring = new LedgerKeyring({
+      // @ts-expect-error: Property '#private' in type LedgerKeyring refers to a
+      // different member that cannot be accessed from within type 'LedgerKeyring'.
       legacyKeyring: new LegacyLedgerKeyring({
         bridge: mockBridge as unknown as LedgerMobileBridge,
       }),

--- a/app/core/Ledger/LedgerDmk.test.ts
+++ b/app/core/Ledger/LedgerDmk.test.ts
@@ -142,6 +142,8 @@ describe('LedgerDmk', () => {
     mockBridge.updateSessionId.mockResolvedValue(true);
     legacyLedgerKeyring = new LegacyLedgerKeyring({ bridge: mockBridge });
     ledgerKeyring = new LedgerKeyring({
+      // @ts-expect-error: Two different types with this name exist, but they
+      // are unrelated.
       legacyKeyring: legacyLedgerKeyring,
       entropySource: 'test-entropy-source',
     });

--- a/app/core/OAuthService/AuthTokenHandler.ts
+++ b/app/core/OAuthService/AuthTokenHandler.ts
@@ -1,11 +1,6 @@
 import { Platform } from 'react-native';
 import { AuthConnection, AuthRefreshTokenResponse } from './OAuthInterface';
 import { createLoginHandler } from './OAuthLoginHandlers';
-import type {
-  RefreshJWTToken,
-  RenewRefreshToken,
-  RevokeRefreshToken,
-} from '@metamask/seedless-onboarding-controller/dist/types.d.cts';
 import ReduxService from '../redux';
 import Device from '../../util/device';
 import {
@@ -32,6 +27,30 @@ export class RefreshTokenHttpError extends Error {
     this.statusCode = statusCode;
   }
 }
+
+// TODO: Export these types from `@metamask/seedless-onboarding-controller` and
+// remove these duplicates.
+type RefreshJWTToken = (params: {
+  connection: AuthConnection;
+  refreshToken: string;
+}) => Promise<{
+  idTokens: string[];
+  accessToken: string;
+  metadataAccessToken: string;
+}>;
+
+type RevokeRefreshToken = (params: {
+  connection: AuthConnection;
+  revokeToken: string;
+}) => Promise<void>;
+
+type RenewRefreshToken = (params: {
+  connection: AuthConnection;
+  revokeToken: string;
+}) => Promise<{
+  newRevokeToken: string;
+  newRefreshToken: string;
+}>;
 
 interface AuthTokenHandlerInterface {
   refreshJWTToken: RefreshJWTToken;

--- a/app/core/QrKeyring/QrKeyring.test.ts
+++ b/app/core/QrKeyring/QrKeyring.test.ts
@@ -36,6 +36,8 @@ const mockQrKeyringBridge: QrKeyringBridge = {
 
 const legacyQrKeyring = new LegacyQrKeyring({ bridge: mockQrKeyringBridge });
 const qrKeyring = new QrKeyring({
+  // @ts-expect-error: Two different types with this name exist, but they are
+  // unrelated.
   legacyKeyring: legacyQrKeyring,
   entropySource: 'test-entropy-source',
 });

--- a/app/core/Snaps/permissions/utils.test.ts
+++ b/app/core/Snaps/permissions/utils.test.ts
@@ -33,10 +33,14 @@ async function getMessenger(deserialize = true) {
 
   const keyrings: Record<string, Keyring> = {
     main: new HdKeyringV2({
+      // @ts-expect-error: Two different types with this name exist, but they
+      // are unrelated.
       legacyKeyring: hdKeyring,
       entropySource: 'mock-hd-keyring-id',
     }),
     ledger: new LedgerKeyringV2({
+      // @ts-expect-error: Two different types with this name exist, but they
+      // are unrelated.
       legacyKeyring: ledgerKeyring,
       entropySource: 'mock-ledger-keyring-id',
     }),

--- a/tests/framework/AppiumContextHelpers.ts
+++ b/tests/framework/AppiumContextHelpers.ts
@@ -1,8 +1,5 @@
 import type { Context } from '@wdio/protocols';
-import type {
-  AndroidDetailedContext,
-  IosDetailedContext,
-} from 'webdriverio/build/types';
+import type { AndroidDetailedContext, IosDetailedContext } from 'webdriverio';
 import { APP_PACKAGE_IDS } from './Constants';
 import { PlatformDetector } from './PlatformLocator';
 import { getDriver, withTimeout } from './AppiumUtilities';

--- a/tests/framework/ChromeCdpHelpers.ts
+++ b/tests/framework/ChromeCdpHelpers.ts
@@ -2,7 +2,7 @@
 import { execFileSync } from 'child_process';
 import { WebSocket as WsClient } from 'ws';
 import type { Context } from '@wdio/protocols';
-import type { AndroidDetailedContext } from 'webdriverio/build/types';
+import type { AndroidDetailedContext } from 'webdriverio';
 import { APP_PACKAGE_IDS } from './Constants.ts';
 import { getDriver, executeMobileDeepLink } from './AppiumUtilities';
 import { PlatformDetector } from './PlatformLocator';

--- a/tests/smoke-appium/notifications/utils/mocks.ts
+++ b/tests/smoke-appium/notifications/utils/mocks.ts
@@ -1,5 +1,4 @@
 import type { Mockttp } from 'mockttp';
-import type { ContentfulResult } from '@metamask/notification-services-controller/dist/NotificationServicesController/services/feature-announcements.d.cts';
 import {
   getMockFeatureAnnouncementResponse,
   getMockListNotificationsResponse,
@@ -31,6 +30,8 @@ import { MockttpNotificationTriggerServer } from './mock-notification-trigger-se
 import { mockAuthServices } from '../../../smoke/identity/utils/mocks';
 import { setupMockRequest } from '../../../api-mocking/helpers/mockHelpers';
 import { createLogger } from '../../../framework/logger';
+import type { Asset, Entry } from 'contentful';
+import type { TypeFeatureAnnouncement } from '@metamask/notification-services-controller/notification-services';
 
 export const mockListNotificationsResponse = getMockListNotificationsResponse();
 const mockNotifications = [
@@ -61,6 +62,16 @@ mockListNotificationsResponse.response = mockNotifications;
 const logger = createLogger({
   name: 'MockNotificationServices',
 });
+
+// TODO: Export this type from `@metamask/notification-services-controller` and
+// remove these duplicates.
+interface ContentfulResult {
+  includes?: {
+    Entry?: Entry[];
+    Asset?: Asset[];
+  };
+  items?: TypeFeatureAnnouncement[];
+}
 
 const mockFeatureAnnouncementResponse = getMockFeatureAnnouncementResponse();
 const mockFeatureAnnouncementContentfulResponse =

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "module": "commonjs",
+    "module": "preserve",
     "lib": ["es2022"],
     "allowJs": true,
     "jsx": "react-native",
@@ -9,7 +9,7 @@
     "incremental": true,
     "isolatedModules": true,
     "strict": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Switches `tsconfig.json` to `module: "preserve"` and `moduleResolution: "bundler"`, which lets TypeScript resolve packages the way Metro and Jest do at runtime. `node` resolution only understands legacy CommonJS-style resolution, so it misses packages that declare export maps or ESM-first entrypoints, which forced a number of workarounds elsewhere in the codebase (deep `.d.cts` imports, duplicated local type declarations, `@ts-expect-error` suppressions for structurally incompatible-looking keyring types). This PR fixes those up to work with the new resolver.

This change is in preparation for `MetaMask/core` switching to ESM-only packages.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

1. Run `yarn lint:tsc` and confirm there are no type errors.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

N/A — type-checking configuration only, no UI changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Not applicable — this is a type-checking configuration change with no
runtime or behavioural impact.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-checking and import-path changes only; no production logic changes, though broad `tsc` config shifts can surface latent type issues elsewhere.
> 
> **Overview**
> Switches **`tsconfig.json`** to **`module: "preserve"`** and **`moduleResolution: "bundler"`** so TypeScript resolves packages like Metro/Jest (export maps, ESM entrypoints), ahead of ESM-only **`@metamask/core`** packages.
> 
> Follow-up fixes remove **Node-resolution workarounds**: public imports for **`ImageOrSvgSrc`**, **`Hex`** from **`viem`**, **`webdriverio`** context types, and **`@nktkas/hyperliquid/api/exchange`** (drops a **`@ts-expect-error`**). **`Engine/types`** uses **`NftDetectionController['state']`** instead of a deep **`.cjs`** type path.
> 
> Where bundler resolution still surfaces duplicate legacy vs v2 keyring types, **hardware/keyring unit tests** add targeted **`@ts-expect-error`** on **`legacyKeyring`** wiring. **`AuthTokenHandler`** and **notification Appium mocks** inline **`ContentfulResult`** / OAuth token types with TODOs to re-export from upstream packages instead of **`dist/*.d.cts`** imports.
> 
> No runtime behavior change; **`yarn lint:tsc`** is the main verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84bcfba275ad3878e542ba15ba226e2e4980a8a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->