### PR TITLE
fix(perps): fill Pro order book taps at displayed price precision

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
@@ -1320,6 +1320,30 @@ describe('PerpsProMarketView', () => {
     expect(mockCommitLimitPrice).toHaveBeenCalledWith('0.0682');
   });
 
+  it('keeps a decimal the BTC ladder never displayed out of the limit price', () => {
+    // Hyperliquid returns BTC levels as "64120.0", and BTC's market price shows
+    // no decimal at all, so the filled limit price must not carry one either —
+    // including while the asset precision is still unknown.
+    mockSzDecimals = undefined;
+    mockUsePerpsLiveOrderBook.mockImplementation(() => ({
+      orderBook: { ...buildLiveBook('64120.0'), midPrice: '64125.0' },
+      isLoading: false,
+      error: null,
+      connectionStatus: 'connected',
+      reconnect: jest.fn(),
+    }));
+
+    const { getByTestId } = renderView();
+
+    fireEvent.press(
+      getByTestId(
+        `${PerpsProMarketViewSelectorsIDs.ORDER_BOOK_PANEL}-bid-row-0`,
+      ),
+    );
+
+    expect(mockCommitLimitPrice).toHaveBeenCalledWith('64120');
+  });
+
   describe('Recently viewed tracking', () => {
     it('records the market view when the screen is focused', () => {
       renderView();

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.test.tsx
@@ -435,6 +435,41 @@ describe('PerpsProOrderBookPanel', () => {
     expect(playSelection).toHaveBeenCalledTimes(2);
   });
 
+  it('reports the price the tapped row displays, not the venue level behind it', () => {
+    // Hyperliquid returns BTC levels as "64120.0". The ladder renders them
+    // without that decimal — and so does the market price — so tapping
+    // "$64,120" must not fill a price the user never saw.
+    const trailingDecimalBook: OrderBookData = {
+      ...mockOrderBook,
+      bids: [{ ...mockOrderBook.bids[0], price: '64120.0' }],
+      asks: [{ ...mockOrderBook.asks[0], price: '64130.0' }],
+      midPrice: '64125.0',
+    };
+    mockUsePerpsLiveOrderBook.mockImplementation(() => ({
+      orderBook: trailingDecimalBook,
+      isLoading: false,
+      error: null,
+      connectionStatus: 'connected',
+      reconnect: mockReconnect,
+    }));
+    const onSelectPrice = jest.fn();
+    const { getByTestId } = renderWithProvider(
+      <PerpsProOrderBookPanel
+        symbol="BTC"
+        marketPrice={64125}
+        szDecimals={5}
+        onSelectPrice={onSelectPrice}
+      />,
+      { state: { engine: { backgroundState } } },
+    );
+
+    fireEvent.press(getByTestId(`${testID}-bid-row-0`));
+    expect(onSelectPrice).toHaveBeenCalledWith('64120');
+
+    fireEvent.press(getByTestId(`${testID}-ask-row-0`));
+    expect(onSelectPrice).toHaveBeenLastCalledWith('64130');
+  });
+
   it('renders static, non-interactive rows when onSelectPrice is omitted', () => {
     const { getByTestId } = renderWithProvider(
       <PerpsProOrderBookPanel symbol="BTC" marketPrice={50000} />,

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
@@ -61,6 +61,7 @@ import {
   getDepthRatio,
   getDepthWidth,
   getOrderBookPriceFormat,
+  getOrderBookPriceValue,
   groupOrderBook,
   FAST_ORDER_BOOK_LEVELS,
   ORDER_BOOK_AGGREGATED_LEVELS,
@@ -454,18 +455,6 @@ const PerpsProOrderBookPanel = ({
     setIsConfigOpen(true);
   }, [playSelection]);
 
-  const handleSelectPrice = useCallback(
-    (price: string) => {
-      if (!onSelectPrice) {
-        return;
-      }
-      playSelection().catch(() => undefined);
-      onSelectPrice(price);
-    },
-    [onSelectPrice, playSelection],
-  );
-  const rowSelectPrice = onSelectPrice ? handleSelectPrice : undefined;
-
   const { savedGrouping, saveGrouping } = usePerpsOrderBookGrouping(symbol);
   const { orderBookPosition, setOrderBookPosition } =
     usePerpsProOrderBookPosition();
@@ -563,6 +552,22 @@ const PerpsProOrderBookPanel = ({
     () => getOrderBookPriceFormat(currentGrouping, midPriceValue, szDecimals),
     [currentGrouping, midPriceValue, szDecimals],
   );
+
+  const handleSelectPrice = useCallback(
+    (price: string) => {
+      if (!onSelectPrice) {
+        return;
+      }
+      playSelection().catch(() => undefined);
+      // Fill the price the tapped row displayed rather than the venue's raw
+      // level: the ladder renders every price at `priceFormat`'s precision, so
+      // a level with more decimals than that would fill a decimal the market
+      // price never shows.
+      onSelectPrice(getOrderBookPriceValue(price, priceFormat));
+    },
+    [onSelectPrice, playSelection, priceFormat],
+  );
+  const rowSelectPrice = onSelectPrice ? handleSelectPrice : undefined;
 
   // Server-aggregated book on its own dedicated socket (does not disturb raw).
   const {

--- a/app/components/UI/Perps/utils/orderBookGrouping.test.ts
+++ b/app/components/UI/Perps/utils/orderBookGrouping.test.ts
@@ -11,6 +11,7 @@ import {
   formatColumnValue,
   formatOrderBookPrice,
   getOrderBookPriceFormat,
+  getOrderBookPriceValue,
 } from './orderBookGrouping';
 import type { OrderBookLevel } from '../hooks/stream/usePerpsLiveOrderBook';
 import type { OrderBookData } from '@metamask/perps-controller';
@@ -641,6 +642,58 @@ describe('orderBookGrouping', () => {
           decimals: 2,
         }),
       ).toBe('—');
+    });
+  });
+
+  describe('getOrderBookPriceValue', () => {
+    it('drops a decimal the BTC ladder never displayed', () => {
+      // "$64,123" is what the row reads, so tapping it must not fill 64123.4.
+      const format = getOrderBookPriceFormat(1, 64123, 5);
+
+      expect(formatOrderBookPrice('64123.4', format)).toBe('$64,123');
+      expect(getOrderBookPriceValue('64123.4', format)).toBe('64123');
+    });
+
+    it('keeps the precision an ETH ladder does display', () => {
+      const format = getOrderBookPriceFormat(0.1, 3452, 4);
+
+      expect(getOrderBookPriceValue('3452.1', format)).toBe('3452.1');
+    });
+
+    it('resolves an abbreviated row to the price it stands for', () => {
+      const format = getOrderBookPriceFormat(10, 61470, 5);
+
+      expect(formatOrderBookPrice('61470', format)).toBe('$61.47K');
+      expect(getOrderBookPriceValue('61470', format)).toBe('61470');
+    });
+
+    it('keeps sub-cent prices in plain decimal notation', () => {
+      const format = getOrderBookPriceFormat(0.000001, 0.0021, 0);
+
+      expect(getOrderBookPriceValue('0.002100999', format)).toBe('0.002101');
+    });
+
+    it('leaves the venue price untouched when the format is unknown', () => {
+      expect(getOrderBookPriceValue('0.0682341', null)).toBe('0.0682341');
+    });
+
+    it('leaves the venue price untouched rather than rounding it away', () => {
+      // A stale mid can set a grouping magnitudes coarser than the ladder that
+      // arrives for the next asset; filling 0 would be worse than filling
+      // more precision than the row showed.
+      const format = getOrderBookPriceFormat(10, 90000, 5);
+
+      expect(getOrderBookPriceValue('0.0682341', format)).toBe('0.0682341');
+    });
+
+    it('leaves unparseable prices untouched', () => {
+      expect(
+        getOrderBookPriceValue('not-a-number', {
+          divisor: 1,
+          suffix: '',
+          decimals: 2,
+        }),
+      ).toBe('not-a-number');
     });
   });
 });

--- a/app/components/UI/Perps/utils/orderBookGrouping.ts
+++ b/app/components/UI/Perps/utils/orderBookGrouping.ts
@@ -2,6 +2,7 @@ import {
   type OrderBookData,
   type OrderBookLevel,
 } from '@metamask/perps-controller';
+import { BigNumber } from 'bignumber.js';
 import {
   type FiatRangeConfig,
   formatPerpsFiat,
@@ -478,6 +479,49 @@ export function formatOrderBookPrice(
     stripTrailingZeros: false,
   });
   return `${formatted}${format.suffix}`;
+}
+
+/**
+ * The numeric value a ladder row stands for, at the precision that row is
+ * rendered with.
+ *
+ * Tapping a row prefills the order form, and the price it fills has to be the
+ * one the user read. `formatOrderBookPrice` rounds every level to the shared
+ * format, so a level carrying more precision than the ladder shows — a BTC row
+ * displaying "$64,123" that sits on a raw `64123.4` — otherwise fills a decimal
+ * that neither the row nor the market price ever displayed.
+ *
+ * Rounding here only ever drops digits, so the result keeps no more decimals
+ * and no more significant figures than the venue's own price and stays on a
+ * valid tick. Abbreviated formats round the scaled mantissa, since that is the
+ * figure on screen ("$64.12K" means `64120`, not `64123.4`).
+ *
+ * @param price - Raw level price from the venue.
+ * @param format - The ladder's shared price format, or null when unknown.
+ * @returns The row's price as a plain decimal string.
+ */
+export function getOrderBookPriceValue(
+  price: string,
+  format: OrderBookPriceFormat | null,
+): string {
+  if (format === null) {
+    return price;
+  }
+
+  const value = new BigNumber(price);
+  if (!value.isFinite()) {
+    return price;
+  }
+
+  const rounded = value
+    .dividedBy(format.divisor)
+    .decimalPlaces(format.decimals, BigNumber.ROUND_HALF_UP)
+    .multipliedBy(format.divisor);
+
+  // A format coarser than the level itself rounds it away entirely (a stale mid
+  // sets the grouping while a fresh ladder arrives for a far cheaper asset).
+  // Committing that zero would be worse than committing extra precision.
+  return rounded.isGreaterThan(0) ? rounded.toFixed() : price;
 }
 
 /**


### PR DESCRIPTION
## **Description**

Tapping a row in the Perps **Pro** order book prefills the order form's price. On BTC that filled a price with a decimal the user never saw — the row (and the market quote above it) read `$64,123`, while the form received `64,123.4`.

**Why it happened**

The ladder renders every level through `formatOrderBookPrice`, which rounds to one shared precision derived from the active grouping step and capped at the asset's Hyperliquid precision (`6 - szDecimals`). For BTC that is **zero decimals**. The tap, however, handed the venue's raw level string straight to the order form:

```js
onPress={() => onSelectPrice(level.price)}
```

Hyperliquid's levels genuinely carry that decimal — verified against `api.hyperliquid.xyz/info`, BTC `l2Book` levels come back as `"77960.0"` at every `nSigFigs`, and `markPx` as `"77970.2"`, which `formatPerpsPrice` renders as `$77,970` (no decimal — hence "BTC has no decimal"). That raw string reaches the limit field verbatim whenever the asset's `szDecimals` has not resolved yet, because #35103 deliberately made the tap skip `canonicalizeOrderPrice` in that window: rounding with the fallback precision used to commit a limit of `0` on sub-dollar assets.

**The fix**

A new `getOrderBookPriceValue` in `app/components/UI/Perps/utils/orderBookGrouping.ts` resolves a level to the number its row actually stands for, and the panel's tap handler commits that instead of the raw level. Because the precision comes from the ladder's own format rather than from `szDecimals`, it holds whether or not market data has loaded, and abbreviated rows resolve to what they mean (`$64.12K` → `64120`, not `64123.4`).

Two properties keep it safe:

- **Rounding only ever drops digits**, so the filled price can never gain decimals or significant figures the venue would reject. This also fixes the reverse case, where a fine grouping on a sub-cent asset serves a 7-decimal level that Hyperliquid itself would not accept in an order.
- **If the format would round a level away entirely** (a stale mid setting the grouping while a ladder for a far cheaper asset arrives), the raw price passes through — so the `0` regression that #35103 fixed stays fixed, and its test passes unmodified.

`handleSelectPrice` moved below the `priceFormat` memo so it can read that format; it is the only reason for the diff's apparent reordering in `PerpsProOrderBookPanel.tsx`. The rounding runs in the tap handler rather than per row, so nothing was added to the ladder's per-tick render path.

**Verification**

- `yarn lint:tsc` — clean
- ESLint on all 5 changed files with `--max-warnings=0` — clean (no MMDS deprecation warnings)
- Prettier — clean
- `yarn messenger-action-types:check` — up to date
- Jest — 203 tests passing across the 3 affected suites plus `locales`; the full `PerpsProMarketView` folder (30 suites, 877 tests) is green

## **Changelog**

CHANGELOG entry: Fixed Perps Pro order-book taps filling a limit price with more decimals than the market price displays

## **Related issues**

Refs: N/A — reported internally ("when I tap on the BTC order book, the filled price shows as `$64,123.4` instead of `$64,123`")

## **Manual testing steps**

```gherkin
Feature: Order-book taps fill the price the row displays

  Scenario: user taps a BTC ladder row
    Given the user opens BTC in Perps Pro mode
    And the market price above the chart shows no decimals (e.g. "$77,970")
    And the order book ladder shows whole-dollar prices (e.g. "$77,960")

    When the user taps a bid or ask row
    Then the order type switches to Limit
    And the limit price field is filled with exactly the price the row displayed
    And it carries no decimal the row and market price did not show

  Scenario: user taps the book before market data has loaded
    Given the user opens a Perps Pro market and taps a ladder row immediately

    When the price is committed to the order form
    Then the limit price still matches the price the row displayed
    And it is not 0

  Scenario: user taps a sub-cent ladder row
    Given the user opens a market priced below $0.01 (e.g. kPEPE) in Perps Pro
    And the ladder renders each level at its full displayed precision

    When the user taps a bid or ask row
    Then the limit price matches the displayed level exactly
    And placing the order is accepted by the venue

  Scenario: user taps an abbreviated ladder row
    Given the user selects a coarse grouping so the ladder abbreviates prices (e.g. "$64.12K")

    When the user taps that row
    Then the limit price is filled with the price the abbreviation stands for (64120)

  Scenario: trigger order routing is unaffected
    Given the user has selected a stop-limit order type
    When the user taps an order-book row
    Then the limit price is filled and the order type stays stop-limit

    Given the user has selected a stop-market order type
    When the user taps an order-book row
    Then the trigger price is filled and the order type stays stop-market
```

## **Screenshots/Recordings**

N/A — the change is the value committed to the limit-price field rather than a visual state, and it is asserted end-to-end in `PerpsProMarketView.test.tsx` and `PerpsProOrderBookPanel.test.tsx`.

### **Before**

Tapping a BTC row reading `$64,120` filled the limit price with `64120.0` (against the previous code the new panel test fails with `Expected: "64120"` / `Received: "64120.0"`).

### **After**

The same tap fills `64120` — identical to the row and to the market price's precision.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

Considered and not applicable to instrumentation — the rounding runs once per tap in the existing handler, adding no rendering, data fetching, subscriptions or list work to the ladder's per-tick path.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to order-book tap handling and a new rounding helper; guards preserve prior behavior for unknown precision and sub-dollar assets.
> 
> **Overview**
> Fixes Perps Pro limit prefills when tapping the order book: the form no longer receives the venue’s raw level string (e.g. `64120.0`) when the ladder and market quote show whole dollars (`$64,120`).
> 
> Adds **`getOrderBookPriceValue`**, which rounds the tapped level to the same precision as the shared ladder format from **`getOrderBookPriceFormat`**, and wires it in **`PerpsProOrderBookPanel`**’s tap handler so **`onSelectPrice`** commits the displayed value. When format is unknown, rounding would zero out a cheap asset, or the price is unparseable, the raw venue string is left unchanged.
> 
> Unit and integration tests cover BTC trailing decimals (including before **`szDecimals`** loads), ETH/sub-cent/abbreviated rows, and the market view → **`commitLimitPrice`** path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c9de404bcccead9cb9b2c5277b70f009b2ad8dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->