### PR TITLE
fix(perps): tP-SL order payload sends negative or zero trigger price — rejected by Hyperliquid

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -365,6 +365,8 @@ export const PerpsTPSLViewSelectorsIDs = {
   TAKE_PROFIT_PERCENTAGE_INPUT: 'perps-tpsl-tp-percentage-input',
   STOP_LOSS_PRICE_INPUT: 'perps-tpsl-sl-input',
   STOP_LOSS_PERCENTAGE_INPUT: 'perps-tpsl-sl-percentage-input',
+  TAKE_PROFIT_ERROR: 'perps-tpsl-tp-error',
+  STOP_LOSS_ERROR: 'perps-tpsl-sl-error',
 } as const;
 
 export const getPerpsTPSLViewSelector = {

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -85,7 +85,8 @@ const priceValueTextProps = {
 const SectionHelpText: React.FC<{
   errorMessage?: string;
   expectedMessage?: string;
-}> = ({ errorMessage, expectedMessage }) => (
+  errorTestID?: string;
+}> = ({ errorMessage, expectedMessage, errorTestID }) => (
   <Box>
     <HelpText
       severity={HelpTextSeverity.Danger}
@@ -98,7 +99,11 @@ const SectionHelpText: React.FC<{
     </HelpText>
     {errorMessage ? (
       <Box twClassName="absolute inset-x-0 top-0">
-        <HelpText severity={HelpTextSeverity.Danger} showIcon>
+        <HelpText
+          severity={HelpTextSeverity.Danger}
+          showIcon
+          testID={errorTestID}
+        >
           {errorMessage}
         </HelpText>
       </Box>
@@ -888,6 +893,7 @@ const PerpsTPSLView: React.FC = () => {
               </Box>
 
               <SectionHelpText
+                errorTestID={PerpsTPSLViewSelectorsIDs.TAKE_PROFIT_ERROR}
                 errorMessage={
                   takeProfitHasError ? takeProfitError || undefined : undefined
                 }
@@ -1016,6 +1022,7 @@ const PerpsTPSLView: React.FC = () => {
               </Box>
 
               <SectionHelpText
+                errorTestID={PerpsTPSLViewSelectorsIDs.STOP_LOSS_ERROR}
                 errorMessage={stopLossErrorMessage || undefined}
                 expectedMessage={
                   stopLossPrice

--- a/app/components/UI/Perps/hooks/usePerpsTPSLForm.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLForm.test.ts
@@ -46,6 +46,8 @@ jest.mock('../../../../../locales/i18n', () => ({
       'perps.tpsl.take_profit_invalid_price': `Take profit must be ${params?.direction} ${params?.priceType} price`,
       'perps.tpsl.stop_loss_invalid_price': `Stop loss must be ${params?.direction} ${params?.priceType} price`,
       'perps.tpsl.stop_loss_beyond_liquidation_error': `Stop loss must be ${params?.direction} liquidation price`,
+      'perps.tpsl.trigger_price_must_be_positive':
+        'Trigger price must be greater than zero',
     };
     return strings[key] || key;
   },
@@ -96,6 +98,75 @@ describe('usePerpsTPSLForm', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('non-positive trigger prices', () => {
+    const shortParams = {
+      asset: 'ETH',
+      currentPrice: 2392.5,
+      direction: 'short' as const,
+      leverage: 1,
+      isVisible: true,
+      liquidationPrice: '3123.4',
+    };
+
+    it('blocks submission when a take profit return of 5000 percent drives the trigger price below zero', () => {
+      // Arrange
+      const { result } = renderHook(() => usePerpsTPSLForm(shortParams), {
+        wrapper: createWrapper(),
+      });
+
+      // Act
+      act(() => {
+        result.current.handlers.handleTakeProfitPercentageChange('5000');
+      });
+
+      // Assert
+      expect(
+        Number.parseFloat(result.current.formState.takeProfitPrice),
+      ).toBeLessThan(0);
+      expect(result.current.validation.isValid).toBe(false);
+      expect(result.current.validation.takeProfitError).toBe(
+        'Trigger price must be greater than zero',
+      );
+    });
+
+    it('allows a take profit return that keeps the trigger price above zero', () => {
+      // Arrange
+      const { result } = renderHook(() => usePerpsTPSLForm(shortParams), {
+        wrapper: createWrapper(),
+      });
+
+      // Act
+      act(() => {
+        result.current.handlers.handleTakeProfitPercentageChange('50');
+      });
+
+      // Assert
+      expect(
+        Number.parseFloat(result.current.formState.takeProfitPrice),
+      ).toBeGreaterThan(0);
+      expect(result.current.validation.isValid).toBe(true);
+      expect(result.current.validation.takeProfitError).toBe('');
+    });
+
+    it('blocks submission when a typed stop loss trigger price is zero', () => {
+      // Arrange
+      const { result } = renderHook(() => usePerpsTPSLForm(defaultParams), {
+        wrapper: createWrapper(),
+      });
+
+      // Act
+      act(() => {
+        result.current.handlers.handleStopLossPriceChange('0');
+      });
+
+      // Assert
+      expect(result.current.validation.isValid).toBe(false);
+      expect(result.current.validation.stopLossError).toBe(
+        'Trigger price must be greater than zero',
+      );
+    });
   });
 
   describe('initialization', () => {

--- a/app/components/UI/Perps/hooks/usePerpsTPSLForm.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLForm.test.ts
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { usePerpsTPSLForm } from './usePerpsTPSLForm';
 import { type Position } from '@metamask/perps-controller';
+import { strings } from '../../../../../locales/i18n';
 
 // Mock DevLogger to avoid console noise in tests
 jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
@@ -42,14 +43,14 @@ jest.mock('../utils/formatUtils', () => ({
 // Mock i18n strings
 jest.mock('../../../../../locales/i18n', () => ({
   strings: (key: string, params?: Record<string, string>) => {
-    const strings: Record<string, string> = {
+    const translations: Record<string, string> = {
       'perps.tpsl.take_profit_invalid_price': `Take profit must be ${params?.direction} ${params?.priceType} price`,
       'perps.tpsl.stop_loss_invalid_price': `Stop loss must be ${params?.direction} ${params?.priceType} price`,
       'perps.tpsl.stop_loss_beyond_liquidation_error': `Stop loss must be ${params?.direction} liquidation price`,
       'perps.tpsl.trigger_price_must_be_positive':
         'Trigger price must be greater than zero',
     };
-    return strings[key] || key;
+    return translations[key] || key;
   },
 }));
 
@@ -127,7 +128,7 @@ describe('usePerpsTPSLForm', () => {
       ).toBeLessThan(0);
       expect(result.current.validation.isValid).toBe(false);
       expect(result.current.validation.takeProfitError).toBe(
-        'Trigger price must be greater than zero',
+        strings('perps.tpsl.trigger_price_must_be_positive'),
       );
     });
 
@@ -164,7 +165,7 @@ describe('usePerpsTPSLForm', () => {
       // Assert
       expect(result.current.validation.isValid).toBe(false);
       expect(result.current.validation.stopLossError).toBe(
-        'Trigger price must be greater than zero',
+        strings('perps.tpsl.trigger_price_must_be_positive'),
       );
     });
   });

--- a/app/components/UI/Perps/hooks/usePerpsTPSLForm.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLForm.ts
@@ -20,6 +20,7 @@ import {
   getTakeProfitErrorDirection,
   hasExceededSignificantFigures,
   hasTPSLValuesChanged,
+  isPositiveTriggerPrice,
   isStopLossSafeFromLiquidation,
   isValidStopLossPrice,
   isValidTakeProfitPrice,
@@ -105,6 +106,32 @@ export interface UsePerpsTPSLFormReturn {
   validation: TPSLFormValidation;
   display: TPSLFormDisplay;
 }
+
+/**
+ * Resolves the inline error for one trigger price field.
+ *
+ * A non-positive price is reported first: it is rejected by the protocol
+ * regardless of which side of the reference price it falls on, and the
+ * direction rules on their own would let it through.
+ *
+ * @param price - The current trigger price value, empty when the field is unset
+ * @param isOnValidSide - Whether the price sits on the correct side of the reference price
+ * @param getWrongSideMessage - Builds the direction-specific message for a wrong-side price
+ * @returns The message to show under the field, or an empty string when there is nothing to report
+ */
+const resolveTriggerPriceError = (
+  price: string,
+  isOnValidSide: boolean,
+  getWrongSideMessage: () => string,
+): string => {
+  if (!price) return '';
+
+  if (!isPositiveTriggerPrice(price)) {
+    return strings('perps.tpsl.trigger_price_must_be_positive');
+  }
+
+  return isOnValidSide ? '' : getWrongSideMessage();
+};
 
 /**
  * Custom hook to manage TPSL form state, validation, and business logic
@@ -889,28 +916,32 @@ export function usePerpsTPSLForm(
   );
 
   // Take Profit Errors
-  const takeProfitError =
-    !isValidTakeProfitPrice(takeProfitPrice, {
+  const takeProfitError = resolveTriggerPriceError(
+    takeProfitPrice,
+    isValidTakeProfitPrice(takeProfitPrice, {
       currentPrice: referencePrice,
       direction: actualDirection,
-    }) && takeProfitPrice
-      ? strings('perps.tpsl.take_profit_invalid_price', {
-          direction: getTakeProfitErrorDirection(actualDirection),
-          priceType,
-        })
-      : '';
+    }),
+    () =>
+      strings('perps.tpsl.take_profit_invalid_price', {
+        direction: getTakeProfitErrorDirection(actualDirection),
+        priceType,
+      }),
+  );
 
   // Stop Loss Errors
-  const stopLossError =
-    !isValidStopLossPrice(stopLossPrice, {
+  const stopLossError = resolveTriggerPriceError(
+    stopLossPrice,
+    isValidStopLossPrice(stopLossPrice, {
       currentPrice: referencePrice,
       direction: actualDirection,
-    }) && stopLossPrice
-      ? strings('perps.tpsl.stop_loss_invalid_price', {
-          direction: getStopLossErrorDirection(actualDirection),
-          priceType,
-        })
-      : '';
+    }),
+    () =>
+      strings('perps.tpsl.stop_loss_invalid_price', {
+        direction: getStopLossErrorDirection(actualDirection),
+        priceType,
+      }),
+  );
 
   const stopLossLiquidationError =
     !isStopLossSafeFromLiquidation(

--- a/app/components/UI/Perps/utils/tpslValidation.test.ts
+++ b/app/components/UI/Perps/utils/tpslValidation.test.ts
@@ -109,8 +109,8 @@ describe('TPSL Validation Utilities', () => {
         unresolvedParams,
       );
       const stopLossResult = validateTPSLPrices(
-        '0',
         undefined,
+        '0',
         unresolvedParams,
       );
 

--- a/app/components/UI/Perps/utils/tpslValidation.test.ts
+++ b/app/components/UI/Perps/utils/tpslValidation.test.ts
@@ -98,6 +98,46 @@ describe('TPSL Validation Utilities', () => {
       expect(result).toBe(false);
     });
 
+    it('reports a non-positive trigger price before the reference price resolves', () => {
+      // Arrange - spot price has not streamed in yet, so the direction rules cannot apply
+      const unresolvedParams = { currentPrice: 0, direction: undefined };
+
+      // Act
+      const takeProfitResult = validateTPSLPrices(
+        '-37482.5',
+        undefined,
+        unresolvedParams,
+      );
+      const stopLossResult = validateTPSLPrices(
+        '0',
+        undefined,
+        unresolvedParams,
+      );
+
+      // Assert
+      expect(takeProfitResult).toBe(false);
+      expect(stopLossResult).toBe(false);
+    });
+
+    it('flags a non-positive trigger price in the order form warnings before the market price resolves', () => {
+      // Arrange - marketPrice of 0 previously short-circuited both warning checks
+      const input = {
+        orderType: 'market' as const,
+        direction: 'short' as const,
+        takeProfitPrice: '-37482.5',
+        stopLossPrice: '0',
+        liquidationPrice: '3123.4',
+        marketPrice: 0,
+      };
+
+      // Act
+      const warnings = getPerpsOrderTpSlWarnings(input);
+
+      // Assert
+      expect(warnings.isTakeProfitPriceInvalid).toBe(true);
+      expect(warnings.isStopLossPriceInvalid).toBe(true);
+    });
+
     it('flags a non-positive take profit in the order form warnings', () => {
       // Arrange
       const input = {

--- a/app/components/UI/Perps/utils/tpslValidation.test.ts
+++ b/app/components/UI/Perps/utils/tpslValidation.test.ts
@@ -1,4 +1,5 @@
 import {
+  isPositiveTriggerPrice,
   isValidTakeProfitPrice,
   isValidStopLossPrice,
   isStopLossSafeFromLiquidation,
@@ -23,6 +24,98 @@ import {
 // tests have been moved to formatUtils.test.ts since the implementations now live in formatUtils.ts
 
 describe('TPSL Validation Utilities', () => {
+  describe('non-positive trigger prices', () => {
+    it('rejects a non-positive take profit trigger price', () => {
+      // Arrange - a short whose take profit return overshoots 100% x leverage
+      const shortParams = { currentPrice: 2392.5, direction: 'short' as const };
+
+      // Act
+      const negativeResult = isValidTakeProfitPrice('-37482.5', shortParams);
+      const zeroResult = isValidTakeProfitPrice('0', shortParams);
+
+      // Assert - both would be rejected by the protocol, so the form must be invalid
+      expect(negativeResult).toBe(false);
+      expect(zeroResult).toBe(false);
+    });
+
+    it('rejects a non-positive stop loss trigger price', () => {
+      // Arrange - a long stop loss sits below current price, where negatives also "pass" direction checks
+      const longParams = { currentPrice: 2392.5, direction: 'long' as const };
+
+      // Act
+      const negativeResult = isValidStopLossPrice('-0.00464', longParams);
+      const zeroResult = isValidStopLossPrice('0', longParams);
+
+      // Assert
+      expect(negativeResult).toBe(false);
+      expect(zeroResult).toBe(false);
+    });
+
+    it('keeps a valid sub-cent trigger price accepted', () => {
+      // Arrange - small-tick markets are the ones that produced the reported failures
+      const shortParams = {
+        currentPrice: 0.00232,
+        direction: 'short' as const,
+      };
+
+      // Act
+      const result = isValidTakeProfitPrice('0.00116', shortParams);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it('treats empty and unparseable prices as nothing to validate', () => {
+      // Arrange
+      const prices = ['', undefined, 'invalid'];
+
+      // Act
+      const results = prices.map((price) => isPositiveTriggerPrice(price));
+
+      // Assert
+      expect(results).toEqual([true, true, true]);
+    });
+
+    it('strips currency formatting before comparing against zero', () => {
+      // Arrange
+      const formattedNegative = '-$1,250.75';
+
+      // Act
+      const result = isPositiveTriggerPrice(formattedNegative);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+
+    it('reports a short take profit below zero through validateTPSLPrices', () => {
+      // Arrange
+      const params = { currentPrice: 2392.5, direction: 'short' as const };
+
+      // Act
+      const result = validateTPSLPrices('-37482.5', undefined, params);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+
+    it('flags a non-positive take profit in the order form warnings', () => {
+      // Arrange
+      const input = {
+        orderType: 'market' as const,
+        direction: 'short' as const,
+        takeProfitPrice: '-37482.5',
+        liquidationPrice: '3123.4',
+        marketPrice: 2392.5,
+      };
+
+      // Act
+      const warnings = getPerpsOrderTpSlWarnings(input);
+
+      // Assert
+      expect(warnings.isTakeProfitPriceInvalid).toBe(true);
+    });
+  });
+
   describe('isValidTakeProfitPrice', () => {
     describe('Long positions', () => {
       const params = { currentPrice: 100, direction: 'long' as const };

--- a/app/components/UI/Perps/utils/tpslValidation.ts
+++ b/app/components/UI/Perps/utils/tpslValidation.ts
@@ -477,13 +477,6 @@ export const calculatePriceForRoE = (
     finalResult,
   });
 
-  if (parseFloat(finalResult) <= 0) {
-    DevLogger.log(
-      '[PR-TAT-3872] BUG_MARKER: calculatePriceForRoE returned a non-positive trigger price:',
-      JSON.stringify({ roePercentage, isProfit, basePrice, finalResult }),
-    );
-  }
-
   return finalResult;
 };
 

--- a/app/components/UI/Perps/utils/tpslValidation.ts
+++ b/app/components/UI/Perps/utils/tpslValidation.ts
@@ -187,20 +187,22 @@ export const getPerpsOrderTpSlWarnings = ({
 
   const isTakeProfitPriceInvalid = Boolean(
     takeProfitPrice?.trim() &&
-      validationReferencePrice > 0 &&
-      !isValidTakeProfitPrice(takeProfitPrice, {
-        currentPrice: validationReferencePrice,
-        direction,
-      }),
+      (!isPositiveTriggerPrice(takeProfitPrice) ||
+        (validationReferencePrice > 0 &&
+          !isValidTakeProfitPrice(takeProfitPrice, {
+            currentPrice: validationReferencePrice,
+            direction,
+          }))),
   );
 
   const isStopLossPriceInvalid = Boolean(
     stopLossPrice?.trim() &&
-      validationReferencePrice > 0 &&
-      !isValidStopLossPrice(stopLossPrice, {
-        currentPrice: validationReferencePrice,
-        direction,
-      }),
+      (!isPositiveTriggerPrice(stopLossPrice) ||
+        (validationReferencePrice > 0 &&
+          !isValidStopLossPrice(stopLossPrice, {
+            currentPrice: validationReferencePrice,
+            direction,
+          }))),
   );
 
   return {
@@ -224,6 +226,15 @@ export const validateTPSLPrices = (
   stopLossPrice: string | undefined,
   params: ValidationParams,
 ): boolean => {
+  // The positive-price floor does not depend on a reference price, so it is
+  // applied before the early return that skips the direction rules.
+  if (
+    !isPositiveTriggerPrice(takeProfitPrice) ||
+    !isPositiveTriggerPrice(stopLossPrice)
+  ) {
+    return false;
+  }
+
   if (!params.currentPrice || !params.direction) return true;
 
   let isValid = true;

--- a/app/components/UI/Perps/utils/tpslValidation.ts
+++ b/app/components/UI/Perps/utils/tpslValidation.ts
@@ -477,6 +477,13 @@ export const calculatePriceForRoE = (
     finalResult,
   });
 
+  if (parseFloat(finalResult) <= 0) {
+    DevLogger.log(
+      '[PR-TAT-3872] BUG_MARKER: calculatePriceForRoE returned a non-positive trigger price:',
+      JSON.stringify({ roePercentage, isProfit, basePrice, finalResult }),
+    );
+  }
+
   return finalResult;
 };
 

--- a/app/components/UI/Perps/utils/tpslValidation.ts
+++ b/app/components/UI/Perps/utils/tpslValidation.ts
@@ -31,6 +31,27 @@ interface ValidationParams {
 }
 
 /**
+ * Checks that a trigger price can be sent to the protocol at all.
+ *
+ * Direction checks alone let a non-positive price through: a negative take
+ * profit is still "below" a short's current price, and a negative stop loss is
+ * still "below" a long's current price. The protocol rejects the whole order
+ * when `p` or `triggerPx` is at or below zero, so this floor is checked before
+ * the direction rules.
+ *
+ * @param price - The trigger price to validate
+ * @returns False only when the price parses to a number at or below zero
+ */
+export const isPositiveTriggerPrice = (price?: string): boolean => {
+  if (!price) return true;
+
+  const parsedPrice = parseFloat(price.replace(/[$,]/g, ''));
+  if (isNaN(parsedPrice)) return true;
+
+  return parsedPrice > 0;
+};
+
+/**
  * Validates if a take profit price is valid for the given direction.
  *
  * @param price - The take profit price to validate
@@ -43,6 +64,8 @@ export const isValidTakeProfitPrice = (
   price: string,
   { currentPrice, direction }: ValidationParams,
 ): boolean => {
+  if (!isPositiveTriggerPrice(price)) return false;
+
   if (!currentPrice || !direction || !price) return true;
 
   const tpPrice = parseFloat(price.replace(/[$,]/g, ''));
@@ -65,6 +88,8 @@ export const isValidStopLossPrice = (
   price: string,
   { currentPrice, direction }: ValidationParams,
 ): boolean => {
+  if (!isPositiveTriggerPrice(price)) return false;
+
   if (!currentPrice || !direction || !price) return true;
 
   const slPrice = parseFloat(price.replace(/[$,]/g, ''));

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2112,6 +2112,7 @@
       "loss_roe_placeholder": "% Loss",
       "usd_label": "$",
       "take_profit_invalid_price": "Take profit must be {{direction}} {{priceType}} price",
+      "trigger_price_must_be_positive": "Trigger price must be greater than zero",
       "stop_loss_invalid_price": "Stop loss must be {{direction}} {{priceType}} price",
       "stop_loss_beyond_liquidation_error": "Stop loss must be {{direction}} liquidation price",
       "stop_loss_order_view_warning": "Stop loss is {{direction}} liquidation price",


### PR DESCRIPTION
## **Description**

Setting a take profit whose return exceeds `leverage × 100` percent on a short makes `calculatePriceForRoE` compute a trigger price below zero (`basePrice × (1 - roe / (leverage × 100))`). The direction validators accepted it — a negative price is still "below" a short's current price — so the Set button stayed enabled and the negative string reached Hyperliquid as `orders[].p` / `orders[].t.trigger.triggerPx`, which rejects the whole order (53 unique Mobile users in 4 weeks).

`isValidTakeProfitPrice` and `isValidStopLossPrice` now reject a trigger price at or below zero before applying the direction rules, and the Auto close sheet shows "Trigger price must be greater than zero" with the confirm button disabled. The floor is checked before the reference-price preconditions in `validateTPSLPrices` and `getPerpsOrderTpSlWarnings` too, so it still holds while the spot price is unresolved. Every TP/SL entry point — order entry and the position sheet, lite and Pro — routes through the same `PerpsTPSLView`, so this covers both the `orders.0.*` and `orders.1.*` variants.

## **Changelog**

CHANGELOG entry: Fixed a bug where a take profit or stop loss with an out-of-range percentage could be submitted with a negative trigger price and rejected by the exchange

## **Related issues**

Fixes: [TAT-3872](https://consensyssoftware.atlassian.net/browse/TAT-3872)

## **Manual testing steps**

```gherkin
Feature: Auto close rejects an unusable trigger price

  Scenario: user enters a take profit return that drives the trigger price below zero
    Given the wallet is unlocked and the ETH perps market is open

    When user selects Short and opens the Auto close section
    And user enters 5000 in the % Profit field
    Then the trigger price field shows a negative value in an error state
    And "Trigger price must be greater than zero" appears under the field
    And the Set button is disabled, so no order is sent

  Scenario: user enters a take profit return that keeps the trigger price positive
    Given the Auto close section is open on a short ETH order

    When user enters 50 in the % Profit field
    Then no validation message appears
    And the Set button is enabled
```

## **Screenshots/Recordings**

Auto close sheet on a short ETH order after asking for a +5000% take profit return, which drives the computed trigger price below zero.

<table>
<tr><td colspan="2"><strong>Negative take profit trigger is now blocked instead of confirmable</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35655/before-ac2-tpsl-inline-error.png?sha=11e5f0329a6c5244" alt="before" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35655/after-ac2-tpsl-inline-error.png?sha=86444c99b23f585e" alt="after" width="320" /></td>
</tr>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Not applicable. This adds a comparison inside an existing validation path in shared TypeScript, with no new rendering, data fetching, or hot-path work, and no platform-specific code. Validated on iOS.

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "TP-SL trigger price can never be submitted at or below zero",
  "description": "Drives the Perps order-entry Auto close sheet on a short ETH order, asks for a take-profit return that makes the computed trigger price go non-positive, and proves the form now surfaces an inline validation message and blocks confirmation instead of accepting the negative price. Data prerequisites: the fixture wallet must be unlocked (metamask.wallet.ensure_unlocked) and the ETH market must render the order form; no open position or perps balance is needed because the trigger price is computed client-side from the market price and the order-form leverage.",
  "workflow": {
    "entry": "setup-status",
    "nodes": {
      "setup-status": {
        "action": "app.status",
        "intent": "Confirm the mobile bridge is reachable before driving the Perps UI",
        "next": "setup-unlock"
      },
      "setup-unlock": {
        "action": "metamask.wallet.ensure_unlocked",
        "intent": "Bring the fixture wallet to an unlocked state so Perps screens can render",
        "next": "setup-open-market"
      },
      "setup-open-market": {
        "action": "ui.navigate",
        "intent": "Open the ETH Perps market that the order will be placed against",
        "page": "perps-market",
        "market": "ETH",
        "next": "setup-confirm-order-form"
      },
      "setup-confirm-order-form": {
        "action": "ui.wait_for",
        "intent": "A trader must be looking at a usable order form before a direction and an auto close target can be chosen",
        "test_id": "perps-pro-order-form-direction-short",
        "expected": "present",
        "timeout_ms": 20000,
        "next": "setup-start-short-order"
      },
      "setup-start-short-order": {
        "action": "ui.press",
        "intent": "Trade the short side, the direction whose take profit target moves down toward zero",
        "test_id": "perps-pro-order-form-direction-short",
        "next": "setup-open-auto-close"
      },
      "setup-open-auto-close": {
        "action": "ui.press",
        "intent": "Open the Auto close section that attaches a take profit leg to the order",
        "test_id": "perps-pro-order-form-tpsl",
        "next": "setup-wait-auto-close"
      },
      "setup-wait-auto-close": {
        "action": "ui.wait_for",
        "intent": "The Auto close sheet must be usable before a take profit target is entered",
        "test_id": "perps-tpsl-tp-percentage-input",
        "expected": "present",
        "timeout_ms": 20000,
        "next": "gate-no-error-before-input"
      },
      "gate-no-error-before-input": {
        "action": "ui.wait_for",
        "intent": "The sheet must start clean so the state captured later is caused only by the entered percentage",
        "test_id": "perps-tpsl-tp-error",
        "expected": "absent",
        "timeout_ms": 10000,
        "next": "ac2-enter-overshooting-profit-percentage"
      },
      "ac2-enter-overshooting-profit-percentage": {
        "action": "ui.set_input",
        "intent": "Ask for a take profit return that would place the short's trigger price below zero",
        "test_id": "perps-tpsl-tp-percentage-input",
        "value": "5000",
        "next": "ac2-wait-inline-error"
      },
      "ac2-wait-inline-error": {
        "action": "ui.wait_for",
        "intent": "The trader must be told that the resulting take profit trigger price is not a usable price",
        "test_id": "perps-tpsl-tp-error",
        "expected": "visible",
        "timeout_ms": 15000,
        "next": "ac2-screenshot-inline-error"
      },
      "ac2-screenshot-inline-error": {
        "action": "ui.screenshot",
        "intent": "Evidence that a trader is warned about an unusable take profit trigger price and cannot confirm it",
        "label": "AC2: inline validation message shown and Set disabled for a non-positive take profit trigger",
        "next": "ac1-run-guard-unit-tests"
      },
      "ac1-run-guard-unit-tests": {
        "action": "command",
        "intent": "Exercise the shared guard that keeps a non-positive trigger price out of the order payload",
        "timeout_ms": 900000,
        "allow_failure": true,
        "next": "ac1-assert-guard-unit-tests-pass"
      },
      "ac1-assert-guard-unit-tests-pass": {
        "action": "assert_exit_code",
        "intent": "Fail the proof if the payload guard is not enforced by the shared validators",
        "node": "ac1-run-guard-unit-tests",
        "expected": 0,
        "next": "ac1-assert-non-positive-rejected"
      },
      "ac1-assert-non-positive-rejected": {
        "action": "assert_output",
        "intent": "The proof must cover the case where the computed trigger price is not positive",
        "node": "ac1-run-guard-unit-tests",
        "stream": "stdout",
        "contains": "rejects a non-positive take profit trigger price",
        "next": "ac3-assert-form-blocks-submission"
      },
      "ac3-assert-form-blocks-submission": {
        "action": "assert_output",
        "intent": "The form must report the computation as invalid instead of handing back a negative trigger price",
        "node": "ac1-run-guard-unit-tests",
        "stream": "stdout",
        "contains": "blocks submission when a take profit return of 5000 percent drives the trigger price below zero",
        "next": "ac1-index-jest-log"
      },
      "ac1-index-jest-log": {
        "action": "index_artifacts",
        "intent": "Make the guard evidence readable by a human reviewer",
        "artifacts": [
          {
            "type": "log",
            "label": "AC1/AC3: jest run for the non-positive trigger price guard"
          }
        ],
        "next": "teardown-close-auto-close"
      },
      "teardown-close-auto-close": {
        "action": "ui.press",
        "intent": "Leave the Auto close sheet so the slot returns to the order form",
        "test_id": "perps-tpsl-cancel-button",
        "next": "done"
      },
      "done": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
  setup_status["setup-status<br/><i>app.status</i>"]
  setup_unlock["setup-unlock<br/><i>metamask.wallet.ensure_unlocked</i>"]
  setup_open_market["setup-open-market<br/><i>ui.navigate</i>"]
  setup_confirm_order_form["setup-confirm-order-form<br/><i>ui.wait_for</i>"]
  setup_start_short_order["setup-start-short-order<br/><i>ui.press</i>"]
  setup_open_auto_close["setup-open-auto-close<br/><i>ui.press</i>"]
  setup_wait_auto_close["setup-wait-auto-close<br/><i>ui.wait_for</i>"]
  gate_no_error_before_input["gate-no-error-before-input<br/><i>ui.wait_for</i>"]
  ac2_enter_overshooting_profit_percentage["ac2-enter-overshooting-profit-percentage<br/><i>ui.set_input</i>"]
  ac2_wait_inline_error["ac2-wait-inline-error<br/><i>ui.wait_for</i>"]
  ac2_screenshot_inline_error["ac2-screenshot-inline-error<br/><i>ui.screenshot</i>"]
  ac1_run_guard_unit_tests["ac1-run-guard-unit-tests<br/><i>command</i>"]
  ac1_assert_guard_unit_tests_pass["ac1-assert-guard-unit-tests-pass<br/><i>assert_exit_code</i>"]
  ac1_assert_non_positive_rejected["ac1-assert-non-positive-rejected<br/><i>assert_output</i>"]
  ac3_assert_form_blocks_submission["ac3-assert-form-blocks-submission<br/><i>assert_output</i>"]
  ac1_index_jest_log["ac1-index-jest-log<br/><i>index_artifacts</i>"]
  teardown_close_auto_close["teardown-close-auto-close<br/><i>ui.press</i>"]
  done["done<br/><i>end</i>"]
  setup_status --> setup_unlock
  setup_unlock --> setup_open_market
  setup_open_market --> setup_confirm_order_form
  setup_confirm_order_form --> setup_start_short_order
  setup_start_short_order --> setup_open_auto_close
  setup_open_auto_close --> setup_wait_auto_close
  setup_wait_auto_close --> gate_no_error_before_input
  gate_no_error_before_input --> ac2_enter_overshooting_profit_percentage
  ac2_enter_overshooting_profit_percentage --> ac2_wait_inline_error
  ac2_wait_inline_error --> ac2_screenshot_inline_error
  ac2_screenshot_inline_error --> ac1_run_guard_unit_tests
  ac1_run_guard_unit_tests --> ac1_assert_guard_unit_tests_pass
  ac1_assert_guard_unit_tests_pass --> ac1_assert_non_positive_rejected
  ac1_assert_non_positive_rejected --> ac3_assert_form_blocks_submission
  ac3_assert_form_blocks_submission --> ac1_index_jest_log
  ac1_index_jest_log --> teardown_close_auto_close
  teardown_close_auto_close --> done
```

</details>

[TAT-3872]: https://consensyssoftware.atlassian.net/browse/TAT-3872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared perps order validation and submit paths; behavior change is narrow (reject non-positive triggers) but affects all TP/SL entry points.
> 
> **Overview**
> **Blocks take-profit and stop-loss trigger prices at or below zero** so they never reach Hyperliquid (e.g. extreme short TP % that computes a negative trigger while direction-only validation still passed).
> 
> Adds **`isPositiveTriggerPrice`** and runs it **before** side-of-market checks in `isValidTakeProfitPrice` / `isValidStopLossPrice`, `validateTPSLPrices`, and `getPerpsOrderTpSlWarnings`—including when market price is still **0** / unresolved. The TP/SL form uses **`resolveTriggerPriceError`** to show **"Trigger price must be greater than zero"** and keep **Set** disabled; **`PerpsTPSLView`** wires **`TAKE_PROFIT_ERROR`** / **`STOP_LOSS_ERROR`** test IDs for automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44b6f7b71f9c0b6b6d9fa03ef237dd73f93b442e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->