### PR TITLE
fix(android): stop nitro-websockets crash when closing mid-handshake cp-8.11.0

### DIFF
--- a/.yarn/patches/react-native-nitro-websockets-npm-1.0.3-fb47e9a867.patch
+++ b/.yarn/patches/react-native-nitro-websockets-npm-1.0.3-fb47e9a867.patch
@@ -1,0 +1,60 @@
+diff --git a/android/src/main/cpp/WebSocketConnection.cpp b/android/src/main/cpp/WebSocketConnection.cpp
+index f5742d83444202bf359a914c57ebdcc6cd915c84..93141ea9cd5baafba2a8a17c88459441026b0881 100644
+--- a/android/src/main/cpp/WebSocketConnection.cpp
++++ b/android/src/main/cpp/WebSocketConnection.cpp
+@@ -196,13 +196,29 @@ void WebSocketConnection::connect(
+ 
+ 
+ void WebSocketConnection::close(int code, const std::string& reason) {
+-  if (_state == State::CLOSED || _state == State::CLOSING) return;
+-  _state = State::CLOSING;
++  // Claim the transition atomically and keep the state we moved away from.
++  // _state is written from both the JS and libwebsockets threads, so a plain
++  // read-then-write races a handshake completing in the same lws_service tick.
++  State prev = _state.load();
++  do {
++    if (prev == State::CLOSING || prev == State::CLOSED) return;
++  } while (!_state.compare_exchange_weak(prev, State::CLOSING));
++
++  int closeCode = (code >= 1000 && code <= 4999) ? code : LWS_CLOSE_STATUS_NORMAL;
+ 
+   auto self = std::static_pointer_cast<WebSocketConnection>(shared_from_this());
+-  LwsContext::instance().schedule([self, code, reason]() {
++  LwsContext::instance().schedule([self, prev, closeCode, reason]() {
+     if (!self->_wsi) return;
+-    int closeCode = (code >= 1000 && code <= 4999) ? code : LWS_CLOSE_STATUS_NORMAL;
++
++    if (prev == State::CONNECTING) {
++      // Mid-handshake: the connection still holds the HTTP role, and
++      // lws_close_reason() asserts lwsi_role_ws(wsi) — see
++      // warmcat/libwebsockets#1335. Drop the socket instead; there is no ws
++      // close handshake to perform on one that never became a websocket.
++      lws_set_timeout(self->_wsi, PENDING_TIMEOUT_USER_OK, LWS_TO_KILL_ASYNC);
++      return;
++    }
++
+     lws_close_reason(self->_wsi,
+                      static_cast<lws_close_status>(closeCode),
+                      reinterpret_cast<unsigned char*>(const_cast<char*>(reason.c_str())),
+diff --git a/android/src/main/cpp/WebSocketConnection.hpp b/android/src/main/cpp/WebSocketConnection.hpp
+index 4bd60ab6914df380bd586d9f16f9f0edfb9f05f4..75719283830583b73c8c4acc7213a37fe48d39fb 100644
+--- a/android/src/main/cpp/WebSocketConnection.hpp
++++ b/android/src/main/cpp/WebSocketConnection.hpp
+@@ -33,7 +33,7 @@ public:
+   void send(const std::string& data) override;
+   void sendBinary(const uint8_t* data, size_t len) override;
+ 
+-  State state() const override { return _state; }
++  State state() const override { return _state.load(); }
+   std::string url() const override { return _url; }
+   std::string protocol() const override { return _negotiatedProtocol; }
+   std::string extensions() const override { return _extensions; }
+@@ -62,7 +62,7 @@ private:
+   std::string _url;
+   std::string _negotiatedProtocol;
+   std::string _extensions;
+-  State       _state = State::CONNECTING;
++  std::atomic<State> _state{State::CONNECTING};
+ 
+   OnOpen    _onOpen;
+   OnMessage _onMessage;

--- a/package.json
+++ b/package.json
@@ -560,7 +560,7 @@
     "react-native-nitro-fetch": "patch:react-native-nitro-fetch@npm%3A1.3.3#~/.yarn/patches/react-native-nitro-fetch-npm-1.3.3-b43385194a.patch",
     "react-native-nitro-modules": "0.35.10",
     "react-native-nitro-text-decoder": "^0.2.0",
-    "react-native-nitro-websockets": "^1.0.3",
+    "react-native-nitro-websockets": "patch:react-native-nitro-websockets@npm%3A1.0.3#~/.yarn/patches/react-native-nitro-websockets-npm-1.0.3-fb47e9a867.patch",
     "react-native-os": "patch:react-native-os@npm%3A1.2.6#~/.yarn/patches/react-native-os-npm-1.2.6-65c52ed3dc.patch",
     "react-native-pager-view": "8.0.4",
     "react-native-permissions": "^5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36151,7 +36151,7 @@ __metadata:
     react-native-nitro-fetch: "patch:react-native-nitro-fetch@npm%3A1.3.3#~/.yarn/patches/react-native-nitro-fetch-npm-1.3.3-b43385194a.patch"
     react-native-nitro-modules: "npm:0.35.10"
     react-native-nitro-text-decoder: "npm:^0.2.0"
-    react-native-nitro-websockets: "npm:^1.0.3"
+    react-native-nitro-websockets: "patch:react-native-nitro-websockets@npm%3A1.0.3#~/.yarn/patches/react-native-nitro-websockets-npm-1.0.3-fb47e9a867.patch"
     react-native-os: "patch:react-native-os@npm%3A1.2.6#~/.yarn/patches/react-native-os-npm-1.2.6-65c52ed3dc.patch"
     react-native-pager-view: "npm:8.0.4"
     react-native-performance: "patch:react-native-performance@npm%3A6.0.0#~/.yarn/patches/react-native-performance-npm-6.0.0-48a0cbc8fc.patch"
@@ -40661,7 +40661,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-nitro-websockets@npm:^1.0.3":
+"react-native-nitro-websockets@npm:1.0.3":
   version: 1.0.3
   resolution: "react-native-nitro-websockets@npm:1.0.3"
   peerDependencies:
@@ -40674,6 +40674,22 @@ __metadata:
     react-native-nitro-fetch:
       optional: true
   checksum: 10/aa53b4f40d62e79294dcc609f38e1426dfe08ca87deafbe8b90bbb64ec5b958742421f6f26e7a497e642189855dfd6c682cb4de1beabab8dd96595538ed93556
+  languageName: node
+  linkType: hard
+
+"react-native-nitro-websockets@patch:react-native-nitro-websockets@npm%3A1.0.3#~/.yarn/patches/react-native-nitro-websockets-npm-1.0.3-fb47e9a867.patch":
+  version: 1.0.3
+  resolution: "react-native-nitro-websockets@patch:react-native-nitro-websockets@npm%3A1.0.3#~/.yarn/patches/react-native-nitro-websockets-npm-1.0.3-fb47e9a867.patch::version=1.0.3&hash=cef141"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+    react-native-nitro-fetch: "*"
+    react-native-nitro-modules: "*"
+    react-native-nitro-text-decoder: ">=0.1.0"
+  peerDependenciesMeta:
+    react-native-nitro-fetch:
+      optional: true
+  checksum: 10/b06c685cfc2ba9fac15d59d1067754783abc362e95a0fabf02cf7d5470b65b31a16b0be378d5c2774572e5fc62cb9a3f822d9cec9ee9187471d499749fdcf2be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Android hard-crashes (SIGABRT) during Perps navigation when live price feeds are torn down:

```
ops-ws.c:975: lws_close_reason(...): assertion "lwsi_role_ws(wsi)" failed
```

`lws_close_reason()` requires the connection to already hold the WebSocket role. That role is only assigned once the handshake completes. This is a libwebsockets bug, [warmcat/libwebsockets#1335](https://github.com/warmcat/libwebsockets/issues/1335), open since 2018.

`react-native-nitro-websockets@1.0.3` hits it because `connect()` publishes `_wsi` as soon as `lws_client_connect_via_info()` returns, while the role only arrives later in `handleEstablished()`. In between, `_wsi` is non-null on a connection that still has the HTTP role. The old `close()` checked only for null, so closing a socket mid-handshake aborted the process.

This backports the fix from `react-native-nitro-websockets@1.3.1` ([margelo/react-native-nitro-fetch](https://github.com/margelo/react-native-nitro-fetch)) onto the 1.0.3 we pin:

- `_state` becomes `std::atomic<State>`, and `close()` claims the CLOSING transition with a compare-exchange loop, keeping the state it moved away from. A plain read-then-write races a handshake that completes in the same `lws_service` tick.
- If that prior state was `CONNECTING`, the socket still has the HTTP role, so the scheduled lambda drops it with `lws_set_timeout(PENDING_TIMEOUT_USER_OK, LWS_TO_KILL_ASYNC)` rather than calling `lws_close_reason()`.

It ships as a yarn patch because of the version pin.

> ### Follow-up: bump the package
>
> 1.3.1 already contains this fix, so bumping beats carrying a native patch we own. The pin is stale anyway: `react-native-nitro-fetch` is on 1.3.3 while websockets sits at 1.0.3, and the two ship together.
>
> It is not a drop-in swap. 1.0.3 to 1.3.1 adds `_selfRef` lifetime handling, `fireClose`, and peer-vs-local close codes, so it needs its own PR and testing pass instead of riding along here.

<details>
<summary>Why it looks intermittent, and why release builds are worse</summary>

The close has to land inside a window of roughly one network round trip, so this is a real race. Slow connections widen the window. Fast navigation is what closes a socket before its feed finishes connecting. Perps opens several feeds per screen, so every transition rolls the dice again. The same build crashes for one user and never for another.

Release builds are worse than debug. `-DNDEBUG` compiles the assertion out, and `lws_close_reason()` then writes through `&wsi->ws->ping_payload_buf[...]` on a connection whose `ws` struct was never allocated. A clean abort becomes a null-derived write. I only reproduced against `prodDebug`; I read the release path from source rather than observing it.

#32472 (2026-07-06) introduced this when it replaced the global `WebSocket` unconditionally. Nobody caught it because `NitroWebSocketSetup.test.ts` mocks the native module, and a native abort produces no JS error and no Sentry event.
</details>

## **Changelog**

CHANGELOG entry: Fixed a crash on Android when navigating between Perps screens

## **Related issues**

Fixes: [TAT-3908](https://consensyssoftware.atlassian.net/browse/TAT-3908)

## **Manual testing steps**

Needs a physical Android device or emulator. Reproduced on a Pixel 6a (Android 17).

**1. Build and install.** Do this on `main` to see the crash, then on this branch to see it fixed.

```bash
cd android && ./gradlew :app:assembleProdDebug -PreactNativeArchitectures=arm64-v8a && cd ..
adb install -r android/app/build/outputs/apk/prod/debug/app-prod-debug.apk
```

**2. Watch for the crash** in a second terminal.

```bash
adb logcat -c && adb logcat | grep -E "Fatal signal 6|lwsi_role_ws"
```

**3. Trigger it.** Unlock the wallet, open Perps, then navigate Perps, wallet home, Perps three times in quick succession. Speed is what matters here. You are trying to leave a screen while its feeds are still connecting.

On `main` the app dies and logcat shows the `lwsi_role_ws` abort. On this branch navigation stays clean and logcat stays silent.

It is a race, so a fast network may take a couple of attempts. A slower connection reproduces it more reliably.

| Build | Perps enter/leave cycles | SIGABRT |
|---|---|---|
| Before fix | 3 | **1** |
| After fix | 15 (5 runs × 3) | **0** |

The pre-fix backtrace put frame `#04` at `LwsContext::loop()`. That is the libwebsockets thread draining its scheduled work queue, which is exactly where `close()` defers its lambda.

I only built `arm64-v8a` locally and never built the release variant. CI covers the full ABI matrix.

## **Screenshots/Recordings**

N/A. This is a native crash fix with no UI change. The evidence is the logcat signature and its absence, per the steps above.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TAT-3908]: https://consensyssoftware.atlassian.net/browse/TAT-3908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native WebSocket teardown on Android under concurrency; scope is limited to the patched dependency and targets a known crash path.
> 
> **Overview**
> Fixes an **Android SIGABRT** when live WebSocket feeds are closed while still handshaking (e.g. fast Perps navigation), by patching `react-native-nitro-websockets@1.0.3` via Yarn instead of bumping the package.
> 
> The native change makes connection `_state` **`std::atomic`** and has `close()` claim **CLOSING** with a compare-exchange so JS and libwebsockets threads cannot race the same `lws_service` tick. The scheduled close lambda remembers the prior state: if it was **`CONNECTING`**, it **async-kills** the socket with `lws_set_timeout` instead of calling **`lws_close_reason()`**, which asserts the WebSocket role and crashes mid-handshake.
> 
> `package.json` and `yarn.lock` now resolve `react-native-nitro-websockets` to this patch entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c3f488d0f344075523db820396d20882caf50a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->