### PR TITLE
fix(activity): match date headers to design-system section labels

### DIFF
--- a/app/components/UI/ActivityListItemRow/ActivityListDateHeader.test.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListDateHeader.test.tsx
@@ -6,17 +6,6 @@ jest.mock('../../../../locales/i18n', () => ({
   strings: (key: string) => key,
 }));
 
-jest.mock('../../../util/theme', () => ({
-  useTheme: () => ({
-    colors: {
-      text: {
-        alternative: 'text-alternative',
-        default: 'text-default',
-      },
-    },
-  }),
-}));
-
 describe('ActivityListDateHeader', () => {
   afterEach(() => {
     jest.useRealTimers();

--- a/app/components/UI/ActivityListItemRow/ActivityListDateHeader.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListDateHeader.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
-import { Box } from '@metamask/design-system-react-native';
-import ListItem from '../../Base/ListItem';
-import { useTheme } from '../../../util/theme';
+import {
+  Box,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import { formatActivityListDateHeader } from '../../../util/activity-adapters';
 
 export const ActivityListDateHeader = ({
@@ -12,28 +15,18 @@ export const ActivityListDateHeader = ({
   timestamp?: number;
   label?: string;
 }) => {
-  const { colors } = useTheme();
-  const styles = StyleSheet.create({
-    dateHeader: {
-      color: colors.text.alternative,
-      fontSize: 14,
-      marginBottom: 0,
-      paddingHorizontal: 0,
-      paddingTop: 16,
-      paddingBottom: 4,
-    },
-  });
-
   const text = label ?? formatActivityListDateHeader(timestamp ?? 0);
 
   return (
-    <Box twClassName="px-4">
-      <ListItem.Date
-        style={styles.dateHeader}
+    <Box twClassName="px-4 pt-4 pb-1">
+      <Text
+        variant={TextVariant.BodyMd}
+        color={TextColor.TextAlternative}
+        fontWeight={FontWeight.Medium}
         testID="activity-list-date-header"
       >
         {text}
-      </ListItem.Date>
+      </Text>
     </Box>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Activity date headers ("Today", "Yesterday", dated groups) used `ListItem.Date` with a hardcoded `fontSize: 14` and regular weight, so they did not match other section labels such as Send's Tokens.

This switches `ActivityListDateHeader` to MMDS `Text` with `BodyMd`, `FontWeight.Medium`, and `TextColor.TextAlternative`, matching the Tokens label, and keeps the existing section spacing.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated Activity date headers to match other section labels

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A. Visual typography polish on Activity date headers; no tracking issue.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Activity date header typography

  Background:
    Given I am logged into MetaMask Mobile
    And I have at least one transaction in Activity

  Scenario: user opens Activity and sees date section labels
    Given I am on the Wallet home screen

    When user opens Activity
    Then date headers such as "Today", "Yesterday", and dated groups use BodyMd, medium weight, and text-alternative
    And the labels match the Tokens section label on Send
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Close-up of the Today header (regular weight, hardcoded 14px):

<img src="https://github.com/user-attachments/assets/b96a1698-c3b9-4c96-9bba-b3c689b3d42c" alt="Before: Today date header in regular-weight gray" width="520" />

Full list with Today, Yesterday, and Aug 20, 2026 headers:

<img src="https://github.com/user-attachments/assets/e77b2a99-d936-49e4-b538-649a0ec9a3fe" alt="Before: Activity date headers in the transaction list" width="390" />

### **After**

Close-up of the Today header (BodyMd, medium, text-alternative):

<img src="https://github.com/user-attachments/assets/dedf53dd-610d-451a-8aad-f44fbe1bb961" alt="After: Today date header in BodyMd medium text-alternative" width="520" />

Full list with Today, Yesterday, and Aug 20, 2026 headers:

<img src="https://github.com/user-attachments/assets/77d113e1-6552-4329-8fb4-c4e3047a18c1" alt="After: Activity date headers matching Send Tokens typography" width="390" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only typography and component swap in Activity date headers; behavior and test IDs unchanged.
> 
> **Overview**
> Activity list date headers (**Today**, **Yesterday**, dated groups) no longer use `ListItem.Date` with theme-driven `StyleSheet` and a hardcoded 14px size.
> 
> They now render with MMDS **`Text`** (`BodyMd`, **medium** weight, `TextAlternative`) and section spacing via **`Box`** Tailwind classes (`pt-4 pb-1`), aligning typography with other section labels (e.g. Send **Tokens**).
> 
> The unit test drops the unused **`useTheme`** mock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9acd0536da5b43cef3bf452516ab39817a380b0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->