### PR TITLE
fix(perps): navigation bug: back button in BTC lite screen takes to order screen after placing a trade

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsRouter/PerpsMarketDetailsRouter.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsRouter/PerpsMarketDetailsRouter.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef } from 'react';
+import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import {
   useNavigation,
   useRoute,
@@ -7,6 +7,7 @@ import {
 } from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { SafeAreaView, type Edge } from 'react-native-safe-area-context';
+import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 import PerpsMarketDetailsView from '../PerpsMarketDetailsView';
 import PerpsProMarketView from '../PerpsProMarketView';
 import { usePerpsProModeEnabled } from './usePerpsProModeEnabled';
@@ -68,6 +69,15 @@ const PerpsMarketDetailsRouter: React.FC = () => {
     symbol,
     mode,
   );
+
+  useEffect(() => {
+    const stack = navigation.getState()?.routes?.map((entry) => entry.name);
+    DevLogger.log(
+      `[PR-TAT-3906] BUG_MARKER: market details mounted over stack ${JSON.stringify(
+        stack,
+      )}`,
+    );
+  }, [navigation]);
 
   useLayoutEffect(() => {
     previousIdentityRef.current = { symbol, mode };

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsRouter/PerpsMarketDetailsRouter.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsRouter/PerpsMarketDetailsRouter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef } from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 import {
   useNavigation,
   useRoute,
@@ -7,7 +7,6 @@ import {
 } from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { SafeAreaView, type Edge } from 'react-native-safe-area-context';
-import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 import PerpsMarketDetailsView from '../PerpsMarketDetailsView';
 import PerpsProMarketView from '../PerpsProMarketView';
 import { usePerpsProModeEnabled } from './usePerpsProModeEnabled';
@@ -69,15 +68,6 @@ const PerpsMarketDetailsRouter: React.FC = () => {
     symbol,
     mode,
   );
-
-  useEffect(() => {
-    const stack = navigation.getState()?.routes?.map((entry) => entry.name);
-    DevLogger.log(
-      `[PR-TAT-3906] BUG_MARKER: market details mounted over stack ${JSON.stringify(
-        stack,
-      )}`,
-    );
-  }, [navigation]);
 
   useLayoutEffect(() => {
     previousIdentityRef.current = { symbol, mode };

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -39,6 +39,7 @@ jest.mock('react-native-gesture-handler', () => {
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
 import { PerpsOrderViewSelectorsIDs } from '../../Perps.testIds';
+import Routes from '../../../../../constants/navigation/Routes';
 import {
   usePerpsLiveAccount,
   usePerpsLiquidationPrice,
@@ -1385,6 +1386,39 @@ describe('PerpsOrderView', () => {
         }),
       }),
     );
+  });
+
+  // The market page the trader came from is still below this screen, so the
+  // post-order navigation has to pop back to it. Pushing a duplicate leaves the
+  // order screen underneath and Back returns here instead of to Perps home.
+  it('pops back to the market page instead of stacking a duplicate over the order screen', async () => {
+    // Arrange
+    (usePerpsOrderExecution as jest.Mock).mockImplementation(() => ({
+      placeOrder: jest.fn().mockResolvedValue({ success: true }),
+      isPlacing: false,
+    }));
+
+    render(<PerpsOrderView />, { wrapper: TestWrapper });
+
+    const placeOrderButton = await screen.findByTestId(
+      PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON,
+    );
+
+    // Act
+    await act(async () => {
+      fireEvent.press(placeOrderButton);
+    });
+
+    // Assert
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.PERPS.ROOT,
+        expect.objectContaining({
+          screen: Routes.PERPS.MARKET_DETAILS,
+          pop: true,
+        }),
+      );
+    });
   });
 
   it('shows standard submitted toast when using perps balance', async () => {

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -442,7 +442,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
   // Check if market is at OI cap (zero network overhead - uses existing webData2 subscription)
   const { isAtCap: isAtOICap } = usePerpsOICap(orderForm.asset);
 
-  // A/B Testing: Button color test (TAT-1937)
+  // A/B Testing: Button color test
   const {
     variantName: buttonColorVariant,
     isActive: isButtonColorTestEnabled,
@@ -544,7 +544,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     return unsubscribe;
   }, [isDataReady, isInitialized, orderForm.asset, subscribeToPrices]);
 
-  // Fast focused price via activeAssetCtx projection (~0.5 s, TAT-3334)
+  // Fast focused price via activeAssetCtx projection (~0.5 s)
   const focusedPriceUpdate = usePerpsLiveFocusedPrice({
     symbol: isDataReady ? orderForm.asset : '',
     enabled: isDataReady,
@@ -1508,6 +1508,10 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
               monitorPositions,
             },
           },
+          // The market page the user came from is still below this screen, so pop
+          // back to it. Without `pop` React Navigation pushes a duplicate market
+          // page, leaving this order screen underneath so Back returns to it.
+          pop: true,
         });
 
         // Execute order using the new hook

--- a/app/components/UI/Perps/utils/perpsModeSwitch.test.ts
+++ b/app/components/UI/Perps/utils/perpsModeSwitch.test.ts
@@ -14,6 +14,7 @@ import {
   useGetPerpsHomeNavigationTarget,
   useNavigateToPerpsHome,
   useDropPerpsHomeFromStackHistory,
+  toPerpsNavigatorScreenParams,
 } from './perpsModeSwitch';
 
 jest.mock('react-redux', () => ({
@@ -224,6 +225,7 @@ describe('perpsModeSwitch', () => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
         screen: Routes.PERPS.PERPS_HOME,
         params: { source: 'activity_details' },
+        pop: true,
       });
     });
 
@@ -244,6 +246,67 @@ describe('perpsModeSwitch', () => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
         screen: Routes.PERPS.MARKET_DETAILS,
         params: { market: buildDefaultProMarket() },
+        pop: true,
+      });
+    });
+
+    // The deposit confirmation sits on top of the Pro market screen when this
+    // runs. Without `pop` React Navigation pushes a second market screen and
+    // Back returns to add funds.
+    it('pops back to the Pro market instead of stacking a duplicate over the caller', () => {
+      // Arrange
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectPerpsProModeEnabledFlag) return true;
+        if (selector === selectPerpsMode) return PerpsMode.Pro;
+        return undefined;
+      });
+
+      const { result } = renderHook(() => useNavigateToPerpsHome());
+
+      // Act
+      result.current();
+
+      // Assert
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.PERPS.ROOT,
+        expect.objectContaining({ pop: true }),
+      );
+    });
+  });
+
+  describe('toPerpsNavigatorScreenParams', () => {
+    it('carries the resolved screen and params through unchanged', () => {
+      // Arrange
+      const target = {
+        screen: Routes.PERPS.PERPS_HOME,
+        params: { source: 'wallet_actions' },
+      };
+
+      // Act
+      const params = toPerpsNavigatorScreenParams(target);
+
+      // Assert
+      expect(params).toEqual({
+        screen: Routes.PERPS.PERPS_HOME,
+        params: { source: 'wallet_actions' },
+      });
+    });
+
+    it('adds pop only when the caller asks to return to an existing entry', () => {
+      // Arrange
+      const target = {
+        screen: Routes.PERPS.MARKET_DETAILS,
+        params: { market: buildDefaultProMarket() },
+      };
+
+      // Act
+      const params = toPerpsNavigatorScreenParams(target, { pop: true });
+
+      // Assert
+      expect(params).toEqual({
+        screen: Routes.PERPS.MARKET_DETAILS,
+        params: { market: buildDefaultProMarket() },
+        pop: true,
       });
     });
   });

--- a/app/components/UI/Perps/utils/perpsModeSwitch.ts
+++ b/app/components/UI/Perps/utils/perpsModeSwitch.ts
@@ -244,10 +244,11 @@ export const useNavigateToPerpsHome = (): ((
 
       navigate(
         Routes.PERPS.ROOT,
-        // Callers reach here from a screen stacked on top of the Perps home
-        // target (e.g. the deposit confirmation), so pop back to it. Without
-        // `pop` React Navigation pushes a duplicate, leaving that confirmation
-        // underneath so Back returns to it.
+        // When the target is already below the caller (e.g. the deposit
+        // confirmation stacked over it), pop back to it: without `pop` React
+        // Navigation pushes a duplicate and leaves that confirmation
+        // underneath, so Back returns to it. When the target is not in the
+        // stack at all, `pop` finds nothing and the push happens as before.
         toPerpsNavigatorScreenParams(getTarget(extraParams), { pop: true }),
       );
     },

--- a/app/components/UI/Perps/utils/perpsModeSwitch.ts
+++ b/app/components/UI/Perps/utils/perpsModeSwitch.ts
@@ -13,7 +13,7 @@ import { selectPerpsProModeEnabledFlag } from '../selectors/featureFlags';
 import type { PerpsStackParamList } from '../types/navigation';
 
 /**
- * Default market a user lands on when switching to Pro mode (TAT-3551, AC #4).
+ * Default market a user lands on when switching to Pro mode.
  */
 export const PERPS_DEFAULT_PRO_MARKET_SYMBOL = 'BTC';
 
@@ -64,7 +64,7 @@ export interface PerpsHomeNavigationTarget {
  * pass the mode they selected rather than reading it back from a selector that
  * has not re-rendered yet.
  *
- * While Pro mode is active, `PerpsHomeView` must never be shown (TAT-3612):
+ * While Pro mode is active, `PerpsHomeView` must never be shown:
  * every entry point instead lands on the default Pro market, so the user
  * only ever moves between a market page and the market list. Centralizing
  * this here keeps every entry point (Trade sheet, Wallet actions, Homepage
@@ -125,11 +125,18 @@ export const useGetPerpsHomeNavigationTarget = (): ((
  * in `usePerpsNavigationHandlers.ts`, or `app/components/UI/Rewards/utils.ts`).
  * Centralized here so every "go to Perps home" call site shares one
  * reviewed assertion instead of repeating it.
+ *
+ * Pass `pop: true` when the destination is already below the caller in the
+ * Perps stack: React Navigation pushes a duplicate entry otherwise.
  */
 export const toPerpsNavigatorScreenParams = (
   target: PerpsHomeNavigationTarget,
+  options: { pop?: boolean } = {},
 ): NavigatorScreenParams<PerpsStackParamList> =>
-  target as unknown as NavigatorScreenParams<PerpsStackParamList>;
+  ({
+    ...target,
+    ...options,
+  }) as unknown as NavigatorScreenParams<PerpsStackParamList>;
 
 /**
  * Navigates directly (not nested under `Routes.PERPS.ROOT`) to a resolved
@@ -156,7 +163,7 @@ export const navigateToPerpsHomeTarget = (
  * Switching to Pro from a market screen swaps the rendered layout in place —
  * `PerpsMarketDetailsRouter` keeps the same route — so a Perps Home entry the
  * user came through stays in history and the back button would reveal the Lite
- * hub while Pro is active (TAT-3612). Screens that switch mode by navigating
+ * hub while Pro is active. Screens that switch mode by navigating
  * (Perps Home itself, the Trade sheet) already avoid seeding Home instead.
  */
 export const dropPerpsHomeFromStackHistory = (navigation: {
@@ -237,7 +244,11 @@ export const useNavigateToPerpsHome = (): ((
 
       navigate(
         Routes.PERPS.ROOT,
-        toPerpsNavigatorScreenParams(getTarget(extraParams)),
+        // Callers reach here from a screen stacked on top of the Perps home
+        // target (e.g. the deposit confirmation), so pop back to it. Without
+        // `pop` React Navigation pushes a duplicate, leaving that confirmation
+        // underneath so Back returns to it.
+        toPerpsNavigatorScreenParams(getTarget(extraParams), { pop: true }),
       );
     },
     [navigation, getTarget],

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -418,9 +418,12 @@ describe('useTransactionConfirm', () => {
         await result.current.onConfirm();
       });
 
+      // `pop` returns to the Perps screen the deposit confirmation was opened
+      // from; without it the confirmation stays underneath and Back reopens it.
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
         screen: Routes.PERPS.PERPS_HOME,
         params: {},
+        pop: true,
       });
     });
 


### PR DESCRIPTION
## **Description**

Perps navigation used `navigate()` to return to a screen that was still below the current one in the stack. React Navigation v7 only pops back to an existing entry when `pop: true` is passed, so both call sites pushed a *second* copy of the destination and left the screen the user had just finished with underneath it — Back then reopened it.

Two call sites, one line each:

- `PerpsOrderView` — after placing an order it returns to the market page, so Back from that page reopened the BTC trade screen instead of going to Perps home.
- `useNavigateToPerpsHome` (called from `useTransactionConfirm` after a Perps deposit) — in Pro mode the "Perps home" target *is* the market screen, so Back after adding funds reopened the add-funds confirmation.

Ticket identifiers were also dropped from the comments in the two touched files.

## **Changelog**

CHANGELOG entry: Fixed the back button reopening the order screen after placing a Perps trade, and the add funds screen after depositing.

## **Related issues**

Fixes: [TAT-3906](https://consensyssoftware.atlassian.net/browse/TAT-3906)
Fixes: [TAT-3838](https://consensyssoftware.atlassian.net/browse/TAT-3838)
Fixes: [TAT-3874](https://consensyssoftware.atlassian.net/browse/TAT-3874)

## **Manual testing steps**

```gherkin
Feature: Perps back navigation returns to the screen the user came from

  Scenario: user places an order from a Lite market page
    Given user is on Perps home
    And user opens the BTC market page in Lite mode
    When user taps Long and places an order
    And user taps the back arrow in the top left corner of the BTC market page
    Then user is returned to Perps home
    And user is not returned to the BTC trade screen

  Scenario: user adds funds from a Pro market screen
    Given user is on the BTC market screen in Pro mode
    When user adds funds and the deposit confirms
    And user taps the back arrow in the top left corner
    Then user is returned to the BTC Pro market screen
    And user is not returned to the add funds screen
```

## **Screenshots/Recordings**

Same Lite BTC path (Long → place order → Back), before the fix and after, re-captured on the branch rebased onto latest main.

<table>
<tr><td colspan="2"><strong>Back after placing an order returns to Perps home instead of the trade screen</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35597/before-ac1-back-lands-on-order-screen.png?sha=69666cd29a07a783" alt="before" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35597/after-ac1-back-lands-on-perps-home.png?sha=163624d4b109036b" alt="after" width="320" /></td>
</tr>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Not applicable: this is a two-line navigation-stack change with no rendering, data-fetching or
startup impact. It was validated on iOS; the defect and the fix are in shared JavaScript
(React Navigation's stack router), so they behave identically on Android.

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

Validated live on iOS against Hyperliquid testnet. The baseline recipe (asserting the buggy values) passes on pre-fix code and the recipe below passes on the fix; removing `pop: true` makes the new unit test fail. Per-AC audit: `recipe-coverage.md` (2/2 PROVEN).

<details>
<summary>recipe.json</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "Perps back navigation returns to the screen the user came from",
  "description": "Places a Lite BTC order the way a user does and proves the market page's back arrow returns to Perps home instead of the order screen (TAT-3906), then runs the focused unit tests that pin the post-deposit Pro navigation (TAT-3874).",
  "workflow": {
    "entry": "setup-status",
    "nodes": {
      "setup-status": {
        "action": "app.status",
        "intent": "Confirm the mobile bridge is reachable before touching the app",
        "next": "setup-unlock"
      },
      "setup-unlock": {
        "action": "metamask.wallet.ensure_unlocked",
        "intent": "Make the wallet usable so Perps screens can render",
        "next": "setup-open-perps"
      },
      "setup-open-perps": {
        "action": "ui.navigate",
        "page": "perps",
        "intent": "Start from the Perps home screen the reporter came from in step 1",
        "next": "gate-perps-home"
      },
      "gate-perps-home": {
        "action": "ui.wait_for",
        "test_id": "perps-home-heading",
        "expected": "present",
        "timeout_ms": 20000,
        "intent": "Confirm Perps home is the screen sitting underneath the market page",
        "next": "setup-open-market"
      },
      "setup-open-market": {
        "action": "ui.navigate",
        "page": "perps-market",
        "market": "BTC",
        "mode": "lite",
        "intent": "Open the BTC market page in Lite mode where the trade is placed",
        "next": "setup-clean-market"
      },
      "setup-clean-market": {
        "action": "metamask.perps.start_state",
        "profile": "clean_market_testnet",
        "market": "BTC",
        "positions": {
          "state": "none",
          "mode": "matching"
        },
        "orders": {
          "state": "none",
          "mode": "matching"
        },
        "page": "market",
        "intent": "Leave BTC with no open position so the market page offers Long rather than Close",
        "next": "gate-market-page"
      },
      "gate-market-page": {
        "action": "ui.wait_for",
        "test_id": "perps-market-details-long-button",
        "expected": "present",
        "timeout_ms": 30000,
        "intent": "Confirm the BTC Lite market page is offering a new position rather than an existing one",
        "next": "ac1-open-order-form"
      },
      "ac1-open-order-form": {
        "action": "ui.press",
        "test_id": "perps-market-details-long-button",
        "intent": "Open the Lite long order form the way the reporter did",
        "next": "ac1-wait-order-form"
      },
      "ac1-wait-order-form": {
        "action": "ui.wait_for",
        "test_id": "perps-order-view-place-order-button",
        "expected": "present",
        "timeout_ms": 30000,
        "intent": "Confirm the BTC trade screen is open with its default order ready to submit",
        "next": "ac1-place-order"
      },
      "ac1-place-order": {
        "action": "ui.press",
        "test_id": "perps-order-view-place-order-button",
        "intent": "Submit the order through the visible Place order control",
        "next": "ac1-wait-position-open"
      },
      "ac1-wait-position-open": {
        "action": "ui.wait_for",
        "test_id": "perps-market-details-close-button",
        "expected": "present",
        "timeout_ms": 60000,
        "intent": "Confirm the order was accepted and the app returned to the BTC market page",
        "next": "ac1-press-back"
      },
      "ac1-press-back": {
        "action": "ui.press",
        "test_id": "perps-market-header-back-button",
        "intent": "Leave the BTC market page the way a user does after their trade lands",
        "next": "ac1-assert-order-screen-gone"
      },
      "ac1-assert-order-screen-gone": {
        "action": "ui.wait_for",
        "test_id": "perps-order-view-place-order-button",
        "expected": "absent",
        "timeout_ms": 20000,
        "intent": "Confirm Back did not land the user back on the BTC trade screen",
        "next": "ac1-assert-back-to-perps-home"
      },
      "ac1-assert-back-to-perps-home": {
        "action": "ui.wait_for",
        "test_id": "perps-home-heading",
        "expected": "present",
        "timeout_ms": 20000,
        "intent": "Confirm Back returned to Perps home, the screen the user came from",
        "next": "ac1-screenshot-perps-home"
      },
      "ac1-screenshot-perps-home": {
        "action": "ui.screenshot",
        "label": "AC1: Back from the post-order market page shows Perps home",
        "intent": "Preserve visible proof that Back reaches Perps home, not the trade screen",
        "next": "ac2-run-navigation-unit-tests"
      },
      "ac2-run-navigation-unit-tests": {
        "action": "command",
        "timeout_ms": 900000,
        "allow_failure": true,
        "intent": "Exercise the post-deposit Pro navigation helper that TAT-3874 reported, which needs a funded on-chain deposit to reach on a device",
        "next": "ac2-assert-navigation-unit-tests-pass"
      },
      "ac2-assert-navigation-unit-tests-pass": {
        "action": "assert_exit_code",
        "node": "ac2-run-navigation-unit-tests",
        "expected": 0,
        "intent": "Confirm the Pro add-funds and Lite post-order navigation contracts both hold",
        "next": "ac2-index-test-log"
      },
      "ac2-index-test-log": {
        "action": "index_artifacts",
        "artifacts": [
        ],
        "intent": "Attach the unit-test output as reviewable evidence for the Pro add-funds claim",
        "next": "teardown-clean-market"
      },
      "teardown-clean-market": {
        "action": "metamask.perps.teardown_state",
        "market": "BTC",
        "positions": {
          "state": "none",
          "mode": "matching"
        },
        "orders": {
          "state": "none",
          "mode": "matching"
        },
        "intent": "Return the BTC testnet market to the clean state the run started from",
        "next": "teardown-end"
      },
      "teardown-end": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
  setup_status["setup-status<br/>app.status"]
  setup_unlock["setup-unlock<br/>metamask.wallet.ensure_unlocked"]
  setup_open_perps["setup-open-perps<br/>ui.navigate"]
  gate_perps_home["gate-perps-home<br/>ui.wait_for"]
  setup_open_market["setup-open-market<br/>ui.navigate"]
  setup_clean_market["setup-clean-market<br/>metamask.perps.start_state"]
  gate_market_page["gate-market-page<br/>ui.wait_for"]
  ac1_open_order_form["ac1-open-order-form<br/>ui.press"]
  ac1_wait_order_form["ac1-wait-order-form<br/>ui.wait_for"]
  ac1_place_order["ac1-place-order<br/>ui.press"]
  ac1_wait_position_open["ac1-wait-position-open<br/>ui.wait_for"]
  ac1_press_back["ac1-press-back<br/>ui.press"]
  ac1_assert_order_screen_gone["ac1-assert-order-screen-gone<br/>ui.wait_for"]
  ac1_assert_back_to_perps_home["ac1-assert-back-to-perps-home<br/>ui.wait_for"]
  ac1_screenshot_perps_home["ac1-screenshot-perps-home<br/>ui.screenshot"]
  ac2_run_navigation_unit_tests["ac2-run-navigation-unit-tests<br/>command"]
  ac2_assert_navigation_unit_tests_pass["ac2-assert-navigation-unit-tests-pass<br/>assert_exit_code"]
  ac2_index_test_log["ac2-index-test-log<br/>index_artifacts"]
  teardown_clean_market["teardown-clean-market<br/>metamask.perps.teardown_state"]
  teardown_end["teardown-end<br/>end"]
  setup_status --> setup_unlock
  setup_unlock --> setup_open_perps
  setup_open_perps --> gate_perps_home
  gate_perps_home --> setup_open_market
  setup_open_market --> setup_clean_market
  setup_clean_market --> gate_market_page
  gate_market_page --> ac1_open_order_form
  ac1_open_order_form --> ac1_wait_order_form
  ac1_wait_order_form --> ac1_place_order
  ac1_place_order --> ac1_wait_position_open
  ac1_wait_position_open --> ac1_press_back
  ac1_press_back --> ac1_assert_order_screen_gone
  ac1_assert_order_screen_gone --> ac1_assert_back_to_perps_home
  ac1_assert_back_to_perps_home --> ac1_screenshot_perps_home
  ac1_screenshot_perps_home --> ac2_run_navigation_unit_tests
  ac2_run_navigation_unit_tests --> ac2_assert_navigation_unit_tests_pass
  ac2_assert_navigation_unit_tests_pass --> ac2_index_test_log
  ac2_index_test_log --> teardown_clean_market
  teardown_clean_market --> teardown_end
```

</details>

[TAT-3906]: https://consensyssoftware.atlassian.net/browse/TAT-3906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared Perps navigation helpers and post-order/post-deposit flows; incorrect stack behavior would affect many entry points, but scope is small and covered by new tests.
> 
> **Overview**
> Fixes Perps **back navigation** after trades and deposits by passing **`pop: true`** when returning to a screen that is already below the current one in the stack. Without it, React Navigation v7 **pushes a duplicate** route and leaves the order or deposit confirmation underneath, so Back reopens those screens instead of Perps home or the market page.
> 
> **`PerpsOrderView`** now pops back to **`MARKET_DETAILS`** after a successful place order. **`useNavigateToPerpsHome`** (including post–Perps-deposit confirmation) does the same via an extended **`toPerpsNavigatorScreenParams`**, which optionally merges **`pop`** into nested Perps navigator params. Unit tests lock in both behaviors; unrelated comment ticket IDs were removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8837af4389495d8ef5be24efd0a78eccf823e8fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
