### PR TITLE
fix: skip profile metrics when basic functionality is off

### DIFF
--- a/app/core/Engine/controllers/profile-metrics-controller-init.test.ts
+++ b/app/core/Engine/controllers/profile-metrics-controller-init.test.ts
@@ -15,10 +15,12 @@ function getInitRequestMock({
   analyticsId,
   analyticsEnabled,
   pna25Acknowledged,
+  basicFunctionalityEnabled,
 }: {
   analyticsId: string;
   analyticsEnabled: boolean;
   pna25Acknowledged: boolean;
+  basicFunctionalityEnabled: boolean;
 }): jest.Mocked<
   MessengerClientInitRequest<
     ProfileMetricsControllerMessenger,
@@ -32,6 +34,9 @@ function getInitRequestMock({
   const mockGetState = jest.fn().mockReturnValue({
     legalNotices: {
       isPna25Acknowledged: pna25Acknowledged,
+    },
+    settings: {
+      basicFunctionalityEnabled,
     },
   });
 
@@ -60,30 +65,46 @@ describe.each([
     analyticsId: 'dd6395a5-7a84-47b8-8bc3-713170c2f3e8',
     analyticsEnabled: true,
     pna25Acknowledged: true,
+    basicFunctionalityEnabled: true,
   },
   {
     analyticsId: '898cbad5-7a5e-4ea1-8ca0-822bb4804665',
     analyticsEnabled: false,
     pna25Acknowledged: false,
+    basicFunctionalityEnabled: true,
   },
   {
     analyticsId: '9c9fe89c-76c3-4ad6-89f8-b76061159458',
     analyticsEnabled: false,
     pna25Acknowledged: false,
+    basicFunctionalityEnabled: false,
   },
   {
     analyticsId: '5aed4107-f430-4bb0-84c9-1e7031599cc2',
     analyticsEnabled: true,
     pna25Acknowledged: false,
+    basicFunctionalityEnabled: true,
   },
   {
     analyticsId: '3f4e2d2a-1c4e-4f5e-9f3a-2b6d8c9e7f10',
     analyticsEnabled: true,
     pna25Acknowledged: false,
+    basicFunctionalityEnabled: false,
+  },
+  {
+    analyticsId: '4a5f3e2d-1c4e-4f5e-9f3a-2b6d8c9e7f11',
+    analyticsEnabled: true,
+    pna25Acknowledged: true,
+    basicFunctionalityEnabled: false,
   },
 ])(
   'profileMetricsControllerInit',
-  ({ analyticsId, analyticsEnabled, pna25Acknowledged }) => {
+  ({
+    analyticsId,
+    analyticsEnabled,
+    pna25Acknowledged,
+    basicFunctionalityEnabled,
+  }) => {
     beforeEach(() => {
       jest.clearAllMocks();
     });
@@ -95,6 +116,7 @@ describe.each([
             analyticsId,
             analyticsEnabled,
             pna25Acknowledged,
+            basicFunctionalityEnabled,
           }),
         );
 
@@ -107,6 +129,7 @@ describe.each([
             analyticsId,
             analyticsEnabled,
             pna25Acknowledged,
+            basicFunctionalityEnabled,
           }),
         );
 
@@ -120,7 +143,7 @@ describe.each([
           initialDelayDuration: 60_000,
         });
         expect(controllerMock.mock.calls[0][0].assertUserOptedIn()).toBe(
-          analyticsEnabled && pna25Acknowledged,
+          analyticsEnabled && pna25Acknowledged && basicFunctionalityEnabled,
         );
         expect(controllerMock.mock.calls[0][0].getMetaMetricsId()).toBe(
           analyticsId,

--- a/app/core/Engine/controllers/profile-metrics-controller-init.ts
+++ b/app/core/Engine/controllers/profile-metrics-controller-init.ts
@@ -3,6 +3,7 @@ import {
   ProfileMetricsControllerMessenger,
 } from '@metamask/profile-metrics-controller';
 import { analyticsControllerSelectors } from '@metamask/analytics-controller';
+import { selectBasicFunctionalityEnabled } from '../../../selectors/settings';
 import { MessengerClientInitFunction } from '../types';
 import { ProfileMetricsControllerInitMessenger } from '../messengers/profile-metrics-controller-messenger';
 
@@ -29,10 +30,13 @@ export const profileMetricsControllerInit: MessengerClientInitFunction<
 }) => {
   const assertUserOptedIn = () => {
     const analyticsState = initMessenger.call('AnalyticsController:getState');
+    const state = getState();
     const isEnabled =
       analyticsControllerSelectors.selectEnabled(analyticsState);
     return (
-      isEnabled === true && getState().legalNotices.isPna25Acknowledged === true
+      isEnabled === true &&
+      state.legalNotices.isPna25Acknowledged === true &&
+      selectBasicFunctionalityEnabled(state) === true
     );
   };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-2210

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

1. Disable basic functionality during onboarding (or after)
2. Verify that profile metrics does not submit data after onboarding (or after adding an account / SRP)

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow privacy/consent gating change with unit test coverage; no auth or data-path refactors.
> 
> **Overview**
> Profile metrics now treats **basic functionality** as a third requirement for opt-in, alongside analytics enabled and PNA 2.5 acknowledgment.
> 
> `assertUserOptedIn` in `profile-metrics-controller-init.ts` reads app state via `selectBasicFunctionalityEnabled` and only returns true when all three flags are on, so the controller should not submit profile metrics when users have disabled basic functionality.
> 
> Init tests were extended with `settings.basicFunctionalityEnabled` in the mock state, extra matrix cases where analytics and PNA are satisfied but basic functionality is off, and updated expectations for `assertUserOptedIn()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bdc1206420a590604af7d7c40b630d42e2c7971. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->