### PR TITLE
test: ai-analyzer per-mode runtime overrides (ai-analyzer#47)

### DIFF
--- a/.ai-pr-analyzer/config.yaml
+++ b/.ai-pr-analyzer/config.yaml
@@ -138,3 +138,9 @@ models:
 
 modes:
   - pr-risk-analysis
+
+# Integration test for MetaMask/ai-analyzer#47 (per-mode runtime overrides).
+# Confirm Analyze logs show "12 iterations" for pr-risk-analysis.
+modeOverrides:
+  pr-risk-analysis:
+    maxIterations: 12

--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -31,12 +31,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Integration test for MetaMask/ai-analyzer#47 — do not merge this pin.
       # https://github.com/MetaMask/ai-analyzer/releases
       - name: Checkout AI Analyzer
         uses: actions/checkout@v6
         with:
           repository: MetaMask/ai-analyzer
-          ref: 68870b76360431110ae00b27a0072d3011e6238c
+          ref: feat/per-mode-runtime-overrides
           path: .ai-analyzer-action
           token: ${{ secrets.AI_ANALYZER_TOKEN }}
 


### PR DESCRIPTION
## Summary
Integration test PR for [MetaMask/ai-analyzer#47](https://github.com/MetaMask/ai-analyzer/pull/47) (`feat/per-mode-runtime-overrides`).

- Pins `ai-pr-risk-analysis.yml` to checkout `MetaMask/ai-analyzer@feat/per-mode-runtime-overrides` instead of the release SHA.
- Adds a `modeOverrides.pr-risk-analysis.maxIterations: 12` in `.ai-pr-analyzer/config.yaml` so the new resolver is exercised.

Branch is cut from current `main` (`6766f343c8`) with only these two files changed.

## What to verify in CI
- [ ] **AI PR risk analysis** job completes successfully
- [ ] Analyze logs show `Mode pr-risk-analysis` using **12 iterations** (not the default 15)
- [ ] Risk label still applied as usual

## Do not merge
This is a throwaway integration test branch. Close after validating ai-analyzer#47.

## Test plan
- [ ] Opening this PR against `main` triggers `AI PR risk analysis`
- [ ] Review workflow logs for the per-mode iteration line
- [ ] Close this PR after the analyzer change is validated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only pin and analyzer config for a temporary integration test; no mobile app or production runtime behavior changes.
> 
> **Overview**
> **Throwaway integration test** for [MetaMask/ai-analyzer#47](https://github.com/MetaMask/ai-analyzer/pull/47); explicitly marked **do not merge**.
> 
> The **AI PR risk analysis** workflow now checks out `MetaMask/ai-analyzer` at branch `feat/per-mode-runtime-overrides` instead of a pinned release commit, so CI runs against the in-flight analyzer change.
> 
> `.ai-pr-analyzer/config.yaml` adds **`modeOverrides.pr-risk-analysis.maxIterations: 12`** to exercise per-mode runtime overrides; CI logs should show 12 iterations instead of the default 15.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a78d77a49ff5803cfccb6d99ee46ccd1ac9a592d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->