### PR TITLE
ci: refit the Appium Android emulator budget for the 8x16 profile

### DIFF
--- a/.github/workflows/prime-appium-e2e-android-emulator.yml
+++ b/.github/workflows/prime-appium-e2e-android-emulator.yml
@@ -42,7 +42,12 @@ jobs:
       ANDROID_SYSTEM_IMAGE_API_LEVEL: '36'
       ANDROID_SYSTEM_IMAGE_TAG: ${{ inputs.android-tag }}
       ANDROID_SYSTEM_IMAGE_ABI: x86_64
-      ANDROID_EMULATOR_CI_CORES: '8'
+      # Must stay identical to the value in run-appium-e2e-workflow.yml. Cores
+      # are part of the snapshot fingerprint, so if prime and shards disagree
+      # every snapshot is rejected and all shards silently cold boot.
+      # 5 rather than 8: the profile is an 8 vCPU shape, so an 8-core emulator
+      # would claim the whole box and leave nothing for the harness.
+      ANDROID_EMULATOR_CI_CORES: '5'
     steps:
       - name: Checkout (Namespace)
         uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -121,7 +121,14 @@ jobs:
       ANDROID_SYSTEM_IMAGE_API_LEVEL: '36'
       ANDROID_SYSTEM_IMAGE_TAG: ${{ inputs.android-tag }}
       ANDROID_SYSTEM_IMAGE_ABI: x86_64
-      ANDROID_EMULATOR_CI_CORES: '8'
+      # Must stay identical to the value in prime-appium-e2e-android-emulator.yml.
+      # Cores are part of the snapshot fingerprint, so if prime and shards
+      # disagree every snapshot is rejected and all shards silently cold boot.
+      # 5 rather than 8: the profile is an 8 vCPU shape, so an 8-core emulator
+      # would claim the whole box and leave nothing for the Appium server,
+      # Playwright, node, adb and the failure-path ffmpeg capture. Drop to 4
+      # before touching the shape if resume or boot timeouts appear.
+      ANDROID_EMULATOR_CI_CORES: '5'
 
     steps:
       - name: Checkout (Namespace)

--- a/tests/framework/services/appium/AndroidGoldenSnapshot.ts
+++ b/tests/framework/services/appium/AndroidGoldenSnapshot.ts
@@ -11,6 +11,18 @@ const logger = createLogger({ name: 'AndroidGoldenSnapshot' });
 const ANDROID_EMULATOR_CI_CORES_DEFAULT = '8';
 const ANDROID_EMULATOR_CI_DNS_SERVER = '8.8.8.8';
 const ANDROID_EMULATOR_CI_SKIN = '1440x3120';
+/**
+ * Guest RAM ceiling, sized for the 8x16 `android-e2e` runner. A 12 GB guest on
+ * a 16 GB host with `swap_size_mb: 0` leaves nothing to absorb a spike, which
+ * is the shape of the INFRA-3891 OOM. Measured peak RSS for the whole instance
+ * is 8.89 GB p50 / 9.23 p99 / 9.33 max, so 10 GB stays clear of real usage
+ * while capping the worst case at ~12 GB of 16. Still 5x a physical Pixel 5.
+ *
+ * A snapshot records its RAM size, so prime and resume must agree — both read
+ * this same constant, and it is part of the fingerprint, so changing it
+ * invalidates cached snapshots and forces a re-prime rather than a bad resume.
+ */
+const ANDROID_EMULATOR_CI_MEMORY_MB = '10240';
 
 /** Named quick-boot snapshot shared by Appium CI shards. */
 export const ANDROID_EMULATOR_GOLDEN_SNAPSHOT_NAME = 'e2e_golden';
@@ -184,7 +196,7 @@ export function buildAndroidEmulatorArgs(options: {
     '-skin',
     skin,
     '-memory',
-    '12288',
+    ANDROID_EMULATOR_CI_MEMORY_MB,
     '-cores',
     cores,
     '-dns-server',

--- a/tests/framework/services/appium/EmulatorHelpers.test.ts
+++ b/tests/framework/services/appium/EmulatorHelpers.test.ts
@@ -156,14 +156,18 @@ describe('EmulatorHelpers', () => {
   describe('buildAndroidEmulatorArgs', () => {
     const base = { avdName: 'appium_smoke_avd', isCI: true };
 
-    it('cold mode reproduces the historical CI flag set exactly', () => {
+    // Pins the cold-boot flag set so it cannot drift silently. It matches the
+    // pre-snapshot set except for `-memory`, deliberately lowered from 12288
+    // when the profile moved to the 8x16 shape (a 12 GB guest on a 16 GB host
+    // with no swap has nothing to absorb a spike).
+    it('cold mode reproduces the pinned CI flag set exactly', () => {
       expect(buildAndroidEmulatorArgs({ ...base, bootMode: 'cold' })).toEqual([
         '-avd',
         'appium_smoke_avd',
         '-skin',
         '1440x3120',
         '-memory',
-        '12288',
+        '10240',
         '-cores',
         '8',
         '-dns-server',


### PR DESCRIPTION
## **Description**

Prepares `namespace-profile-metamask-android-e2e` to drop from 16 vCPU / 32 GB to **8x16**. The shape itself is an `nsc` change rather than a repo change — this PR is the emulator-side half, and it has to land **first** so the shape flip is a no-op for the emulator config.

Measured on the post-snapshot workload (after #35491), 2026-09-01 14:00Z onward — **270 pipelines, n=5,498 successful shards** on 16x32, `cancelled` excluded:

| | p50 | p95 | p99 | max | of |
| --- | --- | --- | --- | --- | --- |
| peak vCPU | 9.10 | 11.33 | 12.47 | 13.95 | 16 |
| peak RAM | 8.92 | 9.14 | 9.24 | **9.36 GB** | 32 (29%) |

**Memory is the clear over-provision, and #35491 made it cleaner to reason about.** The old 11.93 GB tail was a cold-cache artifact and is gone — worst observed is now 9.36 GB, so 16 GB is 1.7x the worst run ever seen.

**CPU is the constraint, and #35491 did not move it.** Peak was 9.0 p50 / 11.2 p95 before the snapshot change and 9.1 / 11.3 after. Removing 144s of cold boot removed *time spent* at high CPU, not the peak — that comes from the test phase rendering through `-gpu swiftshader_indirect`. **82% of runs still peak above 8 vCPU** (24% above 10, 1.9% above 12), so the emulator's own budget has to come down with the host. Worth stating plainly: this is a weaker CPU case than the `ci-linux` right-sizing in #35204/#35384, where the moved jobs were never CPU-bound and cost only +6% wall-clock.

### Two values change, and they must move together

- **`ANDROID_EMULATOR_CI_CORES` 8 → 5**, in both `prime-appium-e2e-android-emulator.yml` and `run-appium-e2e-workflow.yml`. On an 8 vCPU box an 8-core emulator claims the whole machine and starves the Appium server, Playwright, node, adb and the failure-path ffmpeg capture. Measured harness overhead above the emulator cap is ~1–3 vCPU, so 5 + 3 fits 8.
- **emulator `-memory` 12288 → 10240**, hoisted into a named constant. The profile has `swap_size_mb: 0`, so a 12 GB guest on a 16 GB host has nothing to absorb a spike — the shape of the INFRA-3891 OOM. 10 GB stays clear of the 9.24 GB p99 and is still 5x a physical Pixel 5.

Cores are part of the snapshot fingerprint. **If the two workflow files disagree, every snapshot is rejected and all shards silently cold boot** — erasing the #35491 gain while CI stays green. Both files carry a comment saying so. `-memory` is in the fingerprint too, and a snapshot records its RAM size, so prime and resume read the same constant.

### Expect exactly one re-prime per branch

Both changed values are fingerprinted, so merging this invalidates every cached golden snapshot. That is intended, and it is why this lands **while the profile is still 16x32** — a cold prime is cheapest there (~256s). Resume rate will dip for one pipeline per branch and then return to ~100%.

### Test change

`cold mode reproduces the historical CI flag set exactly` fails on the new `-memory` value — the guard doing its job. Updated to the new value and renamed to `...the pinned CI flag set exactly`, with a comment recording that `-memory` is a deliberate deviation from the historical set. The rest of the flag set stays pinned byte-for-byte.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MCWP-736
Refs: MCWP-744

## **Manual testing steps**

N/A for app behaviour — CI runner config only, no app code.

`appium-smoke-tests-android` runs on `pull_request` with no label gate, so this PR self-validates the emulator-config half. It cannot validate the shape, which is a separate `nsc` step below.

**1. Confirm the re-prime happened and resume recovered.** On this PR's run, the first pipeline should re-prime (fingerprint changed); check the prime job log for `Priming golden snapshot` and shard logs for `resumed from golden snapshot`:

```bash
gh run view --job <SHARD_JOB_ID> --log | grep -E 'resumed from golden snapshot|falling back to cold boot'
```

**If shards report `falling back to cold boot` on a second pipeline, stop** — that means prime and shard fingerprints disagree and the two `ANDROID_EMULATOR_CI_CORES` values are out of sync.

**2. Confirm the emulator honours 5 cores** while still on 16x32 — this isolates the emulator-config change from the shape change:

```bash
nsc instance report --start <T0> --repository MetaMask/metamask-mobile \
  --jobname "Appium Smoke Tests (Android)" --out -
```

Expect `resources_cpu == 16` still, peak vCPU to drop by roughly 3 (the emulator's 3 surrendered cores), peak RAM unchanged around 8.9 GB, and job p50 within a modest margin of the current 507s.

**3. Only then flip the shape** (not part of this PR):

```bash
nsc github profile update --profile_id ghpf_25jrnjlnf1o90 --machine_type 8x16
```

This does **not** invalidate snapshots — machine shape is not in the fingerprint — so there is no second re-prime.

**4. Watch flake, not just duration**, for a day after the flip. Peak RAM should stay under 12 GB and resume rate at ~100%. Two things are expected to get slower and are worth measuring rather than assuming: the ~30s per-shard AVD cache restore, since Namespace scales network and disk bandwidth with machine shape; and the prime job's cold path on 5 cores.

**Rollback.** The shape is one command (`--machine_type 16x32`, no PR). The emulator budget is a revert of this commit. They are independent on purpose — if something regresses after step 3, the shape can go back without touching the emulator config.

### Note on current Appium Android failure rate

Unrelated to this PR, but visible in the same telemetry and worth flagging: the post-snapshot day shows a 2.3% shard failure rate, of which **`appium-money-android-smoke (1)` alone is 22.9% (49/214)** — one suite accounting for 35% of all failures. Excluding it the rate is 1.6%, inside the historical 0.5–3.8% range. None of the 142 failures show an OOM signature (peak RAM on failed runs is 9.33 GB max against a 32 GB ceiling), so this is test flake rather than resource pressure, and it does not block right-sizing. It probably deserves its own issue.
