### PR TITLE
chore: POC homepage test toast

### DIFF
--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -688,6 +688,20 @@ const Wallet = ({
     toastRef,
   ]);
 
+  // POC: temporary homepage toast to validate Toast component usage
+  useEffect(() => {
+    const toast = toastRef?.current;
+    toast?.showToast({
+      variant: ToastVariants.Plain,
+      labelOptions: [
+        {
+          label: 'this is a test',
+          isBold: false,
+        },
+      ],
+    });
+  }, [toastRef]);
+
   const isNotificationEnabled = useSelector(
     selectIsMetamaskNotificationsEnabled,
   );


### PR DESCRIPTION
## Summary
- Temporary POC: show a Toast on the Wallet homepage with text `this is a test`
- Uses existing `ToastContext` / `component-library` Toast (`ToastVariants.Plain`)

## Test plan
- [ ] Open the app and land on Wallet home
- [ ] Confirm toast appears with text "this is a test"
- [ ] Confirm toast dismisses on timeout / interaction as expected

**Note:** Throwaway POC — do not merge as-is.

Made with [Cursor](https://cursor.com)