### PR TITLE
fix(perps): reconcile positions after out-of-band closes

### DIFF
--- a/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.test.tsx
@@ -514,6 +514,74 @@ describe('PerpsAdjustMarginView', () => {
     });
   });
 
+  describe('stale position', () => {
+    const enterMarginAmount = () => {
+      fireEvent.press(
+        screen.getByTestId(PerpsAmountDisplaySelectorsIDs.TOUCHABLE),
+      );
+      const keypad = screen.getByTestId('mock-keypad');
+      act(() => {
+        (
+          keypad.props as { onChange: (data: { value: string }) => void }
+        ).onChange({ value: '100' });
+      });
+      // The confirm CTA is hidden while the keypad is up.
+      fireEvent.press(
+        screen.getByTestId(PerpsAdjustMarginViewSelectorsIDs.DONE_BUTTON),
+      );
+    };
+
+    beforeEach(() => {
+      mockRouteParams = {
+        position: mockPosition,
+        mode: 'add',
+      };
+    });
+
+    it('enables the margin CTA while the live position is still open', () => {
+      // Arrange
+      render(<PerpsAdjustMarginView />);
+
+      // Act
+      enterMarginAmount();
+
+      // Assert
+      expect(
+        screen.getByTestId(PerpsAdjustMarginViewSelectorsIDs.CONFIRM_BUTTON)
+          .props.accessibilityState?.disabled,
+      ).not.toBe(true);
+    });
+
+    it('disables the margin CTA once the live stream drops the position', () => {
+      // Arrange
+      mockUsePerpsAdjustMarginData.mockReturnValue({
+        position: null,
+        isLoading: false,
+        currentMargin: 500,
+        positionValue: 5000,
+        maxAmount: 1000,
+        currentLiquidationPrice: 1900,
+        newLiquidationPrice: 1900,
+        currentLiquidationDistance: 5,
+        newLiquidationDistance: 5,
+        spendableBalance: 1000,
+        currentPrice: 2000,
+        isAddMode: true,
+        positionLeverage: 10,
+      });
+      render(<PerpsAdjustMarginView />);
+
+      // Act
+      enterMarginAmount();
+
+      // Assert
+      expect(
+        screen.getByTestId(PerpsAdjustMarginViewSelectorsIDs.CONFIRM_BUTTON)
+          .props.accessibilityState?.disabled,
+      ).toBe(true);
+    });
+  });
+
   describe('remove mode calculations', () => {
     beforeEach(() => {
       mockRouteParams = {

--- a/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx
+++ b/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx
@@ -296,9 +296,14 @@ const PerpsAdjustMarginView: React.FC = () => {
     ? strings('perps.adjust_margin.add_margin')
     : strings('perps.adjust_margin.reduce_margin');
 
+  // The route snapshot outlives the position, so once the live stream has
+  // loaded without it there is nothing left to adjust margin on.
+  const isPositionGone = !isLoading && !position;
+
   const isConfirmDisabled =
     marginAmount <= 0 ||
     isAdjusting ||
+    isPositionGone ||
     marginAmount > flooredMaxAmount ||
     Boolean(validationErrors.length);
 

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
@@ -478,7 +478,51 @@ describe('PerpsClosePositionView', () => {
       expect(PerpsCacheInvalidator.invalidate).toHaveBeenCalledWith(
         'positions',
       );
+      expect(PerpsCacheInvalidator.invalidate).toHaveBeenCalledWith(
+        'accountState',
+      );
       expect(handleClosePosition).not.toHaveBeenCalled();
+    });
+
+    it('does not dismiss a second time when the stream drops the position after a confirmed close', async () => {
+      const handleClosePosition = jest.fn();
+      usePerpsClosePositionMock.mockReturnValue({
+        handleClosePosition,
+        isClosing: false,
+      });
+
+      const { rerender } = renderWithProvider(
+        <PerpsClosePositionView />,
+        {
+          state: STATE_MOCK,
+        },
+        true,
+      );
+
+      fireEvent.press(
+        screen.getByTestId(
+          PerpsClosePositionViewSelectorsIDs.CLOSE_POSITION_CONFIRM_BUTTON,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockGoBack).toHaveBeenCalledTimes(1);
+      });
+
+      usePerpsLivePositionsMock.mockReturnValue({
+        positions: [],
+        isInitialLoading: false,
+      });
+      rerender(<PerpsClosePositionView />);
+
+      await waitFor(() => {
+        expect(handleClosePosition).toHaveBeenCalled();
+      });
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+      expect(defaultPerpsToastsMock.showToast).not.toHaveBeenCalledWith(
+        defaultPerpsToastsMock.PerpsToastOptions.positionManagement
+          .closePosition.positionAlreadyClosed,
+      );
     });
 
     it('keeps the sheet open while positions are still loading', async () => {

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
@@ -182,6 +182,7 @@ const defaultPerpsToastsMock = {
   PerpsToastOptions: {
     positionManagement: {
       closePosition: {
+        positionAlreadyClosed: { label: 'already-closed' },
         limitClose: {
           partial: {
             switchToMarketOrderMissingLimitPrice: {},
@@ -430,6 +431,35 @@ describe('PerpsClosePositionView', () => {
       });
       expect(playImpact).toHaveBeenCalledTimes(1);
       expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
+    });
+
+    it('dismisses the sheet with already-closed toast when live position is gone', async () => {
+      const handleClosePosition = jest.fn();
+      usePerpsClosePositionMock.mockReturnValue({
+        handleClosePosition,
+        isClosing: false,
+      });
+      usePerpsLivePositionsMock.mockReturnValue({
+        positions: [],
+        isInitialLoading: false,
+      });
+
+      renderWithProvider(
+        <PerpsClosePositionView />,
+        {
+          state: STATE_MOCK,
+        },
+        true,
+      );
+
+      await waitFor(() => {
+        expect(mockGoBack).toHaveBeenCalled();
+      });
+      expect(defaultPerpsToastsMock.showToast).toHaveBeenCalledWith(
+        defaultPerpsToastsMock.PerpsToastOptions.positionManagement
+          .closePosition.positionAlreadyClosed,
+      );
+      expect(handleClosePosition).not.toHaveBeenCalled();
     });
 
     it('disables confirm button when closing is in progress', () => {

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
@@ -1,4 +1,10 @@
-import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
 import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
@@ -39,6 +45,7 @@ jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: jest.fn(),
   useRoute: jest.fn(),
+  useIsFocused: jest.fn(),
 }));
 jest.mock('../../../../../util/haptics');
 jest.mock('../../services/PerpsCacheInvalidator', () => ({
@@ -216,6 +223,9 @@ describe('PerpsClosePositionView', () => {
   const useRouteMock = jest.mocked(
     jest.requireMock('@react-navigation/native').useRoute,
   );
+  const useIsFocusedMock = jest.mocked(
+    jest.requireMock('@react-navigation/native').useIsFocused,
+  );
   const usePerpsLivePositionsMock = jest.mocked(
     jest.requireMock('../../hooks/stream').usePerpsLivePositions,
   );
@@ -262,6 +272,8 @@ describe('PerpsClosePositionView', () => {
       goBack: mockGoBack,
       addListener: jest.fn(() => jest.fn()),
     });
+
+    useIsFocusedMock.mockReturnValue(true);
 
     // Setup default route params
     useRouteMock.mockReturnValue({
@@ -488,11 +500,53 @@ describe('PerpsClosePositionView', () => {
         true,
       );
 
-      await waitFor(() => {
-        expect(usePerpsLivePositionsMock).toHaveBeenCalled();
-      });
+      expect(
+        await screen.findByTestId(
+          PerpsClosePositionViewSelectorsIDs.CLOSE_POSITION_CONFIRM_BUTTON,
+        ),
+      ).toBeOnTheScreen();
       expect(mockGoBack).not.toHaveBeenCalled();
       expect(defaultPerpsToastsMock.showToast).not.toHaveBeenCalled();
+    });
+
+    it('defers the already-closed dismissal while the sheet is not focused', async () => {
+      const handleClosePosition = jest.fn();
+      usePerpsClosePositionMock.mockReturnValue({
+        handleClosePosition,
+        isClosing: false,
+      });
+      usePerpsLivePositionsMock.mockReturnValue({
+        positions: [],
+        isInitialLoading: false,
+      });
+      useIsFocusedMock.mockReturnValue(false);
+
+      const { rerender } = renderWithProvider(
+        <PerpsClosePositionView />,
+        {
+          state: STATE_MOCK,
+        },
+        true,
+      );
+
+      expect(
+        await screen.findByTestId(
+          PerpsClosePositionViewSelectorsIDs.CLOSE_POSITION_CONFIRM_BUTTON,
+        ),
+      ).toBeOnTheScreen();
+      expect(mockGoBack).not.toHaveBeenCalled();
+      expect(defaultPerpsToastsMock.showToast).not.toHaveBeenCalled();
+
+      useIsFocusedMock.mockReturnValue(true);
+      rerender(<PerpsClosePositionView />);
+
+      await waitFor(() => {
+        expect(mockGoBack).toHaveBeenCalledTimes(1);
+      });
+      expect(defaultPerpsToastsMock.showToast).toHaveBeenCalledWith(
+        defaultPerpsToastsMock.PerpsToastOptions.positionManagement
+          .closePosition.positionAlreadyClosed,
+      );
     });
 
     it('disables confirm button when closing is in progress', () => {

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
@@ -499,15 +499,15 @@ describe('PerpsClosePositionView', () => {
         true,
       );
 
-      fireEvent.press(
-        screen.getByTestId(
-          PerpsClosePositionViewSelectorsIDs.CLOSE_POSITION_CONFIRM_BUTTON,
-        ),
-      );
-
-      await waitFor(() => {
-        expect(mockGoBack).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        fireEvent.press(
+          screen.getByTestId(
+            PerpsClosePositionViewSelectorsIDs.CLOSE_POSITION_CONFIRM_BUTTON,
+          ),
+        );
       });
+
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
 
       usePerpsLivePositionsMock.mockReturnValue({
         positions: [],

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../__mocks__/perpsHooksMocks';
 import { createPerpsStateMock } from '../../__mocks__/perpsStateMock';
 import PerpsClosePositionView from './PerpsClosePositionView';
+import { PerpsCacheInvalidator } from '../../services/PerpsCacheInvalidator';
 
 // Mock navigation
 const mockGoBack = jest.fn();
@@ -40,6 +41,9 @@ jest.mock('@react-navigation/native', () => ({
   useRoute: jest.fn(),
 }));
 jest.mock('../../../../../util/haptics');
+jest.mock('../../services/PerpsCacheInvalidator', () => ({
+  PerpsCacheInvalidator: { invalidate: jest.fn() },
+}));
 
 // Mock React Native Linking specifically for this test to prevent NavigationContainer errors
 jest.mock('react-native/Libraries/Linking/Linking', () => ({
@@ -459,7 +463,36 @@ describe('PerpsClosePositionView', () => {
         defaultPerpsToastsMock.PerpsToastOptions.positionManagement
           .closePosition.positionAlreadyClosed,
       );
+      expect(PerpsCacheInvalidator.invalidate).toHaveBeenCalledWith(
+        'positions',
+      );
       expect(handleClosePosition).not.toHaveBeenCalled();
+    });
+
+    it('keeps the sheet open while positions are still loading', async () => {
+      const handleClosePosition = jest.fn();
+      usePerpsClosePositionMock.mockReturnValue({
+        handleClosePosition,
+        isClosing: false,
+      });
+      usePerpsLivePositionsMock.mockReturnValue({
+        positions: [],
+        isInitialLoading: true,
+      });
+
+      renderWithProvider(
+        <PerpsClosePositionView />,
+        {
+          state: STATE_MOCK,
+        },
+        true,
+      );
+
+      await waitFor(() => {
+        expect(usePerpsLivePositionsMock).toHaveBeenCalled();
+      });
+      expect(mockGoBack).not.toHaveBeenCalled();
+      expect(defaultPerpsToastsMock.showToast).not.toHaveBeenCalled();
     });
 
     it('disables confirm button when closing is in progress', () => {

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -65,6 +65,7 @@ import {
   usePerpsLivePrices,
   usePerpsTopOfBook,
 } from '../../hooks/stream';
+import { PerpsCacheInvalidator } from '../../services/PerpsCacheInvalidator';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { usePerpsAbandonOrderTracking } from '../../hooks/usePerpsAbandonOrderTracking';
 import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
@@ -114,6 +115,7 @@ const PerpsClosePositionView: React.FC = () => {
   const inputMethodRef = useRef<InputMethod>('default');
   const isAmountInitializedRef = useRef(false);
   const hasConfirmedCloseRef = useRef(false);
+  const hasReconciledGoneRef = useRef(false);
   const latestAbandonPropsRef = useRef<Record<string, unknown>>({});
 
   const { showToast, PerpsToastOptions } = usePerpsToasts();
@@ -202,13 +204,30 @@ const PerpsClosePositionView: React.FC = () => {
 
   // Subscribe to live position updates for this coin
   // This ensures margin and PnL values include real-time funding fees
-  const { positions: livePositions } = usePerpsLivePositions({
-    throttleMs: 1000,
-  });
-  const livePosition = useMemo(
-    () => livePositions.find((p) => p.symbol === position.symbol) || position,
-    [livePositions, position],
+  const { positions: livePositions, isInitialLoading: isPositionsLoading } =
+    usePerpsLivePositions({
+      throttleMs: 1000,
+    });
+  const matchingLivePosition = useMemo(
+    () => livePositions.find((p) => p.symbol === position.symbol),
+    [livePositions, position.symbol],
   );
+  // Keep the route snapshot only for layout until we dismiss a gone position.
+  const livePosition = matchingLivePosition ?? position;
+  const isPositionGone = !isPositionsLoading && !matchingLivePosition;
+
+  useEffect(() => {
+    if (!isPositionGone || hasReconciledGoneRef.current) {
+      return;
+    }
+    hasReconciledGoneRef.current = true;
+    hasConfirmedCloseRef.current = true;
+    showToast(
+      PerpsToastOptions.positionManagement.closePosition.positionAlreadyClosed,
+    );
+    PerpsCacheInvalidator.invalidate('positions');
+    navigation.goBack();
+  }, [isPositionGone, navigation, showToast, PerpsToastOptions]);
 
   // Determine position direction using live position data
   const isLong = parseFloat(livePosition.size) > 0;
@@ -571,7 +590,7 @@ const PerpsClosePositionView: React.FC = () => {
   }, [effectiveOrderType, limitPrice]);
 
   const handleConfirm = useCallback(async () => {
-    if (isClosing) {
+    if (isClosing || isPositionGone) {
       return;
     }
 
@@ -645,6 +664,7 @@ const PerpsClosePositionView: React.FC = () => {
     effectiveOrderType,
     enableHaptics,
     isClosing,
+    isPositionGone,
     limitPrice,
     navigation,
     handleClosePosition,
@@ -834,6 +854,7 @@ const PerpsClosePositionView: React.FC = () => {
 
   const isConfirmDisabled =
     isClosing ||
+    isPositionGone ||
     (effectiveOrderType === 'limit' &&
       (!limitPrice || parseFloat(limitPrice) <= 0)) ||
     (effectiveOrderType === 'market' && closePercentage === 0) ||

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -221,8 +221,15 @@ const PerpsClosePositionView: React.FC = () => {
   useEffect(() => {
     // A tooltip modal can sit on top of this still-mounted sheet. Dismissing
     // then would pop the tooltip instead of the sheet, so wait for focus and
-    // latch only once the dismissal actually runs.
-    if (!isPositionGone || !isScreenFocused || hasReconciledGoneRef.current) {
+    // latch only once the dismissal actually runs. handleConfirm already
+    // dismisses on its own, so a stream drop racing its blur must not goBack
+    // a second time.
+    if (
+      !isPositionGone ||
+      !isScreenFocused ||
+      hasConfirmedCloseRef.current ||
+      hasReconciledGoneRef.current
+    ) {
       return;
     }
     hasReconciledGoneRef.current = true;
@@ -231,6 +238,7 @@ const PerpsClosePositionView: React.FC = () => {
       PerpsToastOptions.positionManagement.closePosition.positionAlreadyClosed,
     );
     PerpsCacheInvalidator.invalidate('positions');
+    PerpsCacheInvalidator.invalidate('accountState');
     navigation.goBack();
   }, [
     isPositionGone,

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -1,4 +1,5 @@
 import {
+  useIsFocused,
   useNavigation,
   useRoute,
   type RouteProp,
@@ -215,9 +216,13 @@ const PerpsClosePositionView: React.FC = () => {
   // Keep the route snapshot only for layout until we dismiss a gone position.
   const livePosition = matchingLivePosition ?? position;
   const isPositionGone = !isPositionsLoading && !matchingLivePosition;
+  const isScreenFocused = useIsFocused();
 
   useEffect(() => {
-    if (!isPositionGone || hasReconciledGoneRef.current) {
+    // A tooltip modal can sit on top of this still-mounted sheet. Dismissing
+    // then would pop the tooltip instead of the sheet, so wait for focus and
+    // latch only once the dismissal actually runs.
+    if (!isPositionGone || !isScreenFocused || hasReconciledGoneRef.current) {
       return;
     }
     hasReconciledGoneRef.current = true;
@@ -227,7 +232,13 @@ const PerpsClosePositionView: React.FC = () => {
     );
     PerpsCacheInvalidator.invalidate('positions');
     navigation.goBack();
-  }, [isPositionGone, navigation, showToast, PerpsToastOptions]);
+  }, [
+    isPositionGone,
+    isScreenFocused,
+    navigation,
+    showToast,
+    PerpsToastOptions,
+  ]);
 
   // Determine position direction using live position data
   const isLong = parseFloat(livePosition.size) > 0;

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -574,7 +574,8 @@ const PerpsClosePositionView: React.FC = () => {
   // emit abandon_order on a real exit (back swipe, hardware back,
   // programmatic dismissal) AND on a genuine tab switch away, but never when a
   // child route (e.g. the limit-price flow) is pushed or after a confirmed close
-  // (hasConfirmedCloseRef).
+  // (hasConfirmedCloseRef). The already-closed auto-dismissal above also sets
+  // that ref: the venue removed the position, so the user abandoned nothing.
   const getAbandonProperties = useCallback(
     () => latestAbandonPropsRef.current,
     [],

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
@@ -40,7 +40,14 @@ jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
 jest.mock('../../hooks/stream', () => ({
   usePerpsLivePrices: jest.fn(() => ({})),
+  usePerpsLivePositions: jest.fn(() => ({
+    positions: [],
+    isInitialLoading: false,
+  })),
 }));
+
+const mockUsePerpsLivePositions =
+  jest.requireMock('../../hooks/stream').usePerpsLivePositions;
 
 jest.mock('../../hooks/usePerpsLiquidationPrice', () => ({
   usePerpsLiquidationPrice: jest.fn(() => ({
@@ -171,6 +178,10 @@ describe('PerpsTPSLView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUsePerpsTPSLForm.mockReturnValue(defaultMockReturn);
+    mockUsePerpsLivePositions.mockReturnValue({
+      positions: [],
+      isInitialLoading: false,
+    });
     mockRouteParams = { ...defaultRouteParams };
   });
 
@@ -786,6 +797,109 @@ describe('PerpsTPSLView', () => {
       expect(
         screen.getByTestId(PerpsTPSLViewSelectorsIDs.SET_BUTTON),
       ).toBeOnTheScreen();
+    });
+  });
+
+  // ==================== Stale position ====================
+
+  describe('Stale position', () => {
+    const stalePosition: Position = {
+      symbol: 'ETH',
+      entryPrice: '2800.00',
+      size: '0.5',
+      positionValue: '1400.00',
+      unrealizedPnl: '100.00',
+      marginUsed: '140.00',
+      leverage: { type: 'isolated', value: 10 },
+      liquidationPrice: '2500.00',
+      maxLeverage: 50,
+      returnOnEquity: '0.71',
+      cumulativeFunding: {
+        allTime: '0.00',
+        sinceOpen: '0.00',
+        sinceChange: '0.00',
+      },
+      takeProfitCount: 0,
+      stopLossCount: 0,
+    };
+
+    const renderEditingView = (onConfirm: jest.Mock) => {
+      mockRouteParams = {
+        ...defaultRouteParams,
+        position: stalePosition,
+        onConfirm,
+      };
+
+      renderView({
+        formState: {
+          ...defaultMockReturn.formState,
+          takeProfitPrice: '$3,150.00',
+        },
+        validation: {
+          ...defaultMockReturn.validation,
+          hasChanges: true,
+        },
+      });
+    };
+
+    it('submits TP/SL while the live position is still open', async () => {
+      // Arrange
+      const mockOnConfirm = jest.fn().mockResolvedValue(undefined);
+      mockUsePerpsLivePositions.mockReturnValue({
+        positions: [stalePosition],
+        isInitialLoading: false,
+      });
+      renderEditingView(mockOnConfirm);
+
+      // Act
+      await act(async () => {
+        fireEvent.press(
+          screen.getByTestId(PerpsTPSLViewSelectorsIDs.SET_BUTTON),
+        );
+      });
+
+      // Assert
+      expect(mockOnConfirm).toHaveBeenCalled();
+    });
+
+    it('does not submit TP/SL once the live stream drops the position', async () => {
+      // Arrange
+      const mockOnConfirm = jest.fn().mockResolvedValue(undefined);
+      mockUsePerpsLivePositions.mockReturnValue({
+        positions: [],
+        isInitialLoading: false,
+      });
+      renderEditingView(mockOnConfirm);
+
+      // Act
+      await act(async () => {
+        fireEvent.press(
+          screen.getByTestId(PerpsTPSLViewSelectorsIDs.SET_BUTTON),
+        );
+      });
+
+      // Assert
+      expect(mockOnConfirm).not.toHaveBeenCalled();
+    });
+
+    it('keeps TP/SL submittable while live positions are still loading', async () => {
+      // Arrange
+      const mockOnConfirm = jest.fn().mockResolvedValue(undefined);
+      mockUsePerpsLivePositions.mockReturnValue({
+        positions: [],
+        isInitialLoading: true,
+      });
+      renderEditingView(mockOnConfirm);
+
+      // Act
+      await act(async () => {
+        fireEvent.press(
+          screen.getByTestId(PerpsTPSLViewSelectorsIDs.SET_BUTTON),
+        );
+      });
+
+      // Assert
+      expect(mockOnConfirm).toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -50,7 +50,7 @@ import {
   PERPS_CONSTANTS,
   DECIMAL_PRECISION_CONFIG,
 } from '@metamask/perps-controller';
-import { usePerpsLivePrices } from '../../hooks/stream';
+import { usePerpsLivePositions, usePerpsLivePrices } from '../../hooks/stream';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import type { PerpsNavigationParamList } from '../../types/navigation';
 import {
@@ -288,6 +288,16 @@ const PerpsTPSLView: React.FC = () => {
 
   // Determine if this is create (new order) or edit (existing position) TP/SL
   const isEditingExistingPosition = !!position;
+
+  // The route snapshot outlives the position. Once the live stream has loaded
+  // without it, submitting would attach TP/SL to nothing and the controller
+  // would record a failed Risk Management request for a benign venue race.
+  const { positions: livePositions, isInitialLoading: isPositionsLoading } =
+    usePerpsLivePositions();
+  const isPositionGone =
+    isEditingExistingPosition &&
+    !isPositionsLoading &&
+    !livePositions.some((p) => p.symbol === position.symbol);
   const tpslScreenType = isEditingExistingPosition
     ? PERPS_EVENT_VALUE.SCREEN_TYPE.EDIT_TPSL
     : PERPS_EVENT_VALUE.SCREEN_TYPE.CREATE_TPSL;
@@ -490,7 +500,7 @@ const PerpsTPSLView: React.FC = () => {
   }, [focusedInput]);
 
   const handleConfirm = useCallback(async () => {
-    if (!hasChanges || !isValid || isUpdating) {
+    if (!hasChanges || !isValid || isUpdating || isPositionGone) {
       return;
     }
 
@@ -565,9 +575,11 @@ const PerpsTPSLView: React.FC = () => {
     hasChanges,
     isValid,
     isUpdating,
+    isPositionGone,
   ]);
 
-  const confirmDisabled = !hasChanges || !isValid || isUpdating;
+  const confirmDisabled =
+    !hasChanges || !isValid || isUpdating || isPositionGone;
   const inputsDisabled = isUpdating;
 
   const handleTakeProfitPresetPress = useCallback(

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -293,7 +293,9 @@ const PerpsTPSLView: React.FC = () => {
   // without it, submitting would attach TP/SL to nothing and the controller
   // would record a failed Risk Management request for a benign venue race.
   const { positions: livePositions, isInitialLoading: isPositionsLoading } =
-    usePerpsLivePositions();
+    usePerpsLivePositions({
+      throttleMs: TP_SL_VIEW_CONFIG.PositionThrottleMs,
+    });
   const isPositionGone =
     isEditingExistingPosition &&
     !isPositionsLoading &&

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.view.test.tsx
@@ -70,6 +70,8 @@ describe('PerpsTPSLView', () => {
         szDecimals: 2,
         onConfirm,
       },
+      // The form only submits against a position the live stream still holds.
+      streamOverrides: { positions: [position] },
     });
 
     fireEvent.changeText(
@@ -113,6 +115,8 @@ describe('PerpsTPSLView', () => {
         szDecimals: 2,
         onConfirm,
       },
+      // The form only submits against a position the live stream still holds.
+      streamOverrides: { positions: [position] },
     });
 
     fireEvent.changeText(

--- a/app/components/UI/Perps/constants/perpsConfig.ts
+++ b/app/components/UI/Perps/constants/perpsConfig.ts
@@ -190,6 +190,10 @@ export const TP_SL_VIEW_CONFIG = {
   // Reduces re-renders by batching price updates in the TP/SL screen
   PriceThrottleMs: 1000,
 
+  // WebSocket position update throttle delay (milliseconds)
+  // The screen only reads position existence, so it does not need every tick
+  PositionThrottleMs: 1000,
+
   // Maximum number of digits allowed in price/percentage input fields
   // Prevents overflow and maintains reasonable input constraints
   MaxInputDigits: MAX_PERPS_INPUT_DIGITS,

--- a/app/components/UI/Perps/constants/perpsCufTags.ts
+++ b/app/components/UI/Perps/constants/perpsCufTags.ts
@@ -31,6 +31,9 @@ export const PERPS_CUF_END_REASON = {
   ORDER_FAILED: 'order_failed',
   REQUEST_FAILED: 'request_failed',
   EXCEPTION: 'exception',
+  /** The venue had already filled, closed or liquidated the position, so the
+   * request could not apply. A benign race, not a close/update failure. */
+  ALREADY_CLOSED: 'already_closed',
   STREAM_TIMEOUT: 'stream_timeout',
   /** A newer operation of the same flow replaced this one before it confirmed. */
   SUPERSEDED: 'superseded',

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@metamask/perps-controller';
 import { usePerpsClosePosition } from './usePerpsClosePosition';
 import { usePerpsTrading } from './usePerpsTrading';
+import { PerpsCacheInvalidator } from '../services/PerpsCacheInvalidator';
 
 const mockNavigate = jest.fn();
 
@@ -22,6 +23,9 @@ jest.mock('@react-navigation/native', () => {
 });
 
 jest.mock('./usePerpsTrading');
+jest.mock('../services/PerpsCacheInvalidator', () => ({
+  PerpsCacheInvalidator: { invalidate: jest.fn() },
+}));
 jest.mock('../../../../core/SDKConnect/utils/DevLogger');
 jest.mock('../../../../util/Logger', () => ({
   __esModule: true,
@@ -729,6 +733,9 @@ describe('usePerpsClosePosition', () => {
             mockPerpsToastOptions.positionManagement.closePosition
               .positionAlreadyClosed,
           );
+          expect(PerpsCacheInvalidator.invalidate).toHaveBeenCalledWith(
+            'positions',
+          );
           expect(onSuccess).not.toHaveBeenCalled();
           expect(Logger.error).not.toHaveBeenCalled();
         });
@@ -757,6 +764,9 @@ describe('usePerpsClosePosition', () => {
           expect(mockShowToast).toHaveBeenCalledWith(
             mockPerpsToastOptions.positionManagement.closePosition
               .positionAlreadyClosed,
+          );
+          expect(PerpsCacheInvalidator.invalidate).toHaveBeenCalledWith(
+            'positions',
           );
           expect(onSuccess).not.toHaveBeenCalled();
           expect(Logger.error).not.toHaveBeenCalled();

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.test.ts
@@ -60,6 +60,7 @@ const mockPerpsToastOptions = {
           partialPositionCloseFailed: {},
         },
       },
+      positionAlreadyClosed: { label: 'already-closed' },
     },
   },
 };
@@ -702,6 +703,65 @@ describe('usePerpsClosePosition', () => {
       });
 
       describe('failure toasts', () => {
+        it('shows already-closed toast when close returns No position found', async () => {
+          mockClosePosition.mockResolvedValue({
+            success: false,
+            error: 'No position found for BTC',
+          });
+          const onSuccess = jest.fn();
+          const { result } = renderHook(() =>
+            usePerpsClosePosition({ onSuccess }),
+          );
+
+          let closeResult: OrderResult | undefined;
+          await act(async () => {
+            closeResult = await result.current.handleClosePosition({
+              position: mockPosition,
+              orderType: 'market',
+            });
+          });
+
+          expect(closeResult).toEqual({
+            success: false,
+            error: 'No position found for BTC',
+          });
+          expect(mockShowToast).toHaveBeenCalledWith(
+            mockPerpsToastOptions.positionManagement.closePosition
+              .positionAlreadyClosed,
+          );
+          expect(onSuccess).not.toHaveBeenCalled();
+          expect(Logger.error).not.toHaveBeenCalled();
+        });
+
+        it('shows already-closed toast when close throws No position found', async () => {
+          mockClosePosition.mockRejectedValue(
+            new Error('No position found for BTC'),
+          );
+          const onSuccess = jest.fn();
+          const { result } = renderHook(() =>
+            usePerpsClosePosition({ onSuccess }),
+          );
+
+          let closeResult: OrderResult | undefined;
+          await act(async () => {
+            closeResult = await result.current.handleClosePosition({
+              position: mockPosition,
+              orderType: 'market',
+            });
+          });
+
+          expect(closeResult).toEqual({
+            success: false,
+            error: 'No position found for BTC',
+          });
+          expect(mockShowToast).toHaveBeenCalledWith(
+            mockPerpsToastOptions.positionManagement.closePosition
+              .positionAlreadyClosed,
+          );
+          expect(onSuccess).not.toHaveBeenCalled();
+          expect(Logger.error).not.toHaveBeenCalled();
+        });
+
         it('should show failure toast for full position market close', async () => {
           const failureResult: OrderResult = {
             success: false,

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.test.ts
@@ -9,6 +9,8 @@ import {
 import { usePerpsClosePosition } from './usePerpsClosePosition';
 import { usePerpsTrading } from './usePerpsTrading';
 import { PerpsCacheInvalidator } from '../services/PerpsCacheInvalidator';
+import { endPerpsCufTrace } from '../utils/perpsCufTrace';
+import { PERPS_CUF_TAG, PERPS_CUF_END_REASON } from '../constants/perpsCufTags';
 
 const mockNavigate = jest.fn();
 
@@ -25,6 +27,14 @@ jest.mock('@react-navigation/native', () => {
 jest.mock('./usePerpsTrading');
 jest.mock('../services/PerpsCacheInvalidator', () => ({
   PerpsCacheInvalidator: { invalidate: jest.fn() },
+}));
+jest.mock('../utils/perpsCufTrace', () => ({
+  ...jest.requireActual('../utils/perpsCufTrace'),
+  startPerpsCufTrace: jest.fn(() => 'close-cuf-op'),
+  endPerpsCufTrace: jest.fn(),
+  endPerpsCufRequestAfter: jest.fn(),
+  watchPerpsCufPositionClosed: jest.fn(),
+  acceptPerpsCufRequest: jest.fn(),
 }));
 jest.mock('../../../../core/SDKConnect/utils/DevLogger');
 jest.mock('../../../../util/Logger', () => ({
@@ -736,6 +746,16 @@ describe('usePerpsClosePosition', () => {
           expect(PerpsCacheInvalidator.invalidate).toHaveBeenCalledWith(
             'positions',
           );
+          expect(PerpsCacheInvalidator.invalidate).toHaveBeenCalledWith(
+            'accountState',
+          );
+          expect(endPerpsCufTrace).toHaveBeenCalledWith({
+            id: 'close-cuf-op',
+            data: {
+              [PERPS_CUF_TAG.SUCCESS]: false,
+              [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.ALREADY_CLOSED,
+            },
+          });
           expect(onSuccess).not.toHaveBeenCalled();
           expect(Logger.error).not.toHaveBeenCalled();
         });
@@ -768,6 +788,16 @@ describe('usePerpsClosePosition', () => {
           expect(PerpsCacheInvalidator.invalidate).toHaveBeenCalledWith(
             'positions',
           );
+          expect(PerpsCacheInvalidator.invalidate).toHaveBeenCalledWith(
+            'accountState',
+          );
+          expect(endPerpsCufTrace).toHaveBeenCalledWith({
+            id: 'close-cuf-op',
+            data: {
+              [PERPS_CUF_TAG.SUCCESS]: false,
+              [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.ALREADY_CLOSED,
+            },
+          });
           expect(onSuccess).not.toHaveBeenCalled();
           expect(Logger.error).not.toHaveBeenCalled();
         });

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
@@ -132,15 +132,13 @@ export const usePerpsClosePosition = (
       // The venue filled, closed or liquidated the position before this
       // request landed. Nothing failed on the user's side, so reconcile the
       // stale local state and say so instead of raising a close failure.
-      const reconcileAlreadyClosed = (
-        reason: (typeof PERPS_CUF_END_REASON)[keyof typeof PERPS_CUF_END_REASON],
-      ) => {
+      const reconcileAlreadyClosed = () => {
         if (closeCufOpId) {
           endPerpsCufTrace({
             id: closeCufOpId,
             data: {
               [PERPS_CUF_TAG.SUCCESS]: false,
-              [PERPS_CUF_TAG.REASON]: reason,
+              [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.ALREADY_CLOSED,
             },
           });
         }
@@ -148,7 +146,10 @@ export const usePerpsClosePosition = (
           PerpsToastOptions.positionManagement.closePosition
             .positionAlreadyClosed,
         );
+        // Closing a position moves margin and balance, so account state is
+        // stale too — the controller pairs these two everywhere it closes.
         PerpsCacheInvalidator.invalidate('positions');
+        PerpsCacheInvalidator.invalidate('accountState');
       };
 
       try {
@@ -241,7 +242,7 @@ export const usePerpsClosePosition = (
         DevLogger.log('usePerpsClosePosition: Close result', result);
 
         if (!result.success && isNoPositionFoundError(result.error)) {
-          reconcileAlreadyClosed(PERPS_CUF_END_REASON.REQUEST_FAILED);
+          reconcileAlreadyClosed();
           return result;
         }
 
@@ -305,7 +306,7 @@ export const usePerpsClosePosition = (
         return result;
       } catch (err) {
         if (isNoPositionFoundError(err)) {
-          reconcileAlreadyClosed(PERPS_CUF_END_REASON.EXCEPTION);
+          reconcileAlreadyClosed();
           return {
             success: false,
             error: err instanceof Error ? err.message : String(err),

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
@@ -9,7 +9,11 @@ import {
   type Position,
   type TrackingData,
 } from '@metamask/perps-controller';
-import { handlePerpsError } from '../utils/translatePerpsError';
+import {
+  handlePerpsError,
+  isNoPositionFoundError,
+} from '../utils/translatePerpsError';
+import { PerpsCacheInvalidator } from '../services/PerpsCacheInvalidator';
 import { TraceName } from '../../../../util/trace';
 import {
   startPerpsCufTrace,
@@ -125,6 +129,28 @@ export const usePerpsClosePosition = (
         );
       }
 
+      // The venue filled, closed or liquidated the position before this
+      // request landed. Nothing failed on the user's side, so reconcile the
+      // stale local state and say so instead of raising a close failure.
+      const reconcileAlreadyClosed = (
+        reason: (typeof PERPS_CUF_END_REASON)[keyof typeof PERPS_CUF_END_REASON],
+      ) => {
+        if (closeCufOpId) {
+          endPerpsCufTrace({
+            id: closeCufOpId,
+            data: {
+              [PERPS_CUF_TAG.SUCCESS]: false,
+              [PERPS_CUF_TAG.REASON]: reason,
+            },
+          });
+        }
+        showToast(
+          PerpsToastOptions.positionManagement.closePosition
+            .positionAlreadyClosed,
+        );
+        PerpsCacheInvalidator.invalidate('positions');
+      };
+
       try {
         setIsClosing(true);
         setError(null);
@@ -214,6 +240,11 @@ export const usePerpsClosePosition = (
 
         DevLogger.log('usePerpsClosePosition: Close result', result);
 
+        if (!result.success && isNoPositionFoundError(result.error)) {
+          reconcileAlreadyClosed(PERPS_CUF_END_REASON.REQUEST_FAILED);
+          return result;
+        }
+
         if (result.success) {
           // Controller accepted the close: only now may a stream shrink/absence
           // complete the CUF as a success. If the position already shrank while
@@ -273,6 +304,14 @@ export const usePerpsClosePosition = (
 
         return result;
       } catch (err) {
+        if (isNoPositionFoundError(err)) {
+          reconcileAlreadyClosed(PERPS_CUF_END_REASON.EXCEPTION);
+          return {
+            success: false,
+            error: err instanceof Error ? err.message : String(err),
+          };
+        }
+
         // A rejected promise (e.g. thrown by the controller/provider) skips the
         // { success: false } branch, so surface the failure toast here unless it
         // was already shown for a returned failure.

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
@@ -214,17 +214,6 @@ export const usePerpsClosePosition = (
 
         DevLogger.log('usePerpsClosePosition: Close result', result);
 
-        if (
-          !result.success &&
-          typeof result.error === 'string' &&
-          /No position found/i.test(result.error)
-        ) {
-          DevLogger.log(
-            '[PR-TAT-3873] BUG_MARKER: stale close after fill returned No position found',
-            { symbol: position.symbol, error: result.error },
-          );
-        }
-
         if (result.success) {
           // Controller accepted the close: only now may a stream shrink/absence
           // complete the CUF as a success. If the position already shrank while

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
@@ -214,6 +214,17 @@ export const usePerpsClosePosition = (
 
         DevLogger.log('usePerpsClosePosition: Close result', result);
 
+        if (
+          !result.success &&
+          typeof result.error === 'string' &&
+          /No position found/i.test(result.error)
+        ) {
+          DevLogger.log(
+            '[PR-TAT-3873] BUG_MARKER: stale close after fill returned No position found',
+            { symbol: position.symbol, error: result.error },
+          );
+        }
+
         if (result.success) {
           // Controller accepted the close: only now may a stream shrink/absence
           // complete the CUF as a success. If the position already shrank while

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
@@ -6,9 +6,19 @@ import { usePerpsTrading } from './usePerpsTrading';
 import usePerpsToasts from './usePerpsToasts';
 import { usePerpsStream } from '../providers/PerpsStreamManager';
 import { PerpsCacheInvalidator } from '../services/PerpsCacheInvalidator';
+import { endPerpsCufTrace } from '../utils/perpsCufTrace';
+import { PERPS_CUF_TAG, PERPS_CUF_END_REASON } from '../constants/perpsCufTags';
 jest.mock('./usePerpsTrading');
 jest.mock('../services/PerpsCacheInvalidator', () => ({
   PerpsCacheInvalidator: { invalidate: jest.fn() },
+}));
+jest.mock('../utils/perpsCufTrace', () => ({
+  ...jest.requireActual('../utils/perpsCufTrace'),
+  startPerpsCufTrace: jest.fn(() => 'tpsl-cuf-op'),
+  endPerpsCufTrace: jest.fn(),
+  endPerpsCufRequestAfter: jest.fn(),
+  watchPerpsCufTpSlChanged: jest.fn(),
+  acceptPerpsCufRequest: jest.fn(),
 }));
 jest.mock('./usePerpsToasts');
 jest.mock('../providers/PerpsStreamManager');
@@ -250,6 +260,17 @@ describe('usePerpsTPSLUpdate', () => {
         .positionAlreadyClosed,
     );
     expect(PerpsCacheInvalidator.invalidate).toHaveBeenCalledWith('positions');
+    expect(PerpsCacheInvalidator.invalidate).toHaveBeenCalledWith(
+      'accountState',
+    );
+    expect(endPerpsCufTrace).toHaveBeenCalledTimes(1);
+    expect(endPerpsCufTrace).toHaveBeenCalledWith({
+      id: 'tpsl-cuf-op',
+      data: {
+        [PERPS_CUF_TAG.SUCCESS]: false,
+        [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.ALREADY_CLOSED,
+      },
+    });
     expect(onSuccess).not.toHaveBeenCalled();
     expect(onError).not.toHaveBeenCalled();
   });
@@ -279,6 +300,17 @@ describe('usePerpsTPSLUpdate', () => {
         .positionAlreadyClosed,
     );
     expect(PerpsCacheInvalidator.invalidate).toHaveBeenCalledWith('positions');
+    expect(PerpsCacheInvalidator.invalidate).toHaveBeenCalledWith(
+      'accountState',
+    );
+    expect(endPerpsCufTrace).toHaveBeenCalledTimes(1);
+    expect(endPerpsCufTrace).toHaveBeenCalledWith({
+      id: 'tpsl-cuf-op',
+      data: {
+        [PERPS_CUF_TAG.SUCCESS]: false,
+        [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.ALREADY_CLOSED,
+      },
+    });
     expect(onSuccess).not.toHaveBeenCalled();
     expect(onError).not.toHaveBeenCalled();
   });

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
@@ -5,7 +5,11 @@ import { usePerpsTPSLUpdate } from './usePerpsTPSLUpdate';
 import { usePerpsTrading } from './usePerpsTrading';
 import usePerpsToasts from './usePerpsToasts';
 import { usePerpsStream } from '../providers/PerpsStreamManager';
+import { PerpsCacheInvalidator } from '../services/PerpsCacheInvalidator';
 jest.mock('./usePerpsTrading');
+jest.mock('../services/PerpsCacheInvalidator', () => ({
+  PerpsCacheInvalidator: { invalidate: jest.fn() },
+}));
 jest.mock('./usePerpsToasts');
 jest.mock('../providers/PerpsStreamManager');
 jest.mock('../../../../../locales/i18n', () => ({
@@ -245,6 +249,7 @@ describe('usePerpsTPSLUpdate', () => {
       mockPerpsToastOptions.positionManagement.closePosition
         .positionAlreadyClosed,
     );
+    expect(PerpsCacheInvalidator.invalidate).toHaveBeenCalledWith('positions');
     expect(onSuccess).not.toHaveBeenCalled();
     expect(onError).not.toHaveBeenCalled();
   });
@@ -273,6 +278,7 @@ describe('usePerpsTPSLUpdate', () => {
       mockPerpsToastOptions.positionManagement.closePosition
         .positionAlreadyClosed,
     );
+    expect(PerpsCacheInvalidator.invalidate).toHaveBeenCalledWith('positions');
     expect(onSuccess).not.toHaveBeenCalled();
     expect(onError).not.toHaveBeenCalled();
   });

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
@@ -52,6 +52,18 @@ describe('usePerpsTPSLUpdate', () => {
 
   const mockPerpsToastOptions = {
     positionManagement: {
+      closePosition: {
+        positionAlreadyClosed: {
+          variant: 'icon',
+          iconName: 'Info',
+          labelOptions: [
+            {
+              label: 'perps.close_position.already_closed',
+              isBold: true,
+            },
+          ],
+        },
+      },
       tpsl: {
         updateTPSLSuccess: {
           variant: 'icon',
@@ -206,6 +218,63 @@ describe('usePerpsTPSLUpdate', () => {
       ),
     );
     expect(onError).toHaveBeenCalledWith('Network error');
+  });
+
+  it('shows already-closed toast when TP/SL update returns No position found', async () => {
+    const onSuccess = jest.fn();
+    const onError = jest.fn();
+    const { result } = renderHookWithToast({ onSuccess, onError });
+    const position = createMockPosition();
+
+    mockUpdatePositionTPSL.mockResolvedValue({
+      success: false,
+      error: 'No position found for ETH',
+    });
+
+    let updateResult: { success: boolean } | undefined;
+    await act(async () => {
+      updateResult = await result.current.handleUpdateTPSL(
+        position,
+        '3300',
+        '2700',
+      );
+    });
+
+    expect(updateResult).toEqual({ success: false });
+    expect(mockShowToast).toHaveBeenCalledWith(
+      mockPerpsToastOptions.positionManagement.closePosition
+        .positionAlreadyClosed,
+    );
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('shows already-closed toast when TP/SL update throws No position found', async () => {
+    const onSuccess = jest.fn();
+    const onError = jest.fn();
+    const { result } = renderHookWithToast({ onSuccess, onError });
+    const position = createMockPosition();
+
+    mockUpdatePositionTPSL.mockRejectedValue(
+      new Error('No position found for ETH'),
+    );
+
+    let updateResult: { success: boolean } | undefined;
+    await act(async () => {
+      updateResult = await result.current.handleUpdateTPSL(
+        position,
+        '3300',
+        '2700',
+      );
+    });
+
+    expect(updateResult).toEqual({ success: false });
+    expect(mockShowToast).toHaveBeenCalledWith(
+      mockPerpsToastOptions.positionManagement.closePosition
+        .positionAlreadyClosed,
+    );
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it('should show error toast and call onError callback on exception', async () => {

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
@@ -10,6 +10,8 @@ import {
   type TPSLTrackingData,
 } from '@metamask/perps-controller';
 import usePerpsToasts from './usePerpsToasts';
+import { isNoPositionFoundError } from '../utils/translatePerpsError';
+import { PerpsCacheInvalidator } from '../services/PerpsCacheInvalidator';
 import { usePerpsStream } from '../providers/PerpsStreamManager';
 import { TraceName } from '../../../../util/trace';
 import {
@@ -67,6 +69,17 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
         PERPS_CUF_STREAM_TIMEOUT_MS,
       );
 
+      // The venue filled, closed or liquidated the position before this
+      // request landed, so there is nothing left to attach TP/SL to. Reconcile
+      // the stale local state and say so instead of raising a generic error.
+      const reconcileAlreadyClosed = () => {
+        showToast(
+          PerpsToastOptions.positionManagement.closePosition
+            .positionAlreadyClosed,
+        );
+        PerpsCacheInvalidator.invalidate('positions');
+      };
+
       try {
         const result = await updatePositionTPSL({
           symbol: position.symbol,
@@ -111,6 +124,11 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
           },
         });
 
+        if (isNoPositionFoundError(result.error)) {
+          reconcileAlreadyClosed();
+          return { success: false };
+        }
+
         const errorMessage = result.error || strings('perps.errors.unknown');
 
         showToast(
@@ -131,6 +149,10 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
             [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.EXCEPTION,
           },
         });
+        if (isNoPositionFoundError(error)) {
+          reconcileAlreadyClosed();
+          return { success: false };
+        }
         DevLogger.log('Error updating position TP/SL:', error);
 
         Logger.error(ensureError(error, 'usePerpsTPSLUpdate.handle'), {
@@ -184,6 +206,7 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
       updatePositionTPSL,
       showToast,
       PerpsToastOptions.positionManagement.tpsl,
+      PerpsToastOptions.positionManagement.closePosition,
       options,
       stream,
     ],

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
@@ -73,11 +73,21 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
       // request landed, so there is nothing left to attach TP/SL to. Reconcile
       // the stale local state and say so instead of raising a generic error.
       const reconcileAlreadyClosed = () => {
+        endPerpsCufTrace({
+          id: tpslCufOpId,
+          data: {
+            [PERPS_CUF_TAG.SUCCESS]: false,
+            [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.ALREADY_CLOSED,
+          },
+        });
         showToast(
           PerpsToastOptions.positionManagement.closePosition
             .positionAlreadyClosed,
         );
+        // The position is gone, so its margin and balance moved with it — the
+        // controller pairs these two everywhere it closes.
         PerpsCacheInvalidator.invalidate('positions');
+        PerpsCacheInvalidator.invalidate('accountState');
       };
 
       try {
@@ -116,6 +126,12 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
           return { success: true };
         }
         DevLogger.log('Failed to update position TP/SL:', result.error);
+
+        if (isNoPositionFoundError(result.error)) {
+          reconcileAlreadyClosed();
+          return { success: false };
+        }
+
         endPerpsCufTrace({
           id: tpslCufOpId,
           data: {
@@ -123,11 +139,6 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
             [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.REQUEST_FAILED,
           },
         });
-
-        if (isNoPositionFoundError(result.error)) {
-          reconcileAlreadyClosed();
-          return { success: false };
-        }
 
         const errorMessage = result.error || strings('perps.errors.unknown');
 
@@ -142,6 +153,11 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
 
         return { success: false };
       } catch (error) {
+        if (isNoPositionFoundError(error)) {
+          reconcileAlreadyClosed();
+          return { success: false };
+        }
+
         endPerpsCufTrace({
           id: tpslCufOpId,
           data: {
@@ -149,10 +165,6 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
             [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.EXCEPTION,
           },
         });
-        if (isNoPositionFoundError(error)) {
-          reconcileAlreadyClosed();
-          return { success: false };
-        }
         DevLogger.log('Error updating position TP/SL:', error);
 
         Logger.error(ensureError(error, 'usePerpsTPSLUpdate.handle'), {

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -948,6 +948,28 @@ describe('usePerpsToasts', () => {
     });
 
     describe('positionManagement.closePosition', () => {
+      it('returns position already closed configuration', () => {
+        const { result } = renderHook(() => usePerpsToasts());
+        const config =
+          result.current.PerpsToastOptions.positionManagement.closePosition
+            .positionAlreadyClosed;
+
+        expect(config).toMatchObject({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Info,
+          iconColor: IconColor.Default,
+          hapticsType: NotificationMoment.Warning,
+        });
+        expect(config.labelOptions).toEqual([
+          { label: 'Position already closed', isBold: true },
+          { label: '\n', isBold: false },
+          {
+            label: 'This position was filled or closed already',
+            isBold: false,
+          },
+        ]);
+      });
+
       it('returns close full position in progress configuration with details', () => {
         const { result } = renderHook(() => usePerpsToasts());
         const config =

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -961,10 +961,13 @@ describe('usePerpsToasts', () => {
           hapticsType: NotificationMoment.Warning,
         });
         expect(config.labelOptions).toEqual([
-          { label: 'Position already closed', isBold: true },
+          {
+            label: strings('perps.close_position.already_closed'),
+            isBold: true,
+          },
           { label: '\n', isBold: false },
           {
-            label: 'This position was filled or closed already',
+            label: strings('perps.close_position.already_closed_subtitle'),
             isBold: false,
           },
         ]);

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -171,6 +171,7 @@ export interface PerpsToastOptionsConfig {
   };
   positionManagement: {
     closePosition: {
+      positionAlreadyClosed: PerpsToastOptions;
       marketClose: {
         full: {
           closeFullPositionInProgress: (
@@ -964,6 +965,13 @@ const usePerpsToasts = (): {
       },
       positionManagement: {
         closePosition: {
+          positionAlreadyClosed: {
+            ...perpsBaseToastOptions.info,
+            labelOptions: getPerpsToastLabels(
+              strings('perps.close_position.already_closed'),
+              strings('perps.close_position.already_closed_subtitle'),
+            ),
+          },
           marketClose: {
             full: {
               closeFullPositionInProgress: (

--- a/app/components/UI/Perps/utils/translatePerpsError.test.ts
+++ b/app/components/UI/Perps/utils/translatePerpsError.test.ts
@@ -48,6 +48,7 @@ import { PERPS_ERROR_CODES } from '@metamask/perps-controller';
 import {
   translatePerpsError,
   isPerpsErrorCode,
+  isNoPositionFoundError,
   handlePerpsError,
 } from './translatePerpsError';
 
@@ -319,6 +320,26 @@ describe('isPerpsErrorCode', () => {
         PERPS_ERROR_CODES.CLIENT_NOT_INITIALIZED,
       ),
     ).toBe(false);
+  });
+});
+
+describe('isNoPositionFoundError', () => {
+  it('returns true for a No position found string', () => {
+    expect(isNoPositionFoundError('No position found for BTC')).toBe(true);
+  });
+
+  it('returns true for an Error wrapping No position found', () => {
+    expect(isNoPositionFoundError(new Error('No position found for ETH'))).toBe(
+      true,
+    );
+  });
+
+  it('returns false for unrelated close errors', () => {
+    expect(isNoPositionFoundError('Insufficient margin')).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isNoPositionFoundError(null)).toBe(false);
   });
 });
 

--- a/app/components/UI/Perps/utils/translatePerpsError.test.ts
+++ b/app/components/UI/Perps/utils/translatePerpsError.test.ts
@@ -325,21 +325,47 @@ describe('isPerpsErrorCode', () => {
 
 describe('isNoPositionFoundError', () => {
   it('returns true for a No position found string', () => {
-    expect(isNoPositionFoundError('No position found for BTC')).toBe(true);
+    // Arrange
+    const error = 'No position found for BTC';
+
+    // Act
+    const result = isNoPositionFoundError(error);
+
+    // Assert
+    expect(result).toBe(true);
   });
 
   it('returns true for an Error wrapping No position found', () => {
-    expect(isNoPositionFoundError(new Error('No position found for ETH'))).toBe(
-      true,
-    );
+    // Arrange
+    const error = new Error('No position found for ETH');
+
+    // Act
+    const result = isNoPositionFoundError(error);
+
+    // Assert
+    expect(result).toBe(true);
   });
 
   it('returns false for unrelated close errors', () => {
-    expect(isNoPositionFoundError('Insufficient margin')).toBe(false);
+    // Arrange
+    const error = 'Insufficient margin';
+
+    // Act
+    const result = isNoPositionFoundError(error);
+
+    // Assert
+    expect(result).toBe(false);
   });
 
   it('returns false for null', () => {
-    expect(isNoPositionFoundError(null)).toBe(false);
+    // Arrange
+    const error = null;
+
+    // Act
+    const result = isNoPositionFoundError(error);
+
+    // Assert
+    expect(result).toBe(false);
   });
 });
 

--- a/app/components/UI/Perps/utils/translatePerpsError.ts
+++ b/app/components/UI/Perps/utils/translatePerpsError.ts
@@ -377,6 +377,23 @@ export function isPerpsErrorCode(
   return error === code;
 }
 
+/** HyperLiquid phrasing for a close/TP-SL aimed at a position it no longer holds. */
+const NO_POSITION_FOUND_PATTERN = /No position found/i;
+
+/**
+ * True when the venue rejected the request because the position was already
+ * filled, closed, or liquidated — a stale-state race, not a user-side failure.
+ */
+export function isNoPositionFoundError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : '';
+  return NO_POSITION_FOUND_PATTERN.test(message);
+}
+
 /**
  * Parameters for handling Perps errors
  */

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2043,6 +2043,8 @@
       "success_title": "Position closed successfully",
       "position_closed": "Position closed",
       "funds_are_available_to_trade": "Funds are available to trade",
+      "already_closed": "Position already closed",
+      "already_closed_subtitle": "This position was filled or closed already",
       "failed_to_close_position": "Failed to close position",
       "failed_to_partially_close_position": "Failed to partially close position",
       "failed_to_place_close_order": "Failed to place close order",


### PR DESCRIPTION
## **Description**

Reconciles Mobile state when a Perps position is filled, closed, or liquidated outside the active screen. Close, TP/SL, and margin actions stop using stale route data once the live position disappears.

If a request races the close and HyperLiquid returns `No position found`, Mobile refreshes position and account state, shows "Position already closed", and records the CUF result as `already_closed` instead of a generic failure.

## **Changelog**

CHANGELOG entry: Fixed stale Perps positions and misleading errors after a position was already closed

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3873

## **Manual testing steps**

```gherkin
Feature: stale Perps position reconciliation

  Scenario: position closes while the close sheet is open
    Given an open Perps position and its close sheet
    When the position closes from another client
    Then the sheet dismisses
    And the position disappears without a manual refresh
    And the user sees "Position already closed"

  Scenario: stale TP/SL or margin screen
    Given a TP/SL or margin screen for an open position
    When the live position disappears
    Then its submit action is disabled
```

## **Screenshots/Recordings**

### Position leaves the list

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35670/before-evidence-ac1-position-list-open.png" width="320" /></td>
    <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35670/after-ac1-position-list-empty.png" width="320" /></td>
  </tr>
  <tr><td>BTC position remains visible before the out-of-band close.</td><td>The position disappears without a manual refresh.</td></tr>
</table>

### Stale action and corrected message

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35670/before-evidence-ac2-close-still-offered.png" width="320" /></td>
    <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35670/after-ac3-no-generic-error.png" width="320" /></td>
  </tr>
  <tr><td>Close remains available against the stale position.</td><td>The stale screen reconciles and reports that the position is already closed.</td></tr>
</table>

### Error behavior

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35670/before-evidence-ac3-generic-error.png" width="320" /></td>
    <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35670/after-ac3-no-generic-error.png" width="320" /></td>
  </tr>
  <tr><td>Generic failure says the position is still active.</td><td>The user gets the specific already-closed message.</td></tr>
</table>
## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Validated on an iOS simulator; the change is platform-neutral TypeScript.
- [ ] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - The already-closed race now ends with the `already_closed` CUF reason.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

- [x] A fully closed position leaves the Perps list without a manual refresh.
- [x] Close is no longer offered once the live position disappears.
- [x] A raced close shows "Position already closed" instead of a generic failure.
- [x] No failed `Perp Position Close Transaction` event is emitted for the race.
- [x] TP/SL and margin stale-position guards have focused test coverage.

## **Validation Logs**

- Focused unit tests: 169 passed.
- View tests: 3 passed.
- Recipe: 27/27 nodes passed on the validated run.
- Latest recipe replay was blocked by a HyperLiquid testnet oracle deviation reproduced on the pre-fix baseline; it was not caused by this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes behavior on close, TP/SL, and margin flows when positions disappear externally; mistakes could block valid actions or dismiss sheets incorrectly, though guards for loading, focus, and confirmed-close reduce that risk.
> 
> **Overview**
> Handles Perps screens that still hold a **navigation route snapshot** after the venue has already filled, closed, or liquidated the position.
> 
> **Close flow:** When the live positions stream drops the symbol (and loading has finished), the close sheet **auto-dismisses** with a new **“Position already closed”** info toast, invalidates positions/account cache, and avoids a second `goBack` if the user already confirmed a close. Dismissal waits until the screen is **focused** so tooltips on top are not popped by mistake.
> 
> **Margin, TP/SL, and close CTAs:** Confirm actions are **disabled or no-op** once live data shows the position is gone (while still loading, actions stay allowed). TP/SL editing subscribes to **`usePerpsLivePositions`** with a throttle config.
> 
> **API races:** `isNoPositionFoundError` detects HyperLiquid’s “No position found” responses in **`usePerpsClosePosition`** and **`usePerpsTPSLUpdate`**, replacing generic failure toasts with the same already-closed UX, refreshing cache, and ending CUF traces with **`already_closed`** instead of request failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3246d72b890056419c36194279cbdbe83e847fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->