### PR TITLE
feat: recurring block confirm

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
@@ -318,6 +318,7 @@ const BridgeRecurringBuyViewContent = ({
         <RecurringConfirmOrderSheet
           isVisible={isConfirmSheetVisible}
           onClose={handleConfirmSheetClosed}
+          latestSourceBalance={latestSourceBalance}
         />
       </Box>
     </Box>

--- a/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.test.tsx
+++ b/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
+import { BigNumber } from 'ethers';
 import renderWithProvider, {
   DeepPartial,
 } from '../../../../../util/test/renderWithProvider';
@@ -8,6 +9,7 @@ import { mockUseBridgeQuoteData } from '../../_mocks_/useBridgeQuoteData.mock';
 import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
 import { BRIDGE_MM_FEE_RATE } from '@metamask/bridge-controller';
 import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
+import { useHasSufficientGas } from '../../hooks/useHasSufficientGas';
 import { createBridgeTestState } from '../../testUtils';
 import type { RootState } from '../../../../../reducers';
 import { strings } from '../../../../../../locales/i18n';
@@ -74,6 +76,10 @@ jest.mock('../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => {
   };
 });
 
+jest.mock('../../hooks/useHasSufficientGas', () => ({
+  useHasSufficientGas: jest.fn(() => true),
+}));
+
 function buildState(
   bridgeReducerOverrides: Record<string, unknown> = {},
 ): DeepPartial<RootState> {
@@ -101,17 +107,35 @@ function buildState(
   });
 }
 
+const SUFFICIENT_SOURCE_BALANCE = {
+  displayBalance: '1000',
+  atomicBalance: BigNumber.from('1000000000000000000000'),
+};
+
+const INSUFFICIENT_SOURCE_BALANCE = {
+  displayBalance: '1',
+  atomicBalance: BigNumber.from('1000000000000000000'),
+};
+
 function renderSheet({
   isVisible = true,
   onClose = jest.fn(),
   state = buildState(),
+  latestSourceBalance = SUFFICIENT_SOURCE_BALANCE,
 }: {
   isVisible?: boolean;
   onClose?: () => void;
   state?: DeepPartial<RootState>;
+  latestSourceBalance?:
+    | { displayBalance: string; atomicBalance: BigNumber }
+    | undefined;
 } = {}) {
   return renderWithProvider(
-    <RecurringConfirmOrderSheet isVisible={isVisible} onClose={onClose} />,
+    <RecurringConfirmOrderSheet
+      isVisible={isVisible}
+      onClose={onClose}
+      latestSourceBalance={latestSourceBalance}
+    />,
     { state },
   );
 }
@@ -129,6 +153,7 @@ describe('RecurringConfirmOrderSheet', () => {
           networkFee: '$1.23',
         },
       }));
+    jest.mocked(useHasSufficientGas).mockReturnValue(true);
   });
 
   it('renders nothing when the sheet is hidden', () => {
@@ -527,5 +552,86 @@ describe('RecurringConfirmOrderSheet', () => {
     );
 
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables Confirm and shows Insufficient funds when source balance is below the per-order amount', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = renderSheet({
+      latestSourceBalance: INSUFFICIENT_SOURCE_BALANCE,
+      onClose,
+    });
+
+    const confirmButton = getByTestId(
+      RecurringConfirmOrderSheetSelectorsIDs.CONFIRM_BUTTON,
+    );
+
+    fireEvent.press(confirmButton);
+
+    expect(confirmButton).toHaveTextContent(
+      strings('bridge.insufficient_funds'),
+    );
+    expect(confirmButton.props.accessibilityState?.disabled).toBe(true);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('shows Confirm when source balance covers the per-order amount', () => {
+    const { getByTestId } = renderSheet();
+
+    const confirmButton = getByTestId(
+      RecurringConfirmOrderSheetSelectorsIDs.CONFIRM_BUTTON,
+    );
+
+    expect(confirmButton).toHaveTextContent(
+      strings('bridge.recurring.confirm'),
+    );
+    expect(confirmButton.props.accessibilityState?.disabled).toBe(false);
+  });
+
+  it('closes from the header when Confirm is disabled for insufficient funds', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = renderSheet({
+      latestSourceBalance: INSUFFICIENT_SOURCE_BALANCE,
+      onClose,
+    });
+
+    fireEvent.press(
+      getByTestId(RecurringConfirmOrderSheetSelectorsIDs.CLOSE_BUTTON),
+    );
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables Confirm and shows Insufficient gas when native gas is short', () => {
+    jest.mocked(useHasSufficientGas).mockReturnValue(false);
+
+    const { getByTestId } = renderSheet({
+      latestSourceBalance: SUFFICIENT_SOURCE_BALANCE,
+    });
+
+    const confirmButton = getByTestId(
+      RecurringConfirmOrderSheetSelectorsIDs.CONFIRM_BUTTON,
+    );
+
+    expect(confirmButton).toHaveTextContent(
+      strings('bridge.insufficient_gas'),
+    );
+    expect(confirmButton.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('shows Insufficient funds when source balance and gas are both short', () => {
+    jest.mocked(useHasSufficientGas).mockReturnValue(false);
+
+    const { getByTestId } = renderSheet({
+      latestSourceBalance: INSUFFICIENT_SOURCE_BALANCE,
+    });
+
+    const confirmButton = getByTestId(
+      RecurringConfirmOrderSheetSelectorsIDs.CONFIRM_BUTTON,
+    );
+
+    expect(confirmButton).toHaveTextContent(
+      strings('bridge.insufficient_funds'),
+    );
+    expect(confirmButton.props.accessibilityState?.disabled).toBe(true);
   });
 });

--- a/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.test.tsx
+++ b/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.test.tsx
@@ -612,9 +612,7 @@ describe('RecurringConfirmOrderSheet', () => {
       RecurringConfirmOrderSheetSelectorsIDs.CONFIRM_BUTTON,
     );
 
-    expect(confirmButton).toHaveTextContent(
-      strings('bridge.insufficient_gas'),
-    );
+    expect(confirmButton).toHaveTextContent(strings('bridge.insufficient_gas'));
     expect(confirmButton.props.accessibilityState?.disabled).toBe(true);
   });
 

--- a/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.tsx
+++ b/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.tsx
@@ -37,6 +37,8 @@ import { getNetworkImageSource } from '../../../../../util/networks';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import { useFeeDisclaimer } from '../../hooks/useFeeDisclaimer';
+import useIsInsufficientBalance from '../../hooks/useInsufficientBalance';
+import { useHasSufficientGas } from '../../hooks/useHasSufficientGas';
 import type { BridgeToken } from '../../types';
 import { formatMinimumReceived } from '../../utils/currencyUtils';
 import { getTokenImageSource } from '../../utils';
@@ -169,6 +171,7 @@ function formatTokenAmountValue(
 const RecurringConfirmOrderSheet = ({
   isVisible,
   onClose,
+  latestSourceBalance,
 }: RecurringConfirmOrderSheetProps) => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation<AppNavigationProp>();
@@ -179,6 +182,19 @@ const RecurringConfirmOrderSheet = ({
   const slippage = useSelector(selectSlippage);
   const { activeQuote, destTokenAmount, formattedQuoteData, isLoading } =
     useBridgeQuoteDataContext();
+  const hasInsufficientBalance = useIsInsufficientBalance({
+    amount: sourceAmount,
+    token: sourceToken,
+    latestAtomicBalance: latestSourceBalance?.atomicBalance,
+  });
+  const hasSufficientGas = useHasSufficientGas({ quote: activeQuote });
+  const hasInsufficientGas = !hasSufficientGas;
+  const isConfirmDisabled = hasInsufficientBalance || hasInsufficientGas;
+  const confirmLabel = hasInsufficientBalance
+    ? strings('bridge.insufficient_funds')
+    : hasInsufficientGas
+      ? strings('bridge.insufficient_gas')
+      : strings('bridge.recurring.confirm');
   const { discountBadge, infoText, infoSuffix, baseFeePercentage } =
     useFeeDisclaimer({ activeQuote });
   const showQuoteSkeletons = isLoading;
@@ -350,8 +366,9 @@ const RecurringConfirmOrderSheet = ({
       </Box>
       <BottomSheetFooter
         primaryButtonProps={{
-          children: strings('bridge.recurring.confirm'),
+          children: confirmLabel,
           onPress: closeSheet,
+          isDisabled: isConfirmDisabled,
           testID: RecurringConfirmOrderSheetSelectorsIDs.CONFIRM_BUTTON,
         }}
       />

--- a/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.types.ts
+++ b/app/components/UI/Bridge/components/RecurringConfirmOrderSheet/RecurringConfirmOrderSheet.types.ts
@@ -1,4 +1,7 @@
+import { useLatestBalance } from '../../hooks/useLatestBalance';
+
 export interface RecurringConfirmOrderSheetProps {
   isVisible: boolean;
   onClose: () => void;
+  latestSourceBalance: ReturnType<typeof useLatestBalance>;
 }

--- a/app/components/UI/Bridge/components/SwapsRecurringBuyConfirmButton/SwapsRecurringBuyConfirmButton.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsRecurringBuyConfirmButton/SwapsRecurringBuyConfirmButton.test.tsx
@@ -68,4 +68,17 @@ describe('SwapsRecurringBuyConfirmButton', () => {
 
     expect(onPress).not.toHaveBeenCalled();
   });
+
+  it('uses the disabled style while loading even when disabled is false', () => {
+    const { getByTestId } = renderWithProvider(
+      <SwapsRecurringBuyConfirmButton
+        onPress={jest.fn()}
+        label="Preview order"
+        testID={TEST_ID}
+        loading
+      />,
+    );
+
+    expect(getByTestId(TEST_ID).props.accessibilityState?.disabled).toBe(true);
+  });
 });

--- a/app/components/UI/Bridge/components/SwapsRecurringBuyConfirmButton/index.tsx
+++ b/app/components/UI/Bridge/components/SwapsRecurringBuyConfirmButton/index.tsx
@@ -27,7 +27,7 @@ export const SwapsRecurringBuyConfirmButton = ({
     onPress={onPress}
     isFullWidth
     testID={testID}
-    isDisabled={disabled}
+    isDisabled={Boolean(disabled || loading)}
   >
     {label}
   </Button>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Recurring confirm currently always shows an enabled Confirm CTA, so a user can proceed through the first-swap review even when they cannot pay that swap. Preview Order also briefly used the primary (clickable) color while a quote was loading, even though press did nothing.

This PR disables the Recurring confirm-sheet Confirm button for the first swap only when per-order token balance is short (`useIsInsufficientBalance`) or native gas is short (`useHasSufficientGas`), using Market’s existing “Insufficient funds” / “Insufficient gas” labels (funds wins if both fail). Preview Order stays available so the sheet can still be opened. The Recurring Preview button now stays disabled while loading so the spinner uses the greyed-out style.

Suggested title: `feat(swaps): block Recurring confirm on insufficient funds or gas`

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Disabled Recurring confirm when the first swap has insufficient token balance or gas, and kept Preview Order greyed out while a quote is loading

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: Recurring confirm insufficient funds/gas follow-up; no linked GitHub or Jira ticket

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Recurring confirm blocks the first swap when funds or gas are short

  Background:
    Given I am logged into MetaMask Mobile
    And the Recurring swap tab is enabled
    And I open Swap and switch to the Recurring tab

  Scenario: Confirm is blocked when token balance cannot cover the first swap
    When I enter a per-order amount larger than my source token balance
    And the schedule is valid
    And a quote is available
    And I tap Preview order
    Then the confirm sheet opens
    And the Confirm button is disabled
    And the Confirm button is labeled "Insufficient funds"
    When I tap the sheet close control
    Then the sheet closes

  Scenario: Confirm is blocked when native gas cannot cover the first swap
    Given I have enough source token for the per-order amount
    And I do not have enough native gas for the quote
    When I tap Preview order
    Then the Confirm button is disabled
    And the Confirm button is labeled "Insufficient gas"

  Scenario: Confirm stays labeled Insufficient funds when both balance and gas are short
    Given my source token balance is below the per-order amount
    And native gas is also short
    When I tap Preview order
    Then the Confirm button is labeled "Insufficient funds"
    And the Confirm button is disabled

  Scenario: Preview Order stays greyed out while a quote is loading
    When I enter a valid source amount
    Then Preview order is greyed out before a quote arrives
    When a quote request is in flight
    Then Preview order shows a loading spinner in the disabled (grey) style
    And tapping it does nothing
    When the quote arrives and the schedule is valid
    Then Preview order uses the primary enabled style
    And tapping it opens the confirm sheet
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

https://github.com/user-attachments/assets/020bb167-27f3-403e-9ecd-d00fae71636c




## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing recurring swap confirmation depends on balance and gas hooks; wrong gating could block valid confirms or mislabel the failure reason.
> 
> **Overview**
> Recurring **Confirm** on the preview sheet is now gated on whether the **first** swap can be paid: per-order source token balance (`useIsInsufficientBalance`) and native gas for the active quote (`useHasSufficientGas`). When either check fails, the primary CTA is disabled and labeled **Insufficient funds** or **Insufficient gas** (funds takes precedence if both fail). **Preview order** is unchanged so users can still open the sheet.
> 
> `BridgeRecurringBuyView` passes `latestSourceBalance` into `RecurringConfirmOrderSheet` for live balance checks. `SwapsRecurringBuyConfirmButton` treats **loading** as disabled so the quote spinner uses the greyed-out style instead of the primary enabled look.
> 
> Tests add confirm-sheet cases for insufficient funds, insufficient gas, combined failure, and loading disabled styling on the preview button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce569df2d5a296a593944fb428a6b311db49c499. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->