### PR TITLE
feat: migrate users with all toggles on/off to consolidated toggle without toast

### DIFF
--- a/app/actions/settings/index.js
+++ b/app/actions/settings/index.js
@@ -80,12 +80,15 @@ export function toggleBasicFunctionality(basicFunctionalityEnabled) {
     const shouldSyncConsolidatedPreferences =
       selectIsBasicFunctionalityConsolidationEnabled(getState());
 
+    // Persist cohort membership before flipping BF so the UI does not briefly
+    // re-show granular toggles while children are still mixed.
+    if (shouldSyncConsolidatedPreferences) {
+      dispatch(setBasicFunctionalityConsolidatedEnabled(true));
+    }
+
     dispatch(setBasicFunctionality(basicFunctionalityEnabled));
 
     if (shouldSyncConsolidatedPreferences) {
-      // Persist cohort membership so later toggles stay consolidated even after
-      // children briefly diverge from the previous consistent legacy state.
-      dispatch(setBasicFunctionalityConsolidatedEnabled(true));
       syncConsolidatedBasicFunctionalityPreferences(basicFunctionalityEnabled);
     }
 

--- a/app/actions/settings/index.js
+++ b/app/actions/settings/index.js
@@ -67,8 +67,6 @@ export function setBasicFunctionalityConsolidatedEnabled(
 // Thunk action creator for user-initiated toggles (includes MultichainAccountService integration)
 export function toggleBasicFunctionality(basicFunctionalityEnabled) {
   return async (dispatch, getState) => {
-    dispatch(setBasicFunctionality(basicFunctionalityEnabled));
-
     const {
       selectIsBasicFunctionalityConsolidationEnabled,
     } = require('../../selectors/featureFlagController/basicFunctionalityConsolidation');
@@ -76,7 +74,18 @@ export function toggleBasicFunctionality(basicFunctionalityEnabled) {
       syncConsolidatedBasicFunctionalityPreferences,
     } = require('../../util/basicFunctionality/syncConsolidatedBasicFunctionalityPreferences');
 
-    if (selectIsBasicFunctionalityConsolidationEnabled(getState())) {
+    // Evaluate consolidation eligibility before flipping BF. Silent-migration
+    // users are eligible via consistent all-on/all-off state; flipping BF first
+    // would make children look mixed and skip sync.
+    const shouldSyncConsolidatedPreferences =
+      selectIsBasicFunctionalityConsolidationEnabled(getState());
+
+    dispatch(setBasicFunctionality(basicFunctionalityEnabled));
+
+    if (shouldSyncConsolidatedPreferences) {
+      // Persist cohort membership so later toggles stay consolidated even after
+      // children briefly diverge from the previous consistent legacy state.
+      dispatch(setBasicFunctionalityConsolidatedEnabled(true));
       syncConsolidatedBasicFunctionalityPreferences(basicFunctionalityEnabled);
     }
 

--- a/app/actions/settings/toggleBasicFunctionality.test.js
+++ b/app/actions/settings/toggleBasicFunctionality.test.js
@@ -1,4 +1,8 @@
-import { toggleBasicFunctionality, setBasicFunctionality } from './index';
+import {
+  toggleBasicFunctionality,
+  setBasicFunctionality,
+  setBasicFunctionalityConsolidatedEnabled,
+} from './index';
 import { selectIsBasicFunctionalityConsolidationEnabled } from '../../selectors/featureFlagController/basicFunctionalityConsolidation';
 import { syncConsolidatedBasicFunctionalityPreferences } from '../../util/basicFunctionality/syncConsolidatedBasicFunctionalityPreferences';
 
@@ -98,11 +102,44 @@ describe('toggleBasicFunctionality action', () => {
     consoleSpy.mockRestore();
   });
 
-  it('syncs consolidated preferences when consolidation is enabled', async () => {
+  it('syncs consolidated preferences when consolidation is enabled before toggle', async () => {
     mockSelectIsBasicFunctionalityConsolidationEnabled.mockReturnValue(true);
     const action = toggleBasicFunctionality(false);
     await action(mockDispatch, mockGetState);
 
+    expect(mockGetState).toHaveBeenCalled();
+    expect(
+      mockSelectIsBasicFunctionalityConsolidationEnabled,
+    ).toHaveBeenCalledWith({});
+    expect(mockDispatch).toHaveBeenCalledWith(
+      setBasicFunctionalityConsolidatedEnabled(true),
+    );
+    expect(
+      mockSyncConsolidatedBasicFunctionalityPreferences,
+    ).toHaveBeenCalledWith(false);
+  });
+
+  it('evaluates consolidation eligibility before flipping BF so silent users still sync', async () => {
+    const callOrder = [];
+    mockSelectIsBasicFunctionalityConsolidationEnabled.mockImplementation(
+      () => {
+        callOrder.push('select');
+        return true;
+      },
+    );
+    mockDispatch.mockImplementation((action) => {
+      callOrder.push(action.type);
+      return action;
+    });
+
+    const action = toggleBasicFunctionality(false);
+    await action(mockDispatch, mockGetState);
+
+    expect(callOrder[0]).toBe('select');
+    expect(callOrder).toContain('TOGGLE_BASIC_FUNCTIONALITY');
+    expect(callOrder.indexOf('select')).toBeLessThan(
+      callOrder.indexOf('TOGGLE_BASIC_FUNCTIONALITY'),
+    );
     expect(
       mockSyncConsolidatedBasicFunctionalityPreferences,
     ).toHaveBeenCalledWith(false);
@@ -115,5 +152,8 @@ describe('toggleBasicFunctionality action', () => {
     expect(
       mockSyncConsolidatedBasicFunctionalityPreferences,
     ).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      setBasicFunctionalityConsolidatedEnabled(true),
+    );
   });
 });

--- a/app/actions/settings/toggleBasicFunctionality.test.js
+++ b/app/actions/settings/toggleBasicFunctionality.test.js
@@ -136,10 +136,11 @@ describe('toggleBasicFunctionality action', () => {
     await action(mockDispatch, mockGetState);
 
     expect(callOrder[0]).toBe('select');
-    expect(callOrder).toContain('TOGGLE_BASIC_FUNCTIONALITY');
-    expect(callOrder.indexOf('select')).toBeLessThan(
-      callOrder.indexOf('TOGGLE_BASIC_FUNCTIONALITY'),
-    );
+    expect(callOrder).toEqual([
+      'select',
+      'SET_BASIC_FUNCTIONALITY_CONSOLIDATED_ENABLED',
+      'TOGGLE_BASIC_FUNCTIONALITY',
+    ]);
     expect(
       mockSyncConsolidatedBasicFunctionalityPreferences,
     ).toHaveBeenCalledWith(false);

--- a/app/selectors/featureFlagController/basicFunctionalityConsolidation/basicFunctionality.ts
+++ b/app/selectors/featureFlagController/basicFunctionalityConsolidation/basicFunctionality.ts
@@ -1,0 +1,117 @@
+import { createSelector } from 'reselect';
+import {
+  selectBasicFunctionalityEnabled,
+  selectIsBasicFunctionalityConsolidatedEnabled,
+} from '../../settings';
+import {
+  selectDisplayNftMedia,
+  selectIsMultiAccountBalancesEnabled,
+  selectIsSecurityAlertsEnabled,
+  selectUseNftDetection,
+  selectUseSafeChainsListValidation,
+  selectUseTokenDetection,
+  selectUseTransactionSimulations,
+} from '../../preferencesController';
+import { selectRemoteFeatureFlags } from '..';
+import {
+  validatedVersionGatedFeatureFlag,
+  type VersionGatedFeatureFlag,
+} from '../../../util/remoteFeatureFlag';
+
+export const MOBILE_UX_BFTC_CONSOLIDATION_FLAG_NAME =
+  'mobileUxBftcConsolidation';
+
+/**
+ * Preference keys unified under consolidated Basic Functionality on mobile.
+ *
+ * Mobile-available Settings toggles only. Extension also consolidates phishing,
+ * 4byte, proposed nicknames, ENS address-bar resolution, and currency-rate
+ * check — those keys do not exist on mobile's PreferencesController.
+ */
+export const BFT_CHILD_PREFERENCES = [
+  'useTransactionSimulations',
+  'securityAlertsEnabled',
+  'isMultiAccountBalancesEnabled',
+  'useSafeChainsListValidation',
+  'useTokenDetection',
+  'displayNftMedia',
+  'useNftDetection',
+] as const;
+
+/**
+ * Remote rollout flag for consolidated Basic Functionality (version-gated).
+ * Default OFF in production; acts as kill-switch when disabled.
+ */
+export const selectMobileUxBftcConsolidationFlagEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const remoteFlag = remoteFeatureFlags?.[
+      MOBILE_UX_BFTC_CONSOLIDATION_FLAG_NAME
+    ] as unknown as VersionGatedFeatureFlag;
+
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  },
+);
+
+const selectBftChildPreferenceValues = createSelector(
+  selectUseTransactionSimulations,
+  selectIsSecurityAlertsEnabled,
+  selectIsMultiAccountBalancesEnabled,
+  selectUseSafeChainsListValidation,
+  selectUseTokenDetection,
+  selectDisplayNftMedia,
+  selectUseNftDetection,
+  (
+    useTransactionSimulations,
+    securityAlertsEnabled,
+    isMultiAccountBalancesEnabled,
+    useSafeChainsListValidation,
+    useTokenDetection,
+    displayNftMedia,
+    useNftDetection,
+  ) => ({
+    useTransactionSimulations,
+    securityAlertsEnabled,
+    isMultiAccountBalancesEnabled,
+    useSafeChainsListValidation,
+    useTokenDetection,
+    displayNftMedia,
+    useNftDetection,
+  }),
+);
+
+/**
+ * True when Basic Functionality and every child preference are aligned
+ * all-on or all-off (silent legacy migration eligibility).
+ */
+export const selectIsBasicFunctionalityConsistent = createSelector(
+  selectBasicFunctionalityEnabled,
+  selectBftChildPreferenceValues,
+  (basicFunctionalityEnabled, childPreferenceValues) => {
+    const areAllChildrenEnabled = BFT_CHILD_PREFERENCES.every(
+      (preference) => childPreferenceValues[preference] === true,
+    );
+    const areAllChildrenDisabled = BFT_CHILD_PREFERENCES.every(
+      (preference) => childPreferenceValues[preference] === false,
+    );
+
+    return (
+      (basicFunctionalityEnabled && areAllChildrenEnabled) ||
+      (!basicFunctionalityEnabled && areAllChildrenDisabled)
+    );
+  },
+);
+
+/**
+ * True when the user should see consolidated Basic Functionality settings.
+ * The remote flag controls rollout. Persisted cohort users and legacy users
+ * with a consistent all-on or all-off configuration are eligible.
+ */
+export const selectIsBasicFunctionalityConsolidationEnabled = createSelector(
+  selectMobileUxBftcConsolidationFlagEnabled,
+  selectIsBasicFunctionalityConsolidatedEnabled,
+  selectIsBasicFunctionalityConsistent,
+  (isRemoteFlagEnabled, isPersistedConsolidatedUser, isConsistentLegacyUser) =>
+    isRemoteFlagEnabled &&
+    (isPersistedConsolidatedUser || isConsistentLegacyUser),
+);

--- a/app/selectors/featureFlagController/basicFunctionalityConsolidation/basicFunctionality.ts
+++ b/app/selectors/featureFlagController/basicFunctionalityConsolidation/basicFunctionality.ts
@@ -3,15 +3,7 @@ import {
   selectBasicFunctionalityEnabled,
   selectIsBasicFunctionalityConsolidatedEnabled,
 } from '../../settings';
-import {
-  selectDisplayNftMedia,
-  selectIsMultiAccountBalancesEnabled,
-  selectIsSecurityAlertsEnabled,
-  selectUseNftDetection,
-  selectUseSafeChainsListValidation,
-  selectUseTokenDetection,
-  selectUseTransactionSimulations,
-} from '../../preferencesController';
+import { RootState } from '../../../reducers';
 import { selectRemoteFeatureFlags } from '..';
 import {
   validatedVersionGatedFeatureFlag,
@@ -38,6 +30,10 @@ export const BFT_CHILD_PREFERENCES = [
   'useNftDetection',
 ] as const;
 
+export type BftChildPreference = (typeof BFT_CHILD_PREFERENCES)[number];
+
+type BftChildPreferenceValues = Record<BftChildPreference, boolean>;
+
 /**
  * Remote rollout flag for consolidated Basic Functionality (version-gated).
  * Default OFF in production; acts as kill-switch when disabled.
@@ -53,31 +49,30 @@ export const selectMobileUxBftcConsolidationFlagEnabled = createSelector(
   },
 );
 
+const selectPreferencesControllerState = (state: RootState) =>
+  state.engine?.backgroundState?.PreferencesController as
+    | Partial<Record<BftChildPreference, boolean>>
+    | undefined;
+
+/**
+ * Reads BFT child prefs directly so partial test stores without
+ * PreferencesController do not throw via preference selectors.
+ * Returns null when PreferencesController is unavailable.
+ */
 const selectBftChildPreferenceValues = createSelector(
-  selectUseTransactionSimulations,
-  selectIsSecurityAlertsEnabled,
-  selectIsMultiAccountBalancesEnabled,
-  selectUseSafeChainsListValidation,
-  selectUseTokenDetection,
-  selectDisplayNftMedia,
-  selectUseNftDetection,
-  (
-    useTransactionSimulations,
-    securityAlertsEnabled,
-    isMultiAccountBalancesEnabled,
-    useSafeChainsListValidation,
-    useTokenDetection,
-    displayNftMedia,
-    useNftDetection,
-  ) => ({
-    useTransactionSimulations,
-    securityAlertsEnabled,
-    isMultiAccountBalancesEnabled,
-    useSafeChainsListValidation,
-    useTokenDetection,
-    displayNftMedia,
-    useNftDetection,
-  }),
+  selectPreferencesControllerState,
+  (preferencesControllerState): BftChildPreferenceValues | null => {
+    if (!preferencesControllerState) {
+      return null;
+    }
+
+    return Object.fromEntries(
+      BFT_CHILD_PREFERENCES.map((preference) => [
+        preference,
+        preferencesControllerState[preference] === true,
+      ]),
+    ) as BftChildPreferenceValues;
+  },
 );
 
 /**
@@ -88,6 +83,10 @@ export const selectIsBasicFunctionalityConsistent = createSelector(
   selectBasicFunctionalityEnabled,
   selectBftChildPreferenceValues,
   (basicFunctionalityEnabled, childPreferenceValues) => {
+    if (!childPreferenceValues) {
+      return false;
+    }
+
     const areAllChildrenEnabled = BFT_CHILD_PREFERENCES.every(
       (preference) => childPreferenceValues[preference] === true,
     );

--- a/app/selectors/featureFlagController/basicFunctionalityConsolidation/index.test.ts
+++ b/app/selectors/featureFlagController/basicFunctionalityConsolidation/index.test.ts
@@ -16,6 +16,7 @@ describe('basicFunctionalityConsolidation selectors', () => {
   let mockHasMinimumRequiredVersion: jest.SpyInstance;
 
   beforeEach(() => {
+    // Clears call counts, keeps implementations
     jest.clearAllMocks();
     mockHasMinimumRequiredVersion = jest.spyOn(
       remoteFeatureFlagModule,
@@ -25,7 +26,8 @@ describe('basicFunctionalityConsolidation selectors', () => {
   });
 
   afterEach(() => {
-    mockHasMinimumRequiredVersion?.mockRestore();
+    // Restores all spies to their original implementations
+    jest.restoreAllMocks();
   });
 
   describe('selectMobileUxBftcConsolidationFlagEnabled', () => {

--- a/app/selectors/featureFlagController/basicFunctionalityConsolidation/index.test.ts
+++ b/app/selectors/featureFlagController/basicFunctionalityConsolidation/index.test.ts
@@ -95,6 +95,12 @@ describe('basicFunctionalityConsolidation selectors', () => {
         selectIsBasicFunctionalityConsistent.resultFunc(true, mixedChildren),
       ).toBe(false);
     });
+
+    it('returns false when PreferencesController child prefs are unavailable', () => {
+      expect(selectIsBasicFunctionalityConsistent.resultFunc(true, null)).toBe(
+        false,
+      );
+    });
   });
 
   describe('selectIsBasicFunctionalityConsolidationEnabled', () => {

--- a/app/selectors/featureFlagController/basicFunctionalityConsolidation/index.test.ts
+++ b/app/selectors/featureFlagController/basicFunctionalityConsolidation/index.test.ts
@@ -1,5 +1,7 @@
 import {
+  BFT_CHILD_PREFERENCES,
   MOBILE_UX_BFTC_CONSOLIDATION_FLAG_NAME,
+  selectIsBasicFunctionalityConsistent,
   selectIsBasicFunctionalityConsolidationEnabled,
   selectMobileUxBftcConsolidationFlagEnabled,
 } from './index';
@@ -56,18 +58,80 @@ describe('basicFunctionalityConsolidation selectors', () => {
     });
   });
 
+  describe('selectIsBasicFunctionalityConsistent', () => {
+    const allOnChildren = Object.fromEntries(
+      BFT_CHILD_PREFERENCES.map((preference) => [preference, true]),
+    );
+    const allOffChildren = Object.fromEntries(
+      BFT_CHILD_PREFERENCES.map((preference) => [preference, false]),
+    );
+
+    it('returns true for an all-on legacy BFT configuration', () => {
+      expect(
+        selectIsBasicFunctionalityConsistent.resultFunc(true, allOnChildren),
+      ).toBe(true);
+    });
+
+    it('returns true for an all-off legacy BFT configuration', () => {
+      expect(
+        selectIsBasicFunctionalityConsistent.resultFunc(false, allOffChildren),
+      ).toBe(true);
+    });
+
+    it('returns false for a mixed legacy BFT configuration', () => {
+      expect(
+        selectIsBasicFunctionalityConsistent.resultFunc(true, {
+          ...allOnChildren,
+          useTokenDetection: false,
+        }),
+      ).toBe(false);
+    });
+  });
+
   describe('selectIsBasicFunctionalityConsolidationEnabled', () => {
     it('returns true when remote flag and cohort marker are enabled', () => {
       const result = selectIsBasicFunctionalityConsolidationEnabled.resultFunc(
         true,
+        true,
+        false,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true for an all-on legacy BFT user when the remote flag is enabled', () => {
+      const result = selectIsBasicFunctionalityConsolidationEnabled.resultFunc(
+        true,
+        false,
         true,
       );
 
       expect(result).toBe(true);
     });
 
-    it('returns false when remote flag is disabled (kill-switch)', () => {
+    it('returns true for an all-off legacy BFT user when the remote flag is enabled', () => {
       const result = selectIsBasicFunctionalityConsolidationEnabled.resultFunc(
+        true,
+        false,
+        true,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false for a mixed legacy BFT user', () => {
+      const result = selectIsBasicFunctionalityConsolidationEnabled.resultFunc(
+        true,
+        false,
+        false,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false for a consistent legacy BFT user when the remote flag is disabled', () => {
+      const result = selectIsBasicFunctionalityConsolidationEnabled.resultFunc(
+        false,
         false,
         true,
       );
@@ -75,10 +139,11 @@ describe('basicFunctionalityConsolidation selectors', () => {
       expect(result).toBe(false);
     });
 
-    it('returns false when cohort marker is missing for existing users', () => {
+    it('returns false when remote flag is disabled (kill-switch)', () => {
       const result = selectIsBasicFunctionalityConsolidationEnabled.resultFunc(
-        true,
         false,
+        true,
+        true,
       );
 
       expect(result).toBe(false);

--- a/app/selectors/featureFlagController/basicFunctionalityConsolidation/index.test.ts
+++ b/app/selectors/featureFlagController/basicFunctionalityConsolidation/index.test.ts
@@ -61,12 +61,17 @@ describe('basicFunctionalityConsolidation selectors', () => {
   });
 
   describe('selectIsBasicFunctionalityConsistent', () => {
+    type BftChildPreferenceValues = Record<
+      (typeof BFT_CHILD_PREFERENCES)[number],
+      boolean
+    >;
+
     const allOnChildren = Object.fromEntries(
       BFT_CHILD_PREFERENCES.map((preference) => [preference, true]),
-    );
+    ) as BftChildPreferenceValues;
     const allOffChildren = Object.fromEntries(
       BFT_CHILD_PREFERENCES.map((preference) => [preference, false]),
-    );
+    ) as BftChildPreferenceValues;
 
     it('returns true for an all-on legacy BFT configuration', () => {
       expect(
@@ -81,11 +86,13 @@ describe('basicFunctionalityConsolidation selectors', () => {
     });
 
     it('returns false for a mixed legacy BFT configuration', () => {
+      const mixedChildren: BftChildPreferenceValues = {
+        ...allOnChildren,
+        useTokenDetection: false,
+      };
+
       expect(
-        selectIsBasicFunctionalityConsistent.resultFunc(true, {
-          ...allOnChildren,
-          useTokenDetection: false,
-        }),
+        selectIsBasicFunctionalityConsistent.resultFunc(true, mixedChildren),
       ).toBe(false);
     });
   });
@@ -141,7 +148,7 @@ describe('basicFunctionalityConsolidation selectors', () => {
       expect(result).toBe(false);
     });
 
-    it('returns false when remote flag is disabled (kill-switch)', () => {
+    it('returns false when remote flag is disabled', () => {
       const result = selectIsBasicFunctionalityConsolidationEnabled.resultFunc(
         false,
         true,

--- a/app/selectors/featureFlagController/basicFunctionalityConsolidation/index.ts
+++ b/app/selectors/featureFlagController/basicFunctionalityConsolidation/index.ts
@@ -1,36 +1,7 @@
-import { createSelector } from 'reselect';
-import { selectRemoteFeatureFlags } from '..';
-import {
-  validatedVersionGatedFeatureFlag,
-  type VersionGatedFeatureFlag,
-} from '../../../util/remoteFeatureFlag';
-import { selectIsBasicFunctionalityConsolidatedEnabled } from '../../settings';
-
-export const MOBILE_UX_BFTC_CONSOLIDATION_FLAG_NAME =
-  'mobileUxBftcConsolidation';
-
-/**
- * Remote rollout flag for consolidated Basic Functionality (version-gated).
- * Default OFF in production; acts as kill-switch when disabled.
- */
-export const selectMobileUxBftcConsolidationFlagEnabled = createSelector(
-  selectRemoteFeatureFlags,
-  (remoteFeatureFlags) => {
-    const remoteFlag = remoteFeatureFlags?.[
-      MOBILE_UX_BFTC_CONSOLIDATION_FLAG_NAME
-    ] as unknown as VersionGatedFeatureFlag;
-
-    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
-  },
-);
-
-/**
- * True when the user should see consolidated Basic Functionality settings.
- * Requires both the remote flag and the persisted onboarding cohort marker.
- */
-export const selectIsBasicFunctionalityConsolidationEnabled = createSelector(
+export {
+  BFT_CHILD_PREFERENCES,
+  MOBILE_UX_BFTC_CONSOLIDATION_FLAG_NAME,
+  selectIsBasicFunctionalityConsistent,
+  selectIsBasicFunctionalityConsolidationEnabled,
   selectMobileUxBftcConsolidationFlagEnabled,
-  selectIsBasicFunctionalityConsolidatedEnabled,
-  (isRemoteFlagEnabled, isConsolidatedUser) =>
-    isRemoteFlagEnabled && isConsolidatedUser,
-);
+} from './basicFunctionality';


### PR DESCRIPTION
## Summary
- Silently enroll legacy users whose Basic Functionality toggle already matches every child preference (all-on or all-off) into the consolidated Settings experience
- Mirrors extension silent migration ([#45958](https://github.com/MetaMask/metamask-extension/pull/45958)): no persisted state rewrite, no toast/modal
- Mixed child-toggle configs remain ineligible until they onboard into the cohort or become consistent

### Eligibility
Consolidation UI shows when `mobileUxBftcConsolidation` is on **and**:
- persisted cohort marker is set, **or**
- BF + all mobile child prefs are consistently all-on or all-off

### Mobile child prefs
- Estimate balance changes
- Security alerts
- Batch balance / token price checker
- Network details check
- Autodetect tokens
- Display NFT media
- Autodetect NFTs

## Changelog
CHANGELOG entry: migrate users with all toggles on/off to consolidated toggle on/off state

## Test plan
- [x] `yarn jest app/selectors/featureFlagController/basicFunctionalityConsolidation/index.test.ts`

### Manual
- [ ] Keep BF and all child toggles **enabled** on main, switch to this branch, enable `mobileUxBftcConsolidation`. Confirm Settings shows consolidated BF only (granular toggles hidden) with BF on
- [ ] Keep BF and all child toggles **disabled** on main, switch to this branch, enable the flag. Confirm consolidated BF only with BF off
- [ ] With a **mixed** child-toggle config and no cohort marker, confirm granular toggles remain visible
- [ ] With cohort marker already set, confirm consolidation still works as before


Made with [Cursor](https://cursor.com)