### PR TITLE
fix: setup `TransactionController` listeners before `Wallet` initialization

### DIFF
--- a/app/core/Engine/wallet-init/initialization.test.ts
+++ b/app/core/Engine/wallet-init/initialization.test.ts
@@ -127,4 +127,16 @@ describe('initializeWallet', () => {
       messenger: 'tx-init-messenger',
     });
   });
+
+  it('sets up TransactionController listeners before constructing the Wallet, so the TransactionController can emit events to the wallet messenger during initialization', () => {
+    initializeWallet({ messenger, state });
+
+    const setupListenersCallOrder = jest.mocked(
+      setupTransactionControllerListeners,
+    ).mock.invocationCallOrder[0];
+    const walletConstructorCallOrder =
+      jest.mocked(Wallet).mock.invocationCallOrder[0];
+
+    expect(setupListenersCallOrder).toBeLessThan(walletConstructorCallOrder);
+  });
 });

--- a/app/core/Engine/wallet-init/initialization.ts
+++ b/app/core/Engine/wallet-init/initialization.ts
@@ -53,6 +53,12 @@ export function initializeWallet({
   const transactionControllerInitMessenger =
     getTransactionControllerInitMessenger(messenger);
 
+  // TC event listeners must be set up before the wallet is initialized.
+  // So that the TC can emit events to the wallet's messenger during initialization.
+  setupTransactionControllerListeners({
+    messenger: transactionControllerInitMessenger,
+  });
+
   const wallet: Wallet = new Wallet({
     // Mobile's root messenger carries a superset action/event union (all app
     // controllers) vs. the wallet's narrower DefaultActions/DefaultEvents.
@@ -83,10 +89,6 @@ export function initializeWallet({
         initMessenger: transactionControllerInitMessenger,
       }),
     },
-  });
-
-  setupTransactionControllerListeners({
-    messenger: transactionControllerInitMessenger,
   });
 
   wallet.init().catch((error: unknown) => console.error(error));


### PR DESCRIPTION
## **Description**

`setupTransactionControllerListeners()` was previously called *after* the `Wallet` was constructed and initialized. (pre `Wallet` introduction) During `Wallet` construction/`init()`, the `TransactionController` can already start emitting events (e.g. via its init messenger), but the mobile-specific listeners (metrics, notifications, money-account handling) were not yet subscribed at that point, meaning early events could be missed.

This PR moves `setupTransactionControllerListeners()` to run **before** `new Wallet(...)` is constructed, ensuring the listeners are attached to the `TransactionController` init messenger before the wallet (and by extension the `TransactionController`) is initialized.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1918

## **Manual testing steps**

```gherkin
Feature: Wallet initialization wires TransactionController listeners before init

  Scenario: App cold start triggers a transaction event during initialization
    Given the app is launched fresh (cold start)
    When the wallet and its controllers are initialized
    Then the mobile-specific TransactionController listeners (metrics, notifications, money-account handling) are already subscribed before any TransactionController event can fire
    And no transaction lifecycle event (e.g. unapprovedTransactionAdded, transactionSubmitted) is missed during startup
```

## **Screenshots/Recordings**

Notice: `subscribed to transaction events for metrics` being executed before init now

### **Before**

<img width="1303" height="1161" alt="before" src="https://github.com/user-attachments/assets/f57e93fb-a857-4f02-8730-29273d516f5d" />


### **After**

<img width="1303" height="1161" alt="after" src="https://github.com/user-attachments/assets/5d03dcac-07c7-4ec6-957f-c7ed88a6f0e9" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup ordering only; same listeners and messenger wiring, with a focused regression test and no auth or persistence changes.
> 
> **Overview**
> **Reorders wallet startup** so mobile `TransactionController` listeners (metrics, notifications, money-account handling) subscribe on the init messenger **before** `new Wallet(...)`, instead of after construction.
> 
> That closes a race where `TransactionController` could emit lifecycle events during wallet construction/`init()` while nothing was listening yet, so early events could be dropped on cold start.
> 
> A unit test asserts `setupTransactionControllerListeners` runs earlier than the `Wallet` constructor via Jest mock call order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b80b5f73fcef455f78dd43d97bf99f750faaff23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->