### PR TITLE
fix: Arc swap token selector defaults

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -92,6 +92,7 @@ import { mergeBridgeTokensWithBalances } from '../../utils/mergeBridgeTokensWith
 import { filterOutRwaTokens } from '../../utils/filterOutRwaTokens';
 import { filterWatchlistBridgeTokens } from '../../utils/filterWatchlistBridgeTokens';
 import { prependWatchlistToSearchResults } from '../../utils/prependWatchlistToSearchResults';
+import { mergeIncludedAssetsWithApiResults } from '../../utils/mergeIncludedAssetsWithApiResults';
 import { trackTokenListItemClicked } from '../../../Assets/watchlist/utils/trackTokenListItemClicked';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
@@ -453,6 +454,15 @@ export const BridgeTokenSelector: React.FC = () => {
     includeAssets: searchIncludeAssets,
   });
 
+  const mergedPopularTokens = useMemo(
+    () => mergeIncludedAssetsWithApiResults(popularTokens, includeAssets),
+    [popularTokens, includeAssets],
+  );
+  const mergedSearchResults = useMemo(
+    () => mergeIncludedAssetsWithApiResults(searchResults, searchIncludeAssets),
+    [searchResults, searchIncludeAssets],
+  );
+
   // React to network filter changes from any source (pill press or modal).
   // Cancels pending searches, resets stale results, and flags for re-search.
   useEffect(() => {
@@ -517,11 +527,11 @@ export const BridgeTokenSelector: React.FC = () => {
 
   // Use custom hook for merging balances
   const popularTokensWithBalance = useRwaFilteredTokens(
-    useTokensWithBalances(popularTokens, balancesByAssetId),
+    useTokensWithBalances(mergedPopularTokens, balancesByAssetId),
     excludeRwaTokens,
   );
   const searchResultsWithBalance = useRwaFilteredTokens(
-    useTokensWithBalances(searchResults, balancesByAssetId),
+    useTokensWithBalances(mergedSearchResults, balancesByAssetId),
     excludeRwaTokens,
   );
 

--- a/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.test.ts
@@ -7,6 +7,10 @@ import {
   createMockTokenWithBalance,
   MOCK_CHAIN_IDS_HEX,
 } from '../../testUtils/fixtures';
+import {
+  ARC_NATIVE_ASSET_ID,
+  ARC_USDC_ASSET_ID,
+} from '../../../../hooks/useArcDefaultTokens';
 
 jest.mock('../useTokensWithBalance', () => ({
   useTokensWithBalance: jest.fn(),
@@ -223,6 +227,45 @@ describe('useBalancesByAssetId', () => {
           'eip155:10/erc20:0x2222222222222222222222222222222222222222' as CaipAssetType
         ],
       ).toBeDefined();
+    });
+
+    it('aliases Arc native USDC balance to the Arc ERC20 USDC asset id', () => {
+      mockUseTokensWithBalance.mockReturnValue([
+        createMockTokenWithBalance({
+          address: '0x0000000000000000000000000000000000000000',
+          chainId: '0x13b2' as Hex,
+          balance: '12.34',
+          balanceFiat: '$12.34',
+          tokenFiatAmount: 12.34,
+        }),
+      ]);
+
+      const { result } = renderHook(() =>
+        useBalancesByAssetId({
+          chainIds: ['0x13b2' as Hex],
+        }),
+      );
+
+      expect(
+        result.current.balancesByAssetId[
+          ARC_USDC_ASSET_ID.toLowerCase() as CaipAssetType
+        ],
+      ).toEqual(
+        expect.objectContaining({
+          balance: '12.34',
+          balanceFiat: '$12.34',
+          tokenFiatAmount: 12.34,
+        }),
+      );
+      expect(
+        result.current.balancesByAssetId[
+          ARC_NATIVE_ASSET_ID.toLowerCase() as CaipAssetType
+        ],
+      ).toEqual(
+        expect.objectContaining({
+          balance: '12.34',
+        }),
+      );
     });
 
     it('handles CAIP chain IDs', () => {

--- a/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.ts
+++ b/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.ts
@@ -1,11 +1,17 @@
 import { useMemo } from 'react';
 import {
+  assetIdsMatch,
   formatAddressToAssetId,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
 import { useTokensWithBalance } from '../useTokensWithBalance';
 import { CaipAssetType, CaipChainId, Hex } from '@metamask/utils';
 import { BridgeToken } from '../../types';
+import {
+  ARC_NATIVE_ASSET_ID,
+  ARC_NATIVE_ASSET_ID_LEGACY,
+  ARC_USDC_ASSET_ID,
+} from '../../../../hooks/useArcDefaultTokens';
 
 /**
  * Interface for the balance data stored in the lookup map
@@ -25,9 +31,15 @@ export interface BalanceData {
 export type BalancesByAssetId = Record<CaipAssetType, BalanceData>;
 
 /**
- * Hook to get balances indexed by assetId (CAIP format) for O(1) lookup
- * @param params - Configuration object containing chainIds
- * @returns Object containing tokens array and map of assetId to balance data
+ * Builds an asset-id keyed balance lookup for the swap token selector.
+ *
+ * Arc is a special case: the selector renders ERC-20 USDC, while the held
+ * balance may still resolve from the native Arc asset entry. To keep the
+ * visible Arc USDC row hydrated, this hook aliases the native Arc balance onto
+ * the ERC-20 Arc USDC asset id in addition to the native asset id.
+ *
+ * @param params - Configuration object containing chainIds.
+ * @returns Tokens with balances plus an O(1) asset-id lookup map.
  */
 export const useBalancesByAssetId = ({
   chainIds,
@@ -61,6 +73,18 @@ export const useBalancesByAssetId = ({
           ? assetId
           : (assetId.toLowerCase() as CaipAssetType);
         balancesMap[normalizedAssetId] = balanceData;
+
+        // Arc displays ERC-20 USDC in the picker even when the held balance is
+        // sourced from the native Arc asset entry. Mirror the native balance to
+        // the ERC-20 asset id so the visible row shows the correct balance.
+        if (
+          assetIdsMatch(assetId, ARC_NATIVE_ASSET_ID) ||
+          assetIdsMatch(assetId, ARC_NATIVE_ASSET_ID_LEGACY)
+        ) {
+          balancesMap[ARC_USDC_ASSET_ID] = balanceData;
+          balancesMap[ARC_USDC_ASSET_ID.toLowerCase() as CaipAssetType] =
+            balanceData;
+        }
       }
     });
 

--- a/app/components/UI/Bridge/hooks/useInitialBridgeTokens.test.ts
+++ b/app/components/UI/Bridge/hooks/useInitialBridgeTokens.test.ts
@@ -6,6 +6,7 @@ import { renderHookWithProvider } from '../../../../util/test/renderWithProvider
 import { initialState } from '../_mocks_/initialState';
 import { CaipChainId } from '@metamask/utils';
 import { popularTokensCache } from '../utils/cacheUtils';
+import { ARC_CAIP_CHAIN_ID } from '../../../../enablement/assets/arc';
 
 let globalFetchSpy: jest.SpyInstance;
 
@@ -87,6 +88,43 @@ describe('useInitialBridgeTokens', () => {
         }),
         searchIncludeAssets: [],
       });
+    });
+
+    it('includes Arc curated swap tokens even when the account holds none', () => {
+      const { result } = renderHookWithProvider(
+        () => useInitialBridgeTokens([ARC_CAIP_CHAIN_ID]),
+        { state: initialState },
+      );
+
+      expect(result.current.includeAssets).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            symbol: 'USDC',
+            assetId:
+              'eip155:5042/erc20:0x3600000000000000000000000000000000000000',
+          }),
+          expect.objectContaining({
+            symbol: 'EURC',
+            assetId:
+              'eip155:5042/erc20:0xbef5f6d51cb62b58e6a8f77868681825c6fe21c1',
+          }),
+        ]),
+      );
+    });
+
+    it('includes Arc ERC20 USDC in exact-symbol search results', () => {
+      const { result } = renderHookWithProvider(
+        () => useInitialBridgeTokens([ARC_CAIP_CHAIN_ID], 'USDC'),
+        { state: initialState },
+      );
+
+      expect(result.current.searchIncludeAssets).toEqual([
+        expect.objectContaining({
+          symbol: 'USDC',
+          assetId:
+            'eip155:5042/erc20:0x3600000000000000000000000000000000000000',
+        }),
+      ]);
     });
 
     it('fetches and caches popular tokens', async () => {

--- a/app/components/UI/Bridge/hooks/useInitialBridgeTokens.ts
+++ b/app/components/UI/Bridge/hooks/useInitialBridgeTokens.ts
@@ -3,10 +3,32 @@ import type { CaipChainId } from '@metamask/utils';
 import { useSelector } from 'react-redux';
 import { useBalancesByAssetId } from './useBalancesByAssetId';
 import { useFetchPopularTokens } from './useFetchPopularTokens';
-import { tokenMatchesQuery, tokenToIncludeAsset } from '../utils/tokenUtils';
+import {
+  getDefaultDestToken,
+  tokenMatchesQuery,
+  tokenToIncludeAsset,
+} from '../utils/tokenUtils';
 import { selectAllowedChainRanking } from '../../../../core/redux/slices/bridge';
 import type { IncludeAsset } from '../types';
 import { getMinimalIncludedAssets } from '../utils/cacheUtils';
+import { ARC_CAIP_CHAIN_ID } from '../../../../enablement/assets/arc';
+import { BRIDGE_CHAINID_TO_DEFAULT_SOURCE_TOKEN } from '../constants/default-swap-dest-tokens';
+
+const dedupeIncludeAssets = (
+  includeAssets: (IncludeAsset | null)[],
+): IncludeAsset[] => {
+  const uniqueAssets = new Map<string, IncludeAsset>();
+
+  for (const asset of includeAssets) {
+    if (!asset) {
+      continue;
+    }
+
+    uniqueAssets.set(asset.assetId.toLowerCase(), asset);
+  }
+
+  return [...uniqueAssets.values()];
+};
 
 /**
  * Custom hook to fetch popular tokens from the Bridge API with caching
@@ -49,15 +71,27 @@ export const useInitialBridgeTokens = (
     [tokensWithBalance],
   );
 
+  const arcDefaultTokens = useMemo(() => {
+    if (!chainIdsToFetch.includes(ARC_CAIP_CHAIN_ID)) {
+      return [];
+    }
+
+    return [
+      BRIDGE_CHAINID_TO_DEFAULT_SOURCE_TOKEN[ARC_CAIP_CHAIN_ID],
+      getDefaultDestToken(ARC_CAIP_CHAIN_ID),
+    ].filter((token) => token !== undefined);
+  }, [chainIdsToFetch]);
+
   // Create includeAssets array from tokens with balance to be sent to API
   // Stringified to avoid triggering the useEffect when only balances change
   const includeAssetsObject = useMemo(
     () =>
-      filteredTokensWithBalance
-        .map(tokenToIncludeAsset)
-        .filter((asset): asset is IncludeAsset => asset !== null),
+      dedupeIncludeAssets([
+        ...filteredTokensWithBalance.map(tokenToIncludeAsset),
+        ...arcDefaultTokens.map(tokenToIncludeAsset),
+      ]),
 
-    [filteredTokensWithBalance],
+    [arcDefaultTokens, filteredTokensWithBalance],
   );
 
   // Stable string key for the includeAssets array — re-derive the callback
@@ -84,15 +118,20 @@ export const useInitialBridgeTokens = (
   const searchIncludeAssets = useMemo(
     () =>
       searchQuery
-        ? tokensWithBalance
-            .map((token) =>
+        ? dedupeIncludeAssets([
+            ...tokensWithBalance.map((token) =>
               tokenMatchesQuery(token, searchQuery)
                 ? tokenToIncludeAsset(token)
                 : null,
-            )
-            .filter((asset): asset is IncludeAsset => asset !== null)
+            ),
+            ...arcDefaultTokens.map((token) =>
+              tokenMatchesQuery(token, searchQuery)
+                ? tokenToIncludeAsset(token)
+                : null,
+            ),
+          ])
         : [],
-    [tokensWithBalance, searchQuery],
+    [arcDefaultTokens, tokensWithBalance, searchQuery],
   );
 
   return {

--- a/app/components/UI/Bridge/hooks/useInitialBridgeTokens.ts
+++ b/app/components/UI/Bridge/hooks/useInitialBridgeTokens.ts
@@ -14,6 +14,16 @@ import { getMinimalIncludedAssets } from '../utils/cacheUtils';
 import { ARC_CAIP_CHAIN_ID } from '../../../../enablement/assets/arc';
 import { BRIDGE_CHAINID_TO_DEFAULT_SOURCE_TOKEN } from '../constants/default-swap-dest-tokens';
 
+/**
+ * Removes null entries and deduplicates include-assets by normalized asset id.
+ *
+ * Arc can contribute curated assets from multiple sources, so this keeps the
+ * include-assets payload stable while preserving the last occurrence for a
+ * given asset id.
+ *
+ * @param includeAssets - Candidate assets, optionally including null entries.
+ * @returns Deduplicated include-assets keyed by lowercased asset id.
+ */
 const dedupeIncludeAssets = (
   includeAssets: (IncludeAsset | null)[],
 ): IncludeAsset[] => {

--- a/app/components/UI/Bridge/hooks/useInitialBridgeTokens.ts
+++ b/app/components/UI/Bridge/hooks/useInitialBridgeTokens.ts
@@ -9,7 +9,7 @@ import {
   tokenToIncludeAsset,
 } from '../utils/tokenUtils';
 import { selectAllowedChainRanking } from '../../../../core/redux/slices/bridge';
-import type { IncludeAsset } from '../types';
+import type { BridgeToken, IncludeAsset } from '../types';
 import { getMinimalIncludedAssets } from '../utils/cacheUtils';
 import { ARC_CAIP_CHAIN_ID } from '../../../../enablement/assets/arc';
 import { BRIDGE_CHAINID_TO_DEFAULT_SOURCE_TOKEN } from '../constants/default-swap-dest-tokens';
@@ -39,6 +39,16 @@ const dedupeIncludeAssets = (
 
   return [...uniqueAssets.values()];
 };
+
+/**
+ * Narrows optional bridge-token entries to defined tokens.
+ *
+ * @param token - Candidate bridge token.
+ * @returns True when the token is defined.
+ */
+const isDefinedBridgeToken = (
+  token: BridgeToken | undefined,
+): token is BridgeToken => token !== undefined;
 
 /**
  * Custom hook to fetch popular tokens from the Bridge API with caching
@@ -89,7 +99,7 @@ export const useInitialBridgeTokens = (
     return [
       BRIDGE_CHAINID_TO_DEFAULT_SOURCE_TOKEN[ARC_CAIP_CHAIN_ID],
       getDefaultDestToken(ARC_CAIP_CHAIN_ID),
-    ].filter((token) => token !== undefined);
+    ].filter(isDefinedBridgeToken);
   }, [chainIdsToFetch]);
 
   // Create includeAssets array from tokens with balance to be sent to API

--- a/app/components/UI/Bridge/utils/mergeIncludedAssetsWithApiResults.test.ts
+++ b/app/components/UI/Bridge/utils/mergeIncludedAssetsWithApiResults.test.ts
@@ -1,0 +1,50 @@
+import {
+  createMockIncludeAsset,
+  createMockPopularToken,
+} from '../testUtils/fixtures';
+import { mergeIncludedAssetsWithApiResults } from './mergeIncludedAssetsWithApiResults';
+
+describe('mergeIncludedAssetsWithApiResults', () => {
+  it('appends included assets that are missing from the API response', () => {
+    const apiResults = [
+      createMockPopularToken({
+        assetId: 'eip155:5042/slip44:5042',
+        symbol: 'USDC',
+        name: 'USDC',
+      }),
+    ];
+    const includeAssets = [
+      createMockIncludeAsset({
+        assetId: 'eip155:5042/erc20:0x3600000000000000000000000000000000000000',
+        symbol: 'USDC',
+        name: 'USDC',
+      }),
+      createMockIncludeAsset({
+        assetId: 'eip155:5042/erc20:0xbef5f6d51cb62b58e6a8f77868681825c6fe21c1',
+        symbol: 'EURC',
+        name: 'EURC',
+      }),
+    ];
+
+    expect(
+      mergeIncludedAssetsWithApiResults(apiResults, includeAssets),
+    ).toEqual([...apiResults, ...includeAssets]);
+  });
+
+  it('dedupes exact asset-id overlaps while preserving API ordering', () => {
+    const apiToken = createMockPopularToken({
+      assetId: 'eip155:5042/erc20:0xbef5f6d51cb62b58e6a8f77868681825c6fe21c1',
+      symbol: 'EURC',
+      name: 'EURC',
+    });
+    const duplicateIncludeAsset = createMockIncludeAsset({
+      assetId: 'eip155:5042/erc20:0xbef5f6d51cb62b58e6a8f77868681825c6fe21c1',
+      symbol: 'EURC',
+      name: 'EURC',
+    });
+
+    expect(
+      mergeIncludedAssetsWithApiResults([apiToken], [duplicateIncludeAsset]),
+    ).toEqual([apiToken]);
+  });
+});

--- a/app/components/UI/Bridge/utils/mergeIncludedAssetsWithApiResults.ts
+++ b/app/components/UI/Bridge/utils/mergeIncludedAssetsWithApiResults.ts
@@ -1,0 +1,27 @@
+import type { IncludeAsset, PopularToken } from '../types';
+
+/**
+ * Appends locally included assets to API results while deduping by asset id.
+ *
+ * This keeps API ordering intact and guarantees locally curated assets remain
+ * visible even when the API only returns a filtered native duplicate.
+ */
+export const mergeIncludedAssetsWithApiResults = (
+  apiResults: readonly (PopularToken | IncludeAsset)[] | null | undefined,
+  includeAssets: readonly IncludeAsset[],
+): (PopularToken | IncludeAsset)[] => {
+  const mergedResults: (PopularToken | IncludeAsset)[] = [];
+  const seenAssetIds = new Set<string>();
+
+  for (const token of [...(apiResults ?? []), ...includeAssets]) {
+    const normalizedAssetId = token.assetId.toLowerCase();
+    if (seenAssetIds.has(normalizedAssetId)) {
+      continue;
+    }
+
+    seenAssetIds.add(normalizedAssetId);
+    mergedResults.push(token);
+  }
+
+  return mergedResults;
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This fixes Arc token selection in Swap FROM and TO pages.
On Arc, the selector could open with an empty token list by default, and exact USDC search could fail even though Arc tokens were available. 
After making Arc tokens visible, the USDC row could also appear without its balance in `Select token`.

The Arc flow diverged from other EVM chains in two places:

- default/search token seeding only relied on held assets, so Arc curated tokens were not always injected into the selector dataset
- the selector displays Arc USDC as the ERC20 asset, while the held balance can still resolve from the Arc native asset entry, so the visible USDC row was not hydrated with a balance

### Changes

- seed Arc curated swap tokens into the token selector default/search include-assets path
- merge locally included Arc assets with API token results so they remain visible even when API results include the native duplicate
- alias Arc native balance data to Arc ERC20 USDC in the selector balance lookup so the visible USDC row shows the correct balance
- add regression tests for
  - Arc curated tokens being included by default
  - exact USDC search on Arc
  - Arc native-to-ERC20 balance hydration in the selector

### User Impact

- Arc tokens are listed by default in Swap token selection
- USDC and EURC search behaves consistently on Arc
- Arc USDC shows the expected balance in Select token

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: shows Arc tokens on `Selet token` list

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [WPN-1959](https://consensyssoftware.atlassian.net/browse/WPN-1959)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

1. Open MetaMask Mobile with an account that has Arc network enabled
2. Go to Swap
3. Open the FROM token selector and choose Arc from the network filter
4. Verify the token list is populated by default and is not blank
5. Confirm Arc USDC is visible and its balance is displayed in the `Select token` list
6. Confirm Arc EURC is visible in the same list
7. Search for USDC in the Arc token selector
8. Verify USDC is returned and no `No token` error is shown
9. Search for EURC in the Arc token selector
10. Verify EURC is returned correctly
11. Repeat the same checks in the TO token selector with Arc selected
12. If possible, repeat with an account with no Arc token balance

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/2001b62e-4af6-49dc-aabc-56316e4bf917

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/c7606d53-4e22-487b-877d-0be8fcb1a9b6

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[WPN-1959]: https://consensyssoftware.atlassian.net/browse/WPN-1959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches swap token list composition and balance lookup for Arc only, but incorrect aliasing or merge logic could mis-display balances or duplicate rows in the selector.
> 
> **Overview**
> Fixes **Arc** swap token selection when the list was empty by default, **USDC** exact search failed, or the visible **ERC-20 USDC** row showed no balance.
> 
> **`useInitialBridgeTokens`** now always adds curated Arc defaults (USDC/EURC) to `includeAssets` and search include-assets when Arc is in scope—even with zero held balance—and dedupes those entries by asset id. **`BridgeTokenSelector`** merges API popular/search results with those include-assets via new **`mergeIncludedAssetsWithApiResults`**, so ERC-20 curated rows stay visible when the API only returns a native duplicate. **`useBalancesByAssetId`** mirrors native Arc balance onto the Arc ERC-20 USDC asset id so the picker row hydrates correctly.
> 
> Regression tests cover default/search seeding, merge/dedupe behavior, and native→ERC-20 balance aliasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed4d39c3543a3523f18c0993a439e3e0cb2b88ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->