### PR TITLE
perf(predict): throttle live prediction chart renders

### DIFF
--- a/app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts
+++ b/app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts
@@ -1418,6 +1418,50 @@ describe('useCryptoUpDownChartData', () => {
       expect(result.current.data).toEqual([{ time: 100, value: 50000 }]);
     });
 
+    it('commits a pending update when the chart freezes before its timer runs', () => {
+      const { Wrapper } = createWrapper();
+      const market = createMarket({
+        endDate: '2026-01-01T00:00:00.100Z',
+      });
+      historicalData = [];
+      const { result, rerender } = renderHook(
+        ({ activeMarket }: { activeMarket: TestMarket }) =>
+          useCryptoUpDownChartData(activeMarket),
+        {
+          initialProps: { activeMarket: market },
+          wrapper: Wrapper,
+        },
+      );
+
+      act(() => {
+        liveUpdateHandler?.({
+          symbol: 'btc/usd',
+          price: 50000,
+          timestamp: 100,
+        });
+        liveUpdateHandler?.({
+          symbol: 'btc/usd',
+          price: 51000,
+          timestamp: 101,
+        });
+      });
+      act(() => {
+        jest.setSystemTime(new Date('2026-01-01T00:00:00.101Z'));
+        rerender({ activeMarket: market });
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+
+      expect(result.current.data).toEqual([
+        { time: 100, value: 50000 },
+        { time: 101, value: 51000 },
+      ]);
+      expect(result.current.value).toBe(51000);
+      expect(result.current.isLive).toBe(false);
+    });
+
     it('accepts live updates after switching from an expired market', () => {
       const { Wrapper } = createWrapper();
       const expiredMarket = createMarket({

--- a/app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts
+++ b/app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts
@@ -353,6 +353,7 @@ describe('useCryptoUpDownChartData', () => {
           price: 51500,
           timestamp: 110,
         });
+        jest.advanceTimersByTime(200);
       });
 
       expect(result.current.data).toEqual([
@@ -367,10 +368,9 @@ describe('useCryptoUpDownChartData', () => {
       const { Wrapper } = createWrapper();
       const market = createMarket();
       historicalData = [];
-      const { result } = renderHook(
-        () => useCryptoUpDownChartData(market),
-        { wrapper: Wrapper },
-      );
+      const { result } = renderHook(() => useCryptoUpDownChartData(market), {
+        wrapper: Wrapper,
+      });
 
       act(() => {
         for (let index = 0; index < 20; index += 1) {
@@ -421,6 +421,7 @@ describe('useCryptoUpDownChartData', () => {
           price: 51500,
           timestamp: 110,
         });
+        jest.advanceTimersByTime(200);
       });
 
       expect(result.current.data).toEqual([
@@ -455,6 +456,7 @@ describe('useCryptoUpDownChartData', () => {
           price: 52000,
           timestamp: 1040,
         });
+        jest.advanceTimersByTime(200);
       });
 
       expect(result.current.data).toEqual([
@@ -470,6 +472,7 @@ describe('useCryptoUpDownChartData', () => {
           price: 52500,
           timestamp: 1055,
         });
+        jest.advanceTimersByTime(200);
       });
 
       expect(result.current.loading).toBe(false);
@@ -615,11 +618,13 @@ describe('useCryptoUpDownChartData', () => {
           price: 51000,
           timestamp: 100,
         });
+        jest.advanceTimersByTime(200);
         liveUpdateHandler?.({
           symbol: 'btcusdt',
           price: 51500,
           timestamp: 130,
         });
+        jest.advanceTimersByTime(200);
         liveUpdateHandler?.({
           symbol: 'btcusdt',
           price: 52000,
@@ -1262,6 +1267,7 @@ describe('useCryptoUpDownChartData', () => {
           price: 51600,
           timestamp: 270,
         });
+        jest.advanceTimersByTime(200);
       });
 
       expect(result.current.data).toEqual([
@@ -1314,6 +1320,7 @@ describe('useCryptoUpDownChartData', () => {
           price: 51500,
           timestamp: 110,
         });
+        jest.advanceTimersByTime(200);
       });
 
       rerender({ targetPrice: undefined });
@@ -1863,6 +1870,7 @@ describe('useCryptoUpDownChartData', () => {
           price: 51500,
           timestamp: 110,
         });
+        jest.advanceTimersByTime(200);
       });
 
       expect(result.current.loading).toBe(false);
@@ -2080,6 +2088,7 @@ describe('useCryptoUpDownChartData', () => {
           price: 51500,
           timestamp: 110,
         });
+        jest.advanceTimersByTime(200);
       });
 
       expect(result.current.connectionError).toBe(false);

--- a/app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts
+++ b/app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts
@@ -363,6 +363,37 @@ describe('useCryptoUpDownChartData', () => {
       expect(result.current.loading).toBe(false);
     });
 
+    it('coalesces rapid live ticks to five React updates per second', () => {
+      const { Wrapper } = createWrapper();
+      const market = createMarket();
+      historicalData = [];
+      const { result } = renderHook(
+        () => useCryptoUpDownChartData(market),
+        { wrapper: Wrapper },
+      );
+
+      act(() => {
+        for (let index = 0; index < 20; index += 1) {
+          liveUpdateHandler?.({
+            symbol: 'btc/usd',
+            price: 51000 + index,
+            timestamp: 100 + index,
+          });
+          jest.advanceTimersByTime(50);
+        }
+      });
+
+      expect(result.current.data).toEqual([
+        { time: 100, value: 51000 },
+        { time: 103, value: 51003 },
+        { time: 107, value: 51007 },
+        { time: 111, value: 51011 },
+        { time: 115, value: 51015 },
+        { time: 119, value: 51019 },
+      ]);
+      expect(result.current.value).toBe(51019);
+    });
+
     it('keeps loading true until the live chart has enough points to render', () => {
       const { Wrapper } = createWrapper();
       const market = createMarket();

--- a/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
+++ b/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
@@ -18,6 +18,7 @@ const LIVE_CHART_RETENTION_SECS = LIVE_CHART_WINDOW_SECS * 2;
 const LIVE_CHART_MAX_POINTS_PER_SEC = 60;
 const CURRENT_TIMESTAMP_TOLERANCE_SECS = 5;
 const MIN_LIVE_POINT_DELTA_SECS = 0.001;
+const LIVE_RENDER_INTERVAL_MS = 200;
 const LIVE_STREAM_STALE_TIMEOUT_MS = LIVE_CHART_WINDOW_SECS * 1000;
 const TWAP_STREAM_STALE_TIMEOUT_MS = 120000;
 const CONNECTION_ERROR_TIMEOUT_MS = 12000;
@@ -183,6 +184,9 @@ export const useCryptoUpDownChartData = (
   >(undefined);
   const [liveValue, setLiveValue] = useState(0);
   const [livePoints, setLivePoints] = useState<LivelinePoint[]>(EMPTY_DATA);
+  const pendingLiveUpdateRef = useRef<CryptoPriceUpdate>();
+  const liveRenderTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const lastLiveRenderAtRef = useRef<number>();
   const stableHistoricalDataRef = useRef<LivelinePoint[]>(EMPTY_DATA);
   const fallbackStartPointRef = useRef<LivelinePoint[]>(EMPTY_DATA);
   const frozenRef = useRef(false);
@@ -276,6 +280,89 @@ export const useCryptoUpDownChartData = (
     );
   }, [twapWindowSeconds]);
 
+  const commitLiveUpdate = useCallback(
+    (update: CryptoPriceUpdate, shouldFreezeAfterUpdate: boolean) => {
+      lastLiveRenderAtRef.current = Date.now();
+      setLiveValue(update.price);
+      setLivePoints((points) => {
+        const lastPoint = points.at(-1);
+        const timeSecs = getLivePointTime(update.timestamp, lastPoint?.time);
+        const point: LivelinePoint = {
+          time: timeSecs,
+          value: update.price,
+        };
+        // Fast path: live ticks almost always arrive in order, so append
+        // instead of re-building (Map + sort) the whole array on every update.
+        const nextPoints =
+          !lastPoint || timeSecs > lastPoint.time
+            ? [...points, point]
+            : mergeLivelinePoints(points, [point]);
+        return trimLivePoints(nextPoints, timeSecs);
+      });
+      if (liveLoadingRef.current) {
+        liveLoadingRef.current = false;
+        setLiveLoading(false);
+      }
+      if (shouldFreezeAfterUpdate) {
+        const currentMarketId = marketIdRef.current;
+        frozenRef.current = true;
+        frozenMarketIdRef.current = currentMarketId;
+        setFrozenMarketId(currentMarketId);
+      }
+    },
+    [],
+  );
+
+  const scheduleLiveUpdate = useCallback(
+    (update: CryptoPriceUpdate, shouldFreezeAfterUpdate: boolean) => {
+      pendingLiveUpdateRef.current = update;
+      const elapsedSinceRender =
+        typeof lastLiveRenderAtRef.current === 'number'
+          ? Date.now() - lastLiveRenderAtRef.current
+          : LIVE_RENDER_INTERVAL_MS;
+
+      if (
+        elapsedSinceRender >= LIVE_RENDER_INTERVAL_MS ||
+        shouldFreezeAfterUpdate
+      ) {
+        if (liveRenderTimerRef.current) {
+          clearTimeout(liveRenderTimerRef.current);
+          liveRenderTimerRef.current = undefined;
+        }
+        pendingLiveUpdateRef.current = undefined;
+        commitLiveUpdate(update, shouldFreezeAfterUpdate);
+        return;
+      }
+
+      if (liveRenderTimerRef.current) {
+        return;
+      }
+
+      liveRenderTimerRef.current = setTimeout(() => {
+        liveRenderTimerRef.current = undefined;
+        const pendingUpdate = pendingLiveUpdateRef.current;
+        pendingLiveUpdateRef.current = undefined;
+        const { id: liveMarketId, liveEndDateMs: currentLiveEndDateMs } =
+          liveMarketRef.current;
+
+        if (
+          !pendingUpdate ||
+          liveMarketId !== marketIdRef.current ||
+          (frozenRef.current &&
+            frozenMarketIdRef.current === marketIdRef.current)
+        ) {
+          return;
+        }
+
+        const shouldFreezePendingUpdate =
+          typeof currentLiveEndDateMs === 'number' &&
+          Date.now() >= currentLiveEndDateMs;
+        commitLiveUpdate(pendingUpdate, shouldFreezePendingUpdate);
+      }, LIVE_RENDER_INTERVAL_MS - elapsedSinceRender);
+    },
+    [commitLiveUpdate],
+  );
+
   const handleLiveUpdate = useCallback(
     (update: CryptoPriceUpdate) => {
       if (!enabledRef.current) return;
@@ -317,33 +404,9 @@ export const useCryptoUpDownChartData = (
       }
 
       markLiveStreamFresh();
-      setLiveValue(update.price);
-      setLivePoints((points) => {
-        const lastPoint = points.at(-1);
-        const timeSecs = getLivePointTime(update.timestamp, lastPoint?.time);
-        const point: LivelinePoint = {
-          time: timeSecs,
-          value: update.price,
-        };
-        // Fast path: live ticks almost always arrive in order, so append
-        // instead of re-building (Map + sort) the whole array on every tick.
-        const nextPoints =
-          !lastPoint || timeSecs > lastPoint.time
-            ? [...points, point]
-            : mergeLivelinePoints(points, [point]);
-        return trimLivePoints(nextPoints, timeSecs);
-      });
-      if (liveLoadingRef.current) {
-        liveLoadingRef.current = false;
-        setLiveLoading(false);
-      }
-      if (shouldFreezeAfterUpdate) {
-        frozenRef.current = true;
-        frozenMarketIdRef.current = currentMarketId;
-        setFrozenMarketId(currentMarketId);
-      }
+      scheduleLiveUpdate(update, shouldFreezeAfterUpdate);
     },
-    [markLiveStreamFresh, twapWindowSeconds],
+    [markLiveStreamFresh, scheduleLiveUpdate, twapWindowSeconds],
   );
 
   useEffect(
@@ -351,9 +414,21 @@ export const useCryptoUpDownChartData = (
       if (staleTimerRef.current) {
         clearTimeout(staleTimerRef.current);
       }
+      if (liveRenderTimerRef.current) {
+        clearTimeout(liveRenderTimerRef.current);
+      }
     },
     [],
   );
+
+  useEffect(() => {
+    if (liveRenderTimerRef.current) {
+      clearTimeout(liveRenderTimerRef.current);
+      liveRenderTimerRef.current = undefined;
+    }
+    pendingLiveUpdateRef.current = undefined;
+    lastLiveRenderAtRef.current = undefined;
+  }, [market.id, twapWindowSeconds]);
 
   const isLive = isLiveByEndDate && !hasFrozenLiveData;
   const shouldStreamLive = isLive && liveUpdatesEnabled;

--- a/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
+++ b/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
@@ -184,9 +184,11 @@ export const useCryptoUpDownChartData = (
   >(undefined);
   const [liveValue, setLiveValue] = useState(0);
   const [livePoints, setLivePoints] = useState<LivelinePoint[]>(EMPTY_DATA);
-  const pendingLiveUpdateRef = useRef<CryptoPriceUpdate>();
-  const liveRenderTimerRef = useRef<ReturnType<typeof setTimeout>>();
-  const lastLiveRenderAtRef = useRef<number>();
+  const pendingLiveUpdateRef = useRef<CryptoPriceUpdate | undefined>(undefined);
+  const liveRenderTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const lastLiveRenderAtRef = useRef<number | undefined>(undefined);
   const stableHistoricalDataRef = useRef<LivelinePoint[]>(EMPTY_DATA);
   const fallbackStartPointRef = useRef<LivelinePoint[]>(EMPTY_DATA);
   const frozenRef = useRef(false);

--- a/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
+++ b/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
@@ -347,12 +347,7 @@ export const useCryptoUpDownChartData = (
         const { id: liveMarketId, liveEndDateMs: currentLiveEndDateMs } =
           liveMarketRef.current;
 
-        if (
-          !pendingUpdate ||
-          liveMarketId !== marketIdRef.current ||
-          (frozenRef.current &&
-            frozenMarketIdRef.current === marketIdRef.current)
-        ) {
+        if (!pendingUpdate || liveMarketId !== marketIdRef.current) {
           return;
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

The live crypto prediction chart committed React state for every WebSocket tick. The supplied React profile showed roughly 20 commit attempts per second, with `setLiveValue` and `setLivePoints` on the hot path.

This change keeps processing every tick for stream freshness and validation, but coalesces visual state to the latest update in a 200 ms leading/trailing window. Market-ending updates still flush immediately. This caps steady-state chart-driven React updates at approximately 5 per second while preserving the latest displayed price.

The trailing flush also preserves an update accepted immediately before market expiry if another render freezes the chart before the timer runs.

## **Changelog**

CHANGELOG entry: Improved performance of live crypto prediction charts

## **Related issues**

Refs: Performance trace supplied with this task

## **Manual testing steps**

```gherkin
Feature: Live crypto prediction chart performance

  Scenario: receive a high-frequency crypto price stream
    Given a live crypto up/down prediction market is visible

    When the WebSocket delivers approximately 20 price ticks per second
    Then the displayed price remains current
    And the chart updates approximately five times per second
    And the final market-ending price is displayed immediately
```

Verified on an iOS Simulator Expo dev build at `7aaa37e` (Home → Predictions → live BTC Up or Down 5m): header price tracked the stream, the chart continued to draw, the market-end freeze kept the last tick, and the screen advanced to the next 5m market. Full write-up: https://github.com/MetaMask/metamask-mobile/pull/35607#issuecomment-5514033679

## **Screenshots/Recordings**

### **Before**

Supplied React performance profile recorded roughly 20 commit attempts per second in the live chart state update path.

### **After**

Live chart streaming on the PR build:

<img alt="live chart streaming" src="https://raw.githubusercontent.com/MetaMask/metamask-mobile/matallui/pr-35607-verification-evidence/01-pr-live-chart-streaming.png" />

Market-end freeze with the final price committed:

<img alt="frozen final price" src="https://raw.githubusercontent.com/MetaMask/metamask-mobile/matallui/pr-35607-verification-evidence/04-market-end-frozen-final-price.png" />

Video of stream → freeze → auto-advance: [pr35607-market-end-freeze.m4v](https://raw.githubusercontent.com/MetaMask/metamask-mobile/matallui/pr-35607-verification-evidence/pr35607-market-end-freeze.m4v)

## **Automated testing**

- `useCryptoUpDownChartData.test.ts`: 74/74 passing
- ESLint: no errors (three pre-existing duplicate-title warnings in the test file)
- Prettier: passing
- TypeScript: passing in CI
- Required GitHub Actions (`Check all jobs pass`) passed on `7aaa37e`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - Existing profiler evidence targets the per-tick React update path; no new flow-level instrumentation was added.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e241c5cd-313e-474e-99db-959a7378b17d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e241c5cd-313e-474e-99db-959a7378b17d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

