### PR TITLE
fix(predict-next): demote missing-configuration log to breadcrumb cp-8.10.0

### DIFF
--- a/app/components/UI/PredictNext/controller/PredictNextController.test.ts
+++ b/app/components/UI/PredictNext/controller/PredictNextController.test.ts
@@ -71,11 +71,10 @@ describe('PredictNextController', () => {
 
     controller.initialize();
 
-    expect(Logger.error).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: 'PredictNext configuration is missing.',
-      }),
+    expect(Logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('PredictNext configuration is missing.'),
     );
+    expect(Logger.error).not.toHaveBeenCalled();
     expect(() =>
       messenger.call('PredictMarketDataService:getVenueStatus', status.venueId),
     ).toThrow();

--- a/app/components/UI/PredictNext/controller/PredictNextController.ts
+++ b/app/components/UI/PredictNext/controller/PredictNextController.ts
@@ -37,7 +37,12 @@ export class PredictNextController {
       return;
     }
     if (!this.#options.baseUrl) {
-      Logger.error(new Error('PredictNext configuration is missing.'));
+      // Expected while the Predict API URL is not yet wired into release builds.
+      // Logged as a breadcrumb (not an error) to avoid Sentry noise until the
+      // production URL ships via builds.yml.
+      Logger.log(
+        'PredictNext configuration is missing. Skipping controller initialization.',
+      );
       return;
     }
 


### PR DESCRIPTION
## **Description**

Demotes the `PredictNextController` missing-configuration log from `Logger.error` (captured to Sentry as an exception) to `Logger.log` (breadcrumb / dev-console only).

**Context:** `PredictNextController.initialize()` runs at every Engine boot and logs `Error: PredictNext configuration is missing.` when `MM_PREDICT_API_URL` is not inlined into the bundle. That env var is only defined locally via `.js.env` — it has no value in `builds.yml` and no production URL exists yet — so every CI release and OTA build reports this to Sentry (e.g. [METAMASK-MOBILE-HQPY](https://metamask.sentry.io/issues/7703509652/), 16 events / 15 users on release `io.metamask@8.9.0+6689`) even though this is an expected dark-launch state with no user-facing impact (the PredictNext service simply stays unregistered and the feature is not yet navigable).

The controller now logs the missing configuration as a breadcrumb and skips initialization, removing the Sentry noise until the production Predict API URL ships. The `PredictNext configuration is malformed.` path remains a `Logger.error`, since once a URL is configured a malformed value would be a genuine build misconfiguration worth surfacing.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: [METAMASK-MOBILE-HQPY](https://metamask.sentry.io/issues/7703509652/) (Sentry — PredictNext configuration is missing.)

## **Manual testing steps**

```gherkin
Feature: PredictNext dark launch

  Scenario: app boots without a Predict API URL configured
    Given the app bundle is built without MM_PREDICT_API_URL defined

    When the app boots and the Engine initializes PredictNextController
    Then no 'PredictNext configuration is missing.' error is reported to Sentry
    And the condition is logged only as a breadcrumb / dev console log
    And PredictNext market data service actions remain unregistered
```

Automated verification: `yarn jest app/components/UI/PredictNext/controller/PredictNextController.test.ts` — 5 passed, including the updated case asserting `Logger.log` (not `Logger.error`) for missing configuration.

## **Screenshots/Recordings**

N/A — log-level-only change, no UI impact.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Log-level-only change for an expected dark-launch state; no auth, data, or user-facing behavior changes beyond reduced Sentry noise.
> 
> **Overview**
> When `PredictNextController` boots without a `baseUrl`, it now records the situation with **`Logger.log`** (breadcrumb / dev console) instead of **`Logger.error`**, which was flooding Sentry on every Engine start while the Predict API URL is not yet in release builds.
> 
> Behavior is unchanged: initialization still exits early and market-data service actions stay unregistered. **Malformed** configuration after a URL is present still goes through **`Logger.error`**.
> 
> Tests now assert the missing-config path calls **`Logger.log`** with the updated message and does **not** call **`Logger.error`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2e1b5ec25445f6f5e3ca5760ed5a940211cc206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->