### PR TITLE
test: AI analyzer per-mode runtime matrix (ai-analyzer#47)

### DIFF
--- a/.ai-pr-analyzer/config.yaml
+++ b/.ai-pr-analyzer/config.yaml
@@ -138,3 +138,9 @@ models:
 
 modes:
   - pr-risk-analysis
+
+# TEST 6: repo override wins over integration-probe's mode-local model.
+modeOverrides:
+  integration-probe:
+    models:
+      default: DeepSeek-V4-Pro

--- a/.ai-pr-analyzer/config.yaml
+++ b/.ai-pr-analyzer/config.yaml
@@ -138,8 +138,3 @@ models:
 
 modes:
   - pr-risk-analysis
-
-# TEST 1: repo config overrides the built-in mode's iteration budget.
-modeOverrides:
-  pr-risk-analysis:
-    maxIterations: 12

--- a/.ai-pr-analyzer/config.yaml
+++ b/.ai-pr-analyzer/config.yaml
@@ -138,3 +138,8 @@ models:
 
 modes:
   - pr-risk-analysis
+
+# TEST 1: repo config overrides the built-in mode's iteration budget.
+modeOverrides:
+  pr-risk-analysis:
+    maxIterations: 12

--- a/.ai-pr-analyzer/modes/integration-probe/mode.yaml
+++ b/.ai-pr-analyzer/modes/integration-probe/mode.yaml
@@ -5,6 +5,6 @@ finalizeToolName: finalize_integration_probe
 outputFile: integration-probe.json
 labels: false
 
-# TEST 3: differs from pr-risk-analysis (9), forcing a separate loop.
+# TEST 4: matches pr-risk-analysis (9), allowing one shared loop.
 config:
-  maxIterations: 6
+  maxIterations: 9

--- a/.ai-pr-analyzer/modes/integration-probe/mode.yaml
+++ b/.ai-pr-analyzer/modes/integration-probe/mode.yaml
@@ -5,6 +5,8 @@ finalizeToolName: finalize_integration_probe
 outputFile: integration-probe.json
 labels: false
 
-# TEST 4: matches pr-risk-analysis (9), allowing one shared loop.
+# TEST 5: mode-local model differs while the budget still matches.
 config:
   maxIterations: 9
+  models:
+    default: claude-sonnet-5

--- a/.ai-pr-analyzer/modes/integration-probe/mode.yaml
+++ b/.ai-pr-analyzer/modes/integration-probe/mode.yaml
@@ -1,0 +1,10 @@
+extends: pr-risk-analysis
+id: integration-probe
+description: Integration-only second mode for runtime grouping evidence
+finalizeToolName: finalize_integration_probe
+outputFile: integration-probe.json
+labels: false
+
+# TEST 3: differs from pr-risk-analysis (9), forcing a separate loop.
+config:
+  maxIterations: 6

--- a/.ai-pr-analyzer/modes/pr-risk-analysis/mode.yaml
+++ b/.ai-pr-analyzer/modes/pr-risk-analysis/mode.yaml
@@ -1,0 +1,5 @@
+extends: pr-risk-analysis
+
+# TEST 2: a repo-owned mode definition sets its own runtime budget.
+config:
+  maxIterations: 9

--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Run AI PR Analysis
         uses: ./.ai-analyzer-action
         with:
-          mode: pr-risk-analysis
+          modes: pr-risk-analysis,integration-probe
           add-comment: false
           add-label: true
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -31,12 +31,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Integration matrix for MetaMask/ai-analyzer#47 — do not merge this pin.
       # https://github.com/MetaMask/ai-analyzer/releases
       - name: Checkout AI Analyzer
         uses: actions/checkout@v6
         with:
           repository: MetaMask/ai-analyzer
-          ref: 68870b76360431110ae00b27a0072d3011e6238c
+          ref: feat/per-mode-runtime-overrides
           path: .ai-analyzer-action
           token: ${{ secrets.AI_ANALYZER_TOKEN }}
 


### PR DESCRIPTION
## Summary
Staged integration evidence for [MetaMask/ai-analyzer#47](https://github.com/MetaMask/ai-analyzer/pull/47).

This is a throwaway test PR. Each push exercised one configuration path, and the exact run evidence was posted back to analyzer PR #47 before advancing.

## Test matrix
- [x] Test 1 — repo `config.yaml` `modeOverrides` iteration budget: [run 33720428743](https://github.com/MetaMask/metamask-mobile/actions/runs/33720428743)
- [x] Test 2 — repo mode `mode.yaml` iteration budget: [run 33721192914](https://github.com/MetaMask/metamask-mobile/actions/runs/33721192914)
- [x] Test 3 — split multi-mode by different budgets: [run 33721696982](https://github.com/MetaMask/metamask-mobile/actions/runs/33721696982)
- [x] Test 4 — shared multi-mode with matching runtime: [run 33721973623](https://github.com/MetaMask/metamask-mobile/actions/runs/33721973623)
- [x] Test 5 — split multi-mode by mode-local model pick: [run 33722211721](https://github.com/MetaMask/metamask-mobile/actions/runs/33722211721)
- [x] Test 6 — repo model override beats mode-local model and restores sharing: [run 33722505335](https://github.com/MetaMask/metamask-mobile/actions/runs/33722505335)

## Do not merge
Close after reviewing the evidence on ai-analyzer#47.