### PR TITLE
chore: bump typescript to 5.8.3

### DIFF
--- a/app/components/UI/Assets/components/AssetLogo/AssetLogo.utils.ts
+++ b/app/components/UI/Assets/components/AssetLogo/AssetLogo.utils.ts
@@ -58,7 +58,10 @@ export function createRotatingSet<T>(maxSize: number = 100): {
     add(value: T): void {
       set.add(value);
       if (set.size > maxSize) {
-        set.delete(set.values().next().value);
+        const oldest = set.values().next().value;
+        if (oldest !== undefined) {
+          set.delete(oldest);
+        }
       }
     },
     has(value: T): boolean {

--- a/app/components/UI/Predict/hooks/usePredictRewards.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictRewards.test.ts
@@ -1,7 +1,11 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import { usePredictRewards } from './usePredictRewards';
-import utils, { type CaipAccountId } from '@metamask/utils';
+import {
+  parseCaipChainId,
+  toCaipAccountId,
+  type CaipAccountId,
+} from '@metamask/utils';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
 import { getFormattedAddressFromInternalAccount } from '../../../../core/Multichain/utils';
@@ -85,11 +89,11 @@ describe('usePredictRewards', () => {
   const mockLoggerError = Logger.error as jest.MockedFunction<
     typeof Logger.error
   >;
-  const mockParseCaipChainId = utils.parseCaipChainId as jest.MockedFunction<
-    typeof utils.parseCaipChainId
+  const mockParseCaipChainId = parseCaipChainId as jest.MockedFunction<
+    typeof parseCaipChainId
   >;
-  const mockToCaipAccountId = utils.toCaipAccountId as jest.MockedFunction<
-    typeof utils.toCaipAccountId
+  const mockToCaipAccountId = toCaipAccountId as jest.MockedFunction<
+    typeof toCaipAccountId
   >;
   const mockGetFormattedAddressFromInternalAccount =
     getFormattedAddressFromInternalAccount as jest.MockedFunction<

--- a/app/components/hooks/useAddressBalance/useAddressBalance.test.tsx
+++ b/app/components/hooks/useAddressBalance/useAddressBalance.test.tsx
@@ -148,7 +148,7 @@ describe('useAddressBalance', () => {
   });
 
   it('render balance if asset is undefined', () => {
-    let asset: Asset;
+    let asset: Asset | undefined;
     let res = renderHook(() => useAddressBalance(asset, MOCK_ADDRESS_1), {
       wrapper: Wrapper,
     });

--- a/app/components/hooks/useCheckNftAutoDetectionModal/useCheckNftAutoDetectionModal.test.ts
+++ b/app/components/hooks/useCheckNftAutoDetectionModal/useCheckNftAutoDetectionModal.test.ts
@@ -47,7 +47,7 @@ describe('useCheckNftAutoDetectionModal', () => {
           return false;
       }
     });
-    (isMainNet as jest.Mock).mockReturnValue(true);
+    (isMainNet as unknown as jest.Mock).mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -66,7 +66,7 @@ describe('useCheckNftAutoDetectionModal', () => {
   });
 
   it('should not navigate or dispatch action when conditions are not met', () => {
-    (isMainNet as jest.Mock).mockReturnValue(false);
+    (isMainNet as unknown as jest.Mock).mockReturnValue(false);
 
     renderHook(() => useCheckNftAutoDetectionModal());
 

--- a/app/core/SnapKeyring/SnapKeyringV2.ts
+++ b/app/core/SnapKeyring/SnapKeyringV2.ts
@@ -41,7 +41,13 @@ export function snapKeyringV2AdaptedAsV1Builder(
 ): KeyringBuilder {
   const SnapKeyringV2AdaptedAsV1BuilderV2 = () => {
     const v2 = new SnapKeyringV2({
-      messenger,
+      // The app and `@metamask/eth-snap-keyring` resolve to separate copies
+      // of `@metamask/messenger`, so TypeScript treats their `Messenger`
+      // `#private` brands as distinct types even though they are the same
+      // version. The messengers are structurally identical.
+      messenger: messenger as unknown as ConstructorParameters<
+        typeof SnapKeyringV2
+      >[0]['messenger'],
       callbacks: new SnapKeyringV2Impl(messenger),
       // Enables generic account creation for new chain integration. We keep
       // it on under e2e to match the v1 keyring's behaviour in this codebase.

--- a/app/core/SnapKeyring/utils/getAccountsBySnapId.test.ts
+++ b/app/core/SnapKeyring/utils/getAccountsBySnapId.test.ts
@@ -70,6 +70,27 @@ describe('getAccountsBySnapId', () => {
     expect(result).toEqual([]);
   });
 
+  it('selects the snap keyring matching the given snap ID', async () => {
+    mockIsSnapKeyring.mockImplementation(
+      (keyring) => 'snapId' in (keyring as object),
+    );
+    const keyring = mockKeyringWithAccounts([]);
+    const otherSnapKeyring = {
+      snapId: 'npm:@metamask/other-snap',
+    } as unknown as KeyringV2;
+    const nonSnapKeyring = {} as KeyringV2;
+
+    await getAccountsBySnapId(MOCK_SNAP_ID);
+
+    const [selector] = mockWithKeyringV2.mock.calls[0];
+    const { filter } = selector as {
+      filter: (keyring: KeyringV2) => boolean;
+    };
+    expect(filter(keyring)).toBe(true);
+    expect(filter(otherSnapKeyring)).toBe(false);
+    expect(filter(nonSnapKeyring)).toBe(false);
+  });
+
   it('returns an empty array when the keyring is not a snap keyring', async () => {
     mockIsSnapKeyring.mockReturnValue(false);
     mockKeyringWithAccounts([]);

--- a/app/core/SnapKeyring/utils/getAccountsBySnapId.ts
+++ b/app/core/SnapKeyring/utils/getAccountsBySnapId.ts
@@ -16,7 +16,10 @@ export const getAccountsBySnapId = async (
     return (await Engine.context.KeyringController.withKeyringV2(
       {
         filter: (keyring) =>
-          isSnapKeyring(keyring) && keyring.snapId === snapId,
+          // Compare as strings: the keyring's `SnapId` brand comes from a
+          // separate copy of `@metamask/snaps-sdk`, which TypeScript treats
+          // as a distinct opaque type.
+          isSnapKeyring(keyring) && (keyring.snapId as string) === snapId,
       },
       async ({ keyring }) => {
         if (!isSnapKeyring(keyring)) {

--- a/app/util/conversion/index.test.ts
+++ b/app/util/conversion/index.test.ts
@@ -184,7 +184,6 @@ describe('conversion utils', () => {
         conversionUtil('1', {
           fromNumericBase: 'dec',
           toNumericBase: 'dec',
-          //@ts-expect-error - conversion.js file needs conversion to ts file
           toCurrency: 'usd',
           conversionRate: 468.58,
           numberOfDecimals: 2,
@@ -197,7 +196,6 @@ describe('conversion utils', () => {
         conversionUtil('1.5', {
           fromNumericBase: 'dec',
           toNumericBase: 'dec',
-          //@ts-expect-error - conversion.js file needs conversion to ts file
           toCurrency: 'usd',
           conversionRate: 468.58,
           numberOfDecimals: 2,
@@ -212,7 +210,6 @@ describe('conversion utils', () => {
         conversionUtil('468.58', {
           fromNumericBase: 'dec',
           toNumericBase: 'dec',
-          //@ts-expect-error - conversion.js file needs conversion to ts file
           toCurrency: 'usd',
           conversionRate: 468.58,
           numberOfDecimals: 2,
@@ -225,7 +222,6 @@ describe('conversion utils', () => {
         conversionUtil('702.87', {
           fromNumericBase: 'dec',
           toNumericBase: 'dec',
-          //@ts-expect-error - conversion.js file needs conversion to ts file
           toCurrency: 'usd',
           conversionRate: 468.58,
           numberOfDecimals: 2,

--- a/app/util/scaling.js
+++ b/app/util/scaling.js
@@ -38,6 +38,18 @@ const _getSizes = (scaleVertical, baseModel) => {
   return { currSize, baseScreenSize };
 };
 
+/**
+ * Scale a size relative to the current device dimensions.
+ *
+ * @param {number} size - The size to scale.
+ * @param {object} [options] - Scaling options.
+ * @param {number} [options.factor] - Interpolation factor for the scaled delta.
+ * @param {boolean} [options.scaleVertical] - Scale against height instead of width.
+ * @param {boolean} [options.scaleUp] - Allow scaling above the original size.
+ * @param {number} [options.baseSize] - Override the current screen size.
+ * @param {0|1|2} [options.baseModel] - Base device model to scale against.
+ * @returns {number} The scaled size.
+ */
 const scale = (
   size,
   {

--- a/package.json
+++ b/package.json
@@ -772,7 +772,7 @@
     "ts-loader": "^9.5.0",
     "ts-node": "^10.9.2",
     "tsx": "^4.21.0",
-    "typescript": "~5.4.5",
+    "typescript": "~5.8.3",
     "webdriverio": "^9.27.0",
     "webextension-polyfill": "^0.12.0",
     "webpack": "^5.88.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -40195,7 +40195,7 @@ __metadata:
     ts-loader: "npm:^9.5.0"
     ts-node: "npm:^10.9.2"
     tsx: "npm:^4.21.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.8.3"
     unicode-confusables: "npm:^0.1.1"
     uri-js: "npm:^4.4.1"
     url: "npm:0.11.0"
@@ -51732,7 +51732,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.2.2":
+"typescript@npm:^5.2.2, typescript@npm:~5.8.3":
   version: 5.8.3
   resolution: "typescript@npm:5.8.3"
   bin:
@@ -51742,33 +51742,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.4.5":
-  version: 5.4.5
-  resolution: "typescript@npm:5.4.5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/d04a9e27e6d83861f2126665aa8d84847e8ebabcea9125b9ebc30370b98cb38b5dff2508d74e2326a744938191a83a69aa9fddab41f193ffa43eabfdf3f190a5
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A~5.8.3#optional!builtin<compat/typescript>":
   version: 5.8.3
   resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/b9b1e73dabac5dc730c041325dbd9c99467c1b0d239f1b74ec3b90d831384af3e2ba973946232df670519147eb51a2c20f6f96163cea2b359f03de1e2091cc4f
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A~5.4.5#optional!builtin<compat/typescript>":
-  version: 5.4.5
-  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=5adc0c"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/760f7d92fb383dbf7dee2443bf902f4365db2117f96f875cf809167f6103d55064de973db9f78fe8f31ec08fff52b2c969aee0d310939c0a3798ec75d0bca2e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Bumps `typescript` ~5.4.5 → ~5.8.3 (devDependency, build-time only). Part of the RN 0.85 pre-upgrade PR ladder: the upgrade branch (#34283) already type-checks on 5.8.3 — landing the compiler bump on `main` now shrinks the upgrade diff and stops new code regressing against 5.8.

TS 5.5–5.8 stricter checks surfaced 12 pre-existing errors in 8 files; all fixed here with minimal, behavior-preserving changes:

- `app/util/scaling.js`: added JSDoc for `scale()` options — 5.8's JS inference dropped the un-defaulted `baseModel` destructured param, breaking the `CollectibleMedia.styles.ts` call site (`baseModel` is a real runtime option)
- `app/core/SnapKeyring/SnapKeyringV2.ts`: messenger cast via `ConstructorParameters<typeof SnapKeyringV2>[0]['messenger']` — the app and `@metamask/eth-snap-keyring` resolve separate copies of `@metamask/messenger`, and 5.8 treats their `Messenger` `#private` brands as distinct (structurally identical)
- `app/core/SnapKeyring/utils/getAccountsBySnapId.ts`: compare `SnapId` as string — same duplicate-brand issue with `@metamask/snaps-sdk`
- `AssetLogo.utils.ts`: guard `set.values().next().value` (TS 5.6+ types iterator `value` as `T | undefined`)
- Test-only fixes: `Asset | undefined` declaration (useAddressBalance), `as unknown as jest.Mock` for a type-guard fn (useCheckNftAutoDetectionModal), named imports instead of non-existent default import of `@metamask/utils` (usePredictRewards), removed 4 now-unused `@ts-expect-error` directives (conversion)

Verified: `yarn lint:tsc` clean, eslint clean on changed files, 15 affected test suites / 137 tests green.

Supersedes #34415 (closed during ladder trim; recut fresh on current `main`).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #34415 (superseded predecessor — RN 0.85 upgrade prep, toolchain bump; no user-facing change)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — devDependency/toolchain change only; no runtime behavior change. Covered by `yarn lint:tsc` and the unit test suite.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — toolchain bump, no visual changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Snap keyring selection and adapter wiring, but changes are documented type-compat fixes and string comparison that should preserve runtime behavior; primary impact is build-time typing.
> 
> **Overview**
> Upgrades the dev **TypeScript** compiler from **~5.4.5** to **~5.8.3** (including **yarn.lock**), ahead of the RN 0.85 upgrade ladder so **main** type-checks on the same compiler version.
> 
> Stricter **5.5–5.8** checks required small, mostly type-level fixes: **JSDoc** on **`scale()`** in **`scaling.js`** so optional **`baseModel`** stays visible to JS inference; **casts** when wiring **`SnapKeyringV2`**’s messenger and when comparing **`snapId`** in **`getAccountsBySnapId`** (duplicate **`@metamask/messenger`** / **`@metamask/snaps-sdk`** copies with incompatible branded types); and an **undefined** guard before evicting the oldest entry in **`createRotatingSet`**.
> 
> Tests were updated to match (**named `@metamask/utils` imports**, **`Asset | undefined`**, **`as unknown as jest.Mock`** for a type guard, removal of stale **`@ts-expect-error`** in conversion tests), plus a new unit test asserting the **`withKeyringV2`** filter selects only the matching snap keyring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a320a875768420701af850027db78c01101c6f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->