### PR TITLE
feat: migrate legacy users into consolidated Basic Functionality

### DIFF
--- a/app/actions/settings/index.js
+++ b/app/actions/settings/index.js
@@ -64,6 +64,15 @@ export function setBasicFunctionalityConsolidatedEnabled(
   };
 }
 
+export function setBasicFunctionalityMigrationNotificationPending(
+  basicFunctionalityMigrationNotificationPending,
+) {
+  return {
+    type: 'SET_BASIC_FUNCTIONALITY_MIGRATION_NOTIFICATION_PENDING',
+    basicFunctionalityMigrationNotificationPending,
+  };
+}
+
 // Thunk action creator for user-initiated toggles (includes MultichainAccountService integration)
 export function toggleBasicFunctionality(basicFunctionalityEnabled) {
   return async (dispatch, getState) => {

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -121,6 +121,7 @@ import OnboardingSecuritySettings from '../../Views/OnboardingSuccess/Onboarding
 import FirstPredictOnUsSplashScreen from '../../UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsSplashScreen';
 import FirstPredictOnUsOrderSheet from '../../UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsOrderSheet';
 import BasicFunctionalityModal from '../../UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal';
+import BasicFunctionalityMigrationModal from '../../UI/BasicFunctionality/BasicFunctionalityMigrationModal/BasicFunctionalityMigrationModal';
 import PermittedNetworksInfoSheet from '../../Views/AccountPermissions/PermittedNetworksInfoSheet/PermittedNetworksInfoSheet';
 import NFTAutoDetectionModal from '../../Views/NFTAutoDetectionModal/NFTAutoDetectionModal';
 import NftOptions from '../../Views/NftOptions';
@@ -681,6 +682,10 @@ const RootModalFlow = (props: RootModalFlowProps) => (
     <NativeStack.Screen
       name={Routes.SHEET.BASIC_FUNCTIONALITY}
       component={BasicFunctionalityModal}
+    />
+    <NativeStack.Screen
+      name={Routes.SHEET.BASIC_FUNCTIONALITY_MIGRATION}
+      component={BasicFunctionalityMigrationModal}
     />
     <NativeStack.Screen
       name={Routes.SHEET.CONFIRM_TURN_ON_BACKUP_AND_SYNC}

--- a/app/components/UI/BasicFunctionality/BasicFunctionality.tsx
+++ b/app/components/UI/BasicFunctionality/BasicFunctionality.tsx
@@ -17,6 +17,7 @@ import AppConstants from '../../../core/AppConstants';
 export default function BasicFunctionalityComponent({
   handleSwitchToggle,
   flushTop,
+  disabled = false,
 }: Readonly<BasicFunctionalityComponentProps>) {
   const theme = useTheme();
   const { colors } = theme;
@@ -37,12 +38,14 @@ export default function BasicFunctionalityComponent({
         <Switch
           value={isEnabled}
           onChange={handleSwitchToggle}
+          disabled={disabled}
           trackColor={{
             true: colors.primary.default,
             false: colors.border.muted,
           }}
           thumbColor={theme.brandColors.white}
           ios_backgroundColor={colors.border.muted}
+          testID="basic-functionality-switch"
         />
       </View>
       <Text

--- a/app/components/UI/BasicFunctionality/BasicFunctionality.types.ts
+++ b/app/components/UI/BasicFunctionality/BasicFunctionality.types.ts
@@ -2,4 +2,6 @@ export interface BasicFunctionalityComponentProps {
   handleSwitchToggle: () => void;
   /** Omit top margin when stacked directly under a section title (e.g. Privacy heading). */
   flushTop?: boolean;
+  /** When true, the switch cannot be changed (e.g. social-login users). */
+  disabled?: boolean;
 }

--- a/app/components/UI/BasicFunctionality/BasicFunctionalityMigrationModal/BasicFunctionalityMigrationModal.tsx
+++ b/app/components/UI/BasicFunctionality/BasicFunctionalityMigrationModal/BasicFunctionalityMigrationModal.tsx
@@ -1,0 +1,78 @@
+import React, { useRef } from 'react';
+import { View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useDispatch } from 'react-redux';
+import BottomSheet, {
+  BottomSheetRef,
+} from '../../../../component-library/components/BottomSheets/BottomSheet';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../locales/i18n';
+import { setBasicFunctionalityMigrationNotificationPending } from '../../../../actions/settings';
+import Routes from '../../../../constants/navigation/Routes';
+import type { AppNavigationProp } from '../../../../core/NavigationService/types';
+import { useTheme } from '../../../../util/theme';
+import createStyles from '../../Notification/Modal/styles';
+
+const BasicFunctionalityMigrationModal = () => {
+  const navigation = useNavigation<AppNavigationProp>();
+  const dispatch = useDispatch();
+  const { colors } = useTheme();
+  const styles = createStyles(colors);
+  const bottomSheetRef = useRef<BottomSheetRef>(null);
+
+  const dismiss = () => {
+    dispatch(setBasicFunctionalityMigrationNotificationPending(false));
+  };
+
+  const closeSheet = (afterClose?: () => void) => {
+    bottomSheetRef.current?.onCloseBottomSheet(() => {
+      dismiss();
+      afterClose?.();
+    });
+  };
+
+  const openPrivacySettings = () => {
+    closeSheet(() => {
+      navigation.navigate(Routes.SETTINGS_VIEW, {
+        screen: Routes.SETTINGS.SECURITY_SETTINGS,
+      });
+    });
+  };
+
+  return (
+    <BottomSheet ref={bottomSheetRef} onClose={dismiss}>
+      <View style={styles.container}>
+        <Text variant={TextVariant.HeadingMd} style={styles.title}>
+          {strings('default_settings.migration_modal.title')}
+        </Text>
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          style={styles.subtitle}
+        >
+          {strings('default_settings.migration_modal.description')}
+        </Text>
+        <View style={styles.buttonsContainer}>
+          <Button
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Lg}
+            style={styles.button}
+            onPress={openPrivacySettings}
+            testID="basic-functionality-migration-modal-open-settings"
+          >
+            {strings('default_settings.migration_modal.open_settings')}
+          </Button>
+        </View>
+      </View>
+    </BottomSheet>
+  );
+};
+
+export default BasicFunctionalityMigrationModal;

--- a/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
+++ b/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
@@ -72,7 +72,10 @@ import BatchAccountBalanceSettings from '../../Settings/BatchAccountBalanceSetti
 import useCheckNftAutoDetectionModal from '../../../hooks/useCheckNftAutoDetectionModal';
 import useCheckMultiRpcModal from '../../../hooks/useCheckMultiRpcModal';
 import { useStyles } from '../../../../component-library/hooks/useStyles';
-import { selectIsBasicFunctionalityConsolidationEnabled } from '../../../../selectors/featureFlagController/basicFunctionalityConsolidation';
+import {
+  selectIsBasicFunctionalityConsolidationEnabled,
+  selectIsBasicFunctionalityToggleDisabled,
+} from '../../../../selectors/featureFlagController/basicFunctionalityConsolidation';
 
 const Settings: React.FC = () => {
   const { trackEvent, isEnabled, createEventBuilder } = useAnalytics();
@@ -93,6 +96,9 @@ const Settings: React.FC = () => {
   );
   const isBasicFunctionalityConsolidationEnabled = useSelector(
     selectIsBasicFunctionalityConsolidationEnabled,
+  );
+  const isBasicFunctionalityToggleDisabled = useSelector(
+    selectIsBasicFunctionalityToggleDisabled,
   );
   const scrollViewRef = useRef<ScrollView>(null);
   const metaMetricsSectionRef = useRef<View>(null);
@@ -347,6 +353,9 @@ const Settings: React.FC = () => {
   );
 
   const toggleBasicFunctionality = () => {
+    if (isBasicFunctionalityToggleDisabled) {
+      return;
+    }
     navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
       screen: Routes.SHEET.BASIC_FUNCTIONALITY,
     });
@@ -390,6 +399,7 @@ const Settings: React.FC = () => {
           <View style={styles.halfSetting}>
             <BasicFunctionalityComponent
               flushTop
+              disabled={isBasicFunctionalityToggleDisabled}
               handleSwitchToggle={toggleBasicFunctionality}
             />
           </View>

--- a/app/components/Views/Wallet/index.test.tsx
+++ b/app/components/Views/Wallet/index.test.tsx
@@ -26,6 +26,12 @@ jest.mock('../../hooks/useCheckNftAutoDetectionModal', () =>
   }),
 );
 
+jest.mock('../../hooks/useBasicFunctionalityMigrationNotification', () =>
+  jest.fn(() => {
+    // Hook implementation mocked to prevent toast/modal interference
+  }),
+);
+
 jest.mock('../../UI/Assets/components/Balance/AccountGroupBalance', () => ({
   __esModule: true,
   default: jest.fn(() => null),

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -133,6 +133,7 @@ import type { HomeSectionName } from '../Homepage/hooks/useHomeViewedEvent';
 import { trackExploreSearchOpened } from '../TrendingView/search/analytics';
 import AccountGroupBalance from '../../UI/Assets/components/Balance/AccountGroupBalance';
 import useCheckNftAutoDetectionModal from '../../hooks/useCheckNftAutoDetectionModal';
+import useBasicFunctionalityMigrationNotification from '../../hooks/useBasicFunctionalityMigrationNotification';
 import useCheckMultiRpcModal from '../../hooks/useCheckMultiRpcModal';
 import { useMultichainAccountsIntroModal } from '../../hooks/useMultichainAccountsIntroModal';
 import { useAccountsWithNetworkActivitySync } from '../../hooks/useAccountsWithNetworkActivitySync';
@@ -702,6 +703,7 @@ const Wallet = ({
    * Shows Nft auto detect modal if the user is on mainnet, never saw the modal and have nft detection off
    */
   useCheckNftAutoDetectionModal();
+  useBasicFunctionalityMigrationNotification();
 
   /**
    * Show multi rpc modal if there are networks duplicated and if never showed before

--- a/app/components/hooks/useBasicFunctionalityMigrationNotification/index.ts
+++ b/app/components/hooks/useBasicFunctionalityMigrationNotification/index.ts
@@ -1,0 +1,1 @@
+export { default } from './useBasicFunctionalityMigrationNotification';

--- a/app/components/hooks/useBasicFunctionalityMigrationNotification/useBasicFunctionalityMigrationNotification.ts
+++ b/app/components/hooks/useBasicFunctionalityMigrationNotification/useBasicFunctionalityMigrationNotification.ts
@@ -1,0 +1,94 @@
+import { useCallback, useContext, useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigation } from '@react-navigation/native';
+import type { AppNavigationProp } from '../../../core/NavigationService/types';
+import {
+  ToastContext,
+  ToastVariants,
+} from '../../../component-library/components/Toast';
+import { IconName } from '../../../component-library/components/Icons/Icon';
+import { strings } from '../../../../locales/i18n';
+import { setBasicFunctionalityMigrationNotificationPending } from '../../../actions/settings';
+import Routes from '../../../constants/navigation/Routes';
+import { selectBasicFunctionalityMigrationNotificationPending } from '../../../selectors/settings';
+import {
+  selectIsBasicFunctionalitySocialLoginUser,
+  selectMobileUxBftcConsolidationFlagEnabled,
+} from '../../../selectors/featureFlagController/basicFunctionalityConsolidation';
+
+/**
+ * Presents the Basic Functionality migration toast (non-social) or modal
+ * (social) once after unlock when the migration left a pending notification.
+ */
+const useBasicFunctionalityMigrationNotification = () => {
+  const dispatch = useDispatch();
+  const navigation = useNavigation<AppNavigationProp>();
+  const { toastRef } = useContext(ToastContext);
+  const hasPresentedRef = useRef(false);
+
+  const isRemoteFlagEnabled = useSelector(
+    selectMobileUxBftcConsolidationFlagEnabled,
+  );
+  const isNotificationPending = useSelector(
+    selectBasicFunctionalityMigrationNotificationPending,
+  );
+  const isSocialLoginUser = useSelector(
+    selectIsBasicFunctionalitySocialLoginUser,
+  );
+
+  const dismiss = useCallback(() => {
+    dispatch(setBasicFunctionalityMigrationNotificationPending(false));
+  }, [dispatch]);
+
+  const openPrivacySettings = useCallback(() => {
+    dismiss();
+    navigation.navigate(Routes.SETTINGS_VIEW, {
+      screen: Routes.SETTINGS.SECURITY_SETTINGS,
+    });
+  }, [dismiss, navigation]);
+
+  useEffect(() => {
+    if (
+      !isRemoteFlagEnabled ||
+      !isNotificationPending ||
+      hasPresentedRef.current
+    ) {
+      return;
+    }
+
+    hasPresentedRef.current = true;
+
+    if (isSocialLoginUser) {
+      navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+        screen: Routes.SHEET.BASIC_FUNCTIONALITY_MIGRATION,
+      });
+      return;
+    }
+
+    toastRef?.current?.showToast({
+      variant: ToastVariants.Icon,
+      iconName: IconName.Info,
+      hasNoTimeout: false,
+      labelOptions: [
+        {
+          label: strings('default_settings.migration_toast.description'),
+        },
+      ],
+      linkButtonOptions: {
+        label: strings('default_settings.migration_toast.open_settings'),
+        onPress: openPrivacySettings,
+      },
+    });
+    dismiss();
+  }, [
+    dismiss,
+    isNotificationPending,
+    isRemoteFlagEnabled,
+    isSocialLoginUser,
+    navigation,
+    openPrivacySettings,
+    toastRef,
+  ]);
+};
+
+export default useBasicFunctionalityMigrationNotification;

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -256,6 +256,7 @@ const Routes = {
     ADD_WALLET: 'AddWallet',
     AMBIGUOUS_ADDRESS: 'AmbiguousAddress',
     BASIC_FUNCTIONALITY: 'BasicFunctionality',
+    BASIC_FUNCTIONALITY_MIGRATION: 'BasicFunctionalityMigration',
     CONFIRM_TURN_ON_BACKUP_AND_SYNC: 'ConfirmTurnOnBackupAndSync',
     FEATURE_NOTIFICATIONS_GATE: 'FeatureNotificationsGate',
     SDK_LOADING: 'SDKLoading',

--- a/app/reducers/settings/index.js
+++ b/app/reducers/settings/index.js
@@ -9,6 +9,7 @@ const initialState = {
   hideZeroBalanceTokens: true,
   basicFunctionalityEnabled: true,
   isBasicFunctionalityConsolidatedEnabled: false,
+  basicFunctionalityMigrationNotificationPending: false,
   deepLinkModalDisabled: false,
   hapticsEnabled: true,
   // Whether this account is shown on the Top Traders leaderboard. Local mirror
@@ -67,6 +68,12 @@ const settingsReducer = (state = initialState, action) => {
         ...state,
         isBasicFunctionalityConsolidatedEnabled:
           action.isBasicFunctionalityConsolidatedEnabled,
+      };
+    case 'SET_BASIC_FUNCTIONALITY_MIGRATION_NOTIFICATION_PENDING':
+      return {
+        ...state,
+        basicFunctionalityMigrationNotificationPending:
+          action.basicFunctionalityMigrationNotificationPending,
       };
     case 'TOGGLE_DEVICE_NOTIFICATIONS':
       return {

--- a/app/selectors/featureFlagController/basicFunctionalityConsolidation/basicFunctionality.ts
+++ b/app/selectors/featureFlagController/basicFunctionalityConsolidation/basicFunctionality.ts
@@ -1,0 +1,76 @@
+import { createSelector } from 'reselect';
+import {
+  selectSeedlessOnboardingAuthConnection,
+  selectSeedlessOnboardingLoginFlow,
+} from '../../seedlessOnboardingController';
+import { selectBasicFunctionalityEnabled } from '../../settings';
+import {
+  selectDisplayNftMedia,
+  selectIsMultiAccountBalancesEnabled,
+  selectIsSecurityAlertsEnabled,
+  selectUseNftDetection,
+  selectUseSafeChainsListValidation,
+  selectUseTokenDetection,
+  selectUseTransactionSimulations,
+} from '../../preferencesController';
+import { BFT_CHILD_PREFERENCES } from '../../../util/basicFunctionality/bftChildPreferences';
+
+/**
+ * True when the user authenticated via social / seedless onboarding.
+ * Social users cannot turn Basic Functionality off once consolidated.
+ */
+export const selectIsBasicFunctionalitySocialLoginUser = createSelector(
+  selectSeedlessOnboardingLoginFlow,
+  selectSeedlessOnboardingAuthConnection,
+  (isSeedlessLoginFlow, authConnection) =>
+    Boolean(isSeedlessLoginFlow || authConnection),
+);
+
+const selectBftChildPreferenceValues = createSelector(
+  selectUseTransactionSimulations,
+  selectIsSecurityAlertsEnabled,
+  selectIsMultiAccountBalancesEnabled,
+  selectUseSafeChainsListValidation,
+  selectUseTokenDetection,
+  selectDisplayNftMedia,
+  selectUseNftDetection,
+  (
+    useTransactionSimulations,
+    securityAlertsEnabled,
+    isMultiAccountBalancesEnabled,
+    useSafeChainsListValidation,
+    useTokenDetection,
+    displayNftMedia,
+    useNftDetection,
+  ) => ({
+    useTransactionSimulations,
+    securityAlertsEnabled,
+    isMultiAccountBalancesEnabled,
+    useSafeChainsListValidation,
+    useTokenDetection,
+    displayNftMedia,
+    useNftDetection,
+  }),
+);
+
+/**
+ * Legacy users whose BF toggle already matches every child preference.
+ * Used so consolidation UI can apply before/without a persisted cohort marker.
+ */
+export const selectIsBasicFunctionalityConsistent = createSelector(
+  selectBasicFunctionalityEnabled,
+  selectBftChildPreferenceValues,
+  (basicFunctionalityEnabled, childPreferenceValues) => {
+    const enabledChildren = BFT_CHILD_PREFERENCES.filter(
+      (preference) => childPreferenceValues[preference] === true,
+    ).length;
+    const areAllChildrenEnabled =
+      enabledChildren === BFT_CHILD_PREFERENCES.length;
+    const areAllChildrenDisabled = enabledChildren === 0;
+
+    return (
+      (basicFunctionalityEnabled && areAllChildrenEnabled) ||
+      (!basicFunctionalityEnabled && areAllChildrenDisabled)
+    );
+  },
+);

--- a/app/selectors/featureFlagController/basicFunctionalityConsolidation/index.test.ts
+++ b/app/selectors/featureFlagController/basicFunctionalityConsolidation/index.test.ts
@@ -1,6 +1,7 @@
 import {
   MOBILE_UX_BFTC_CONSOLIDATION_FLAG_NAME,
   selectIsBasicFunctionalityConsolidationEnabled,
+  selectIsBasicFunctionalityToggleDisabled,
   selectMobileUxBftcConsolidationFlagEnabled,
 } from './index';
 // eslint-disable-next-line import-x/no-namespace
@@ -61,6 +62,17 @@ describe('basicFunctionalityConsolidation selectors', () => {
       const result = selectIsBasicFunctionalityConsolidationEnabled.resultFunc(
         true,
         true,
+        false,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true for consistent legacy users when remote flag is on', () => {
+      const result = selectIsBasicFunctionalityConsolidationEnabled.resultFunc(
+        true,
+        false,
+        true,
       );
 
       expect(result).toBe(true);
@@ -70,18 +82,34 @@ describe('basicFunctionalityConsolidation selectors', () => {
       const result = selectIsBasicFunctionalityConsolidationEnabled.resultFunc(
         false,
         true,
+        true,
       );
 
       expect(result).toBe(false);
     });
 
-    it('returns false when cohort marker is missing for existing users', () => {
+    it('returns false when cohort marker is missing and state is inconsistent', () => {
       const result = selectIsBasicFunctionalityConsolidationEnabled.resultFunc(
         true,
+        false,
         false,
       );
 
       expect(result).toBe(false);
+    });
+  });
+
+  describe('selectIsBasicFunctionalityToggleDisabled', () => {
+    it('returns true for consolidated social login users', () => {
+      expect(
+        selectIsBasicFunctionalityToggleDisabled.resultFunc(true, true),
+      ).toBe(true);
+    });
+
+    it('returns false when consolidation is off', () => {
+      expect(
+        selectIsBasicFunctionalityToggleDisabled.resultFunc(false, true),
+      ).toBe(false);
     });
   });
 });

--- a/app/selectors/featureFlagController/basicFunctionalityConsolidation/index.ts
+++ b/app/selectors/featureFlagController/basicFunctionalityConsolidation/index.ts
@@ -5,9 +5,18 @@ import {
   type VersionGatedFeatureFlag,
 } from '../../../util/remoteFeatureFlag';
 import { selectIsBasicFunctionalityConsolidatedEnabled } from '../../settings';
+import {
+  selectIsBasicFunctionalityConsistent,
+  selectIsBasicFunctionalitySocialLoginUser,
+} from './basicFunctionality';
 
 export const MOBILE_UX_BFTC_CONSOLIDATION_FLAG_NAME =
   'mobileUxBftcConsolidation';
+
+export {
+  selectIsBasicFunctionalityConsistent,
+  selectIsBasicFunctionalitySocialLoginUser,
+} from './basicFunctionality';
 
 /**
  * Remote rollout flag for consolidated Basic Functionality (version-gated).
@@ -26,11 +35,25 @@ export const selectMobileUxBftcConsolidationFlagEnabled = createSelector(
 
 /**
  * True when the user should see consolidated Basic Functionality settings.
- * Requires both the remote flag and the persisted onboarding cohort marker.
+ * Requires the remote flag plus either the persisted cohort marker or a
+ * consistent legacy all-on / all-off configuration.
  */
 export const selectIsBasicFunctionalityConsolidationEnabled = createSelector(
   selectMobileUxBftcConsolidationFlagEnabled,
   selectIsBasicFunctionalityConsolidatedEnabled,
-  (isRemoteFlagEnabled, isConsolidatedUser) =>
-    isRemoteFlagEnabled && isConsolidatedUser,
+  selectIsBasicFunctionalityConsistent,
+  (isRemoteFlagEnabled, isPersistedConsolidatedUser, isConsistentLegacyUser) =>
+    isRemoteFlagEnabled &&
+    (isPersistedConsolidatedUser || isConsistentLegacyUser),
+);
+
+/**
+ * True when social-login users should have the Basic Functionality toggle
+ * disabled (locked on) under consolidation.
+ */
+export const selectIsBasicFunctionalityToggleDisabled = createSelector(
+  selectIsBasicFunctionalityConsolidationEnabled,
+  selectIsBasicFunctionalitySocialLoginUser,
+  (isConsolidationEnabled, isSocialLoginUser) =>
+    isConsolidationEnabled && isSocialLoginUser,
 );

--- a/app/selectors/settings.ts
+++ b/app/selectors/settings.ts
@@ -29,6 +29,11 @@ export const selectIsBasicFunctionalityConsolidatedEnabled = createSelector(
     Boolean(settingsState.isBasicFunctionalityConsolidatedEnabled),
 );
 
+export const selectBasicFunctionalityMigrationNotificationPending =
+  createSelector(selectSettings, (settingsState: Record<string, unknown>) =>
+    Boolean(settingsState.basicFunctionalityMigrationNotificationPending),
+  );
+
 export const selectHideZeroBalanceTokens = createSelector(
   selectSettings,
   (settingsState: Record<string, unknown>) =>

--- a/app/store/migrations/153.test.ts
+++ b/app/store/migrations/153.test.ts
@@ -1,0 +1,215 @@
+import { AuthConnection } from '../../core/OAuthService/OAuthInterface';
+import { BFT_CHILD_PREFERENCES } from '../../util/basicFunctionality/bftChildPreferences';
+import migrate, { migrationVersion } from './153';
+import { ensureValidState } from './util';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+}));
+
+const mockedEnsureValidState = jest.mocked(ensureValidState);
+
+function buildChildren(enabledCount: number) {
+  return Object.fromEntries(
+    BFT_CHILD_PREFERENCES.map((preference, index) => [
+      preference,
+      index < enabledCount,
+    ]),
+  );
+}
+
+function buildState({
+  basicFunctionalityEnabled = true,
+  enabledChildren = BFT_CHILD_PREFERENCES.length,
+  isBasicFunctionalityConsolidatedEnabled = false,
+  authConnection,
+  vault,
+}: {
+  basicFunctionalityEnabled?: boolean;
+  enabledChildren?: number;
+  isBasicFunctionalityConsolidatedEnabled?: boolean;
+  authConnection?: AuthConnection;
+  vault?: string;
+} = {}) {
+  return {
+    settings: {
+      basicFunctionalityEnabled,
+      isBasicFunctionalityConsolidatedEnabled,
+    },
+    security: {},
+    engine: {
+      backgroundState: {
+        PreferencesController: {
+          ...buildChildren(enabledChildren),
+          isIpfsGatewayEnabled: true,
+        },
+        SeedlessOnboardingController: {
+          ...(authConnection ? { authConnection } : {}),
+          ...(vault ? { vault } : {}),
+        },
+      },
+    },
+  };
+}
+
+describe(`migration #${migrationVersion}`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedEnsureValidState.mockReturnValue(true);
+  });
+
+  it('skips users already enrolled in the consolidated cohort', () => {
+    const state = buildState({
+      isBasicFunctionalityConsolidatedEnabled: true,
+      basicFunctionalityEnabled: false,
+      enabledChildren: 0,
+    });
+
+    const migrated = migrate(state) as typeof state;
+
+    expect(migrated).toBe(state);
+  });
+
+  it('silently consolidates BF ON with all children ON', () => {
+    const migrated = migrate(
+      buildState({
+        basicFunctionalityEnabled: true,
+        enabledChildren: BFT_CHILD_PREFERENCES.length,
+      }),
+    ) as ReturnType<typeof buildState> & {
+      settings: {
+        basicFunctionalityMigrationNotificationPending?: boolean;
+      };
+    };
+
+    expect(migrated.settings.basicFunctionalityEnabled).toBe(true);
+    expect(migrated.settings.isBasicFunctionalityConsolidatedEnabled).toBe(
+      true,
+    );
+    expect(
+      migrated.settings.basicFunctionalityMigrationNotificationPending,
+    ).toBe(false);
+
+    for (const preference of BFT_CHILD_PREFERENCES) {
+      expect(
+        migrated.engine.backgroundState.PreferencesController[preference],
+      ).toBe(true);
+    }
+  });
+
+  it('silently consolidates BF OFF with all children OFF', () => {
+    const migrated = migrate(
+      buildState({
+        basicFunctionalityEnabled: false,
+        enabledChildren: 0,
+      }),
+    ) as ReturnType<typeof buildState> & {
+      settings: {
+        basicFunctionalityMigrationNotificationPending?: boolean;
+      };
+    };
+
+    expect(migrated.settings.basicFunctionalityEnabled).toBe(false);
+    expect(migrated.settings.isBasicFunctionalityConsolidatedEnabled).toBe(
+      true,
+    );
+    expect(
+      migrated.settings.basicFunctionalityMigrationNotificationPending,
+    ).toBe(false);
+  });
+
+  it('lands ON with notification when BF is ON and children are mixed', () => {
+    const migrated = migrate(
+      buildState({
+        basicFunctionalityEnabled: true,
+        enabledChildren: 2,
+      }),
+    ) as ReturnType<typeof buildState> & {
+      settings: {
+        basicFunctionalityMigrationNotificationPending?: boolean;
+      };
+    };
+
+    expect(migrated.settings.basicFunctionalityEnabled).toBe(true);
+    expect(
+      migrated.settings.basicFunctionalityMigrationNotificationPending,
+    ).toBe(true);
+
+    for (const preference of BFT_CHILD_PREFERENCES) {
+      expect(
+        migrated.engine.backgroundState.PreferencesController[preference],
+      ).toBe(true);
+    }
+  });
+
+  it('lands OFF with notification when BF is OFF and some children are ON', () => {
+    const migrated = migrate(
+      buildState({
+        basicFunctionalityEnabled: false,
+        enabledChildren: 3,
+      }),
+    ) as ReturnType<typeof buildState> & {
+      settings: {
+        basicFunctionalityMigrationNotificationPending?: boolean;
+      };
+    };
+
+    expect(migrated.settings.basicFunctionalityEnabled).toBe(false);
+    expect(
+      migrated.settings.basicFunctionalityMigrationNotificationPending,
+    ).toBe(true);
+
+    for (const preference of BFT_CHILD_PREFERENCES) {
+      expect(
+        migrated.engine.backgroundState.PreferencesController[preference],
+      ).toBe(false);
+    }
+  });
+
+  it('lands ON with notification for social login users with BF OFF', () => {
+    const migrated = migrate(
+      buildState({
+        basicFunctionalityEnabled: false,
+        enabledChildren: 0,
+        authConnection: AuthConnection.Google,
+        vault: 'seedless-vault',
+      }),
+    ) as ReturnType<typeof buildState> & {
+      settings: {
+        basicFunctionalityMigrationNotificationPending?: boolean;
+      };
+    };
+
+    expect(migrated.settings.basicFunctionalityEnabled).toBe(true);
+    expect(migrated.settings.isBasicFunctionalityConsolidatedEnabled).toBe(
+      true,
+    );
+    expect(
+      migrated.settings.basicFunctionalityMigrationNotificationPending,
+    ).toBe(true);
+
+    for (const preference of BFT_CHILD_PREFERENCES) {
+      expect(
+        migrated.engine.backgroundState.PreferencesController[preference],
+      ).toBe(true);
+    }
+  });
+
+  it('does not change IPFS gateway preference', () => {
+    const migrated = migrate(
+      buildState({
+        basicFunctionalityEnabled: false,
+        enabledChildren: 3,
+      }),
+    ) as ReturnType<typeof buildState>;
+
+    expect(
+      migrated.engine.backgroundState.PreferencesController
+        .isIpfsGatewayEnabled,
+    ).toBe(true);
+  });
+});

--- a/app/store/migrations/153.ts
+++ b/app/store/migrations/153.ts
@@ -1,0 +1,134 @@
+import { captureException } from '@sentry/react-native';
+import { hasProperty, isObject } from '@metamask/utils';
+import { AuthConnection } from '../../core/OAuthService/OAuthInterface';
+import { BFT_CHILD_PREFERENCES } from '../../util/basicFunctionality/bftChildPreferences';
+import { computeBasicFunctionalityMigrationLandingState } from '../../util/basicFunctionality/computeBasicFunctionalityMigrationLandingState';
+import { ensureValidState } from './util';
+
+export const migrationVersion = 153;
+
+function isSocialLoginUser(
+  seedlessOnboardingController: Record<string, unknown> | undefined,
+): boolean {
+  if (!seedlessOnboardingController) {
+    return false;
+  }
+
+  const authConnection = seedlessOnboardingController.authConnection;
+  const hasAuthConnection =
+    authConnection === AuthConnection.Google ||
+    authConnection === AuthConnection.Apple ||
+    authConnection === AuthConnection.Telegram;
+
+  const socialBackupsMetadata =
+    seedlessOnboardingController.socialBackupsMetadata;
+  const hasSocialBackups =
+    Array.isArray(socialBackupsMetadata) && socialBackupsMetadata.length > 0;
+
+  return (
+    hasAuthConnection ||
+    hasSocialBackups ||
+    seedlessOnboardingController.vault != null
+  );
+}
+
+/**
+ * Migration 153: Consolidate legacy Basic Functionality preferences.
+ *
+ * Existing users are enrolled into the consolidated Basic Functionality cohort.
+ * Child preference toggles are aligned with the computed landing state.
+ * Inconsistent or social-login migrations set a pending notification flag for
+ * toast / modal presentation after unlock.
+ *
+ * @param state - The persisted Redux state.
+ * @returns The migrated Redux state.
+ */
+export default function migrate(state: unknown): unknown {
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  if (!isObject(state.settings)) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid settings state: '${typeof state.settings}'`,
+      ),
+    );
+    return state;
+  }
+
+  if (state.settings.isBasicFunctionalityConsolidatedEnabled === true) {
+    return state;
+  }
+
+  const preferencesController =
+    state.engine.backgroundState.PreferencesController;
+
+  if (!isObject(preferencesController)) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid PreferencesController state: '${typeof preferencesController}'`,
+      ),
+    );
+    return state;
+  }
+
+  const seedlessOnboardingController = hasProperty(
+    state.engine.backgroundState,
+    'SeedlessOnboardingController',
+  )
+    ? (state.engine.backgroundState.SeedlessOnboardingController as
+        | Record<string, unknown>
+        | undefined)
+    : undefined;
+
+  const basicFunctionalityEnabled =
+    state.settings.basicFunctionalityEnabled === true;
+
+  const childPreferenceValues = Object.fromEntries(
+    BFT_CHILD_PREFERENCES.map((preference) => [
+      preference,
+      preferencesController[preference],
+    ]),
+  );
+
+  const isSocialLogin =
+    !basicFunctionalityEnabled &&
+    isSocialLoginUser(
+      isObject(seedlessOnboardingController)
+        ? seedlessOnboardingController
+        : undefined,
+    );
+
+  const { landingState, shouldNotify } =
+    computeBasicFunctionalityMigrationLandingState({
+      basicFunctionalityEnabled,
+      childPreferenceValues,
+      isSocialLogin,
+    });
+
+  const updatedPreferencesController = {
+    ...preferencesController,
+  };
+
+  for (const preference of BFT_CHILD_PREFERENCES) {
+    updatedPreferencesController[preference] = landingState;
+  }
+
+  return {
+    ...state,
+    settings: {
+      ...state.settings,
+      basicFunctionalityEnabled: landingState,
+      isBasicFunctionalityConsolidatedEnabled: true,
+      basicFunctionalityMigrationNotificationPending: shouldNotify,
+    },
+    engine: {
+      ...state.engine,
+      backgroundState: {
+        ...state.engine.backgroundState,
+        PreferencesController: updatedPreferencesController,
+      },
+    },
+  };
+}

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -153,6 +153,7 @@ import migration149 from './149';
 import migration150 from './150';
 import migration151 from './151';
 import migration152 from './152';
+import migration153 from './153';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -325,6 +326,7 @@ export const migrationList: MigrationsList = {
   150: migration150,
   151: migration151,
   152: migration152,
+  153: migration153,
 };
 
 // Enable both synchronous and asynchronous migrations

--- a/app/util/basicFunctionality/bftChildPreferences.ts
+++ b/app/util/basicFunctionality/bftChildPreferences.ts
@@ -1,0 +1,28 @@
+/**
+ * Preference keys unified under consolidated Basic Functionality on mobile.
+ *
+ * Mobile only exposes these PreferencesController toggles in Settings.
+ * Extension also consolidates phishing, 4byte, proposed nicknames, ENS
+ * address-bar resolution, and currency-rate check — those keys do not exist
+ * on mobile's PreferencesController.
+ */
+export const BFT_CHILD_PREFERENCES = [
+  'useTransactionSimulations',
+  'securityAlertsEnabled',
+  'isMultiAccountBalancesEnabled',
+  'useSafeChainsListValidation',
+  'useTokenDetection',
+  'displayNftMedia',
+  'useNftDetection',
+] as const;
+
+export type BftChildPreference = (typeof BFT_CHILD_PREFERENCES)[number];
+
+/**
+ * Same threshold as extension migration: BF OFF users with more than this many
+ * child prefs enabled land with BF ON.
+ *
+ * Mobile currently has only {@link BFT_CHILD_PREFERENCES.length} children, so
+ * this branch cannot fire until additional prefs are added to the mobile set.
+ */
+export const BFT_ENABLED_CHILDREN_LANDING_THRESHOLD = 9;

--- a/app/util/basicFunctionality/computeBasicFunctionalityMigrationLandingState.test.ts
+++ b/app/util/basicFunctionality/computeBasicFunctionalityMigrationLandingState.test.ts
@@ -1,0 +1,88 @@
+import { BFT_CHILD_PREFERENCES } from './bftChildPreferences';
+import { computeBasicFunctionalityMigrationLandingState } from './computeBasicFunctionalityMigrationLandingState';
+
+function buildChildren(enabledCount: number) {
+  return Object.fromEntries(
+    BFT_CHILD_PREFERENCES.map((preference, index) => [
+      preference,
+      index < enabledCount,
+    ]),
+  );
+}
+
+describe('computeBasicFunctionalityMigrationLandingState', () => {
+  it('lands ON silently when BF is ON and all children are ON', () => {
+    const result = computeBasicFunctionalityMigrationLandingState({
+      basicFunctionalityEnabled: true,
+      childPreferenceValues: buildChildren(BFT_CHILD_PREFERENCES.length),
+      isSocialLogin: false,
+    });
+
+    expect(result).toEqual({
+      landingState: true,
+      enabledChildren: BFT_CHILD_PREFERENCES.length,
+      isConsistent: true,
+      shouldNotify: false,
+    });
+  });
+
+  it('lands OFF silently when BF is OFF and all children are OFF', () => {
+    const result = computeBasicFunctionalityMigrationLandingState({
+      basicFunctionalityEnabled: false,
+      childPreferenceValues: buildChildren(0),
+      isSocialLogin: false,
+    });
+
+    expect(result).toEqual({
+      landingState: false,
+      enabledChildren: 0,
+      isConsistent: true,
+      shouldNotify: false,
+    });
+  });
+
+  it('lands ON with notification when BF is ON and children are mixed', () => {
+    const result = computeBasicFunctionalityMigrationLandingState({
+      basicFunctionalityEnabled: true,
+      childPreferenceValues: buildChildren(3),
+      isSocialLogin: false,
+    });
+
+    expect(result).toEqual({
+      landingState: true,
+      enabledChildren: 3,
+      isConsistent: false,
+      shouldNotify: true,
+    });
+  });
+
+  it('lands OFF with notification when BF is OFF and 1-9 children are ON', () => {
+    const result = computeBasicFunctionalityMigrationLandingState({
+      basicFunctionalityEnabled: false,
+      childPreferenceValues: buildChildren(3),
+      isSocialLogin: false,
+    });
+
+    expect(result).toEqual({
+      landingState: false,
+      enabledChildren: 3,
+      isConsistent: false,
+      shouldNotify: true,
+    });
+  });
+
+  it('lands ON for social login users with BF OFF and notifies', () => {
+    const result = computeBasicFunctionalityMigrationLandingState({
+      basicFunctionalityEnabled: false,
+      childPreferenceValues: buildChildren(0),
+      isSocialLogin: true,
+    });
+
+    expect(result).toEqual({
+      landingState: true,
+      enabledChildren: 0,
+      isConsistent: true,
+      shouldNotify: true,
+    });
+  });
+});

--- a/app/util/basicFunctionality/computeBasicFunctionalityMigrationLandingState.ts
+++ b/app/util/basicFunctionality/computeBasicFunctionalityMigrationLandingState.ts
@@ -1,0 +1,60 @@
+import {
+  BFT_CHILD_PREFERENCES,
+  BFT_ENABLED_CHILDREN_LANDING_THRESHOLD,
+  type BftChildPreference,
+} from './bftChildPreferences';
+
+export interface ComputeBasicFunctionalityMigrationLandingStateParams {
+  basicFunctionalityEnabled: boolean;
+  childPreferenceValues: Partial<Record<BftChildPreference, unknown>>;
+  isSocialLogin: boolean;
+}
+
+export interface BasicFunctionalityMigrationLandingState {
+  landingState: boolean;
+  enabledChildren: number;
+  isConsistent: boolean;
+  shouldNotify: boolean;
+}
+
+/**
+ * Computes consolidated Basic Functionality landing state for legacy users.
+ *
+ * Rules matching extension migration:
+ * - BF ON → land ON
+ * - Social login with BF OFF → land ON
+ * - BF OFF with more than {@link BFT_ENABLED_CHILDREN_LANDING_THRESHOLD}
+ * children ON → land ON
+ * - Otherwise land OFF
+ *
+ * Notification is skipped only when the pre-migration config was already
+ * consistent (all children match BF). Social login always notifies.
+ */
+export function computeBasicFunctionalityMigrationLandingState({
+  basicFunctionalityEnabled,
+  childPreferenceValues,
+  isSocialLogin,
+}: ComputeBasicFunctionalityMigrationLandingStateParams): BasicFunctionalityMigrationLandingState {
+  const enabledChildren = BFT_CHILD_PREFERENCES.filter(
+    (preference) => childPreferenceValues[preference] === true,
+  ).length;
+
+  const areAllChildrenEnabled =
+    enabledChildren === BFT_CHILD_PREFERENCES.length;
+  const areAllChildrenDisabled = enabledChildren === 0;
+  const isConsistent =
+    (basicFunctionalityEnabled && areAllChildrenEnabled) ||
+    (!basicFunctionalityEnabled && areAllChildrenDisabled);
+
+  const landingState =
+    basicFunctionalityEnabled ||
+    isSocialLogin ||
+    enabledChildren > BFT_ENABLED_CHILDREN_LANDING_THRESHOLD;
+
+  return {
+    landingState,
+    enabledChildren,
+    isConsistent,
+    shouldNotify: isSocialLogin || !isConsistent,
+  };
+}

--- a/app/util/basicFunctionality/syncConsolidatedBasicFunctionalityPreferences.test.ts
+++ b/app/util/basicFunctionality/syncConsolidatedBasicFunctionalityPreferences.test.ts
@@ -46,11 +46,17 @@ describe('syncConsolidatedBasicFunctionalityPreferences', () => {
       Engine.context.PreferencesController.setDisplayNftMedia,
     ).toHaveBeenCalledWith(true);
     expect(
-      Engine.context.PreferencesController.setIsIpfsGatewayEnabled,
-    ).toHaveBeenCalledWith(true);
-    expect(
       Engine.context.PreferencesController.setUseSafeChainsListValidation,
     ).toHaveBeenCalledWith(true);
+  });
+
+  it('does not sync IPFS gateway so it stays independent like extension', () => {
+    syncConsolidatedBasicFunctionalityPreferences(true);
+    syncConsolidatedBasicFunctionalityPreferences(false);
+
+    expect(
+      Engine.context.PreferencesController.setIsIpfsGatewayEnabled,
+    ).not.toHaveBeenCalled();
   });
 
   it('disables all consolidated preference toggles when enabled is false', () => {

--- a/app/util/basicFunctionality/syncConsolidatedBasicFunctionalityPreferences.ts
+++ b/app/util/basicFunctionality/syncConsolidatedBasicFunctionalityPreferences.ts
@@ -1,17 +1,11 @@
 import Engine from '../../core/Engine';
+import { BFT_CHILD_PREFERENCES } from './bftChildPreferences';
 
 /**
- * Preference keys unified under consolidated Basic Functionality on mobile.
+ * Aligns mobile-available Basic Functionality child preferences with the
+ * consolidated Basic Functionality toggle.
  *
- * Product toggle mapping (mobile-available only):
- * - Estimate balance changes → setUseTransactionSimulations
- * - Security alerts → setSecurityAlertsEnabled
- * - Batch balance / token price checker → setIsMultiAccountBalancesEnabled
- * - Network details check → setUseSafeChainsListValidation
- * - Autodetect tokens → setUseTokenDetection
- * - Display NFT media (OpenSea / third-party API) → setDisplayNftMedia
- * - Autodetect NFTs → setUseNftDetection
- * - IPFS gateway → setIsIpfsGatewayEnabled
+ * IPFS gateway stays a separate Settings toggle (same as extension).
  *
  * Not exposed as PreferencesController toggles on mobile:
  * phishing detection, 4byte.directory, proposed nicknames, authentication API.
@@ -21,12 +15,35 @@ export function syncConsolidatedBasicFunctionalityPreferences(
 ): void {
   const { PreferencesController } = Engine.context;
 
-  PreferencesController.setUseTransactionSimulations(enabled);
-  PreferencesController.setIsMultiAccountBalancesEnabled(enabled);
-  PreferencesController.setSecurityAlertsEnabled(enabled);
-  PreferencesController.setUseTokenDetection(enabled);
-  PreferencesController.setUseNftDetection(enabled);
-  PreferencesController.setDisplayNftMedia(enabled);
-  PreferencesController.setIsIpfsGatewayEnabled(enabled);
-  PreferencesController.setUseSafeChainsListValidation(enabled);
+  for (const preference of BFT_CHILD_PREFERENCES) {
+    switch (preference) {
+      case 'useTransactionSimulations':
+        PreferencesController.setUseTransactionSimulations(enabled);
+        break;
+      case 'securityAlertsEnabled':
+        PreferencesController.setSecurityAlertsEnabled(enabled);
+        break;
+      case 'isMultiAccountBalancesEnabled':
+        PreferencesController.setIsMultiAccountBalancesEnabled(enabled);
+        break;
+      case 'useSafeChainsListValidation':
+        PreferencesController.setUseSafeChainsListValidation(enabled);
+        break;
+      case 'useTokenDetection':
+        PreferencesController.setUseTokenDetection(enabled);
+        break;
+      case 'displayNftMedia':
+        PreferencesController.setDisplayNftMedia(enabled);
+        break;
+      case 'useNftDetection':
+        PreferencesController.setUseNftDetection(enabled);
+        break;
+      default: {
+        const exhaustiveCheck: never = preference;
+        throw new Error(
+          `Unhandled BFT child preference: ${String(exhaustiveCheck)}`,
+        );
+      }
+    }
+  }
 }

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8480,6 +8480,15 @@
     "default_settings": "Default settings",
     "done": "Done",
     "basic_functionality": "Basic functionality",
+    "migration_toast": {
+      "description": "Your settings have changed. Third-party APIs are now part of Basic Functionality.",
+      "open_settings": "Open settings"
+    },
+    "migration_modal": {
+      "title": "Your settings have changed",
+      "description": "Third-party APIs are now part of Basic Functionality. Basic Functionality has been enabled to keep your wallet working as expected. You can review these settings in Privacy.",
+      "open_settings": "Open settings"
+    },
     "manage_networks": "Choose your network",
     "manage_networks_body": "We use Infura as our remote procedure call (RPC) provider to offer the most reliable and private access to Ethereum data we can. You can choose your own RPC, but remember that any RPC will receive your IP address and Ethereum wallet to make transactions. Read our ",
     "manage_networks_body2": " to learn more about how Infura handles data for EVM accounts, for Solana accounts ",

--- a/tests/framework/fixtures/json/default-fixture.json
+++ b/tests/framework/fixtures/json/default-fixture.json
@@ -994,6 +994,7 @@
       "avatarAccountType": "Maskicon",
       "basicFunctionalityEnabled": true,
       "isBasicFunctionalityConsolidatedEnabled": false,
+      "basicFunctionalityMigrationNotificationPending": false,
       "deepLinkModalDisabled": false,
       "deviceNotificationEnabled": false,
       "hapticsEnabled": true,


### PR DESCRIPTION
## Summary
- Add migration `153` to enroll existing users into the consolidated Basic Functionality cohort using the same landing-state rules as extension ([#45959](https://github.com/MetaMask/metamask-extension/pull/45959))
- Align mobile-available child preferences with the computed landing state; keep IPFS gateway independent
- Show a toast for inconsistent non-social migrations and a modal for social-login migrations; lock the Basic Functionality toggle for social users

### Landing rules
| Pre-state | Result | Notification |
|---|---|---|
| BF ON + all children ON | BF ON, consolidated | Silent |
| BF OFF + all children OFF | BF OFF, consolidated | Silent |
| BF ON + mixed children | BF ON, all children ON | Toast |
| BF OFF + >9 children ON | BF ON, all children ON | Toast |
| BF OFF + 1–9 children ON | BF OFF, all children OFF | Toast |
| Social login with BF OFF | BF ON, toggle disabled | Modal |

> Mobile currently has 7 child prefs (extension has 12). The `>9` threshold matches extension and cannot fire until more mobile prefs are added.

## Test plan
- [x] `yarn jest app/util/basicFunctionality/computeBasicFunctionalityMigrationLandingState.test.ts`
- [x] `yarn jest app/store/migrations/153.test.ts`
- [x] `yarn jest app/selectors/featureFlagController/basicFunctionalityConsolidation/index.test.ts`
- [x] `yarn jest app/util/basicFunctionality/syncConsolidatedBasicFunctionalityPreferences.test.ts`

### Manual
- [ ] Enable `mobileUxBftcConsolidation`, upgrade an existing install, and verify the correct landing state + notification for each row above
- [ ] Confirm IPFS gateway does not change when Basic Functionality is toggled after consolidation
- [ ] Confirm social-login users see the migration modal and cannot turn Basic Functionality off
- [ ] Confirm Settings hides granular privacy toggles for consolidated users


Made with [Cursor](https://cursor.com)