### PR TITLE
fix(confirmations): skip pay balance alert for non-MetaMask Pay token sends cp-8.10.0

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
@@ -123,9 +123,9 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
     useTransactionPayIsPostQuoteMock.mockReturnValue(false);
     useIsTransactionPayLoadingMock.mockReturnValue(false);
     useTransactionPayingAccountMock.mockReturnValue(PAYER_ADDRESS);
-    useTransactionMetadataRequestMock.mockReturnValue(
-      undefined as unknown as TransactionMeta,
-    );
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.perpsDeposit,
+    } as unknown as TransactionMeta);
     jest
       .mocked(useTransactionPaySelectedFiatPaymentMethod)
       .mockReturnValue(undefined);
@@ -581,7 +581,8 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
       // transactionMeta.chainId is the *source* chain (e.g. Polygon 0x89)
       useTransactionMetadataRequestMock.mockReturnValue({
         chainId: SOURCE_CHAIN_ID,
-      } as TransactionMeta);
+        type: TransactionType.perpsWithdraw,
+      } as unknown as TransactionMeta);
 
       // In withdrawal flows the spendable balance is the withdrawable balance,
       // resolved independently of payToken. Default it high enough that both the
@@ -718,7 +719,8 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
     it('skips source network fee check when source chain is Monad', () => {
       useTransactionMetadataRequestMock.mockReturnValue({
         chainId: CHAIN_IDS.MONAD as Hex,
-      } as TransactionMeta);
+        type: TransactionType.perpsWithdraw,
+      } as unknown as TransactionMeta);
 
       useTokenWithBalanceMock.mockReturnValue({
         ...NATIVE_TOKEN_MOCK,
@@ -788,7 +790,8 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
       useTransactionMetadataRequestMock.mockReturnValue({
         id: 'tx-post-quote-override',
         chainId: SOURCE_CHAIN_ID,
-      } as TransactionMeta);
+        type: TransactionType.perpsWithdraw,
+      } as unknown as TransactionMeta);
 
       useTokenWithBalanceMock.mockReturnValue({
         ...NATIVE_TOKEN_MOCK,
@@ -833,7 +836,8 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
     beforeEach(() => {
       useTransactionMetadataRequestMock.mockReturnValue({
         id: TRANSACTION_ID_MOCK,
-      } as TransactionMeta);
+        type: TransactionType.moneyAccountDeposit,
+      } as unknown as TransactionMeta);
     });
 
     it('uses money account balance instead of on-chain balance for input check', () => {
@@ -981,7 +985,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
     });
   });
 
-  describe('without a pay balance source', () => {
+  describe('non MetaMask Pay transaction', () => {
     beforeEach(() => {
       // A plain ERC-20 send: the pay controller still derives a required token
       // from the transfer calldata, but nothing is funded through MetaMask Pay.
@@ -990,6 +994,9 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
         setPayToken: jest.fn(),
       });
       useTransactionPayTotalsMock.mockReturnValue(undefined);
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        { ...REQUIRED_TOKEN_MOCK, amountUsd: '1.06' },
+      ]);
       useTransactionMetadataRequestMock.mockReturnValue({
         id: 'tx-transfer',
         chainId: '0x2105',
@@ -997,20 +1004,13 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
       } as unknown as TransactionMeta);
     });
 
-    it('returns no alert for a token transfer without a pay token', () => {
-      useTransactionPayRequiredTokensMock.mockReturnValue([
-        { ...REQUIRED_TOKEN_MOCK, amountUsd: '1.06' },
-      ]);
-
+    it('returns no alert for a token transfer', () => {
       const { result } = runHook();
 
       expect(result.current).toStrictEqual([]);
     });
 
-    it('returns no alert when native balance is below gas on a non-pay transfer', () => {
-      useTransactionPayRequiredTokensMock.mockReturnValue([
-        { ...REQUIRED_TOKEN_MOCK, amountUsd: '1.06' },
-      ]);
+    it('returns no alert when native balance is below gas', () => {
       useTokenWithBalanceMock.mockReturnValue({
         ...NATIVE_TOKEN_MOCK,
         balanceRaw: '0',
@@ -1021,28 +1021,25 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
       expect(result.current).toStrictEqual([]);
     });
 
-    it('returns the input alert once a pay token is selected', () => {
+    it('returns no alert for a token transfer even with a pay token selected', () => {
       useTransactionPayTokenMock.mockReturnValue({
         payToken: { ...PAY_TOKEN_MOCK, balanceUsd: '0.5' },
         setPayToken: jest.fn(),
       });
-      useTransactionPayRequiredTokensMock.mockReturnValue([
-        { ...REQUIRED_TOKEN_MOCK, amountUsd: '1.06' },
-      ]);
 
       const { result } = runHook();
 
-      expect(result.current).toStrictEqual([
-        {
-          key: AlertKeys.InsufficientPayTokenBalance,
-          field: RowAlertKey.Amount,
-          isBlocking: true,
-          message: strings(
-            'alert_system.insufficient_pay_token_balance.message',
-          ),
-          severity: Severity.Danger,
-        },
-      ]);
+      expect(result.current).toStrictEqual([]);
+    });
+
+    it('returns no alert when there is no transaction metadata', () => {
+      useTransactionMetadataRequestMock.mockReturnValue(
+        undefined as unknown as TransactionMeta,
+      );
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([]);
     });
   });
 

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
@@ -981,6 +981,71 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
     });
   });
 
+  describe('without a pay balance source', () => {
+    beforeEach(() => {
+      // A plain ERC-20 send: the pay controller still derives a required token
+      // from the transfer calldata, but nothing is funded through MetaMask Pay.
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: undefined,
+        setPayToken: jest.fn(),
+      });
+      useTransactionPayTotalsMock.mockReturnValue(undefined);
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: 'tx-transfer',
+        chainId: '0x2105',
+        type: TransactionType.tokenMethodTransfer,
+      } as unknown as TransactionMeta);
+    });
+
+    it('returns no alert for a token transfer without a pay token', () => {
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        { ...REQUIRED_TOKEN_MOCK, amountUsd: '1.06' },
+      ]);
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([]);
+    });
+
+    it('returns no alert when native balance is below gas on a non-pay transfer', () => {
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        { ...REQUIRED_TOKEN_MOCK, amountUsd: '1.06' },
+      ]);
+      useTokenWithBalanceMock.mockReturnValue({
+        ...NATIVE_TOKEN_MOCK,
+        balanceRaw: '0',
+      } as ReturnType<typeof useTokenWithBalance>);
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([]);
+    });
+
+    it('returns the input alert once a pay token is selected', () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: { ...PAY_TOKEN_MOCK, balanceUsd: '0.5' },
+        setPayToken: jest.fn(),
+      });
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        { ...REQUIRED_TOKEN_MOCK, amountUsd: '1.06' },
+      ]);
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([
+        {
+          key: AlertKeys.InsufficientPayTokenBalance,
+          field: RowAlertKey.Amount,
+          isBlocking: true,
+          message: strings(
+            'alert_system.insufficient_pay_token_balance.message',
+          ),
+          severity: Severity.Danger,
+        },
+      ]);
+    });
+  });
+
   describe('fiat payment', () => {
     it('returns no alerts when fiat payment method is selected', () => {
       useTransactionPayTokenMock.mockReturnValue({

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
@@ -141,10 +141,21 @@ export function useInsufficientPayTokenBalanceAlert({
   //   flow (`!isPostQuote`), where gas is sponsored by the override path rather
   //   than paid from the user's native balance. Post-quote (withdrawal) flows
   //   still pay gas on the source chain, so the override alone is not enough.
+  const isMoneyAccountOverride =
+    paymentOverride === PaymentOverride.MoneyAccount;
+
   const isGaslessSourceChain =
     sourceChainId === CHAIN_IDS.MONAD ||
     isTransactionMarkedAsGasFeeSponsored(transactionMeta) ||
-    (!isPostQuote && paymentOverride === PaymentOverride.MoneyAccount);
+    (!isPostQuote && isMoneyAccountOverride);
+
+  // Mirrors the balance sources in `useTransactionPayBalance`: the wallet
+  // balance is only meaningful once a pay token is selected, while withdrawals
+  // and money-account overrides draw from their own balances. Without any of
+  // these the transaction is not funded through MetaMask Pay (e.g. a plain
+  // ERC-20 send still yields a required token), so no balance check applies.
+  const hasPayBalanceSource =
+    Boolean(payToken) || isPostQuote || isMoneyAccountOverride;
 
   // For non-gasless source chains we still need to check the user has enough
   // native token to pay for gas on the source network (e.g., POL for Polygon).
@@ -172,7 +183,7 @@ export function useInsufficientPayTokenBalanceAlert({
       isBlocking: true,
     };
 
-    if (selectedFiatPaymentMethod) {
+    if (selectedFiatPaymentMethod || !hasPayBalanceSource) {
       return [];
     }
 
@@ -219,6 +230,7 @@ export function useInsufficientPayTokenBalanceAlert({
 
     return [];
   }, [
+    hasPayBalanceSource,
     isInsufficientForInput,
     isInsufficientForFees,
     isInsufficientForSourceNetwork,

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
@@ -20,7 +20,11 @@ import { useTokenWithBalance } from '../tokens/useTokenWithBalance';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useTransactionPaySelectedFiatPaymentMethod } from '../pay/useTransactionPaySelectedFiatPaymentMethod';
 import { useTransactionPayBalance } from '../pay/useTransactionPayBalance';
-import { CHAIN_IDS } from '@metamask/transaction-controller';
+import {
+  CHAIN_IDS,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
+import { MM_PAY_TRANSACTION_TYPES } from '../../constants/confirmations';
 import { useTransactionPayingAccount } from '../transactions/useTransactionPayingAccount';
 import { PaymentOverride } from '@metamask/transaction-pay-controller';
 import { selectPaymentOverrideByTransactionId } from '../../../../../selectors/transactionPayController';
@@ -141,21 +145,17 @@ export function useInsufficientPayTokenBalanceAlert({
   //   flow (`!isPostQuote`), where gas is sponsored by the override path rather
   //   than paid from the user's native balance. Post-quote (withdrawal) flows
   //   still pay gas on the source chain, so the override alone is not enough.
-  const isMoneyAccountOverride =
-    paymentOverride === PaymentOverride.MoneyAccount;
-
   const isGaslessSourceChain =
     sourceChainId === CHAIN_IDS.MONAD ||
     isTransactionMarkedAsGasFeeSponsored(transactionMeta) ||
-    (!isPostQuote && isMoneyAccountOverride);
+    (!isPostQuote && paymentOverride === PaymentOverride.MoneyAccount);
 
-  // Mirrors the balance sources in `useTransactionPayBalance`: the wallet
-  // balance is only meaningful once a pay token is selected, while withdrawals
-  // and money-account overrides draw from their own balances. Without any of
-  // these the transaction is not funded through MetaMask Pay (e.g. a plain
-  // ERC-20 send still yields a required token), so no balance check applies.
-  const hasPayBalanceSource =
-    Boolean(payToken) || isPostQuote || isMoneyAccountOverride;
+  // A plain ERC-20 send also yields a required token, but it is not funded
+  // through MetaMask Pay, so the pay balance check does not apply.
+  const isMMPayTransaction = hasTransactionType(
+    transactionMeta,
+    MM_PAY_TRANSACTION_TYPES,
+  );
 
   // For non-gasless source chains we still need to check the user has enough
   // native token to pay for gas on the source network (e.g., POL for Polygon).
@@ -183,7 +183,7 @@ export function useInsufficientPayTokenBalanceAlert({
       isBlocking: true,
     };
 
-    if (selectedFiatPaymentMethod || !hasPayBalanceSource) {
+    if (selectedFiatPaymentMethod || !isMMPayTransaction) {
       return [];
     }
 
@@ -230,7 +230,7 @@ export function useInsufficientPayTokenBalanceAlert({
 
     return [];
   }, [
-    hasPayBalanceSource,
+    isMMPayTransaction,
     isInsufficientForInput,
     isInsufficientForFees,
     isInsufficientForSourceNetwork,


### PR DESCRIPTION
## **Description**

Sending any ERC-20 token showed a disabled "Review alert" button with no visible alert, so the send could not be completed. Native sends were unaffected.

The transaction pay controller derives a required token from any ERC-20 `transfer` calldata. After the recent pay balance consolidation, `useInsufficientPayTokenBalanceAlert` no longer required a selected pay token, so for a plain token send it compared the transfer amount against a wallet pay-token balance of `0` and emitted a blocking danger alert on the `Amount` field, which the transfer screen never renders.

The alert is now skipped for transactions that are not MetaMask Pay types (`MM_PAY_TRANSACTION_TYPES`), matching how the footer and `useGasSponsorshipWarningAlert` already decide whether a confirmation is a Pay flow.

## **Changelog**

CHANGELOG entry: Fixed a bug where sending ERC-20 tokens showed a disabled "Review alert" button and could not be confirmed

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/35587

## **Manual testing steps**

```gherkin
Feature: ERC-20 send confirmation

  Scenario: user sends an ERC-20 token
    Given an account holding an ERC-20 token (e.g. USDC on Base) and enough native gas
    When the user starts a send for that token and reaches the confirmation screen
    Then the primary button reads "Confirm" and is enabled
    And the transaction can be submitted

  Scenario: pay flows still block on insufficient balance
    Given a MetaMask Pay deposit with a selected pay token whose balance is below the amount
    When the confirmation is shown
    Then the insufficient balance alert is still shown and blocks confirmation
```

## **Screenshots/Recordings**

### **Before**

See the recording in the linked issue.

### **After**

N/A — hook-only change; the confirm button behaves as before the regression.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped confirmation-alert logic for ERC-20 sends; MetaMask Pay deposit/withdraw flows should still surface insufficient balance alerts when transaction types match.
> 
> **Overview**
> Fixes a regression where **plain ERC-20 sends** could hit a **blocking insufficient pay-token balance alert** (often with no visible message on the transfer screen), leaving **Confirm** disabled even when gas and token balance were fine.
> 
> `useInsufficientPayTokenBalanceAlert` now **bails out early** unless the transaction is a **MetaMask Pay** type (`hasTransactionType` + `MM_PAY_TRANSACTION_TYPES`), same idea as skipping when fiat pay is selected. Ordinary `tokenMethodTransfer` flows still get a required token from pay controller calldata parsing, but **no pay balance checks** run on them.
> 
> Tests are updated so default mocks use real Pay transaction types, and a **non–MetaMask Pay** suite asserts no alerts for transfers (including low native gas and optional pay token selected).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92637a0a1625a61e422b75fe6c2bebb0c80a866f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

