### PR TITLE
feat: swap order of agent wallet and trading signals in notif settings view

### DIFF
--- a/app/components/Views/Settings/NotificationsSettings/index.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/index.tsx
@@ -161,21 +161,6 @@ const NotificationsSettings = ({ navigation }: Props) => {
               }
             />
 
-            <NotificationRow
-              title={strings(
-                'app_settings.notifications_opts.agentic_cli_title',
-              )}
-              status={getStatusText(preferences?.agenticCli)}
-              iconName={IconName.Code}
-              onPress={() =>
-                navigateToSection(
-                  'agenticCli',
-                  strings('app_settings.notifications_opts.agentic_cli_title'),
-                  strings('app_settings.notifications_opts.agentic_cli_desc'),
-                )
-              }
-            />
-
             {isSocialLeaderboardEnabled && (
               <NotificationRow
                 title={strings(
@@ -192,6 +177,21 @@ const NotificationsSettings = ({ navigation }: Props) => {
                 }
               />
             )}
+
+            <NotificationRow
+              title={strings(
+                'app_settings.notifications_opts.agentic_cli_title',
+              )}
+              status={getStatusText(preferences?.agenticCli)}
+              iconName={IconName.Code}
+              onPress={() =>
+                navigateToSection(
+                  'agenticCli',
+                  strings('app_settings.notifications_opts.agentic_cli_title'),
+                  strings('app_settings.notifications_opts.agentic_cli_desc'),
+                )
+              }
+            />
 
             <NotificationRow
               title={strings('app_settings.notifications_opts.marketing_title')}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Reorders the notification preference rows on the Notifications Settings screen so **Trading signals** appears above **Agent wallet**.

Previously, Agent wallet was listed before Trading signals (when the social leaderboard flag is enabled). This change moves the Agent wallet row below Trading signals so the list order better matches product priority, with no behavior changes to the toggles themselves.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated notification settings so Trading signals appears above Agent wallet

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

https://consensyssoftware.atlassian.net/browse/GE-465

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Notifications settings row order

  Background:
    Given I am logged into MetaMask Mobile
    And push notifications are enabled
    And the social leaderboard / trading signals feature flag is enabled

  Scenario: Trading signals appears above Agent wallet
    Given I open Settings
    And I open Notifications

    When I view the notification preference list
    Then I should see "Trading signals" above "Agent wallet"
    And tapping either row should still open the correct preference section
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="378" height="790" alt="Screenshot 2026-09-02 at 10 32 02" src="https://github.com/user-attachments/assets/c5c6c93a-3653-4f96-9eb2-d5c26e30d527" />

### **After**

<img width="376" height="784" alt="Screenshot 2026-09-02 at 10 29 41" src="https://github.com/user-attachments/assets/8813b71c-431c-4025-a2ff-824dbdaddf54" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only reorder in settings UI; no changes to notification preference storage or navigation handlers.
> 
> **Overview**
> Reorders rows on the **Notifications** settings screen in `NotificationsSettings/index.tsx` so **Trading signals** (`socialAI`, behind `isSocialLeaderboardEnabled`) renders **above** **Agent wallet** (`agenticCli`). The Agent wallet `NotificationRow` is moved from immediately after Perps to after the conditional trading-signals row.
> 
> Row copy, icons, `getStatusText`, and `navigateToSection` targets are unchanged—only list order when the social leaderboard flag is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d870b0cc08a4510d377943442c04f4a889c52d75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->