### PR TITLE
fix(perps): align position list item design

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionCard.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionCard.test.tsx
@@ -129,6 +129,12 @@ describe('PerpsProPositionCard', () => {
     expect(screen.getByText('$2,500')).toBeOnTheScreen();
   });
 
+  it('renders a zero-size position with a short direction', () => {
+    render(<PerpsProPositionCard position={{ ...position, size: '0' }} />);
+
+    expect(screen.getByText('3x Short')).toBeOnTheScreen();
+  });
+
   it('renders TP/SL edit control when handler is provided', () => {
     const onEditTpSl = jest.fn();
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionCard.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionCard.tsx
@@ -21,11 +21,7 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import {
-  PERPS_CONSTANTS,
-  getPerpsDisplaySymbol,
-  type Position,
-} from '@metamask/perps-controller';
+import { PERPS_CONSTANTS, type Position } from '@metamask/perps-controller';
 import React from 'react';
 import { Pressable } from 'react-native';
 import { useSelector } from 'react-redux';
@@ -35,14 +31,12 @@ import PerpsTokenLogo from '../../../components/PerpsTokenLogo';
 import { LIQUIDATION_DISTANCE_DECIMALS } from '../../../constants/perpsConfig';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 import {
-  formatPercentage,
   formatPerpsFiat,
-  formatPnl,
-  formatPositionSize,
   formatPositionTriggerSummary,
   PRICE_RANGES_MINIMAL_VIEW,
   PRICE_RANGES_UNIVERSAL,
 } from '../../../utils/formatUtils';
+import { getPerpsPositionHeaderDisplay } from '../../../utils/positionDisplay';
 
 interface PerpsProPositionCardProps {
   position: Position;
@@ -173,18 +167,16 @@ const PerpsProPositionCard = ({
   isEditMarginDisabled = false,
 }: PerpsProPositionCardProps) => {
   const privacyMode = useSelector(selectPrivacyMode);
-  const displaySymbol = getPerpsDisplaySymbol(position.symbol);
-  const sizeNum = parseFloat(position.size);
-  const isLong = sizeNum >= 0;
-  const absoluteSize = Math.abs(sizeNum);
-
-  const pnlNum = parseFloat(position.unrealizedPnl);
-  const roe = (parseFloat(position.returnOnEquity) || 0) * 100;
-
-  const directionLabel = isLong
-    ? strings('perps.market.long')
-    : strings('perps.market.short');
-  const directionSeverity = isLong ? TagSeverity.Success : TagSeverity.Danger;
+  const {
+    displaySymbol,
+    absoluteSize,
+    directionLabel,
+    directionSeverity,
+    description,
+    pnlText,
+    roeText,
+    pnlColor,
+  } = getPerpsPositionHeaderDisplay(position);
 
   const marginTypeLabel =
     position.leverage.type === 'isolated'
@@ -261,10 +253,6 @@ const PerpsProPositionCard = ({
         { ranges: PRICE_RANGES_MINIMAL_VIEW },
       )}`;
 
-  const positionValueDisplay = formatPerpsFiat(position.positionValue, {
-    ranges: PRICE_RANGES_MINIMAL_VIEW,
-  });
-
   const handlePress = onPress ? () => onPress(position) : undefined;
 
   return (
@@ -317,9 +305,7 @@ const PerpsProPositionCard = ({
                   >
                     {displaySymbol}
                   </Text>
-                  <Tag
-                    severity={directionSeverity}
-                  >{`${position.leverage.value}x ${directionLabel}`}</Tag>
+                  <Tag severity={directionSeverity}>{directionLabel}</Tag>
                 </Box>
                 <SensitiveText
                   variant={TextVariant.BodySm}
@@ -328,9 +314,7 @@ const PerpsProPositionCard = ({
                   isHidden={privacyMode}
                   length={SensitiveTextLength.Short}
                 >
-                  {`${formatPositionSize(
-                    absoluteSize.toString(),
-                  )} ${displaySymbol} • ${positionValueDisplay}`}
+                  {description}
                 </SensitiveText>
               </Box>
             </Box>
@@ -338,32 +322,20 @@ const PerpsProPositionCard = ({
               <SensitiveText
                 variant={TextVariant.BodyMd}
                 fontWeight={FontWeight.Medium}
-                color={
-                  privacyMode
-                    ? TextColor.TextDefault
-                    : pnlNum >= 0
-                      ? TextColor.SuccessDefault
-                      : TextColor.ErrorDefault
-                }
+                color={privacyMode ? TextColor.TextDefault : pnlColor}
                 isHidden={privacyMode}
                 length={SensitiveTextLength.Short}
                 testID={PerpsProMarketViewSelectorsIDs.POSITION_PNL_TEXT}
               >
-                {formatPnl(pnlNum)}
+                {pnlText}
               </SensitiveText>
               <SensitiveText
                 variant={TextVariant.BodySm}
-                color={
-                  privacyMode
-                    ? TextColor.TextDefault
-                    : pnlNum >= 0
-                      ? TextColor.SuccessDefault
-                      : TextColor.ErrorDefault
-                }
+                color={privacyMode ? TextColor.TextDefault : pnlColor}
                 isHidden={privacyMode}
                 length={SensitiveTextLength.Short}
               >
-                {formatPercentage(roe, 1)}
+                {roeText}
               </SensitiveText>
             </Box>
           </Box>

--- a/app/components/UI/Perps/__mocks__/perpsHooksMocks.ts
+++ b/app/components/UI/Perps/__mocks__/perpsHooksMocks.ts
@@ -111,7 +111,7 @@ export const defaultPerpsPositionMock: Position = {
   },
   liquidationPrice: '2500.00',
   maxLeverage: 50,
-  returnOnEquity: '10.3',
+  returnOnEquity: '0.103',
   cumulativeFunding: {
     allTime: '0',
     sinceOpen: '0',

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
@@ -51,12 +51,6 @@ jest.mock('../../../../../../locales/i18n', () => ({
     if (key === 'perps.order.short_label' || key === 'perps.market.short') {
       return 'Short';
     }
-    if (key === 'perps.market.long_lowercase') {
-      return 'long';
-    }
-    if (key === 'perps.market.short_lowercase') {
-      return 'short';
-    }
     return key;
   },
 }));
@@ -68,10 +62,7 @@ jest.mock('../../hooks/usePerpsMarkets', () => ({
 jest.mock('../PerpsTokenLogo', () => 'PerpsTokenLogo');
 
 describe('PerpsCard', () => {
-  const mockPosition = {
-    ...defaultPerpsPositionMock,
-    returnOnEquity: '0.103',
-  };
+  const mockPosition = { ...defaultPerpsPositionMock };
   const mockOrder = { ...defaultPerpsOrderMock };
   const mockUsePerpsMarkets = jest.mocked(usePerpsMarkets);
 

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
@@ -68,7 +68,10 @@ jest.mock('../../hooks/usePerpsMarkets', () => ({
 jest.mock('../PerpsTokenLogo', () => 'PerpsTokenLogo');
 
 describe('PerpsCard', () => {
-  const mockPosition = { ...defaultPerpsPositionMock };
+  const mockPosition = {
+    ...defaultPerpsPositionMock,
+    returnOnEquity: '0.103',
+  };
   const mockOrder = { ...defaultPerpsOrderMock };
   const mockUsePerpsMarkets = jest.mocked(usePerpsMarkets);
 
@@ -220,13 +223,17 @@ describe('PerpsCard', () => {
   describe('Rendering', () => {
     it('renders position card with correct content', () => {
       // Arrange & Act
-      const { getByText } = render(
+      const { getByText, getByTestId } = render(
         <PerpsCard position={mockPosition} testID="test-position-card" />,
       );
 
       // Assert
-      expect(getByText('ETH 3x long')).toBeDefined();
-      expect(getByText('1.5 ETH')).toBeDefined();
+      expect(getByText('ETH')).toBeOnTheScreen();
+      expect(getByText('3x Long')).toBeOnTheScreen();
+      expect(getByTestId('test-position-card-direction-tag')).toBeOnTheScreen();
+      expect(getByText('1.5 ETH • $4,350')).toBeOnTheScreen();
+      expect(getByText('+$150.00')).toBeOnTheScreen();
+      expect(getByText('+10.3%')).toBeOnTheScreen();
     });
 
     it('renders order card with correct content', () => {
@@ -266,7 +273,8 @@ describe('PerpsCard', () => {
       );
 
       // Assert
-      expect(getByText('+$100.50 (+5.0%)')).toBeDefined();
+      expect(getByText('+$100.50')).toBeOnTheScreen();
+      expect(getByText('+5.0%')).toBeOnTheScreen();
     });
 
     it('displays correct PnL color for negative position', () => {
@@ -283,7 +291,8 @@ describe('PerpsCard', () => {
       );
 
       // Assert
-      expect(getByText('-$50.25 (-2.5%)')).toBeDefined();
+      expect(getByText('-$50.25')).toBeOnTheScreen();
+      expect(getByText('-2.5%')).toBeOnTheScreen();
     });
 
     it('displays short position correctly', () => {
@@ -299,8 +308,9 @@ describe('PerpsCard', () => {
       );
 
       // Assert
-      expect(getByText('ETH 3x short')).toBeDefined();
-      expect(getByText('1.5 ETH')).toBeDefined();
+      expect(getByText('ETH')).toBeOnTheScreen();
+      expect(getByText('3x Short')).toBeOnTheScreen();
+      expect(getByText('1.5 ETH • $4,350')).toBeOnTheScreen();
     });
 
     it('displays order side correctly', () => {
@@ -448,7 +458,7 @@ describe('PerpsCard', () => {
         ...mockPosition,
         positionValue: '4350.00',
         unrealizedPnl: '150.00',
-        returnOnEquity: '10.3',
+        returnOnEquity: '0.103',
       };
 
       // Act
@@ -457,10 +467,11 @@ describe('PerpsCard', () => {
       );
 
       // Assert - right-side financial values replaced with dots
-      expect(queryByText('$4,350')).toBeNull();
-      expect(queryByText(/\+\$150/)).toBeNull();
+      expect(queryByText('1.5 ETH • $4,350')).toBeNull();
+      expect(queryByText('+$150.00')).toBeNull();
+      expect(queryByText('+10.3%')).toBeNull();
       const hiddenElements = getAllByText(DOTS_SHORT);
-      expect(hiddenElements.length).toBeGreaterThanOrEqual(2);
+      expect(hiddenElements.length).toBeGreaterThanOrEqual(3);
     });
 
     it('shows position value and PnL label when privacy mode is disabled', () => {
@@ -478,7 +489,8 @@ describe('PerpsCard', () => {
       );
 
       // Assert - actual values visible, no hiding dots
-      expect(getByText('+$100.50 (+5.0%)')).toBeOnTheScreen();
+      expect(getByText('+$100.50')).toBeOnTheScreen();
+      expect(getByText('+5.0%')).toBeOnTheScreen();
       expect(queryByText(DOTS_SHORT)).toBeNull();
     });
 
@@ -508,8 +520,9 @@ describe('PerpsCard', () => {
       );
 
       // Assert - title stays visible; size is treated as sensitive
-      expect(getByText('ETH 3x long')).toBeOnTheScreen();
-      expect(queryByText('1.5 ETH')).toBeNull();
+      expect(getByText('ETH')).toBeOnTheScreen();
+      expect(getByText('3x Long')).toBeOnTheScreen();
+      expect(queryByText('1.5 ETH • $4,350')).toBeNull();
     });
   });
 });

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -9,6 +9,8 @@ import {
   ListItemVariant,
   SensitiveText,
   SensitiveTextLength,
+  Tag,
+  TagSeverity,
   Text,
   TextColor,
   TextVariant,
@@ -46,8 +48,11 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics/MetaMetrics.eve
 
 interface PositionListDisplay {
   title: string;
+  directionLabel: string;
+  directionSeverity: TagSeverity;
   description: string;
   valueText: string;
+  valueColor: TextColor;
   subvalueText: string;
   subvalueColor: TextColor;
 }
@@ -56,6 +61,7 @@ interface OrderListDisplay {
   title: string;
   description: string;
   valueText: string;
+  valueColor: TextColor;
   subvalueText: string;
   subvalueColor: TextColor;
 }
@@ -64,23 +70,29 @@ const getPositionListDisplay = (position: Position): PositionListDisplay => {
   const isLong = parseFloat(position.size) > 0;
   const displaySymbol = getPerpsDisplaySymbol(position.symbol);
   const absoluteSize = Math.abs(parseFloat(position.size));
-  const directionLower = isLong
-    ? strings('perps.market.long_lowercase')
-    : strings('perps.market.short_lowercase');
+  const directionLabel = isLong
+    ? strings('perps.market.long')
+    : strings('perps.market.short');
 
   const pnlValue = parseFloat(position.unrealizedPnl);
   const roeValue = parseFloat(position.returnOnEquity) * 100;
+  const pnlColor =
+    pnlValue >= 0 ? TextColor.SuccessDefault : TextColor.ErrorDefault;
+  const positionValue = formatPerpsFiat(position.positionValue, {
+    ranges: PRICE_RANGES_MINIMAL_VIEW,
+  });
 
   return {
-    // Match main: leverage lives in the title string (e.g. "ETH 3x long")
-    title: `${displaySymbol} ${position.leverage.value}x ${directionLower}`,
-    description: `${formatPositionSize(absoluteSize.toString())} ${displaySymbol}`,
-    valueText: formatPerpsFiat(position.positionValue, {
-      ranges: PRICE_RANGES_MINIMAL_VIEW,
-    }),
-    subvalueText: `${formatPnl(pnlValue)} (${formatPercentage(roeValue, 1)})`,
-    subvalueColor:
-      pnlValue >= 0 ? TextColor.SuccessDefault : TextColor.ErrorDefault,
+    title: displaySymbol,
+    directionLabel: `${position.leverage.value}x ${directionLabel}`,
+    directionSeverity: isLong ? TagSeverity.Success : TagSeverity.Danger,
+    description: `${formatPositionSize(
+      absoluteSize.toString(),
+    )} ${displaySymbol} • ${positionValue}`,
+    valueText: formatPnl(pnlValue),
+    valueColor: pnlColor,
+    subvalueText: formatPercentage(roeValue, 1),
+    subvalueColor: pnlColor,
   };
 };
 
@@ -99,6 +111,7 @@ const getOrderListDisplay = (order: Order): OrderListDisplay => {
         : labelKey === 'perps.order.market_price'
           ? strings('perps.order.market')
           : PERPS_CONSTANTS.FallbackPriceDisplay,
+    valueColor: TextColor.TextDefault,
     subvalueText: strings(labelKey),
     subvalueColor: TextColor.TextAlternative,
   };
@@ -198,7 +211,13 @@ const PerpsCardContent: React.FC<PerpsCardContentProps> = ({
     <SensitiveText
       variant={TextVariant.BodyMd}
       fontWeight={FontWeight.Medium}
-      color={TextColor.TextDefault}
+      color={
+        privacyMode && position
+          ? TextColor.TextDefault
+          : (positionDisplay?.valueColor ??
+            orderDisplay?.valueColor ??
+            TextColor.TextDefault)
+      }
       isHidden={privacyMode}
       length={SensitiveTextLength.Short}
     >
@@ -235,10 +254,21 @@ const PerpsCardContent: React.FC<PerpsCardContentProps> = ({
     <ListItem
       isInteractive
       variant={ListItemVariant.TwoLines}
+      twClassName={position ? 'min-h-[56px] py-2' : undefined}
       avatar={
         symbol ? <PerpsTokenLogo symbol={symbol} size={iconSize} /> : undefined
       }
       title={title}
+      titleEndAccessory={
+        positionDisplay ? (
+          <Tag
+            severity={positionDisplay.directionSeverity}
+            testID={testID ? `${testID}-direction-tag` : undefined}
+          >
+            {positionDisplay.directionLabel}
+          </Tag>
+        ) : undefined
+      }
       description={descriptionNode}
       value={valueNode}
       subvalue={subvalueNode}

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -10,7 +10,6 @@ import {
   SensitiveText,
   SensitiveTextLength,
   Tag,
-  TagSeverity,
   Text,
   TextColor,
   TextVariant,
@@ -25,16 +24,13 @@ import {
   PERPS_EVENT_PROPERTY,
   type Order,
   type PerpsMarketData,
-  type Position,
 } from '@metamask/perps-controller';
 import {
   formatPerpsFiat,
   formatPositionSize,
-  formatPnl,
-  formatPercentage,
-  PRICE_RANGES_MINIMAL_VIEW,
   PRICE_RANGES_UNIVERSAL,
 } from '../../utils/formatUtils';
+import { getPerpsPositionHeaderDisplay } from '../../utils/positionDisplay';
 import {
   formatOrderLabel,
   resolveOrderDisplayPriceAndLabel,
@@ -46,55 +42,13 @@ import { HOME_SCREEN_CONFIG } from '../../constants/perpsConfig';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { MetaMetricsEvents } from '../../../../../core/Analytics/MetaMetrics.events';
 
-interface PositionListDisplay {
-  title: string;
-  directionLabel: string;
-  directionSeverity: TagSeverity;
-  description: string;
-  valueText: string;
-  valueColor: TextColor;
-  subvalueText: string;
-  subvalueColor: TextColor;
-}
-
 interface OrderListDisplay {
   title: string;
   description: string;
   valueText: string;
-  valueColor: TextColor;
   subvalueText: string;
   subvalueColor: TextColor;
 }
-
-const getPositionListDisplay = (position: Position): PositionListDisplay => {
-  const isLong = parseFloat(position.size) > 0;
-  const displaySymbol = getPerpsDisplaySymbol(position.symbol);
-  const absoluteSize = Math.abs(parseFloat(position.size));
-  const directionLabel = isLong
-    ? strings('perps.market.long')
-    : strings('perps.market.short');
-
-  const pnlValue = parseFloat(position.unrealizedPnl);
-  const roeValue = parseFloat(position.returnOnEquity) * 100;
-  const pnlColor =
-    pnlValue >= 0 ? TextColor.SuccessDefault : TextColor.ErrorDefault;
-  const positionValue = formatPerpsFiat(position.positionValue, {
-    ranges: PRICE_RANGES_MINIMAL_VIEW,
-  });
-
-  return {
-    title: displaySymbol,
-    directionLabel: `${position.leverage.value}x ${directionLabel}`,
-    directionSeverity: isLong ? TagSeverity.Success : TagSeverity.Danger,
-    description: `${formatPositionSize(
-      absoluteSize.toString(),
-    )} ${displaySymbol} • ${positionValue}`,
-    valueText: formatPnl(pnlValue),
-    valueColor: pnlColor,
-    subvalueText: formatPercentage(roeValue, 1),
-    subvalueColor: pnlColor,
-  };
-};
 
 const getOrderListDisplay = (order: Order): OrderListDisplay => {
   const displaySymbol = getPerpsDisplaySymbol(order.symbol);
@@ -111,7 +65,6 @@ const getOrderListDisplay = (order: Order): OrderListDisplay => {
         : labelKey === 'perps.order.market_price'
           ? strings('perps.order.market')
           : PERPS_CONSTANTS.FallbackPriceDisplay,
-    valueColor: TextColor.TextDefault,
     subvalueText: strings(labelKey),
     subvalueColor: TextColor.TextAlternative,
   };
@@ -142,7 +95,9 @@ const PerpsCardContent: React.FC<PerpsCardContentProps> = ({
 
   const symbol = position?.symbol || order?.symbol || '';
 
-  const positionDisplay = position ? getPositionListDisplay(position) : null;
+  const positionDisplay = position
+    ? getPerpsPositionHeaderDisplay(position)
+    : null;
   const orderDisplay = order ? getOrderListDisplay(order) : null;
 
   const handlePress = useCallback(() => {
@@ -195,7 +150,7 @@ const PerpsCardContent: React.FC<PerpsCardContentProps> = ({
     return null;
   }
 
-  const title = positionDisplay?.title ?? orderDisplay?.title ?? '';
+  const title = positionDisplay?.displaySymbol ?? orderDisplay?.title ?? '';
   const descriptionNode = (
     <SensitiveText
       variant={TextVariant.BodySm}
@@ -214,20 +169,18 @@ const PerpsCardContent: React.FC<PerpsCardContentProps> = ({
       color={
         privacyMode && position
           ? TextColor.TextDefault
-          : (positionDisplay?.valueColor ??
-            orderDisplay?.valueColor ??
-            TextColor.TextDefault)
+          : (positionDisplay?.pnlColor ?? TextColor.TextDefault)
       }
       isHidden={privacyMode}
       length={SensitiveTextLength.Short}
     >
-      {positionDisplay?.valueText ?? orderDisplay?.valueText ?? ''}
+      {positionDisplay?.pnlText ?? orderDisplay?.valueText ?? ''}
     </SensitiveText>
   );
   const subvalueColor =
     privacyMode && position
       ? TextColor.TextDefault
-      : (positionDisplay?.subvalueColor ??
+      : (positionDisplay?.pnlColor ??
         orderDisplay?.subvalueColor ??
         TextColor.TextDefault);
   const subvalueNode = position ? (
@@ -238,7 +191,7 @@ const PerpsCardContent: React.FC<PerpsCardContentProps> = ({
       isHidden={privacyMode}
       length={SensitiveTextLength.Short}
     >
-      {positionDisplay?.subvalueText ?? ''}
+      {positionDisplay?.roeText ?? ''}
     </SensitiveText>
   ) : (
     <Text
@@ -250,11 +203,15 @@ const PerpsCardContent: React.FC<PerpsCardContentProps> = ({
     </Text>
   );
 
+  // TAT-3776's Figma position row uses 8px vertical padding. Reset the
+  // ListItem minimum so its 40px avatar determines the row height.
+  const rowClassName = position ? 'min-h-0 py-2' : undefined;
+
   return (
     <ListItem
       isInteractive
       variant={ListItemVariant.TwoLines}
-      twClassName={position ? 'min-h-[56px] py-2' : undefined}
+      twClassName={rowClassName}
       avatar={
         symbol ? <PerpsTokenLogo symbol={symbol} size={iconSize} /> : undefined
       }
@@ -296,7 +253,7 @@ const PerpsCardWithMarketLookup: React.FC<PerpsCardProps> = (props) => {
  * PerpsCard Component
  *
  * A unified list row for positions and orders on the Perps home tab.
- * Uses MMDS ListItem defaults (including horizontal padding).
+ * Uses MMDS ListItem defaults, with compact position spacing from TAT-3776.
  *
  * When `onPress` is provided, stream/market lookup is skipped so the card can
  * render outside PerpsStreamProvider (e.g. Asset overview).

--- a/app/components/UI/Perps/utils/positionDisplay.test.ts
+++ b/app/components/UI/Perps/utils/positionDisplay.test.ts
@@ -1,0 +1,85 @@
+import { TagSeverity, TextColor } from '@metamask/design-system-react-native';
+import type { Position } from '@metamask/perps-controller';
+import { getPerpsPositionHeaderDisplay } from './positionDisplay';
+
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: (key: string) => {
+    if (key === 'perps.market.long') {
+      return 'Long';
+    }
+    if (key === 'perps.market.short') {
+      return 'Short';
+    }
+    return key;
+  },
+}));
+
+const createPosition = (overrides: Partial<Position> = {}): Position => ({
+  symbol: 'ETH',
+  size: '1.5',
+  entryPrice: '2900',
+  positionValue: '4350',
+  unrealizedPnl: '150',
+  marginUsed: '1450',
+  leverage: { type: 'isolated', value: 3 },
+  liquidationPrice: '2500',
+  maxLeverage: 50,
+  returnOnEquity: '0.103',
+  cumulativeFunding: { allTime: '0', sinceOpen: '0', sinceChange: '0' },
+  takeProfitCount: 0,
+  stopLossCount: 0,
+  ...overrides,
+});
+
+describe('getPerpsPositionHeaderDisplay', () => {
+  it('formats a long position header', () => {
+    const position = createPosition();
+
+    const result = getPerpsPositionHeaderDisplay(position);
+
+    expect(result).toEqual({
+      displaySymbol: 'ETH',
+      absoluteSize: 1.5,
+      directionLabel: '3x Long',
+      directionSeverity: TagSeverity.Success,
+      description: '1.5 ETH • $4,350',
+      pnlText: '+$150.00',
+      roeText: '+10.3%',
+      pnlColor: TextColor.SuccessDefault,
+    });
+  });
+
+  it('formats a short position header', () => {
+    const position = createPosition({
+      size: '-1.5',
+      unrealizedPnl: '-50.25',
+      returnOnEquity: '-0.025',
+    });
+
+    const result = getPerpsPositionHeaderDisplay(position);
+
+    expect(result.directionLabel).toBe('3x Short');
+    expect(result.directionSeverity).toBe(TagSeverity.Danger);
+    expect(result.description).toBe('1.5 ETH • $4,350');
+    expect(result.pnlText).toBe('-$50.25');
+    expect(result.roeText).toBe('-2.5%');
+    expect(result.pnlColor).toBe(TextColor.ErrorDefault);
+  });
+
+  it('classifies a zero-size position as short', () => {
+    const position = createPosition({ size: '0' });
+
+    const result = getPerpsPositionHeaderDisplay(position);
+
+    expect(result.directionLabel).toBe('3x Short');
+    expect(result.directionSeverity).toBe(TagSeverity.Danger);
+  });
+
+  it('formats a nonnumeric return on equity as zero percent', () => {
+    const position = createPosition({ returnOnEquity: 'not-a-number' });
+
+    const result = getPerpsPositionHeaderDisplay(position);
+
+    expect(result.roeText).toBe('+0.0%');
+  });
+});

--- a/app/components/UI/Perps/utils/positionDisplay.ts
+++ b/app/components/UI/Perps/utils/positionDisplay.ts
@@ -1,0 +1,64 @@
+import { TagSeverity, TextColor } from '@metamask/design-system-react-native';
+import {
+  getPerpsDisplaySymbol,
+  type Position,
+} from '@metamask/perps-controller';
+import { strings } from '../../../../../locales/i18n';
+import {
+  formatPercentage,
+  formatPerpsFiat,
+  formatPnl,
+  formatPositionSize,
+  PRICE_RANGES_MINIMAL_VIEW,
+} from './formatUtils';
+
+export interface PerpsPositionHeaderDisplay {
+  displaySymbol: string;
+  absoluteSize: number;
+  directionLabel: string;
+  directionSeverity: TagSeverity;
+  description: string;
+  pnlText: string;
+  roeText: string;
+  pnlColor: TextColor;
+}
+
+/**
+ * Derives the shared display values used by Lite and Pro position headers.
+ *
+ * Position size is signed by direction, while return on equity is provided as
+ * a decimal ratio (for example, 0.1 represents 10%).
+ *
+ * @param position - Perps position to format.
+ * @returns Shared position header display values.
+ */
+export const getPerpsPositionHeaderDisplay = (
+  position: Position,
+): PerpsPositionHeaderDisplay => {
+  const size = Number.parseFloat(position.size);
+  const isLong = size > 0;
+  const absoluteSize = Math.abs(size);
+  const displaySymbol = getPerpsDisplaySymbol(position.symbol);
+  const direction = isLong
+    ? strings('perps.market.long')
+    : strings('perps.market.short');
+  const pnl = Number.parseFloat(position.unrealizedPnl);
+  const roe = (Number.parseFloat(position.returnOnEquity) || 0) * 100;
+  const pnlColor = pnl >= 0 ? TextColor.SuccessDefault : TextColor.ErrorDefault;
+  const positionValue = formatPerpsFiat(position.positionValue, {
+    ranges: PRICE_RANGES_MINIMAL_VIEW,
+  });
+
+  return {
+    displaySymbol,
+    absoluteSize,
+    directionLabel: `${position.leverage.value}x ${direction}`,
+    directionSeverity: isLong ? TagSeverity.Success : TagSeverity.Danger,
+    description: `${formatPositionSize(
+      absoluteSize.toString(),
+    )} ${displaySymbol} • ${positionValue}`,
+    pnlText: formatPnl(pnl),
+    roeText: formatPercentage(roe, 1),
+    pnlColor,
+  };
+};

--- a/tests/page-objects/Perps/PerpsView.ts
+++ b/tests/page-objects/Perps/PerpsView.ts
@@ -19,7 +19,7 @@ import PerpsMarketListView from './PerpsMarketListView';
 import PerpsMarketDetailsView from './PerpsMarketDetailsView';
 import { type AppiumElement, PlatformDetector, sleep } from '../../framework';
 
-/** Portfolio: limit order primary (`formatOrderLabel`) + position primary (`{symbol} {n}x {side}`). */
+/** Portfolio: limit order primary (`formatOrderLabel`) + position direction badge (`{n}x {side}`). */
 export interface PerpsPortfolioLimitFlowExpectOptions {
   symbol: string;
   direction: 'long' | 'short';
@@ -138,14 +138,10 @@ class PerpsView {
     return Matchers.getElementByID(`perps-position-row-${symbol}`);
   }
 
-  private getPositionPrimaryLine(
-    symbol: string,
+  private getPositionDirectionBadge(
     direction: 'long' | 'short',
   ): Promise<AppiumElement> {
-    const escapedSymbol = symbol.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return Matchers.getElementByText(
-      new RegExp(`${escapedSymbol} \\d+x ${direction}`),
-    );
+    return Matchers.getElementByText(new RegExp(`^\\d+x ${direction}$`, 'i'));
   }
 
   // Orders section on the Perps main tab
@@ -256,7 +252,7 @@ class PerpsView {
   }
 
   /**
-   * After fill: order label gone and position row matches `{symbol} {n}x {direction}` (PerpsCard).
+   * After fill: order label gone and the position row or its `{n}x {direction}` badge is visible.
    */
   async expectPositionRowAfterLimitOrderFilled(
     options: PerpsPortfolioLimitFlowExpectOptions,
@@ -266,7 +262,7 @@ class PerpsView {
     const positionLocators: Promise<AppiumElement>[] = [
       this.getPortfolioPositionCard(0),
       this.getWalletHomePositionRow(symbol),
-      this.getPositionPrimaryLine(symbol, direction),
+      this.getPositionDirectionBadge(direction),
     ];
     await Utilities.executeWithRetry(
       async () => {

--- a/tests/page-objects/Perps/PerpsView.ts
+++ b/tests/page-objects/Perps/PerpsView.ts
@@ -122,26 +122,24 @@ class PerpsView {
     return Matchers.getElementByID(PerpsHomeViewSelectorsIDs.ADD_FUNDS_BUTTON);
   }
 
-  private getPortfolioPositionCard(index = 0): Promise<AppiumElement> {
-    return Matchers.getElementByID(
-      `${PerpsHomeViewSelectorsIDs.POSITION_CARD}-${index}`,
-    );
-  }
-
   private getPortfolioOrderCard(index = 0): Promise<AppiumElement> {
     return Matchers.getElementByID(
       `${PerpsHomeViewSelectorsIDs.ORDER_CARD}-${index}`,
     );
   }
 
-  private getWalletHomePositionRow(symbol: string): Promise<AppiumElement> {
-    return Matchers.getElementByID(`perps-position-row-${symbol}`);
+  private getPortfolioPositionDirectionTag(index = 0): Promise<AppiumElement> {
+    return Matchers.getElementByID(
+      `${PerpsHomeViewSelectorsIDs.POSITION_CARD}-${index}-direction-tag`,
+    );
   }
 
-  private getPositionDirectionBadge(
-    direction: 'long' | 'short',
+  private getWalletHomePositionDirectionTag(
+    symbol: string,
   ): Promise<AppiumElement> {
-    return Matchers.getElementByText(new RegExp(`^\\d+x ${direction}$`, 'i'));
+    return Matchers.getElementByID(
+      `perps-position-row-${symbol}-direction-tag`,
+    );
   }
 
   // Orders section on the Perps main tab
@@ -259,10 +257,10 @@ class PerpsView {
   ): Promise<void> {
     const { symbol, direction } = options;
     const orderLabel = options.orderLabel ?? `Limit ${direction}`;
+    const directionLabel = direction === 'long' ? 'Long' : 'Short';
     const positionLocators: Promise<AppiumElement>[] = [
-      this.getPortfolioPositionCard(0),
-      this.getWalletHomePositionRow(symbol),
-      this.getPositionDirectionBadge(direction),
+      this.getPortfolioPositionDirectionTag(0),
+      this.getWalletHomePositionDirectionTag(symbol),
     ];
     await Utilities.executeWithRetry(
       async () => {
@@ -278,6 +276,14 @@ class PerpsView {
               description: `${symbol} position row visible (${direction})`,
               timeout: 3000,
             });
+            await Assertions.expectElementToContainText(
+              locator,
+              directionLabel,
+              {
+                description: `${symbol} position direction is ${direction}`,
+                timeout: 3000,
+              },
+            );
             positionVisible = true;
             break;
           } catch {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Perps position rows displayed different information layouts across Wallet Home, Perps Home, Asset Detail, and Pro mode. This created an inconsistent experience for the same position data.

This change updates the shared `PerpsCard` position row to match the Pro design:

- Shows leverage and direction in a success/danger badge beside the ticker.
- Displays position size and USD position value together in the subtitle.
- Separates unrealized P&L and ROE into the right-side value and subvalue.
- Preserves privacy-mode masking and leaves order rows unchanged.
- Updates the Appium fallback locator and unit coverage for the new structure.

Automated verification completed with the targeted `PerpsCard` Jest suite, ESLint, and TypeScript checks.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated Perps position rows to use a consistent layout across Wallet Home, Perps Home, and Asset Detail

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [TAT-3776](https://consensyssoftware.atlassian.net/browse/TAT-3776)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Consistent Perps position list items

  Background:
    Given I am logged into MetaMask Mobile
    And my Perps account has an open position

  Scenario Outline: Position details use the Pro layout on each supported surface
    Given I am viewing the "<surface>" surface

    When the open Perps position row is displayed
    Then the ticker symbol should be shown as the title
    And leverage and direction should be shown in a colored badge beside the title
    And the subtitle should show the position size and USD position value
    And unrealized P&L should be shown as the right-side value
    And ROE percentage should be shown as the right-side subvalue

    Examples:
      | surface      |
      | Wallet Home  |
      | Perps Home   |
      | Asset Detail |

  Scenario: Long and short positions use the correct badge and P&L color
    Given I can view both a long position and a short position

    When the position rows are displayed
    Then the long position should show a success-colored "<leverage>x Long" badge
    And the short position should show a danger-colored "<leverage>x Short" badge
    And positive P&L and ROE should use the success color
    And negative P&L and ROE should use the danger color

  Scenario: Privacy mode masks financial position values
    Given privacy mode is enabled

    When an open Perps position row is displayed
    Then the ticker symbol and leverage direction badge should remain visible
    And the position size and USD position value should be masked
    And unrealized P&L and ROE should be masked
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

[Current inconsistent behavior documented in TAT-3776](https://consensyssoftware.atlassian.net/browse/TAT-3776)

### **After**

[Target MyPositionPro design in Figma](https://www.figma.com/design/RKxgK44BoVRyKtmjjP4SFc/PERPS---13-Jul---xx-Nov?node-id=10163-18999&m=dev)

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-02 at 21 04 41" src="https://github.com/user-attachments/assets/8f1c25ea-1b7c-43f4-abe2-43f5251bb42f" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-02 at 21 04 58" src="https://github.com/user-attachments/assets/048274b5-bf4f-47e2-b72f-ab6473c962a3" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-02 at 21 05 28" src="https://github.com/user-attachments/assets/9bcef737-f9f4-4fd8-bfed-a4ba1cc51df8" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


[TAT-3776]: https://consensyssoftware.atlassian.net/browse/TAT-3776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Perps list formatting with shared display logic and updated tests/E2E locators; no auth, payments, or persistence changes.
> 
> **Overview**
> Introduces **`getPerpsPositionHeaderDisplay`** so Lite list rows and the Pro position card share one formatter for symbol, leverage/direction badge, size • USD value, PnL, ROE, and success/danger colors.
> 
> **`PerpsCard`** position rows now match the Pro header: ticker as title, **`{n}x Long/Short`** in a colored **`Tag`** (`titleEndAccessory`), combined subtitle, unrealized P&L on the right with ROE as subvalue (replacing the old single-line title and fiat value column). Position rows use compact **`ListItem`** padding; order rows are unchanged.
> 
> **`PerpsProPositionCard`** drops duplicate header math and uses the same helper. **Zero-size** positions are treated as **short** for the direction badge (not long via `size >= 0`).
> 
> Tests and mocks align **`returnOnEquity`** with decimal ratios; Appium **`PerpsView`** locators target **`…-direction-tag`** test IDs after limit fills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bbc08f693fcab58db43b4c678351358d92942dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->