### PR TITLE
fix(e2e): increase cardViewTitle timeout in card-home-add-funds spec

### DIFF
--- a/tests/smoke-appium/card/card-home-add-funds.spec.ts
+++ b/tests/smoke-appium/card/card-home-add-funds.spec.ts
@@ -47,7 +47,13 @@ appiumTest.describe(SmokeMoney('CardHome - Add Funds'), () => {
             WalletView.navbarCardButton,
           );
           await WalletView.tapNavbarCardButton();
-          await Assertions.expectElementToBeVisible(CardHomeView.cardViewTitle);
+          await Assertions.expectElementToBeVisible(
+            CardHomeView.cardViewTitle,
+            {
+              timeout: 30000,
+              elemDescription: 'Card Home view title',
+            },
+          );
           await CardHomeView.tapAddFundsButton();
           await Assertions.expectElementToBeVisible(
             CardHomeView.addFundsBottomSheetDepositOption,


### PR DESCRIPTION
## Summary

- Increases the `cardViewTitle` assertion timeout from the default 15 s to 30 s in `card-home-add-funds.spec.ts`
- On CI Android emulators, CardHome takes longer to mount after navigation due to CardController async hydration and mock HTTP latency — 15 s was sometimes not enough
- 30 s matches the pattern used by other post-navigation readiness assertions across smoke specs

## Test plan

- [ ] Confirm `card-home-add-funds.spec.ts` passes consistently on CI Android without retries
- [ ] No other smoke specs affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to assertion timing; no production or app logic affected.
> 
> **Overview**
> **Card Home add-funds smoke test** now waits up to **30 s** (instead of the default **15 s**) for `CardHomeView.cardViewTitle` after tapping the wallet navbar card button, with an explicit `elemDescription` for clearer failure output.
> 
> This targets flaky CI on Android emulators where Card Home is slow to appear after navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ac1bbbb4d422e353149dd4b60fa805078abca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->