### PR TITLE
feat(perps): perpsOrderView.test.tsx is order-dependent: 6 hook mocks never reset between tests

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -190,6 +190,102 @@ jest.mock('../../hooks/usePerpsNetworkManagement', () => ({
   }),
 }));
 
+// Default return values for hooks that individual tests override.
+// jest.clearAllMocks() keeps implementations, so beforeEach must re-apply these.
+// mock* prefix is required so jest.mock factories can call them after hoist.
+const mockDefaultUsePerpsOrderForm = () => ({
+  orderForm: {
+    asset: 'ETH',
+    amount: '11',
+    leverage: 3,
+    direction: 'long',
+    type: 'market',
+    limitPrice: undefined,
+    takeProfitPrice: undefined,
+    stopLossPrice: undefined,
+  },
+  setAmount: jest.fn(),
+  setLeverage: jest.fn(),
+  setTakeProfitPrice: jest.fn(),
+  setStopLossPrice: jest.fn(),
+  setLimitPrice: jest.fn(),
+  setOrderType: jest.fn(),
+  updateOrderForm: jest.fn(),
+  handlePercentageAmount: jest.fn(),
+  handleMaxAmount: jest.fn(),
+  optimizeOrderAmount: jest.fn(),
+  maxPossibleAmount: 1000,
+  balanceForValidation: 1000,
+  calculations: {
+    marginRequired: 11,
+    positionSize: 0.0037,
+  },
+});
+
+const mockDefaultUsePerpsOrderExecution = () => ({
+  placeOrder: jest.fn().mockResolvedValue({ success: true }),
+  isPlacing: false,
+});
+
+const mockDefaultUsePerpsRewards = () => ({
+  shouldShowRewardsRow: false,
+  isLoading: false,
+  estimatedPoints: undefined,
+  bonusBips: undefined,
+  feeDiscountPercentage: undefined,
+  hasError: false,
+  isRefresh: false,
+  accountOptedIn: null,
+  account: undefined,
+});
+
+const mockDefaultUsePerpsToasts = () => ({
+  showToast: jest.fn(),
+  PerpsToastOptions: {
+    formValidation: {
+      orderForm: {
+        limitPriceRequired: {},
+        validationError: jest.fn(),
+      },
+    },
+    orderManagement: {
+      market: {
+        submitted: jest.fn(),
+        confirmed: jest.fn(),
+        creationFailed: jest.fn(),
+      },
+      limit: {
+        submitted: jest.fn(),
+        confirmed: jest.fn(),
+        creationFailed: jest.fn(),
+      },
+    },
+    positionManagement: {
+      tpsl: {
+        updateTPSLError: jest.fn(),
+      },
+    },
+    dataFetching: {
+      market: {
+        error: {
+          marketDataUnavailable: jest.fn(),
+        },
+      },
+    },
+  },
+});
+
+const mockDefaultUsePerpsEstimatedSlippage = () => ({
+  estimatedSlippageBps: null,
+  isReady: false,
+});
+
+const mockDefaultUsePerpsMaxSlippage = () => ({
+  maxSlippageBps: 300,
+  maxSlippageSource: 'default',
+  setMaxSlippage: jest.fn(),
+});
+
 // Mock the hooks module - these will be overridden in beforeEach
 jest.mock('../../hooks', () => ({
   useBottomSafeAreaInset: jest.fn(() => 0),
@@ -240,34 +336,7 @@ jest.mock('../../hooks', () => ({
     error: null,
   })),
   formatFeeRate: jest.fn((rate) => `${(rate * 100).toFixed(3)}%`),
-  usePerpsOrderForm: jest.fn(() => ({
-    orderForm: {
-      asset: 'ETH',
-      amount: '11',
-      leverage: 3,
-      direction: 'long',
-      type: 'market',
-      limitPrice: undefined,
-      takeProfitPrice: undefined,
-      stopLossPrice: undefined,
-    },
-    setAmount: jest.fn(),
-    setLeverage: jest.fn(),
-    setTakeProfitPrice: jest.fn(),
-    setStopLossPrice: jest.fn(),
-    setLimitPrice: jest.fn(),
-    setOrderType: jest.fn(),
-    updateOrderForm: jest.fn(),
-    handlePercentageAmount: jest.fn(),
-    handleMaxAmount: jest.fn(),
-    optimizeOrderAmount: jest.fn(),
-    maxPossibleAmount: 1000,
-    balanceForValidation: 1000,
-    calculations: {
-      marginRequired: 11,
-      positionSize: 0.0037,
-    },
-  })),
+  usePerpsOrderForm: jest.fn(() => mockDefaultUsePerpsOrderForm()),
   usePerpsOrderValidation: jest.fn(() => ({
     isValid: true,
     errors: [],
@@ -277,10 +346,7 @@ jest.mock('../../hooks', () => ({
     insufficientBalanceErrors: [],
     validateNow: jest.fn(),
   })),
-  usePerpsOrderExecution: jest.fn(() => ({
-    placeOrder: jest.fn().mockResolvedValue({ success: true }),
-    isPlacing: false,
-  })),
+  usePerpsOrderExecution: jest.fn(() => mockDefaultUsePerpsOrderExecution()),
   usePerpsOrderDepositTracking: jest.fn(() => ({
     handleDepositConfirm: jest.fn(),
   })),
@@ -321,52 +387,8 @@ jest.mock('../../hooks', () => ({
   usePerpsEventTracking: jest.fn(() => ({
     track: jest.fn(),
   })),
-  usePerpsRewards: jest.fn(() => ({
-    shouldShowRewardsRow: false,
-    isLoading: false,
-    estimatedPoints: undefined,
-    bonusBips: undefined,
-    feeDiscountPercentage: undefined,
-    hasError: false,
-    isRefresh: false,
-    accountOptedIn: null,
-    account: undefined,
-  })),
-  usePerpsToasts: jest.fn(() => ({
-    showToast: jest.fn(),
-    PerpsToastOptions: {
-      formValidation: {
-        orderForm: {
-          limitPriceRequired: {},
-          validationError: jest.fn(),
-        },
-      },
-      orderManagement: {
-        market: {
-          submitted: jest.fn(),
-          confirmed: jest.fn(),
-          creationFailed: jest.fn(),
-        },
-        limit: {
-          submitted: jest.fn(),
-          confirmed: jest.fn(),
-          creationFailed: jest.fn(),
-        },
-      },
-      positionManagement: {
-        tpsl: {
-          updateTPSLError: jest.fn(),
-        },
-      },
-      dataFetching: {
-        market: {
-          error: {
-            marketDataUnavailable: jest.fn(),
-          },
-        },
-      },
-    },
-  })),
+  usePerpsRewards: jest.fn(() => mockDefaultUsePerpsRewards()),
+  usePerpsToasts: jest.fn(() => mockDefaultUsePerpsToasts()),
 }));
 
 // Mock direct hook imports (when imported from specific file paths)
@@ -818,18 +840,13 @@ jest.mock(
 );
 
 jest.mock('../../hooks/usePerpsEstimatedSlippage', () => ({
-  usePerpsEstimatedSlippage: jest.fn(() => ({
-    estimatedSlippageBps: null,
-    isReady: false,
-  })),
+  usePerpsEstimatedSlippage: jest.fn(() =>
+    mockDefaultUsePerpsEstimatedSlippage(),
+  ),
 }));
 
 jest.mock('../../hooks/usePerpsMaxSlippage', () => ({
-  usePerpsMaxSlippage: jest.fn(() => ({
-    maxSlippageBps: 300,
-    maxSlippageSource: 'default',
-    setMaxSlippage: jest.fn(),
-  })),
+  usePerpsMaxSlippage: jest.fn(() => mockDefaultUsePerpsMaxSlippage()),
 }));
 
 // Test setup
@@ -1030,9 +1047,54 @@ global.requestAnimationFrame = jest.fn((cb) => {
   return 1;
 });
 
+function applyDefaultHookMocks() {
+  (usePerpsOrderForm as jest.Mock).mockImplementation(
+    mockDefaultUsePerpsOrderForm,
+  );
+  (usePerpsOrderExecution as jest.Mock).mockImplementation(
+    mockDefaultUsePerpsOrderExecution,
+  );
+  (usePerpsRewards as jest.Mock).mockImplementation(mockDefaultUsePerpsRewards);
+  (usePerpsToasts as jest.Mock).mockImplementation(mockDefaultUsePerpsToasts);
+  (usePerpsEstimatedSlippage as jest.Mock).mockImplementation(
+    mockDefaultUsePerpsEstimatedSlippage,
+  );
+  (usePerpsMaxSlippage as jest.Mock).mockImplementation(
+    mockDefaultUsePerpsMaxSlippage,
+  );
+
+  mockUseIsPerpsBalanceSelected.mockReturnValue(false);
+  mockUseTransactionPayToken.mockReturnValue({
+    payToken: undefined,
+    setPayToken: jest.fn(),
+    isNative: undefined,
+  });
+  mockUseABTest.mockReturnValue({
+    variantName: 'control',
+    variant: { long: 'white', short: 'white' },
+    isActive: false,
+  });
+  mockCreateEventBuilder.mockImplementation(() => ({
+    addProperties: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({}),
+  }));
+
+  const { useInsufficientPayTokenBalanceAlert } = jest.requireMock(
+    '../../../../Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert',
+  ) as { useInsufficientPayTokenBalanceAlert: jest.Mock };
+  useInsufficientPayTokenBalanceAlert.mockReturnValue([]);
+
+  const { useNoPayTokenQuotesAlert } = jest.requireMock(
+    '../../../../Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert',
+  ) as { useNoPayTokenQuotesAlert: jest.Mock };
+  useNoPayTokenQuotesAlert.mockReturnValue([]);
+}
+
 describe('PerpsOrderView', () => {
   beforeEach(() => {
+    jest.useRealTimers();
     jest.clearAllMocks();
+    applyDefaultHookMocks();
     (usePerpsOrderValidation as jest.Mock).mockReturnValue({
       isValid: true,
       errors: [],
@@ -1048,6 +1110,9 @@ describe('PerpsOrderView', () => {
     mockIsPaySubmitReady = true;
     mockPayTokenAccountBalanceUsd = '0';
     mockProviderEffectiveAvailableBalance = undefined;
+    mockIsPayQuoteLoading = false;
+    mockPayTotals = undefined;
+    mockPayRequiredTokens = [];
 
     jest.mocked(useAnalytics).mockReturnValue({
       trackEvent: mockTrackEvent,


### PR DESCRIPTION
## **Description**

`PerpsOrderView.test.tsx` passed in default Jest order and failed under `--randomize` because `jest.clearAllMocks()` keeps implementations. Tests overrode hook and pay-token mocks and never put the defaults back. The global `beforeEach` now re-applies those defaults so no test depends on leftover mock state.

AC1 `--randomize` on 5 seeds: PASS
AC2 no leftover mock state: PASS
AC3 default order 128/128: PASS (ticket said 129; current suite is 128)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3910

## **Manual testing steps**

N/A — test isolation only. No product UI change.

```gherkin
Feature: PerpsOrderView hook mock isolation

  Scenario: suite is order-independent
    Given the PerpsOrderView unit suite
    When yarn jest app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx --no-coverage
    Then Tests: 128 passed, 128 total
    When yarn jest ... --no-coverage --randomize --seed=1
    And the same command with seeds 7, 13, 42, and 99
    Then each run exits 0 with 128 passed
```

## **Screenshots/Recordings**

No visual evidence required. Isolation is proven by Jest default-order and randomized-seed output.

## **Validation Recipe**
<details><summary>recipe.json (19 steps — default Jest order plus five --randomize seeds)</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "TAT-3910 PerpsOrderView hook-mock isolation",
  "description": "Proves PerpsOrderView.test.tsx is order-independent: default Jest order still passes 128/128, and --randomize passes on five seeds. If the six leaking hook defaults are not reset in beforeEach, randomized seeds fail.",
  "workflow": {
    "entry": "jest-default-order",
    "nodes": {
      "jest-default-order": {
        "action": "command",
        "cmd": "yarn jest app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx --no-coverage",
        "timeout_ms": 300000,
        "allow_failure": true,
        "intent": "Run the suite in default order so AC3 can be asserted from this output",
        "next": "assert-default-exit"
      },
      "assert-default-exit": {
        "action": "assert_exit_code",
        "source": "jest-default-order",
        "expected": 0,
        "intent": "AC3: default order must exit 0",
        "next": "assert-default-count"
      },
      "assert-default-count": {
        "action": "assert_output",
        "source": "jest-default-order",
        "stream": "stderr",
        "contains": "128 passed",
        "intent": "AC3: default order still reports 128 passed",
        "next": "jest-seed-1"
      },
      "jest-seed-1": {
        "action": "command",
        "cmd": "yarn jest app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx --no-coverage --randomize --seed=1",
        "timeout_ms": 300000,
        "allow_failure": true,
        "intent": "AC1/AC2: run seed 1; a leaked hook mock fails this order",
        "next": "assert-seed-1-exit"
      },
      "assert-seed-1-exit": {
        "action": "assert_exit_code",
        "source": "jest-seed-1",
        "expected": 0,
        "intent": "AC1: seed 1 must exit 0",
        "next": "assert-seed-1-count"
      },
      "assert-seed-1-count": {
        "action": "assert_output",
        "source": "jest-seed-1",
        "stream": "stderr",
        "contains": "128 passed",
        "intent": "AC1/AC2: seed 1 still runs all 128 tests",
        "next": "jest-seed-7"
      },
      "jest-seed-7": {
        "action": "command",
        "cmd": "yarn jest app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx --no-coverage --randomize --seed=7",
        "timeout_ms": 300000,
        "allow_failure": true,
        "intent": "AC1/AC2: run seed 7 against the same isolation contract",
        "next": "assert-seed-7-exit"
      },
      "assert-seed-7-exit": {
        "action": "assert_exit_code",
        "source": "jest-seed-7",
        "expected": 0,
        "intent": "AC1: seed 7 must exit 0",
        "next": "assert-seed-7-count"
      },
      "assert-seed-7-count": {
        "action": "assert_output",
        "source": "jest-seed-7",
        "stream": "stderr",
        "contains": "128 passed",
        "intent": "AC1/AC2: seed 7 still runs all 128 tests",
        "next": "jest-seed-13"
      },
      "jest-seed-13": {
        "action": "command",
        "cmd": "yarn jest app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx --no-coverage --randomize --seed=13",
        "timeout_ms": 300000,
        "allow_failure": true,
        "intent": "AC1/AC2: run seed 13 against the same isolation contract",
        "next": "assert-seed-13-exit"
      },
      "assert-seed-13-exit": {
        "action": "assert_exit_code",
        "source": "jest-seed-13",
        "expected": 0,
        "intent": "AC1: seed 13 must exit 0",
        "next": "assert-seed-13-count"
      },
      "assert-seed-13-count": {
        "action": "assert_output",
        "source": "jest-seed-13",
        "stream": "stderr",
        "contains": "128 passed",
        "intent": "AC1/AC2: seed 13 still runs all 128 tests",
        "next": "jest-seed-42"
      },
      "jest-seed-42": {
        "action": "command",
        "cmd": "yarn jest app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx --no-coverage --randomize --seed=42",
        "timeout_ms": 300000,
        "allow_failure": true,
        "intent": "AC1/AC2: run seed 42 against the same isolation contract",
        "next": "assert-seed-42-exit"
      },
      "assert-seed-42-exit": {
        "action": "assert_exit_code",
        "source": "jest-seed-42",
        "expected": 0,
        "intent": "AC1: seed 42 must exit 0",
        "next": "assert-seed-42-count"
      },
      "assert-seed-42-count": {
        "action": "assert_output",
        "source": "jest-seed-42",
        "stream": "stderr",
        "contains": "128 passed",
        "intent": "AC1/AC2: seed 42 still runs all 128 tests",
        "next": "jest-seed-99"
      },
      "jest-seed-99": {
        "action": "command",
        "cmd": "yarn jest app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx --no-coverage --randomize --seed=99",
        "timeout_ms": 300000,
        "allow_failure": true,
        "intent": "AC1/AC2: run seed 99 against the same isolation contract",
        "next": "assert-seed-99-exit"
      },
      "assert-seed-99-exit": {
        "action": "assert_exit_code",
        "source": "jest-seed-99",
        "expected": 0,
        "intent": "AC1: seed 99 must exit 0",
        "next": "assert-seed-99-count"
      },
      "assert-seed-99-count": {
        "action": "assert_output",
        "source": "jest-seed-99",
        "stream": "stderr",
        "contains": "128 passed",
        "intent": "AC1/AC2: seed 99 still runs all 128 tests",
        "next": "done"
      },
      "done": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}
```
</details>

## **Validation Logs**
Command:
```bash
```

<details><summary>Full output (19/19 passed)</summary>

```
status: pass
exitCode: 0
result: default order 128 passed; --randomize seeds 1, 7, 13, 42, 99 each 128 passed
sideFindings: 1 pre-existing act(...) warning from PerpsOrderViewContentBase setIsDataReady; not caused by this change
```
</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A — test isolation only
- [x] I've tested with a power user scenario
  - N/A — test isolation only
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — test isolation only

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock reset and refactor in `PerpsOrderView.test.tsx`; no runtime or product behavior changes.
> 
> **Overview**
> Fixes **order-dependent failures** in `PerpsOrderView.test.tsx` when Jest runs with `--randomize`. Individual tests override hook and pay-token mocks, but `jest.clearAllMocks()` leaves **mock implementations** in place, so later tests could inherit stale behavior.
> 
> The PR **centralizes default hook return values** in shared `mockDefault*` helpers (order form, execution, rewards, toasts, estimated/max slippage) and wires `jest.mock` factories through them. A new **`applyDefaultHookMocks()`** re-applies those defaults (plus pay-token, A/B test, analytics, and pay-alert mocks) on every **`beforeEach`**, alongside resets for pay-quote module flags. **`jest.useRealTimers()`** is also enabled in setup so timer state does not leak between tests.
> 
> **No production code changes**—only test isolation for the Perps order view suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 409ffbf6e383adfce9372c2b2ab8dec41d126d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->