### PR TITLE
fix(send): match Tokens and NFTs section label spacing

### DIFF
--- a/app/components/Views/confirmations/components/send/asset/asset.tsx
+++ b/app/components/Views/confirmations/components/send/asset/asset.tsx
@@ -55,6 +55,8 @@ const AssetSendHeader = () => {
 };
 
 const SKELETON_ROW_COUNT = 4;
+/** Shared so Tokens and NFTs keep the same space below the section label. */
+const ASSET_SECTION_LABEL_TW = 'mx-4 mb-2';
 
 /**
  * Placeholder rows shown while a first-time asset load is in flight for a pay
@@ -304,7 +306,7 @@ export const Asset: React.FC<AssetProps> = (props = {}) => {
               (filteredTokens.length > 0 ||
                 filteredHighlightedItemsInAssetList.length > 0) && (
                 <Text
-                  twClassName="m-4 mt-2 mb-2"
+                  twClassName={`${ASSET_SECTION_LABEL_TW} mt-2`}
                   variant={TextVariant.BodyMd}
                   color={TextColor.TextAlternative}
                   fontWeight={FontWeight.Medium}
@@ -322,7 +324,7 @@ export const Asset: React.FC<AssetProps> = (props = {}) => {
               <>
                 {filteredNfts.length > 0 && (
                   <Text
-                    twClassName="m-4 mt-4 mb-4"
+                    twClassName={`${ASSET_SECTION_LABEL_TW} mt-4`}
                     variant={TextVariant.BodyMd}
                     color={TextColor.TextAlternative}
                     fontWeight={FontWeight.Medium}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

On the Send asset picker, the Tokens and NFTs section labels used different bottom margins (`mb-2` vs `mb-4`) plus a conflicting `m-4` shorthand, so the space below each heading did not match.

This gives both labels the same `mx-4 mb-2` spacing. NFTs still uses a larger top margin so it stays separated from the token list.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Send asset list so Tokens and NFTs labels use the same spacing

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
Refs: no GitHub issue — visual-only Send section label spacing

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Send asset section label spacing

  Background:
    Given I am logged into MetaMask Mobile
    And I have at least one token and one NFT on the same network

  Scenario: Tokens and NFTs labels share the same space below the heading
    Given I open Send
    And I am on the asset picker

    When I compare the Tokens heading to the first token row
    And I compare the NFTs heading to the first NFT row
    Then the space below each heading should match
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img src="https://github.com/user-attachments/assets/60b96f26-bc8b-40fe-b3ea-79ffd7f6da36" width="360" alt="Before: Tokens and NFTs section labels use different bottom spacing" />

### **After**

<!-- [screenshots/recordings] -->

<img src="https://github.com/user-attachments/assets/6973202e-9681-4fa9-8180-b36149984161" width="360" alt="After: Tokens and NFTs section labels use the same bottom spacing" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only Tailwind class changes on Send asset picker section labels with no logic or data impact.
> 
> **Overview**
> Aligns **Tokens** and **NFTs** section heading spacing on the Send asset picker by introducing a shared Tailwind class (`mx-4 mb-2`) and applying it to both labels instead of mixed `m-4` / `mb-2` vs `mb-4` values.
> 
> The NFTs label still uses a larger top margin (`mt-4` vs `mt-2`) so it stays visually separated from the token list; only the space **below** each heading is unified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93122896e4d9626a4f1937e28f69f221b9a307d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->