### PR TITLE
fix(ui): center FoxLoader using window dimensions, not screen dimensions

### DIFF
--- a/app/components/UI/FoxLoader/FoxLoader.styles.ts
+++ b/app/components/UI/FoxLoader/FoxLoader.styles.ts
@@ -17,11 +17,13 @@ const STATIC_FOX_SIZE = Platform.OS === 'android' ? 98 : 88;
  */
 const styleSheet = (params: {
   theme: Theme;
-  vars: { screenH: number; screenW: number };
+  // Window (not physical screen) size — see FoxLoader.tsx for why this
+  // distinction matters on iPad (Split View / Stage Manager / compat mode).
+  vars: { windowH: number; windowW: number };
 }) => {
   const { theme, vars } = params;
   const { colors } = theme;
-  const { screenH, screenW } = vars;
+  const { windowH, windowW } = vars;
 
   return StyleSheet.create({
     container: {
@@ -35,8 +37,8 @@ const styleSheet = (params: {
       width: FOX_SIZE,
       height: FOX_SIZE,
       position: 'absolute',
-      top: Math.round((screenH - FOX_SIZE) / 2),
-      left: Math.round((screenW - FOX_SIZE) / 2),
+      top: Math.round((windowH - FOX_SIZE) / 2),
+      left: Math.round((windowW - FOX_SIZE) / 2),
     },
     riveAnimation: {
       width: FOX_SIZE,

--- a/app/components/UI/FoxLoader/FoxLoader.tsx
+++ b/app/components/UI/FoxLoader/FoxLoader.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { View, Animated, Dimensions } from 'react-native';
+import { View, Animated, useWindowDimensions } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   Alignment,
@@ -63,10 +63,14 @@ const FoxLoaderAnimation = ({
   appServicesReady = false,
   onAnimationComplete = () => undefined,
 }: FoxLoaderProps) => {
-  const screenDims = Dimensions.get('screen');
-  const screenH = screenDims.height;
-  const screenW = screenDims.width;
-  const { styles } = useStyles(styleSheet, { screenH, screenW });
+  // Use the app's window (not the physical screen) so the fox stays centered
+  // in the box it's actually rendered inside. On iPad the two can diverge
+  // (Split View, Stage Manager, or iPhone-compatibility-mode scaling), which
+  // pushed the fox off-screen and left users looking at a blank loader.
+  // useWindowDimensions (vs. a one-time Dimensions.get) also keeps the fox
+  // centered if the window resizes after mount, e.g. a Split View resize.
+  const { width: windowW, height: windowH } = useWindowDimensions();
+  const { styles } = useStyles(styleSheet, { windowH, windowW });
   const { riveFile } = useRiveFile(splashRiveFile);
   const { riveRef, riveViewRef, setHybridRef } = useRive();
   const isPlaying = riveViewRef != null;


### PR DESCRIPTION

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Multiple support tickets report MetaMask never getting past the splash/loading screen on iPad (5th, 6th, and 9th generation, across iPadOS 16/17/26 and app versions 8.6–8.20). Investigation ruled out a release regression — the failure reproduces across many versions and OS majors — and found that `FoxLoader` (the animated fox shown while app services initialize) centers itself using `Dimensions.get('screen')`, the physical display size, while it actually renders inside a `SafeAreaView` sized to the app's **window**.

On iPhone these two are always equal, so the bug has been invisible. On iPad they can diverge — Split View, Stage Manager, or iPhone-compatibility-mode scaling — which pushes the fox's absolutely-positioned wrapper outside the visible area, leaving only a flat background-colored screen. That reads exactly like "stuck on the splash screen" and explains why nothing is ever logged to Sentry: there's no error, just a mispositioned view.

This PR switches `FoxLoader` to `useWindowDimensions()` so the fox is centered in the box it's actually drawn inside, and stays correct if the window resizes after mount (e.g. an in-flight Split View resize).

**Caveat for reviewers:** this fixes a confirmed positioning bug that would produce a blank-looking loader on iPad. It has not yet been confirmed on a physical/simulated iPad to be the full explanation for a *permanent* hang — if `appServicesReady` still resolves normally, the loader should still fade out regardless of where the fox was drawn. Opening as draft to validate on-device before this is considered a full fix; if the hang persists after this change, the next suspect is `startAppServices` in `app/store/sagas/index.ts` (Engine/controller startup), which has no timeout and no error boundary.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the loading animation rendering off-screen on some iPad window configurations

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #3488

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: App startup loading animation on iPad

  Scenario: App launches on an iPad in Split View or Stage Manager
    Given the app is installed on an iPad running iPadOS 16+
    And the app window is resized via Split View or Stage Manager to be smaller than the physical screen

    When the app is launched (cold start)

    Then the animated fox loader is centered and visible within the app window
    And the loader fades out once app services finish initializing, revealing the wallet home screen

  Scenario: Device is rotated while the loader is visible
    Given the app is mid-launch and the fox loader is on screen

    When the iPad is rotated between portrait and landscape

    Then the fox remains centered within the current window bounds after rotation
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no iPad device/simulator build available in this environment to capture. This PR is opened as draft specifically to gather that evidence.

### **After**

N/A — see above.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
  - Not yet done — no device/simulator available in this environment; needed before marking ready for review
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
  - Not applicable — change only affects layout math for a startup loading screen, no perf-sensitive data loading involved
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Not applicable — this change adjusts static layout math, it doesn't add an operation to instrument
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
