### PR TITLE
feat: remove tutorial gate after mode selection

### DIFF
--- a/app/components/UI/Perps/Views/PerpsModeSelectionView/PerpsModeSelectionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsModeSelectionView/PerpsModeSelectionView.test.tsx
@@ -41,7 +41,6 @@ const fireNavigationEvent = (event: string) => {
 };
 
 let mockIsProModeEnabled = true;
-let mockIsFirstTimePerpsUser = true;
 let mockPerpsMode = PerpsMode.Lite;
 let mockRouteParams: { entry?: string; source?: string } = {};
 
@@ -64,10 +63,6 @@ jest.mock('@react-navigation/native', () => ({
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useSelector: (selector: () => unknown) => selector(),
-}));
-
-jest.mock('../../selectors/perpsController', () => ({
-  selectIsFirstTimePerpsUser: () => mockIsFirstTimePerpsUser,
 }));
 
 jest.mock('../../selectors/featureFlags', () => ({
@@ -138,7 +133,6 @@ describe('PerpsModeSelectionView', () => {
       delete mockNavigationListeners[key];
     });
     mockIsProModeEnabled = true;
-    mockIsFirstTimePerpsUser = true;
     mockPerpsMode = PerpsMode.Lite;
     mockRouteParams = {};
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
@@ -198,7 +192,7 @@ describe('PerpsModeSelectionView', () => {
     ).toEqual({ selected: false });
   });
 
-  it('persists Lite, dismisses, and continues to the tutorial for first-time users', async () => {
+  it('persists Lite, dismisses, and continues to Perps Home for first-time users', async () => {
     render(<PerpsModeSelectionView />);
 
     fireEvent.press(
@@ -221,12 +215,17 @@ describe('PerpsModeSelectionView', () => {
       },
     );
     expect(mockGoBack).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.TUTORIAL, {
-      source: PERPS_EVENT_VALUE.SOURCE.TRADE_MENU_ACTION,
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
+      screen: Routes.PERPS.PERPS_HOME,
+      params: { source: PERPS_EVENT_VALUE.SOURCE.TRADE_MENU_ACTION },
     });
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      Routes.PERPS.TUTORIAL,
+      expect.anything(),
+    );
   });
 
-  it('persists Pro and continues to the tutorial with a Pro market redirect', async () => {
+  it('persists Pro and continues to the default Pro market for first-time users', async () => {
     render(<PerpsModeSelectionView />);
 
     fireEvent.press(
@@ -238,19 +237,20 @@ describe('PerpsModeSelectionView', () => {
     expect(mockSetMode).toHaveBeenCalledWith(PerpsMode.Pro);
     expect(mockMarkPerpsModeSelectionCompleted).toHaveBeenCalledTimes(1);
     expect(mockGoBack).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.TUTORIAL, {
-      source: PERPS_EVENT_VALUE.SOURCE.TRADE_MENU_ACTION,
-      redirectScreen: Routes.PERPS.MARKET_DETAILS,
-      redirectParams: {
-        market: { symbol: 'BTC', name: 'Bitcoin' },
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
+      screen: Routes.PERPS.MARKET_DETAILS,
+      params: {
+        market: expect.objectContaining({ symbol: 'BTC' }),
         source: PERPS_EVENT_VALUE.SOURCE.TRADE_MENU_ACTION,
       },
     });
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      Routes.PERPS.TUTORIAL,
+      expect.anything(),
+    );
   });
 
   it('continues to Perps Home when a returning Trade-entry user selects Lite', async () => {
-    mockIsFirstTimePerpsUser = false;
-
     render(<PerpsModeSelectionView />);
 
     fireEvent.press(
@@ -268,7 +268,6 @@ describe('PerpsModeSelectionView', () => {
   it('continues to the default Pro market when a returning Trade-entry user selects Pro', async () => {
     // Regression: the destination must come from the selected mode, not from the
     // Pro-mode selector, which still reads Lite at this point.
-    mockIsFirstTimePerpsUser = false;
     mockPerpsMode = PerpsMode.Lite;
 
     render(<PerpsModeSelectionView />);
@@ -290,7 +289,6 @@ describe('PerpsModeSelectionView', () => {
   });
 
   it('continues to Perps Home when Pro is selected but the Pro-mode flag is off', async () => {
-    mockIsFirstTimePerpsUser = false;
     mockIsProModeEnabled = false;
 
     render(<PerpsModeSelectionView />);
@@ -308,7 +306,6 @@ describe('PerpsModeSelectionView', () => {
   });
 
   it('resets onto the default Pro market when selecting Pro from home', async () => {
-    mockIsFirstTimePerpsUser = false;
     mockRouteParams = {
       entry: 'home',
       source: PERPS_EVENT_VALUE.SOURCE.PERPS_HOME,
@@ -339,7 +336,6 @@ describe('PerpsModeSelectionView', () => {
   });
 
   it('drops Perps Home from the parent stack when selecting Pro from a market', async () => {
-    mockIsFirstTimePerpsUser = false;
     mockRouteParams = {
       entry: 'market',
       source: PERPS_EVENT_VALUE.SOURCE.PERP_ASSET_SCREEN,
@@ -368,7 +364,6 @@ describe('PerpsModeSelectionView', () => {
   });
 
   it('dismisses only when selecting Lite from a market header', async () => {
-    mockIsFirstTimePerpsUser = false;
     mockRouteParams = {
       entry: 'market',
       source: PERPS_EVENT_VALUE.SOURCE.PERP_ASSET_SCREEN,

--- a/app/components/UI/Perps/Views/PerpsModeSelectionView/PerpsModeSelectionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsModeSelectionView/PerpsModeSelectionView.tsx
@@ -16,7 +16,6 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import PerpsModeSelectionBottomSheet from '../../components/PerpsModeSelectionBottomSheet';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { usePerpsMode } from '../../hooks/usePerpsMode';
-import { selectIsFirstTimePerpsUser } from '../../selectors/perpsController';
 import { selectPerpsProModeEnabledFlag } from '../../selectors/featureFlags';
 import { markPerpsModeSelectionCompleted } from '../../utils/perpsModeSelectionStorage';
 import { PERPS_MODE_ANALYTICS_PROPERTY } from '../../utils/perpsModeAnalytics';
@@ -61,7 +60,6 @@ const PerpsModeSelectionView: React.FC = () => {
     },
   });
   const { mode: selectedMode, setMode } = usePerpsMode();
-  const isFirstTimePerpsUser = useSelector(selectIsFirstTimePerpsUser);
   const isProModeEnabled = useSelector(selectPerpsProModeEnabledFlag);
 
   const hasSelectedRef = useRef(false);
@@ -101,23 +99,6 @@ const PerpsModeSelectionView: React.FC = () => {
 
   const continueAfterSelection = useCallback(
     (mode: PerpsMode) => {
-      if (isFirstTimePerpsUser) {
-        navigation.navigate(
-          Routes.PERPS.TUTORIAL,
-          mode === PerpsMode.Pro
-            ? {
-                source,
-                redirectScreen: Routes.PERPS.MARKET_DETAILS,
-                redirectParams: {
-                  market: buildDefaultProMarket(),
-                  source,
-                },
-              }
-            : { source },
-        );
-        return;
-      }
-
       if (entry === 'home' && mode === PerpsMode.Pro) {
         // Modal is nested under the Perps stack when opened from home.
         // Reset that parent stack so Perps Home is discarded while Pro is
@@ -166,7 +147,7 @@ const PerpsModeSelectionView: React.FC = () => {
 
       // `home` + Lite: dismiss only — already on Perps Home.
     },
-    [entry, isFirstTimePerpsUser, isProModeEnabled, navigation, source],
+    [entry, isProModeEnabled, navigation, source],
   );
 
   const handleSelect = useCallback(
@@ -184,18 +165,14 @@ const PerpsModeSelectionView: React.FC = () => {
       });
 
       // Home → Pro resets the parent Perps stack (clears the modal too).
-      if (entry === 'home' && mode === PerpsMode.Pro && !isFirstTimePerpsUser) {
+      if (entry === 'home' && mode === PerpsMode.Pro) {
         continueAfterSelection(mode);
         return;
       }
 
       // Market → Pro must drop Home while the modal is still nested under the
       // Perps stack — after goBack the parent relationship is gone.
-      if (
-        entry === 'market' &&
-        mode === PerpsMode.Pro &&
-        !isFirstTimePerpsUser
-      ) {
+      if (entry === 'market' && mode === PerpsMode.Pro) {
         continueAfterSelection(mode);
         navigation.goBack();
         return;
@@ -206,15 +183,7 @@ const PerpsModeSelectionView: React.FC = () => {
         continueAfterSelection(mode);
       });
     },
-    [
-      continueAfterSelection,
-      entry,
-      isFirstTimePerpsUser,
-      navigation,
-      setMode,
-      source,
-      track,
-    ],
+    [continueAfterSelection, entry, navigation, setMode, source, track],
   );
 
   return (


### PR DESCRIPTION
## **Description**

  <!-- mms-check: type=text required=true -->

  Selecting Lite or Pro sent first-time users to the tutorial before trading. That gate is removed, so they now fall through to the same destinations as returning users — Perps Home for Lite, the default Pro market for Pro.

  `isFirstTimePerpsUser` was read in three places, not one. Besides the early-return, two guards in `handleSelect` skipped the Pro fast paths for first-time users. Those paths call `continueAfterSelection` *before* `goBack()` so `navigation.getParent()` is still valid for the stack surgery — leaving them would have meant first-time Pro users never run the `reset()` or `dropPerpsHomeFromStackHistory`, and back would reveal the Lite hub under Pro (the TAT-3612 regression those comments warn about). All three references are removed together.

  Nothing was orphaned: `selectIsFirstTimePerpsUser`, `usePerpsFirstTimeUser`, and `TUTORIAL_PRELOAD` all still have live consumers, so there are no removals outside this file.

  **Where to test it:** the Trade menu is the only door with no tutorial gate of its own, so it's the only place this is observable. The homepage Perps button, homepage section, and deeplink handler still gate first-time users to the tutorial — untouched per the ticket's Out of Scope on `isFirstTimeUser` state.

  ## **Changelog**

  <!-- mms-check: type=changelog required=true blocking=true -->

  CHANGELOG entry: Removed the forced tutorial after choosing Lite or Pro mode, so first-time users go straight to trading

  ## **Related issues**

  <!-- mms-check: type=issue-link required=true -->

  Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3756

  ## **Manual testing steps**

  <!-- mms-check: type=manual-testing required=true -->

  Needs both flags cleared: `resetFirstTimeUserState()` (Settings → Advanced → Reset Account) and the `PERPS_MODE_SELECTION_COMPLETED` key in `StorageWrapper`.

  ```gherkin
  Feature: First-time mode selection skips the tutorial

    Scenario Outline: first-time user picks a mode from the Trade menu
      Given the user has completed neither the tutorial nor mode selection
      When the user opens Perps from the Trade menu and selects <mode>
      Then the user lands on <destination>
      And the tutorial carousel is not shown

      Examples:
        | mode | destination            |
        | Lite | Perps Home             |
        | Pro  | the Pro market details |

    Scenario: Pro stack handling is unchanged
      Given a fresh first-time state and the user is on Perps Home
      When the user switches to Pro from the header
      Then Perps Home is discarded and back does not reveal the Lite hub

    Scenario: the tutorial stays available on demand
      When the user taps Tutorial in Perps Home or market details
      Then the tutorial carousel opens
  ```

  ## **Screenshots/Recordings**

  <!-- mms-check: type=screenshot required=true -->

  ### **Before**

  <!-- [screenshots/recordings] -->

  ### **After**

  <!-- [screenshots/recordings] -->

  ## **Pre-merge author checklist**

  <!-- mms-check: type=checklist required=true -->

  - [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
  - [x] I've completed the PR template to the best of my ability
  - [x] I've included tests if applicable
  - [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

  #### Performance checks (if applicable)

  - [x] I've tested on Android
    - Ideally on a mid-range device; emulator is acceptable
  - [x] I've tested with a power user scenario
    - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
  - [x] I've instrumented key operations with Sentry traces for production performance metrics
    - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

  For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

  ## **Pre-merge reviewer checklist**

  - [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
  - [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Perps onboarding navigation and stack handling for first-time users; other tutorial entry points are unchanged but wrong routing could strand users or break back-stack behavior (TAT-3612).
> 
> **Overview**
> **Removes the first-time-user tutorial detour** after picking Lite or Pro in the mode selection sheet (e.g. from the Trade menu). First-time users now follow the same post-selection navigation as everyone else: **Perps Home** for Lite and the **default Pro market** when Pro is enabled.
> 
> `PerpsModeSelectionView` no longer reads `selectIsFirstTimePerpsUser` or navigates to `Routes.PERPS.TUTORIAL`. The **home/market Pro stack fixes** (`reset` / `dropPerpsHomeFromStackHistory`) apply on first selection too, since the `!isFirstTimePerpsUser` guards on those paths were removed.
> 
> Tests drop the first-time mock and assert **ROOT → PERPS_HOME / MARKET_DETAILS** instead of the tutorial, including explicit checks that tutorial navigation is not used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dd861657aeb014388cccb441b4af71677c63689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->