### PR TITLE
fix(perf): look up app profiling baselines in the workflow that runs on main

### DIFF
--- a/.github/workflows/app-profiling-check.yml
+++ b/.github/workflows/app-profiling-check.yml
@@ -1,7 +1,7 @@
 # Compares BrowserStack app profiling for a failed performance scenario against
 # the last green baseline on main, then posts a diff comment on the PR.
 #
-# Automatic: run-performance-e2e.yml embeds this in its PR results comment.
+# Automatic: run-performance-e2e.yml posts this for failed PR scenarios.
 #
 # Manual trigger via bot command on a PR:
 #   @metamaskbot app-profiling-check --test "Cold Start Login" --platform Android --device "Google Pixel 8 Pro+14.0" --run 123456789

--- a/.github/workflows/app-profiling-check.yml
+++ b/.github/workflows/app-profiling-check.yml
@@ -1,7 +1,7 @@
 # Compares BrowserStack app profiling for a failed performance scenario against
 # the last green baseline on main, then posts a diff comment on the PR.
 #
-# Automatic: run-performance-e2e.yml posts this for failed PR scenarios.
+# Automatic: run-performance-e2e.yml embeds this in its PR results comment.
 #
 # Manual trigger via bot command on a PR:
 #   @metamaskbot app-profiling-check --test "Cold Start Login" --platform Android --device "Google Pixel 8 Pro+14.0" --run 123456789

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -701,12 +701,25 @@ node tests/scripts/aggregate-performance-reports.mjs
 | `tests/aggregated-reports/performance-report.html`            | **Visual HTML dashboard**                   |
 | `tests/aggregated-reports/app-profiling/*.json`               | Per-scenario app profiling + API call files |
 
-### App profiling check (automatic on PR failures)
+### App profiling check (automatic on every PR run)
 
-When a PR performance run has failed scenarios, the results comment includes
-an inline **App profiling check** under each failed scenario that has a prior
-usable baseline on `main` (short summary + collapsed metric table). Scenarios
-without a prior baseline are omitted from that block.
+Every PR performance run posts app profiling in the results comment:
+
+- **Failed scenarios** get an inline **App profiling check** (short summary +
+  collapsed metric table) under each scenario that has a prior usable baseline
+  on `main`.
+- **Passed scenarios** are listed in the collapsed **App profiling vs `main`**
+  section, which also carries the run-wide coverage, average CPU/memory and
+  issue counts. Scenarios over the +10% margin additionally get the full metric
+  table there.
+- Scenarios without a prior baseline are omitted from those blocks.
+
+Baselines come from the scheduled `main` runs of
+[`run-performance-e2e-manual.yml`](../../.github/workflows/run-performance-e2e-manual.yml)
+(`BASELINE_WORKFLOW` in `tests/scripts/diff-app-profiling.mjs`). The reusable
+`run-performance-e2e.yml` cannot be used as the baseline source: it is
+`workflow_call` only, so its invocations are jobs of the caller run and never
+appear in `gh run list --workflow run-performance-e2e.yml`.
 
 Header uses ⚠️ when there are failed tests.
 
@@ -725,6 +738,9 @@ Or compare all failed scenarios from that run:
 This uses `.github/workflows/app-profiling-check.yml` (bot command /
 `workflow_dispatch`). The automatic PR path embeds profiling into the
 performance results comment from `run-performance-e2e.yml`.
+
+Both paths share `tests/scripts/diff-app-profiling.mjs`, so a `--workflow`
+override on the manual command also changes where baselines are looked up.
 
 ### Weekly app profiling report (Cursor Automation)
 

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -701,18 +701,12 @@ node tests/scripts/aggregate-performance-reports.mjs
 | `tests/aggregated-reports/performance-report.html`            | **Visual HTML dashboard**                   |
 | `tests/aggregated-reports/app-profiling/*.json`               | Per-scenario app profiling + API call files |
 
-### App profiling check (automatic on every PR run)
+### App profiling check (automatic on PR failures)
 
-Every PR performance run posts app profiling in the results comment:
-
-- **Failed scenarios** get an inline **App profiling check** (short summary +
-  collapsed metric table) under each scenario that has a prior usable baseline
-  on `main`.
-- **Passed scenarios** are listed in the collapsed **App profiling vs `main`**
-  section, which also carries the run-wide coverage, average CPU/memory and
-  issue counts. Scenarios over the +10% margin additionally get the full metric
-  table there.
-- Scenarios without a prior baseline are omitted from those blocks.
+When a PR performance run has failed scenarios, the results comment includes
+an inline **App profiling check** under each failed scenario that has a prior
+usable baseline on `main` (short summary + collapsed metric table). Scenarios
+without a prior baseline are omitted from that block.
 
 Baselines come from the scheduled `main` runs of
 [`run-performance-e2e-manual.yml`](../../.github/workflows/run-performance-e2e-manual.yml)

--- a/tests/performance/app-profiling-baseline-workflow.test.ts
+++ b/tests/performance/app-profiling-baseline-workflow.test.ts
@@ -1,0 +1,55 @@
+/* eslint-disable import-x/no-nodejs-modules */
+import fs from 'fs';
+import path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+const readRepoFile = (relativePath: string): string =>
+  fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8');
+
+const getBaselineWorkflow = (): string => {
+  const source = readRepoFile('tests/scripts/diff-app-profiling.mjs');
+  const match = source.match(/const BASELINE_WORKFLOW = '([^']+)';/);
+
+  if (!match) {
+    throw new Error('BASELINE_WORKFLOW not found in diff-app-profiling.mjs');
+  }
+
+  return match[1];
+};
+
+describe('app profiling baseline workflow', () => {
+  it('points at a workflow that exists', () => {
+    const workflowPath = path.join(
+      REPO_ROOT,
+      '.github/workflows',
+      getBaselineWorkflow(),
+    );
+
+    expect(fs.existsSync(workflowPath)).toBe(true);
+  });
+
+  it('points at a workflow that produces listable runs on main', () => {
+    // `gh run list --workflow <file>` only returns runs of workflows with their
+    // own triggers. A `workflow_call`-only workflow runs as jobs of its caller,
+    // so using one as baseline source silently yields zero candidate runs.
+    const workflow = readRepoFile(`.github/workflows/${getBaselineWorkflow()}`);
+    const triggers = workflow.slice(
+      workflow.indexOf('on:'),
+      workflow.indexOf('jobs:'),
+    );
+
+    expect(triggers).toContain('schedule:');
+    expect(triggers).toContain('workflow_dispatch:');
+    expect(triggers).not.toContain('workflow_call:');
+  });
+
+  it('shares the baseline workflow with the PR comment generator', () => {
+    const commentGenerator = readRepoFile(
+      'tests/scripts/generate-performance-pr-comment.mjs',
+    );
+
+    expect(commentGenerator).toContain('BASELINE_WORKFLOW');
+    expect(commentGenerator).not.toMatch(/'run-performance-e2e[^']*\.yml'/);
+  });
+});

--- a/tests/scripts/diff-app-profiling.mjs
+++ b/tests/scripts/diff-app-profiling.mjs
@@ -30,7 +30,11 @@ import path from 'path';
 
 const COMMENT_MARKER = '<!-- app-profiling-check -->';
 const DEFAULT_BASELINE_BRANCH = 'main';
-const DEFAULT_WORKFLOW = 'run-performance-e2e.yml';
+// Baselines come from the scheduled main runs, which are dispatched by
+// run-performance-e2e-manual.yml. run-performance-e2e.yml is `workflow_call`
+// only, so its invocations are jobs of the caller run and never appear in
+// `gh run list --workflow run-performance-e2e.yml`.
+const BASELINE_WORKFLOW = 'run-performance-e2e-manual.yml';
 /** Current may be up to baseline + 10% without being highlighted as a regression. */
 const RELATIVE_WARN_THRESHOLD = 0.1;
 
@@ -43,7 +47,7 @@ function parseArgs(argv) {
     device: null,
     all: false,
     baselineBranch: DEFAULT_BASELINE_BRANCH,
-    workflow: DEFAULT_WORKFLOW,
+    workflow: BASELINE_WORKFLOW,
     repo: process.env.GITHUB_REPOSITORY || null,
     dryRun: false,
     /** When set, use this local aggregated-reports dir instead of downloading the current run. */
@@ -268,7 +272,15 @@ function downloadAggregatedReports(runId, destDir, repo, { runGhFn = runGh } = {
   return { reused: false };
 }
 
+/** Candidate runs are identical for every scenario of a run, so list them once. */
+const baselineCandidateCache = new Map();
+
 function listBaselineCandidateRuns({ repo, workflow, branch, limit = 40 }) {
+  const cacheKey = `${repo}|${workflow}|${branch}|${limit}`;
+  if (baselineCandidateCache.has(cacheKey)) {
+    return baselineCandidateCache.get(cacheKey);
+  }
+
   const raw = runGh([
     'run',
     'list',
@@ -283,7 +295,9 @@ function listBaselineCandidateRuns({ repo, workflow, branch, limit = 40 }) {
     '--json',
     'databaseId,conclusion,createdAt,headSha,url,displayTitle',
   ]);
-  return JSON.parse(raw || '[]');
+  const runs = JSON.parse(raw || '[]');
+  baselineCandidateCache.set(cacheKey, runs);
+  return runs;
 }
 
 function flattenPerformanceResults(results) {
@@ -933,6 +947,7 @@ export {
   findBaselineScenario,
   findProfilingArtifacts,
   parseArgs,
+  BASELINE_WORKFLOW,
   COMMENT_MARKER,
 };
 

--- a/tests/scripts/generate-performance-pr-comment.mjs
+++ b/tests/scripts/generate-performance-pr-comment.mjs
@@ -3,9 +3,9 @@
 /**
  * Generate a GitHub PR comment with performance test results.
  *
- * Failed scenarios with a prior app-profiling baseline are enriched inline
- * (short summary + collapsed metric table) so a separate profiling comment
- * is not required.
+ * Every scenario with a prior app-profiling baseline is enriched (short
+ * summary + collapsed metric table) so a separate profiling comment is not
+ * required: failed scenarios inline, passed scenarios in a collapsed section.
  *
  * Usage:
  *   node generate-performance-pr-comment.mjs [summary_file] [output_file]
@@ -30,13 +30,18 @@ import {
   findMatchingArtifact,
   findBaselineScenario,
   buildEmbeddedProfilingSection,
+  buildRegressionSummary,
+  getMetricRows,
+  hasUsableProfilingSummary,
+  BASELINE_WORKFLOW,
   COMMENT_MARKER as APP_PROFILING_MARKER,
 } from './diff-app-profiling.mjs';
 
 const SUMMARY_FILE = process.argv[2] || 'aggregated-reports/summary.json';
 const OUTPUT_FILE = process.argv[3] || 'performance-pr-comment.md';
 const DEFAULT_BASELINE_BRANCH = 'main';
-const DEFAULT_WORKFLOW = 'run-performance-e2e.yml';
+/** GitHub rejects issue comments over 65536 characters. */
+const MAX_COMMENT_LENGTH = 60000;
 
 async function main() {
   if (!fs.existsSync(SUMMARY_FILE)) {
@@ -68,6 +73,7 @@ async function main() {
     summary.metadata?.workflowRun ?? process.env.GITHUB_RUN_ID ?? '';
   const repo = process.env.GITHUB_REPOSITORY ?? '';
 
+  const profilingStats = summary.profilingStats ?? null;
   const failedStats = summary.failedTestsStats ?? {};
   const uniqueFailedTests = failedStats.uniqueFailedTests ?? 0;
   const failedByTeam = failedStats.failedTestsByTeam ?? {};
@@ -173,6 +179,7 @@ async function main() {
               : '—';
 
           return {
+            key: `${platform}|${deviceKey}|${test.testName}`,
             passed: !failed,
             status: failed ? '❌ Failed' : '✅ Passed',
             testName: test.testName,
@@ -195,70 +202,118 @@ async function main() {
     );
   }
 
+  /**
+   * Every scenario of the run, keyed the same way as the failed-test rows and
+   * the passed-test rows so profiling blocks can be looked up while rendering.
+   */
+  function getScenariosToEnrich() {
+    const scenarios = new Map();
+
+    const add = ({ platform, device, testName }) => {
+      const key = `${platform}|${getDeviceKey(device)}|${testName}`;
+      if (!scenarios.has(key)) {
+        scenarios.set(key, {
+          key,
+          platform,
+          testName,
+          device: parseDeviceKey(device),
+        });
+      }
+    };
+
+    for (const teamData of Object.values(failedByTeam)) {
+      for (const test of teamData.tests ?? []) {
+        add(test);
+      }
+    }
+
+    for (const [platform, devices] of Object.entries(performanceResults ?? {})) {
+      for (const [deviceKey, tests] of Object.entries(devices ?? {})) {
+        for (const test of tests ?? []) {
+          add({ platform, device: deviceKey, testName: test.testName });
+        }
+      }
+    }
+
+    return [...scenarios.values()];
+  }
+
   const skipEnrichment =
     process.env.SKIP_APP_PROFILING_ENRICHMENT === 'true' || !repo || !runId;
 
   const profilingByKey = new Map();
-  if (!skipEnrichment && uniqueFailedTests > 0) {
+  if (!skipEnrichment) {
     const workRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), 'perf-pr-profiling-'),
     );
     const currentArtifacts = findProfilingArtifacts(reportsDir);
 
     console.log(
-      `🔬 Enriching failed scenarios with app profiling vs \`${DEFAULT_BASELINE_BRANCH}\`...`,
+      `🔬 Enriching scenarios with app profiling vs \`${DEFAULT_BASELINE_BRANCH}\`...`,
     );
 
-    for (const teamData of Object.values(failedByTeam)) {
-      for (const test of teamData.tests ?? []) {
-        const device = parseDeviceKey(test.device);
-        const key = `${test.platform}|${getDeviceKey(test.device)}|${test.testName}`;
+    for (const scenario of getScenariosToEnrich()) {
+      const { key, testName, device } = scenario;
 
-        let currentArtifact = findMatchingArtifact(currentArtifacts, {
-          testName: test.testName,
-          device,
-        })?.data;
+      let currentArtifact = findMatchingArtifact(currentArtifacts, {
+        testName,
+        device,
+      })?.data;
 
-        if (!currentArtifact && !device.name) {
-          currentArtifact = currentArtifacts.find(
-            ({ data }) => data.testName === test.testName,
-          )?.data;
-        }
+      if (!currentArtifact && !device.name) {
+        currentArtifact = currentArtifacts.find(
+          ({ data }) => data.testName === testName,
+        )?.data;
+      }
 
-        try {
-          const baseline = findBaselineScenario({
-            repo,
-            workflow: DEFAULT_WORKFLOW,
-            baselineBranch: DEFAULT_BASELINE_BRANCH,
-            currentRunId: runId,
-            testName: test.testName,
-            device: currentArtifact?.device ?? device,
-            workRoot,
+      if (!hasUsableProfilingSummary(currentArtifact)) {
+        console.warn(
+          `⏭️  No usable profiling for "${testName}" — omitting profiling block`,
+        );
+        continue;
+      }
+
+      try {
+        const baseline = findBaselineScenario({
+          repo,
+          workflow: BASELINE_WORKFLOW,
+          baselineBranch: DEFAULT_BASELINE_BRANCH,
+          currentRunId: runId,
+          testName,
+          device: currentArtifact?.device ?? device,
+          workRoot,
+        });
+
+        const section = buildEmbeddedProfilingSection({
+          currentRunId: runId,
+          currentArtifact,
+          baseline,
+          repo,
+          baselineBranch: DEFAULT_BASELINE_BRANCH,
+          includeRawJson: false,
+        });
+
+        if (section) {
+          const rows = getMetricRows(
+            baseline.artifact.profilingSummary,
+            currentArtifact.profilingSummary,
+          );
+          profilingByKey.set(key, {
+            section,
+            summary: buildRegressionSummary(rows),
+            hasRegression: rows.some((row) => row.warn),
           });
-
-          const section = buildEmbeddedProfilingSection({
-            currentRunId: runId,
-            currentArtifact,
-            baseline,
-            repo,
-            baselineBranch: DEFAULT_BASELINE_BRANCH,
-            includeRawJson: false,
-          });
-
-          if (section) {
-            profilingByKey.set(key, section);
-          } else {
-            console.warn(
-              `⏭️  No comparable baseline for "${test.testName}" — omitting profiling block`,
-            );
-          }
-        } catch (error) {
+        } else {
           console.warn(
-            `⚠️  Could not enrich "${test.testName}": ${
-              error instanceof Error ? error.message : String(error)
-            }`,
+            `⏭️  No comparable baseline for "${testName}" — omitting profiling block`,
           );
         }
+      } catch (error) {
+        console.warn(
+          `⚠️  Could not enrich "${testName}": ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
       }
     }
   }
@@ -340,7 +395,7 @@ async function main() {
           ? `[📹 Watch](${t.recordingLink})`
           : '—';
         const key = `${t.platform}|${getDeviceKey(t.device)}|${t.testName}`;
-        const profilingSection = profilingByKey.get(key);
+        const profiling = profilingByKey.get(key);
 
         md += `#### ${escapeMarkdownTable(t.testName)}\n\n`;
         md += `| Platform | Device | Reason | Recording |\n`;
@@ -349,8 +404,8 @@ async function main() {
           device,
         )} | ${escapeMarkdownTable(reason)} | ${recording} |\n\n`;
 
-        if (profilingSection) {
-          md += `${profilingSection}\n`;
+        if (profiling) {
+          md += `${profiling.section}\n`;
         }
       }
     }
@@ -374,6 +429,76 @@ async function main() {
     }
 
     md += `\n</details>\n\n`;
+  }
+
+  // App profiling for the passed scenarios, which have no inline block above.
+  // Only regressions get the full metric table, to keep the comment well under
+  // GitHub's 65k character limit as the number of scenarios grows.
+  const passedWithProfiling = passedTestRuns
+    .map((test) => ({ test, profiling: profilingByKey.get(test.key) }))
+    .filter(({ profiling }) => profiling);
+
+  if (profilingStats || passedWithProfiling.length > 0) {
+    md += `<details>\n<summary>🔬 App profiling vs \`main\`${
+      passedWithProfiling.length > 0
+        ? ` (${passedWithProfiling.length} passed scenario${
+            passedWithProfiling.length !== 1 ? 's' : ''
+          })`
+        : ''
+    }</summary>\n\n`;
+
+    if (profilingStats) {
+      md += `**Coverage:** ${
+        profilingStats.testsWithProfiling ?? 0
+      }/${totalTests} scenarios (${profilingStats.profilingCoverage ?? '—'})`;
+      md += ` · **Avg CPU:** ${profilingStats.avgCpuUsage ?? '—'}`;
+      md += ` · **Avg memory:** ${profilingStats.avgMemoryUsage ?? '—'}`;
+      md += ` · **Issues:** ${profilingStats.totalPerformanceIssues ?? 0} (${
+        profilingStats.totalCriticalIssues ?? 0
+      } critical)\n\n`;
+    }
+
+    if (passedWithProfiling.length > 0) {
+      md += `| Test | Platform | Device | Profiling vs \`main\` |\n`;
+      md += `|------|----------|--------|---------------------|\n`;
+
+      for (const { test, profiling } of passedWithProfiling) {
+        md += `| ${escapeMarkdownTable(test.testName)} | ${
+          test.platform
+        } | ${escapeMarkdownTable(test.device)} | ${escapeMarkdownTable(
+          profiling.summary,
+        )} |\n`;
+      }
+
+      md += '\n';
+
+      let omittedTables = 0;
+
+      for (const { test, profiling } of passedWithProfiling) {
+        if (!profiling.hasRegression) {
+          continue;
+        }
+
+        let block = `#### ${escapeMarkdownTable(test.testName)}\n\n`;
+        block += `${test.platform} · ${escapeMarkdownTable(test.device)}\n\n`;
+        block += `${profiling.section}\n`;
+
+        if (md.length + block.length > MAX_COMMENT_LENGTH) {
+          omittedTables += 1;
+          continue;
+        }
+
+        md += block;
+      }
+
+      if (omittedTables > 0) {
+        md += `> ℹ️ Metric tables for ${omittedTables} more scenario${
+          omittedTables !== 1 ? 's' : ''
+        } were omitted to stay within GitHub's comment size limit — full data is in the \`aggregated-reports\` artifact.\n\n`;
+      }
+    }
+
+    md += `</details>\n\n`;
   }
 
   // Footer

--- a/tests/scripts/generate-performance-pr-comment.mjs
+++ b/tests/scripts/generate-performance-pr-comment.mjs
@@ -3,9 +3,9 @@
 /**
  * Generate a GitHub PR comment with performance test results.
  *
- * Every scenario with a prior app-profiling baseline is enriched (short
- * summary + collapsed metric table) so a separate profiling comment is not
- * required: failed scenarios inline, passed scenarios in a collapsed section.
+ * Failed scenarios with a prior app-profiling baseline are enriched inline
+ * (short summary + collapsed metric table) so a separate profiling comment
+ * is not required.
  *
  * Usage:
  *   node generate-performance-pr-comment.mjs [summary_file] [output_file]
@@ -30,9 +30,6 @@ import {
   findMatchingArtifact,
   findBaselineScenario,
   buildEmbeddedProfilingSection,
-  buildRegressionSummary,
-  getMetricRows,
-  hasUsableProfilingSummary,
   BASELINE_WORKFLOW,
   COMMENT_MARKER as APP_PROFILING_MARKER,
 } from './diff-app-profiling.mjs';
@@ -40,8 +37,6 @@ import {
 const SUMMARY_FILE = process.argv[2] || 'aggregated-reports/summary.json';
 const OUTPUT_FILE = process.argv[3] || 'performance-pr-comment.md';
 const DEFAULT_BASELINE_BRANCH = 'main';
-/** GitHub rejects issue comments over 65536 characters. */
-const MAX_COMMENT_LENGTH = 60000;
 
 async function main() {
   if (!fs.existsSync(SUMMARY_FILE)) {
@@ -73,7 +68,6 @@ async function main() {
     summary.metadata?.workflowRun ?? process.env.GITHUB_RUN_ID ?? '';
   const repo = process.env.GITHUB_REPOSITORY ?? '';
 
-  const profilingStats = summary.profilingStats ?? null;
   const failedStats = summary.failedTestsStats ?? {};
   const uniqueFailedTests = failedStats.uniqueFailedTests ?? 0;
   const failedByTeam = failedStats.failedTestsByTeam ?? {};
@@ -179,7 +173,6 @@ async function main() {
               : '—';
 
           return {
-            key: `${platform}|${deviceKey}|${test.testName}`,
             passed: !failed,
             status: failed ? '❌ Failed' : '✅ Passed',
             testName: test.testName,
@@ -202,118 +195,70 @@ async function main() {
     );
   }
 
-  /**
-   * Every scenario of the run, keyed the same way as the failed-test rows and
-   * the passed-test rows so profiling blocks can be looked up while rendering.
-   */
-  function getScenariosToEnrich() {
-    const scenarios = new Map();
-
-    const add = ({ platform, device, testName }) => {
-      const key = `${platform}|${getDeviceKey(device)}|${testName}`;
-      if (!scenarios.has(key)) {
-        scenarios.set(key, {
-          key,
-          platform,
-          testName,
-          device: parseDeviceKey(device),
-        });
-      }
-    };
-
-    for (const teamData of Object.values(failedByTeam)) {
-      for (const test of teamData.tests ?? []) {
-        add(test);
-      }
-    }
-
-    for (const [platform, devices] of Object.entries(performanceResults ?? {})) {
-      for (const [deviceKey, tests] of Object.entries(devices ?? {})) {
-        for (const test of tests ?? []) {
-          add({ platform, device: deviceKey, testName: test.testName });
-        }
-      }
-    }
-
-    return [...scenarios.values()];
-  }
-
   const skipEnrichment =
     process.env.SKIP_APP_PROFILING_ENRICHMENT === 'true' || !repo || !runId;
 
   const profilingByKey = new Map();
-  if (!skipEnrichment) {
+  if (!skipEnrichment && uniqueFailedTests > 0) {
     const workRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), 'perf-pr-profiling-'),
     );
     const currentArtifacts = findProfilingArtifacts(reportsDir);
 
     console.log(
-      `🔬 Enriching scenarios with app profiling vs \`${DEFAULT_BASELINE_BRANCH}\`...`,
+      `🔬 Enriching failed scenarios with app profiling vs \`${DEFAULT_BASELINE_BRANCH}\`...`,
     );
 
-    for (const scenario of getScenariosToEnrich()) {
-      const { key, testName, device } = scenario;
+    for (const teamData of Object.values(failedByTeam)) {
+      for (const test of teamData.tests ?? []) {
+        const device = parseDeviceKey(test.device);
+        const key = `${test.platform}|${getDeviceKey(test.device)}|${test.testName}`;
 
-      let currentArtifact = findMatchingArtifact(currentArtifacts, {
-        testName,
-        device,
-      })?.data;
+        let currentArtifact = findMatchingArtifact(currentArtifacts, {
+          testName: test.testName,
+          device,
+        })?.data;
 
-      if (!currentArtifact && !device.name) {
-        currentArtifact = currentArtifacts.find(
-          ({ data }) => data.testName === testName,
-        )?.data;
-      }
+        if (!currentArtifact && !device.name) {
+          currentArtifact = currentArtifacts.find(
+            ({ data }) => data.testName === test.testName,
+          )?.data;
+        }
 
-      if (!hasUsableProfilingSummary(currentArtifact)) {
-        console.warn(
-          `⏭️  No usable profiling for "${testName}" — omitting profiling block`,
-        );
-        continue;
-      }
-
-      try {
-        const baseline = findBaselineScenario({
-          repo,
-          workflow: BASELINE_WORKFLOW,
-          baselineBranch: DEFAULT_BASELINE_BRANCH,
-          currentRunId: runId,
-          testName,
-          device: currentArtifact?.device ?? device,
-          workRoot,
-        });
-
-        const section = buildEmbeddedProfilingSection({
-          currentRunId: runId,
-          currentArtifact,
-          baseline,
-          repo,
-          baselineBranch: DEFAULT_BASELINE_BRANCH,
-          includeRawJson: false,
-        });
-
-        if (section) {
-          const rows = getMetricRows(
-            baseline.artifact.profilingSummary,
-            currentArtifact.profilingSummary,
-          );
-          profilingByKey.set(key, {
-            section,
-            summary: buildRegressionSummary(rows),
-            hasRegression: rows.some((row) => row.warn),
+        try {
+          const baseline = findBaselineScenario({
+            repo,
+            workflow: BASELINE_WORKFLOW,
+            baselineBranch: DEFAULT_BASELINE_BRANCH,
+            currentRunId: runId,
+            testName: test.testName,
+            device: currentArtifact?.device ?? device,
+            workRoot,
           });
-        } else {
+
+          const section = buildEmbeddedProfilingSection({
+            currentRunId: runId,
+            currentArtifact,
+            baseline,
+            repo,
+            baselineBranch: DEFAULT_BASELINE_BRANCH,
+            includeRawJson: false,
+          });
+
+          if (section) {
+            profilingByKey.set(key, section);
+          } else {
+            console.warn(
+              `⏭️  No comparable baseline for "${test.testName}" — omitting profiling block`,
+            );
+          }
+        } catch (error) {
           console.warn(
-            `⏭️  No comparable baseline for "${testName}" — omitting profiling block`,
+            `⚠️  Could not enrich "${test.testName}": ${
+              error instanceof Error ? error.message : String(error)
+            }`,
           );
         }
-      } catch (error) {
-        console.warn(
-          `⚠️  Could not enrich "${testName}": ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
       }
     }
   }
@@ -395,7 +340,7 @@ async function main() {
           ? `[📹 Watch](${t.recordingLink})`
           : '—';
         const key = `${t.platform}|${getDeviceKey(t.device)}|${t.testName}`;
-        const profiling = profilingByKey.get(key);
+        const profilingSection = profilingByKey.get(key);
 
         md += `#### ${escapeMarkdownTable(t.testName)}\n\n`;
         md += `| Platform | Device | Reason | Recording |\n`;
@@ -404,8 +349,8 @@ async function main() {
           device,
         )} | ${escapeMarkdownTable(reason)} | ${recording} |\n\n`;
 
-        if (profiling) {
-          md += `${profiling.section}\n`;
+        if (profilingSection) {
+          md += `${profilingSection}\n`;
         }
       }
     }
@@ -429,76 +374,6 @@ async function main() {
     }
 
     md += `\n</details>\n\n`;
-  }
-
-  // App profiling for the passed scenarios, which have no inline block above.
-  // Only regressions get the full metric table, to keep the comment well under
-  // GitHub's 65k character limit as the number of scenarios grows.
-  const passedWithProfiling = passedTestRuns
-    .map((test) => ({ test, profiling: profilingByKey.get(test.key) }))
-    .filter(({ profiling }) => profiling);
-
-  if (profilingStats || passedWithProfiling.length > 0) {
-    md += `<details>\n<summary>🔬 App profiling vs \`main\`${
-      passedWithProfiling.length > 0
-        ? ` (${passedWithProfiling.length} passed scenario${
-            passedWithProfiling.length !== 1 ? 's' : ''
-          })`
-        : ''
-    }</summary>\n\n`;
-
-    if (profilingStats) {
-      md += `**Coverage:** ${
-        profilingStats.testsWithProfiling ?? 0
-      }/${totalTests} scenarios (${profilingStats.profilingCoverage ?? '—'})`;
-      md += ` · **Avg CPU:** ${profilingStats.avgCpuUsage ?? '—'}`;
-      md += ` · **Avg memory:** ${profilingStats.avgMemoryUsage ?? '—'}`;
-      md += ` · **Issues:** ${profilingStats.totalPerformanceIssues ?? 0} (${
-        profilingStats.totalCriticalIssues ?? 0
-      } critical)\n\n`;
-    }
-
-    if (passedWithProfiling.length > 0) {
-      md += `| Test | Platform | Device | Profiling vs \`main\` |\n`;
-      md += `|------|----------|--------|---------------------|\n`;
-
-      for (const { test, profiling } of passedWithProfiling) {
-        md += `| ${escapeMarkdownTable(test.testName)} | ${
-          test.platform
-        } | ${escapeMarkdownTable(test.device)} | ${escapeMarkdownTable(
-          profiling.summary,
-        )} |\n`;
-      }
-
-      md += '\n';
-
-      let omittedTables = 0;
-
-      for (const { test, profiling } of passedWithProfiling) {
-        if (!profiling.hasRegression) {
-          continue;
-        }
-
-        let block = `#### ${escapeMarkdownTable(test.testName)}\n\n`;
-        block += `${test.platform} · ${escapeMarkdownTable(test.device)}\n\n`;
-        block += `${profiling.section}\n`;
-
-        if (md.length + block.length > MAX_COMMENT_LENGTH) {
-          omittedTables += 1;
-          continue;
-        }
-
-        md += block;
-      }
-
-      if (omittedTables > 0) {
-        md += `> ℹ️ Metric tables for ${omittedTables} more scenario${
-          omittedTables !== 1 ? 's' : ''
-        } were omitted to stay within GitHub's comment size limit — full data is in the \`aggregated-reports\` artifact.\n\n`;
-      }
-    }
-
-    md += `</details>\n\n`;
   }
 
   // Footer

--- a/tests/scripts/generate-performance-pr-comment.test.mjs
+++ b/tests/scripts/generate-performance-pr-comment.test.mjs
@@ -110,16 +110,6 @@ function generateComment({ summary = SUMMARY, performanceResults } = {}) {
   return fs.readFileSync(outputFile, 'utf8');
 }
 
-test('reports app profiling coverage for the whole run', () => {
-  const md = generateComment({ performanceResults: PERFORMANCE_RESULTS });
-
-  assert.match(md, /🔬 App profiling vs `main`/);
-  assert.match(md, /\*\*Coverage:\*\* 2\/2 scenarios \(100\.0%\)/);
-  assert.match(md, /\*\*Avg CPU:\*\* 10\.80%/);
-  assert.match(md, /\*\*Avg memory:\*\* 698\.10 MB/);
-  assert.match(md, /\*\*Issues:\*\* 4 \(1 critical\)/);
-});
-
 test('warns in the header and lists failed scenarios', () => {
   const md = generateComment({ performanceResults: PERFORMANCE_RESULTS });
 
@@ -136,19 +126,37 @@ test('lists passed scenarios with their duration', () => {
   assert.match(md, /\| Asset View \| Android \|.*\| 2\.50s \|/);
 });
 
-test('omits per-scenario profiling blocks without a baseline', () => {
+test('omits profiling blocks without a baseline', () => {
   const md = generateComment({ performanceResults: PERFORMANCE_RESULTS });
 
   assert.doesNotMatch(md, /App profiling check/);
   assert.doesNotMatch(md, /Full metric table/);
 });
 
-test('omits the profiling section when the run has no profiling stats', () => {
+test('keeps profiling out of the passed scenarios section', () => {
   const md = generateComment({
-    summary: { ...SUMMARY, profilingStats: undefined },
-    performanceResults: PERFORMANCE_RESULTS,
+    summary: {
+      ...SUMMARY,
+      failedTestsStats: { uniqueFailedTests: 0, failedTestsByTeam: {} },
+    },
+    performanceResults: {
+      Android: {
+        'Google Pixel 8 Pro+14.0': [
+          {
+            testName: 'Asset View',
+            sessionId: 'session-passed',
+            totalTime: 2.5,
+            device: { name: 'Google Pixel 8 Pro', osVersion: '14.0' },
+            team: { teamId: '@assets-dev-team' },
+            qualityGates: { passed: true, hasThresholds: true },
+          },
+        ],
+      },
+    },
   });
 
+  assert.match(md, /## ⚡ Performance Test Results/);
+  assert.match(md, /✅ Passed Tests \(1\)/);
   assert.doesNotMatch(md, /App profiling/);
 });
 

--- a/tests/scripts/generate-performance-pr-comment.test.mjs
+++ b/tests/scripts/generate-performance-pr-comment.test.mjs
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'generate-performance-pr-comment.mjs',
+);
+
+const SUMMARY = {
+  totalTests: 2,
+  uniqueTests: 2,
+  branch: 'feature-branch',
+  commit: 'abcdef1234567890',
+  buildType: 'E2E',
+  platformDevices: { Android: ['Google Pixel 8 Pro+14.0'] },
+  profilingStats: {
+    testsWithProfiling: 2,
+    profilingCoverage: '100.0%',
+    avgCpuUsage: '10.80%',
+    avgMemoryUsage: '698.10 MB',
+    totalPerformanceIssues: 4,
+    totalCriticalIssues: 1,
+  },
+  failedTestsStats: {
+    uniqueFailedTests: 1,
+    failedTestsByTeam: {
+      '@performance-team': {
+        team: { teamId: '@performance-team' },
+        tests: [
+          {
+            testName: 'Cold Start Login',
+            platform: 'Android',
+            device: 'Google Pixel 8 Pro+14.0',
+            failureReason: 'quality_gates_exceeded',
+            sessionId: 'session-failed',
+          },
+        ],
+      },
+    },
+  },
+};
+
+const PERFORMANCE_RESULTS = {
+  Android: {
+    'Google Pixel 8 Pro+14.0': [
+      {
+        testName: 'Cold Start Login',
+        sessionId: 'session-failed',
+        totalTime: 4.2,
+        device: { name: 'Google Pixel 8 Pro', osVersion: '14.0' },
+        team: { teamId: '@performance-team' },
+        qualityGates: { passed: false, hasThresholds: true },
+      },
+      {
+        testName: 'Asset View',
+        sessionId: 'session-passed',
+        totalTime: 2.5,
+        device: { name: 'Google Pixel 8 Pro', osVersion: '14.0' },
+        team: { teamId: '@assets-dev-team' },
+        qualityGates: { passed: true, hasThresholds: true },
+      },
+    ],
+  },
+};
+
+/**
+ * Run the generator against a temporary aggregated-reports directory and
+ * return the comment markdown it produced.
+ */
+function generateComment({ summary = SUMMARY, performanceResults } = {}) {
+  const workRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'perf-pr-comment-'));
+  const reportsDir = path.join(workRoot, 'aggregated-reports');
+  fs.mkdirSync(reportsDir);
+
+  if (summary) {
+    fs.writeFileSync(
+      path.join(reportsDir, 'summary.json'),
+      JSON.stringify(summary),
+    );
+  }
+
+  if (performanceResults) {
+    fs.writeFileSync(
+      path.join(reportsDir, 'performance-results.json'),
+      JSON.stringify(performanceResults),
+    );
+  }
+
+  const outputFile = path.join(workRoot, 'comment.md');
+  const result = spawnSync(
+    process.execPath,
+    [SCRIPT, path.join(reportsDir, 'summary.json'), outputFile],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        SKIP_APP_PROFILING_ENRICHMENT: 'true',
+        GITHUB_REPOSITORY: 'MetaMask/metamask-mobile',
+        GITHUB_RUN_ID: '123',
+      },
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  return fs.readFileSync(outputFile, 'utf8');
+}
+
+test('reports app profiling coverage for the whole run', () => {
+  const md = generateComment({ performanceResults: PERFORMANCE_RESULTS });
+
+  assert.match(md, /🔬 App profiling vs `main`/);
+  assert.match(md, /\*\*Coverage:\*\* 2\/2 scenarios \(100\.0%\)/);
+  assert.match(md, /\*\*Avg CPU:\*\* 10\.80%/);
+  assert.match(md, /\*\*Avg memory:\*\* 698\.10 MB/);
+  assert.match(md, /\*\*Issues:\*\* 4 \(1 critical\)/);
+});
+
+test('warns in the header and lists failed scenarios', () => {
+  const md = generateComment({ performanceResults: PERFORMANCE_RESULTS });
+
+  assert.match(md, /## ⚠️ Performance Test Results/);
+  assert.match(md, /### ❌ Failed Tests \(1\)/);
+  assert.match(md, /#### Cold Start Login/);
+  assert.match(md, /Quality gates exceeded/);
+});
+
+test('lists passed scenarios with their duration', () => {
+  const md = generateComment({ performanceResults: PERFORMANCE_RESULTS });
+
+  assert.match(md, /✅ Passed Tests \(1\)/);
+  assert.match(md, /\| Asset View \| Android \|.*\| 2\.50s \|/);
+});
+
+test('omits per-scenario profiling blocks without a baseline', () => {
+  const md = generateComment({ performanceResults: PERFORMANCE_RESULTS });
+
+  assert.doesNotMatch(md, /App profiling check/);
+  assert.doesNotMatch(md, /Full metric table/);
+});
+
+test('omits the profiling section when the run has no profiling stats', () => {
+  const md = generateComment({
+    summary: { ...SUMMARY, profilingStats: undefined },
+    performanceResults: PERFORMANCE_RESULTS,
+  });
+
+  assert.doesNotMatch(md, /App profiling/);
+});
+
+test('writes a placeholder when the summary file is missing', () => {
+  const md = generateComment({ summary: null });
+
+  assert.match(md, /Performance test results are not available for this run/);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

App profiling stopped appearing under failed scenarios in the **Performance Test Results** PR comment. The baseline lookup in `tests/scripts/diff-app-profiling.mjs` runs `gh run list --workflow run-performance-e2e.yml --branch main`, but since the performance workflow refactor ([#34163](https://github.com/MetaMask/metamask-mobile/pull/34163)) `run-performance-e2e.yml` is `workflow_call` only. Reusable workflow invocations are jobs of the caller run, so they never appear in that listing: the only candidates left were pre-refactor runs from 2026-08-04, all but two of them failed, and the last surviving `aggregated-reports` artifact expired on 2026-09-03. Every failed scenario resolved to "no comparable baseline" and its profiling block was dropped without any visible error.

The scheduled `main` runs that do carry fresh profiling artifacts (23 of 23 scenarios with data) live under `run-performance-e2e-manual.yml`, where nothing was looking.

Changes:

- `BASELINE_WORKFLOW` now points at `run-performance-e2e-manual.yml`, and is shared by the PR comment generator and the `@metamaskbot app-profiling-check` path.
- The candidate run list is fetched once per process instead of once per scenario.
- The comment section itself is unchanged from [#33902](https://github.com/MetaMask/metamask-mobile/pull/33902): profiling is embedded under failed scenarios only, and green runs post no profiling at all.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: [#33902](https://github.com/MetaMask/metamask-mobile/pull/33902) (inline app profiling on failed scenarios), [#34163](https://github.com/MetaMask/metamask-mobile/pull/34163) (performance workflow refactor that broke baseline discovery)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: App profiling baselines in the performance PR comment

  Scenario: failed scenarios get their profiling block back
    Given the aggregated-reports of a performance run with failed scenarios
    When the performance PR comment is generated
    Then baselines are resolved from run-performance-e2e-manual.yml runs on main
    And each failed scenario with a baseline shows its inline App profiling check

  Scenario: green runs stay compact
    Given a performance run with zero failed scenarios
    When the performance PR comment is generated
    Then no baseline lookup happens and no profiling is posted

  Scenario: no baseline available
    Given a failed scenario that never ran with profiling on main
    When the performance PR comment is generated
    Then that scenario has no profiling block
```

Verified against real data, using the `aggregated-reports` of scheduled main run `33721692898` as the current run:

```bash
gh run download 33721692898 -n aggregated-reports -D /tmp/bl
GH_TOKEN=$(gh auth token) GITHUB_REPOSITORY=MetaMask/metamask-mobile GITHUB_RUN_ID=33721692898 \
  node tests/scripts/generate-performance-pr-comment.mjs /tmp/bl/summary.json /tmp/comment.md
```

Baselines resolved to run `33698202260`, the previous scheduled main run, for 22 of the 23 scenarios; the 23rd is a scenario that is also red on `main`, so it used the documented "scenario also failing" baseline. On `main` today the same command resolves no baseline for any scenario. Re-running after the scoping revert produces exactly 6 profiling blocks for the run's 6 failed scenarios and nothing for the 17 passed ones.

Automated tests:

```bash
yarn jest tests/performance/app-profiling-baseline-workflow.test.ts
node --test tests/scripts/diff-app-profiling.test.mjs tests/scripts/generate-performance-pr-comment.test.mjs
```

`tests/performance/app-profiling-baseline-workflow.test.ts` is the regression guard: it fails if `BASELINE_WORKFLOW` ever points at a workflow without its own `schedule` / `workflow_dispatch` triggers, which is exactly the condition that broke this.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — CI comment generation and Node scripts only, no app UI. Evidence is the generated markdown below.

### **Before**

On `main`, failed scenarios show the row but no profiling block:

```markdown
### ❌ Failed Tests (2)

#### Measure Warm Start: Login To Wallet Screen

| Platform | Device | Reason | Recording |
|----------|--------|--------|-----------|
| Android | Google Pixel 8 Pro (v14.0) | no_performance_metrics | [📹 Watch](…) |
```

### **After**

```markdown
### ❌ Failed Tests (2)

> 🔬 App profiling vs `main` is included under each failed scenario that has a prior baseline.

#### Measure Warm Start: Login To Wallet Screen

| Platform | Device | Reason | Recording |
|----------|--------|--------|-----------|
| Android | Google Pixel 8 Pro (v14.0) | no_performance_metrics | [📹 Watch](…) |

🔬 **App profiling check** · Current [run 33721692898](…) · Baseline (last green on `main`) [run 33698202260](…) @ `d25dfd2`

**Summary:** ⚠️ **2** metrics over +10%: CPU max (+4.32 (+20.1%)), Memory max (+139.67 (+18.8%))

<details>
<summary>Full metric table (+10% variance rules)</summary>

| Metric | Baseline | Current | Δ |
|--------|----------|---------|---|
| CPU max | 21.46% | **25.78%** | +4.32 (**+20.1%**) ⚠️ |
| Memory max | 744.77 MB | **884.44 MB** | +139.67 (**+18.8%**) ⚠️ |

</details>
```

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A for this PR: CI comment generation and Node scripts only, no app or runtime change.
- [x] I've tested with a power user scenario
  - N/A for this PR: CI comment generation and Node scripts only, no app or runtime change.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A for this PR: CI comment generation and Node scripts only, no app or runtime change.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-793c063c-52b0-4c47-bc28-72a433e04bd3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-793c063c-52b0-4c47-bc28-72a433e04bd3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

