### PR TITLE
fix(swaps): keep footer visible during quote refresh

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeMarketView/BridgeMarketViewFooter.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeMarketView/BridgeMarketViewFooter.test.tsx
@@ -60,8 +60,24 @@ jest.mock(
     SwapsMarketOrderConfirmButton: ({ testID }: { testID?: string }) => {
       const MockReact = jest.requireActual('react');
       const { View } = jest.requireActual('react-native');
+      const { useBridgeQuoteData: getBridgeQuoteData } = jest.requireMock(
+        '../../../hooks/useBridgeQuoteData',
+      ) as {
+        useBridgeQuoteData: () => {
+          isLoading: boolean;
+          activeQuote: unknown;
+          needsNewQuote: boolean;
+        };
+      };
+      const { isLoading, activeQuote, needsNewQuote } = getBridgeQuoteData();
+      const isLoadingWithoutActiveQuote =
+        isLoading && !activeQuote && !needsNewQuote;
       return MockReact.createElement(View, {
         testID: testID ?? 'bridge-confirm-button',
+        accessibilityState: {
+          disabled: isLoadingWithoutActiveQuote,
+          busy: isLoadingWithoutActiveQuote,
+        },
       });
     },
   }),
@@ -160,7 +176,7 @@ describe('BridgeMarketViewFooter', () => {
   });
 
   describe('Rendering conditions', () => {
-    it('renders nothing when loading without an active quote', () => {
+    it('renders a disabled loading button when loading without an active quote', () => {
       jest
         .mocked(useBridgeQuoteData as unknown as jest.Mock)
         .mockImplementation(() => ({
@@ -169,9 +185,12 @@ describe('BridgeMarketViewFooter', () => {
           activeQuote: null,
         }));
 
-      const { queryByTestId } = renderFooter(buildActiveQuoteState());
+      const { getByTestId } = renderFooter(buildActiveQuoteState());
+      const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
 
-      expect(queryByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON)).toBeNull();
+      expect(button).toBeTruthy();
+      expect(button.props.accessibilityState?.disabled).toBe(true);
+      expect(button.props.accessibilityState?.busy).toBe(true);
     });
 
     it('renders nothing when there is no active quote', () => {

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeMarketView/BridgeMarketViewFooter.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeMarketView/BridgeMarketViewFooter.tsx
@@ -56,16 +56,12 @@ export const BridgeMarketViewFooter = ({
   const isValidSourceAmount =
     sourceAmount !== undefined && sourceAmount !== '.' && sourceToken?.decimals;
 
-  if (isLoading && !activeQuote && !needsNewQuote) {
-    return null;
-  }
-
   const footerContainerStyle = [
     styles.buttonContainer,
     { paddingBottom: bottomInset },
   ];
 
-  if (needsNewQuote) {
+  if (needsNewQuote || (isLoading && !activeQuote)) {
     return (
       <Box style={footerContainerStyle}>
         <SwapsMarketOrderConfirmButton

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeMarketView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeMarketView/index.tsx
@@ -321,10 +321,7 @@ const BridgeMarketViewContent = ({
   );
 
   const isFooterVisible = useMemo(() => {
-    if (isLoading && !activeQuote && !needsNewQuote) {
-      return false;
-    }
-    if (needsNewQuote) {
+    if (needsNewQuote || (isLoading && !activeQuote)) {
       return true;
     }
     if (!activeQuote) {

--- a/app/components/UI/Bridge/components/SwapsMarketOrderConfirmButton/SwapsMarketOrderConfirmButton.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsMarketOrderConfirmButton/SwapsMarketOrderConfirmButton.test.tsx
@@ -953,6 +953,13 @@ describe('SwapsMarketOrderConfirmButton', () => {
     });
 
     it('enables confirmation after the custom-slippage quote settles', () => {
+      const initialSlippageQuote = {
+        ...mockActiveQuote,
+        quote: {
+          ...mockActiveQuote.quote,
+          slippage: 2,
+        },
+      };
       const customSlippageQuote = {
         ...mockActiveQuote,
         quote: {
@@ -962,7 +969,7 @@ describe('SwapsMarketOrderConfirmButton', () => {
       };
       let quoteData = {
         ...mockUseBridgeQuoteData,
-        activeQuote: mockActiveQuote,
+        activeQuote: initialSlippageQuote,
         isLoading: false,
       };
       jest
@@ -972,17 +979,20 @@ describe('SwapsMarketOrderConfirmButton', () => {
         ...mockState,
         bridge: {
           ...mockState.bridge,
-          slippage: '3.5',
+          slippage: '2',
           isSlippageUserOverride: true,
         },
       };
-      const { getByTestId, rerender } = renderWithProvider(
+      const { getByTestId, rerender, store } = renderWithProvider(
         <SwapsMarketOrderConfirmButton
           latestSourceBalance={mockLatestSourceBalance}
           location={MetaMetricsSwapsEventSource.MainView}
         />,
         { state },
       );
+      act(() => {
+        store.dispatch(setSlippageUserOverride('3.5'));
+      });
       quoteData = {
         ...quoteData,
         isLoading: true,

--- a/app/components/UI/Bridge/components/SwapsMarketOrderConfirmButton/index.tsx
+++ b/app/components/UI/Bridge/components/SwapsMarketOrderConfirmButton/index.tsx
@@ -172,9 +172,12 @@ export const SwapsMarketOrderConfirmButton = ({
   // True when the sourceAmount changed from what the current quote was
   // fetched for (stale quote during debounce window).
   const isPendingQuoteRefresh = isSourceAmountChanged && hasNonZeroSourceAmount;
+  // The ref covers the gap while a refresh has cleared the active quote; once
+  // a quote is present, its slippage is the source of truth.
   const isPendingSlippageRefresh =
     Boolean(isSlippageUserOverride) &&
-    (slippage !== settledSlippageRef.current || isActiveQuoteSlippageMismatch);
+    (isActiveQuoteSlippageMismatch ||
+      (!activeQuote && slippage !== settledSlippageRef.current));
 
   const isSubmitDisabled =
     !hasNonZeroSourceAmount ||

--- a/tests/helpers/analytics/expectations/swap-action.analytics.ts
+++ b/tests/helpers/analytics/expectations/swap-action.analytics.ts
@@ -130,8 +130,9 @@ export const swapActionExpectations: AnalyticsExpectations = {
   validate: async ({ events }) => {
     const inputChanged = filterEvents(events, INPUT_CHANGED);
 
-    // 9 with Auto/unset slippage (no client default InputChanged); was 11/12 before.
-    await Assertions.checkIfArrayHasLength(inputChanged, 9);
+    // 10 with custom slippage (no client default InputChanged); was 9 while
+    // the custom slippage smoke path was disabled.
+    await Assertions.checkIfArrayHasLength(inputChanged, 10);
 
     for (const event of inputChanged) {
       await Assertions.checkIfValueIsDefined(event.properties.input);
@@ -150,11 +151,10 @@ export const swapActionExpectations: AnalyticsExpectations = {
         `Expected input=token_destination in Input Changed events. Found: ${inputs.join(', ')}`,
       );
     }
-    // Re-enable when swap-action smoke sets custom slippage again (bug #29615).
-    // if (!inputs.includes('slippage')) {
-    //   throw new Error(
-    //     `Expected input=slippage in Input Changed events. Found: ${inputs.join(', ')}`,
-    //   );
-    // }
+    if (!inputs.includes('slippage')) {
+      throw new Error(
+        `Expected input=slippage in Input Changed events. Found: ${inputs.join(', ')}`,
+      );
+    }
   },
 };

--- a/tests/helpers/swap/swap-unified-ui.ts
+++ b/tests/helpers/swap/swap-unified-ui.ts
@@ -67,6 +67,7 @@ export async function submitSwapUnifiedUI(
   // Set custom slippage if provided
   if (options?.slippage) {
     await SlippageModal.setCustomSlippage(options.slippage);
+    await QuoteView.waitForQuoteReady({ timeout: 60000 });
     // Verify the slippage has been updated in the quote view
     await QuoteView.verifySlippageDisplayed(options.slippage);
   } else {

--- a/tests/smoke-appium/swap/swap-action-smoke.spec.ts
+++ b/tests/smoke-appium/swap/swap-action-smoke.spec.ts
@@ -61,8 +61,7 @@ appiumTest.describe(SmokeSwap('Swap from Actions'), () => {
 
           // Submit first swap: ETH->ERC20 (USDC) with custom slippage
           await submitSwapUnifiedUI('1', 'ETH', 'USDC', '0x1', {
-            // slippage: '3.5',
-            // comment out until bug #29615 is fixed
+            slippage: '3.5',
           });
           await checkSwapActivity('ETH', 'USDC');
 


### PR DESCRIPTION
## **Description**

Fixes issue #29615. When a user changes custom slippage, the BridgeController clears `activeQuote` while fetching the replacement quote. Because this is a normal refresh rather than an expired quote, `needsNewQuote` remains false; the swap footer previously returned `null`, hiding the confirmation action.

The footer now remains mounted during this transient loading state and shows the existing confirm button as busy and disabled. `needsNewQuote` remains reserved for expired-quote retries, so a normal refresh does not incorrectly show an enabled “Get new quote” action.

CI then exposed a second edge case: after the matching 3.5% quote arrived, `settledSlippageRef` could still contain the previous value because updating a ref in `useEffect` does not rerender the button. The button now uses the active quote’s slippage as the source of truth once a quote exists, while retaining the ref check only during the no-quote gap.

The original proposal to include every `isLoading && !activeQuote` state in `needsNewQuote` is intentionally not used because it changes the CTA semantics and triggers an unnecessary reset/refetch. The custom-slippage swap smoke path and analytics assertion have been restored.

## **Changelog**

CHANGELOG entry: Fixed a bug that could hide the swap confirmation button during quote refresh

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/29615

## **Manual testing steps**

```gherkin
Feature: Swap quote refresh

  Background:
    Given I am logged into MetaMask Mobile
    And I am on the Wallet screen with enough ETH to swap

  Scenario: custom slippage refresh keeps the confirm action available
    Given I start a swap from ETH to USDC on Ethereum
    And a swap quote has loaded
    When I set custom slippage to "3.5"
    Then the quote area shows a loading skeleton while the refreshed quote is unavailable
    And the confirm action remains visible, busy, and disabled
    When the refreshed quote arrives
    Then the 3.5% slippage value is visible
    And the confirm action is enabled
```

Automated verification:
- Focused BridgeView, footer, and confirm-button Jest suites reported `PASS`.
- Prettier and ESLint passed; the commit hook also completed full ESLint successfully.
- Android Appium smoke tests passed in [CI run 33631666409](https://github.com/MetaMask/metamask-mobile/actions/runs/33631666409), including the restored custom-slippage swap path.
- Local Appium execution was not run because the required `build/ci-main-e2e/MetaMask.app` artifact was unavailable.

## **Screenshots/Recordings**

### **Before**

N/A — no local main-e2e app artifact was available for a device recording.

### **After**

N/A — behavior is covered by the focused regression test and the passing Android smoke path.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Verified by the passing Android Appium smoke job in CI run 33631666409.
- [x] I've tested with a power user scenario
  - N/A for this focused rendering and quote-settlement fix.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A; this change does not add a new performance-sensitive operation.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Bridge swap UI visibility and confirm-button disabled/loading logic; no auth, payments, or data-layer changes. Regression coverage added via unit and smoke tests.
> 
> **Overview**
> Fixes **#29615**: when a quote refresh clears `activeQuote` (e.g. after changing custom slippage), the swap footer no longer disappears while the quote skeleton is shown.
> 
> **Bridge market view** keeps `SwapsMarketOrderConfirmButton` mounted during `isLoading && !activeQuote`; `needsNewQuote` remains expiry-only.
> 
> **Confirm button** uses the active quote’s slippage as authoritative after refresh, avoiding a stale `settledSlippageRef` from keeping the CTA stuck loading.
> 
> **Tests & E2E**: footer/confirm Jest expectations updated; swap smoke re-enables 3.5% custom slippage, waits for quote readiness, restores analytics checks, and passes in Android CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b5d11718411f218f79ea0c43f91ad05c415f033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->