### PR TITLE
ci: make yarn audit:ci advisory instead of blocking merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,30 +394,19 @@ jobs:
   # needing to know anything about what (if anything) reacts to it.
   dependency-audit:
     name: Dependency audit (advisory)
-    runs-on: >-
-      ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
-      }}
+    # Unlike the older jobs in this file, this one has no GitHub-hosted
+    # fallback: it's new, and this repo is already fully committed to
+    # Namespace runners, so there's no dual-provider transition to support
+    # here.
+    runs-on: namespace-profile-metamask-ci-linux-small
     outputs:
       has-advisories: ${{ steps.audit.outputs.has-advisories }}
-    env:
-      # Effective provider for this job. Steps must test this, never inputs.runner_provider
-      # directly, or a provider set through the repo variables would be ignored.
-      RESOLVED_RUNNER_PROVIDER: >-
-        ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
-        }}
     if: ${{ needs.get_requirements.outputs.skip_everything != 'true' }}
     needs:
       - get_requirements
     steps:
       - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
-      - uses: actions/checkout@v6
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
       - name: Configure Namespace cache
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
         uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
         with:
           path: |
@@ -428,7 +417,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
-          cache: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' && 'yarn' || '' }}
       - name: Install Yarn dependencies with retry
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,19 +394,30 @@ jobs:
   # needing to know anything about what (if anything) reacts to it.
   dependency-audit:
     name: Dependency audit (advisory)
-    # Unlike the older jobs in this file, this one has no GitHub-hosted
-    # fallback: it's new, and this repo is already fully committed to
-    # Namespace runners, so there's no dual-provider transition to support
-    # here.
-    runs-on: namespace-profile-metamask-ci-linux-small
+    runs-on: >-
+      ${{
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
+      }}
     outputs:
       has-advisories: ${{ steps.audit.outputs.has-advisories }}
+    env:
+      # Effective provider for this job. Steps must test this, never inputs.runner_provider
+      # directly, or a provider set through the repo variables would be ignored.
+      RESOLVED_RUNNER_PROVIDER: >-
+        ${{
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+        }}
     if: ${{ needs.get_requirements.outputs.skip_everything != 'true' }}
     needs:
       - get_requirements
     steps:
       - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
+      - uses: actions/checkout@v6
+        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
       - name: Configure Namespace cache
+        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
         uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
         with:
           path: |
@@ -417,6 +428,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
+          cache: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' && 'yarn' || '' }}
       - name: Install Yarn dependencies with retry
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,8 +340,6 @@ jobs:
             profile: namespace-profile-metamask-ci-linux-small
           - scripts: format:check
             profile: namespace-profile-metamask-ci-linux-small
-          - scripts: audit:ci
-            profile: namespace-profile-metamask-ci-linux-small
           - scripts: test:depcheck
             profile: namespace-profile-metamask-ci-linux-small
           - scripts: test:tgz-check
@@ -389,6 +387,73 @@ jobs:
           else
             echo "No changes detected"
           fi
+
+  # Advisory only: never fails, never gates merges. Surfaces findings via a
+  # workflow warning and step summary instead. Exposes `has-advisories` as a
+  # job output so a follow-up automation can consume it without this job
+  # needing to know anything about what (if anything) reacts to it.
+  dependency-audit:
+    name: Dependency audit (advisory)
+    runs-on: >-
+      ${{
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
+      }}
+    outputs:
+      has-advisories: ${{ steps.audit.outputs.has-advisories }}
+    env:
+      # Effective provider for this job. Steps must test this, never inputs.runner_provider
+      # directly, or a provider set through the repo variables would be ignored.
+      RESOLVED_RUNNER_PROVIDER: >-
+        ${{
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+        }}
+    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' }}
+    needs:
+      - get_requirements
+    steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
+      - uses: actions/checkout@v6
+        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
+      - name: Configure Namespace cache
+        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+        with:
+          path: |
+            ~/.cache/yarn
+            .metamask
+            node_modules
+            .yarn/cache
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' && 'yarn' || '' }}
+      - name: Install Yarn dependencies with retry
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: yarn install --immutable
+      - name: Dependency audit (advisory only, never fails this job)
+        id: audit
+        shell: bash
+        run: |
+          set -uo pipefail
+          if yarn audit:ci; then
+            echo "No production advisories at moderate severity or above."
+            echo "has-advisories=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "has-advisories=true" >> "$GITHUB_OUTPUT"
+          echo "::warning title=Dependency audit::Production dependency advisories found at moderate severity or above. This does not block merge."
+          {
+            echo '### Dependency audit'
+            echo
+            echo 'Advisories found at moderate severity or above. This check is advisory only and does not block merge.'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
 
   js-bundle-size-check:
     # Stays on 8x16 (MCWP-813). It is the thinnest margin on the profile — 14.3 GB


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

**Why:** `yarn audit:ci` was a required leg of the `scripts` matrix job in `ci.yml`. Any new advisory at moderate severity or above (including ones with no available fix yet, or in transitive deps we don't control) blocked every PR into `main` until someone manually intervened. There was no single owner and no escalation path — just a red check that sat there until whoever noticed it fixed the lockfile.

**What changed:** Moved `audit:ci` out of the blocking `scripts` matrix and into its own `dependency-audit` job that still runs `yarn audit:ci` on every push/PR/hourly-schedule run `ci.yml` already has, but only ever warns (`::warning` + a step summary) instead of failing. The job exposes `has-advisories` as a job output.

This PR is deliberately scoped to just that: advisories no longer block merges, and findings are still visible (as a workflow warning + step summary) so nobody's surprised. It does **not** add any auto-fix, PR, or Slack escalation — that's a separate, stacked follow-up PR (owner/Slack/AI-fix escalation loop), kept out of this PR to keep both small and independently reviewable. This PR is fully valuable and mergeable on its own; the follow-up PR only adds a consumer of the `has-advisories` output this PR introduces.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

CI-only change, no user-facing behavior. Manual verification:

- `actionlint .github/workflows/ci.yml` — clean.
- `yarn prettier --check .github/workflows/ci.yml` — the new hunk is clean (the file has a pre-existing, unrelated `needs: [...]` array-wrapping issue on `main` that this PR doesn't touch or introduce).
- Confirmed via GitHub's Rulesets API that `audit:ci`/`scripts` isn't itself in `main`'s or `release/*`'s required-status-checks list — only the aggregate `Check all jobs pass` / `policy-bot` checks are required, and this PR's new `dependency-audit` job is intentionally excluded from `check-all-jobs-pass`'s `needs`, so it can never gate a merge even if it fails outright.
- This PR's own CI run exercises the real thing: `Dependency audit (advisory)` runs `yarn audit:ci` against this branch (which currently has real, pre-existing advisories) and is expected to post a `::warning` + step summary while still passing the job.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — CI/tooling-only change, no UI.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A — this PR only touches `ci.yml` (a CI workflow definition), no app code, so there's nothing to profile on-device.

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change; it relaxes a merge gate for dependency advisories while keeping visibility via warnings, with no app or security-logic changes.
> 
> **Overview**
> **`yarn audit:ci` no longer fails the blocking `scripts` matrix** — that leg was removed so moderate+ production advisories can't hold every PR on `main` until someone fixes the lockfile.
> 
> A new **`dependency-audit`** job still runs `yarn audit:ci` on the same CI triggers, but the step always exits 0: it sets job output **`has-advisories`** and surfaces findings via a workflow **`::warning`** and GitHub step summary instead of a red check. The job is **not** in **`check-all-jobs-pass`** `needs`, so it cannot gate merges even if the job itself misbehaves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25fe09899271473b6d5db913b2afd667fe1dd40e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->