### PR TITLE
fix: charge displayed total for fiat checkout control

### DIFF
--- a/app/components/UI/Ramp/hooks/useContinueWithQuote.test.ts
+++ b/app/components/UI/Ramp/hooks/useContinueWithQuote.test.ts
@@ -120,6 +120,7 @@ const mockReportRampsError = jest.requireMock('../utils/reportRampsError')
 
 const mockNavigate = jest.fn();
 const mockNavigationReset = jest.fn();
+const mockGetQuotes = jest.fn();
 const mockGetBuyWidgetData = jest.fn();
 const mockAddPrecreatedOrder = jest.fn();
 const mockCheckExistingToken = jest.fn();
@@ -160,6 +161,8 @@ const WIDGET_PROVIDER_QUOTE = {
   outputAmount: '0.05',
   outputCurrency: { symbol: 'ETH', assetId: 'eip155:1/slip44:60' },
   quote: {
+    amountIn: 100,
+    paymentMethod: SELECTED_PAYMENT_METHOD.id,
     buyWidget: { browser: 'IN_APP_OS_BROWSER' as const },
     buyURL: 'https://widget.example.com/checkout',
   },
@@ -173,6 +176,8 @@ const IN_APP_CHECKOUT_QUOTE = {
   outputAmount: '0.05',
   outputCurrency: { symbol: 'ETH', assetId: 'eip155:1/slip44:60' },
   quote: {
+    amountIn: 100,
+    paymentMethod: SELECTED_PAYMENT_METHOD.id,
     buyURL: 'https://widget.example.com/checkout',
   },
 } as const;
@@ -209,6 +214,7 @@ const buildController = (overrides: ControllerOverrides = {}) => ({
   selectedProvider: WIDGET_PROVIDER,
   selectedToken: SELECTED_TOKEN,
   selectedPaymentMethod: SELECTED_PAYMENT_METHOD,
+  getQuotes: mockGetQuotes,
   getBuyWidgetData: mockGetBuyWidgetData,
   addPrecreatedOrder: mockAddPrecreatedOrder,
   ...overrides,
@@ -462,11 +468,120 @@ describe('useContinueWithQuote', () => {
       const caught = await invoke(result, IN_APP_CHECKOUT_QUOTE);
 
       expect(caught).toBeUndefined();
+      expect(mockGetQuotes).not.toHaveBeenCalled();
       expect(mockGetBuyWidgetData).toHaveBeenCalled();
       expect(mockNavigate).toHaveBeenCalled();
       const navigateArgs = JSON.stringify(mockNavigate.mock.calls);
       expect(navigateArgs).toContain('https://checkout.example.com/embed');
       expect(navigateArgs).toContain('MoonPay');
+    });
+
+    it('refreshes a mismatched quote before fetching the widget URL', async () => {
+      const initialQuote = {
+        ...IN_APP_CHECKOUT_QUOTE,
+        inputAmount: 15,
+        quote: {
+          ...IN_APP_CHECKOUT_QUOTE.quote,
+          amountIn: 15,
+          paymentMethod: SELECTED_PAYMENT_METHOD.id,
+        },
+      };
+      const refreshedQuote = {
+        ...initialQuote,
+        inputAmount: 15.55,
+        quote: {
+          ...initialQuote.quote,
+          amountIn: 15.55,
+          buyURL: 'https://widget.example.com/refreshed-checkout',
+        },
+      };
+      mockGetQuotes.mockResolvedValue({ success: [refreshedQuote] });
+      mockGetBuyWidgetData.mockResolvedValue({
+        url: 'https://checkout.example.com/embed',
+      });
+
+      const { result } = renderHook(() => useContinueWithQuote());
+
+      const caught = await invoke(result, initialQuote, {
+        amount: 15.55,
+        assetId: CTX.assetId,
+      });
+
+      expect(caught).toBeUndefined();
+      expect(mockGetQuotes).toHaveBeenCalledWith({
+        assetId: CTX.assetId,
+        amount: 15.55,
+        walletAddress: '0x1234567890123456789012345678901234567890',
+        paymentMethods: [SELECTED_PAYMENT_METHOD.id],
+        providers: ['moonpay'],
+        fiat: 'USD',
+        redirectUrl: expect.any(String),
+        forceRefresh: true,
+      });
+      expect(mockGetBuyWidgetData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          quote: expect.objectContaining({
+            amountIn: 15.55,
+            buyURL: expect.stringContaining('refreshed-checkout'),
+          }),
+        }),
+      );
+    });
+
+    it('throws when refreshing a mismatched quote returns no quote', async () => {
+      const initialQuote = {
+        ...WIDGET_PROVIDER_QUOTE,
+        quote: {
+          ...WIDGET_PROVIDER_QUOTE.quote,
+          amountIn: 15,
+          paymentMethod: SELECTED_PAYMENT_METHOD.id,
+        },
+      };
+      mockGetQuotes.mockResolvedValue({ success: [] });
+
+      const { result } = renderHook(() => useContinueWithQuote());
+
+      const caught = await invoke(result, initialQuote, {
+        amount: 15.55,
+        assetId: CTX.assetId,
+      });
+
+      expect(caught).toBeInstanceOf(Error);
+      expect(mockGetBuyWidgetData).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('throws when the refreshed quote has no widget URL', async () => {
+      const initialQuote = {
+        ...WIDGET_PROVIDER_QUOTE,
+        quote: {
+          ...WIDGET_PROVIDER_QUOTE.quote,
+          amountIn: 15,
+          paymentMethod: SELECTED_PAYMENT_METHOD.id,
+        },
+      };
+      mockGetQuotes.mockResolvedValue({
+        success: [
+          {
+            ...initialQuote,
+            quote: {
+              amountIn: 15.55,
+              paymentMethod: SELECTED_PAYMENT_METHOD.id,
+            },
+          },
+        ],
+      });
+
+      const { result } = renderHook(() => useContinueWithQuote());
+
+      const caught = await invoke(result, initialQuote, {
+        amount: 15.55,
+        assetId: CTX.assetId,
+      });
+
+      expect(caught).toBeInstanceOf(Error);
+      expect(mockGetBuyWidgetData).toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
 
     it('throws when getBuyWidgetData returns no URL', async () => {
@@ -710,6 +825,19 @@ describe('useContinueWithQuote', () => {
       mockGetBuyWidgetData.mockResolvedValue({
         url: 'https://checkout.example.com/headless',
         orderId: 'ord-headless-1',
+      });
+      mockGetQuotes.mockResolvedValue({
+        success: [
+          {
+            ...IN_APP_CHECKOUT_QUOTE,
+            inputAmount: HEADLESS_CTX.amount,
+            quote: {
+              ...IN_APP_CHECKOUT_QUOTE.quote,
+              amountIn: HEADLESS_CTX.amount,
+              paymentMethod: HEADLESS_CTX.paymentMethodId,
+            },
+          },
+        ],
       });
 
       const { result } = renderHook(() => useContinueWithQuote());

--- a/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
+++ b/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
@@ -123,6 +123,7 @@ export function useContinueWithQuote(
     selectedProvider,
     selectedPaymentMethod,
     userRegion,
+    getQuotes,
     getBuyWidgetData,
     addPrecreatedOrder,
   } = useRampsController();
@@ -307,7 +308,34 @@ export function useContinueWithQuote(
         );
         useExternalBrowser = redirectConfig.useExternalBrowser;
         redirectUrl = redirectConfig.redirectUrl;
-        const quoteForWidget = buildQuoteWithRedirectUrl(quote, redirectUrl);
+        let checkoutQuote = quote;
+        const quotedAmount = Number(quote.quote.amountIn);
+
+        if (quotedAmount !== ctx.amount) {
+          const refreshedQuotes = await getQuotes({
+            assetId: ctx.assetId,
+            amount: ctx.amount,
+            walletAddress: effectiveWalletAddress ?? '',
+            paymentMethods: [ctx.paymentMethodId ?? quote.quote.paymentMethod],
+            providers: [quote.provider],
+            fiat: effectiveCurrency,
+            redirectUrl,
+            forceRefresh: true,
+          });
+          const refreshedQuote = refreshedQuotes.success?.find(
+            (candidate) => candidate.provider === quote.provider,
+          );
+
+          if (!refreshedQuote) {
+            throw new Error('No refreshed widget quote available');
+          }
+          checkoutQuote = refreshedQuote;
+        }
+
+        const quoteForWidget = buildQuoteWithRedirectUrl(
+          checkoutQuote,
+          redirectUrl,
+        );
         buyWidget = await getBuyWidgetData(quoteForWidget);
       } catch (error) {
         endCheckoutCuf(false, RAMPS_BUY_CUF_END_REASON.ERROR);
@@ -427,6 +455,7 @@ export function useContinueWithQuote(
       walletAddress,
       currency,
       navigation,
+      getQuotes,
       getBuyWidgetData,
       addPrecreatedOrder,
       navigateAfterExternalBrowser,

--- a/app/components/Views/confirmations/hooks/pay/useFiatConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useFiatConfirm.test.ts
@@ -166,7 +166,7 @@ describe('useFiatConfirm', () => {
         {
           quote: mockQuote,
           assetId: 'eip155:1/erc20:0xabc',
-          amount: 52,
+          amount: 55,
           paymentMethodId: 'pm-123',
           currency: 'USD',
           walletAddress: undefined,
@@ -402,7 +402,7 @@ describe('useFiatConfirm', () => {
       );
     });
 
-    it('subtracts providerFiat fee from total for buy amount', () => {
+    it('requests the full total as the buy amount', () => {
       jest.mocked(useTransactionPayTotals).mockReturnValue({
         total: { fiat: '100.00', usd: '100.00' },
         fees: {
@@ -431,7 +431,7 @@ describe('useFiatConfirm', () => {
       });
 
       expect(startHeadlessBuyMock).toHaveBeenCalledWith(
-        expect.objectContaining({ amount: 85 }),
+        expect.objectContaining({ amount: 100 }),
         expect.any(Object),
       );
     });

--- a/app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts
+++ b/app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts
@@ -87,12 +87,9 @@ export function useFiatConfirm() {
 
     setIsHeadlessBuyInProgress(true);
 
-    // Subtract the on-ramp provider fee from the total so the Ramps order
-    // amount covers exactly the Relay leg of the intent (fees + deposit).
-    // The on-ramp provider adds its own fee on top of what we request.
-    const totalAmountToBuy = new BigNumber(totals?.total?.usd ?? 0)
-      .minus(new BigNumber(totals?.fees.providerFiat?.usd ?? 0))
-      .toNumber();
+    // The on-ramp treats this amount as the total charge and takes its fee
+    // from it, so request the full total shown to the user.
+    const totalAmountToBuy = new BigNumber(totals?.total?.usd ?? 0).toNumber();
 
     // `rampSurface` is analytics-only; it does not filter the quote.
     const rampSurface = transactionMetadata?.type


### PR DESCRIPTION
## **Description**

This A/B control change reproduces commit `86c58df14692347d17191f66707a3ea9d707d562` on current `main`. Fiat confirmation sends the full displayed USD total to every on-ramp provider, including native Transak, and aggregator widgets refresh a stale quote before checkout when its amount differs from the displayed total.

It intentionally excludes the later native-specific typed-amount and `isFeeExcludedFromFiat` changes. For the row-4 Transak case, a displayed $15.55 total is sent with fee exclusion omitted/default false, Transak charges $15.55, takes about $0.57 in fees, and spends about $14.98 on crypto.

## **Changelog**

CHANGELOG entry: Fixed fiat checkout to charge the full amount displayed to users

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/pull/35527

## **Manual testing steps**

```gherkin
Feature: Fiat checkout control amount

  Scenario: Native Transak charges the displayed full total
    Given fiat confirmation displays a total of $15.55
    And native Transak is the selected provider
    When the user confirms the fiat payment
    Then the checkout request amount is $15.55
    And fee exclusion is omitted or false
    And Transak charges $15.55 with about $0.57 in fees and about $14.98 spent on crypto

  Scenario: Aggregator checkout refreshes a stale quote
    Given fiat confirmation displays a total that differs from the selected aggregator quote
    When the user confirms the fiat payment
    Then the app refreshes the quote for the displayed total
    And the refreshed quote is used to fetch the widget URL
```

## **Screenshots/Recordings**

### **Before**

N/A - this change restores previously built control behavior and has no new visual UI.

### **After**

Existing control RC evidence: https://github.com/MetaMask/metamask-mobile/actions/runs/33506230114 (TestFlight 8.11.0 build 6722, rc production).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)