### PR TITLE
feat: implement limit order confirmation bottom sheet

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.test.tsx
@@ -110,7 +110,13 @@ function buildActiveQuoteState(
 }
 
 function renderFooter(state: DeepPartial<RootState>) {
-  return renderWithProvider(<BridgeLimitOrderFooterView />, { state });
+  return renderWithProvider(
+    <BridgeLimitOrderFooterView
+      onCTAPress={jest.fn()}
+      ctaLabel="Create Order"
+    />,
+    { state },
+  );
 }
 
 describe('BridgeLimitOrderFooterView', () => {

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
 import renderWithProvider, {
   DeepPartial,
 } from '../../../../../../util/test/renderWithProvider';
 import { RequestStatus } from '@metamask/bridge-controller';
 import { Hex } from '@metamask/utils';
 import { mockUseBridgeQuoteData } from '../../../_mocks_/useBridgeQuoteData.mock';
-import { useBridgeQuoteData } from '../../../hooks/useBridgeQuoteData';
 import { mockQuoteWithMetadata } from '../../../_mocks_/bridgeQuoteWithMetadata';
 import { ethToken1Address } from '../../../_mocks_/initialState';
 import { createBridgeTestState, createMockToken } from '../../../testUtils';
@@ -17,34 +17,6 @@ const pricedDestToken = createMockToken({
   address: ethToken1Address,
   symbol: 'TOKEN1',
 });
-const unpricedDestToken = createMockToken({
-  address: '0x00000000000000000000000000000000000000ff',
-  symbol: 'MUSD',
-});
-
-const quoteWithPriceImpact = {
-  ...mockQuoteWithMetadata,
-  quote: {
-    ...mockQuoteWithMetadata.quote,
-    priceData: {
-      ...mockQuoteWithMetadata.quote.priceData,
-      priceImpact: { amount: '0.01' },
-    },
-  },
-};
-
-const quoteWithoutPriceImpact = {
-  ...mockQuoteWithMetadata,
-  quote: {
-    ...mockQuoteWithMetadata.quote,
-    priceData: undefined,
-  },
-};
-
-const mockQuoteDataWithPriceImpact = {
-  ...mockUseBridgeQuoteData,
-  activeQuote: quoteWithPriceImpact,
-};
 
 jest.mock(
   '../../../../../../multichain-accounts/controllers/account-tree-controller',
@@ -74,7 +46,7 @@ jest.mock('../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => {
 
 /**
  * Builds Redux state that satisfies BridgeLimitOrderFooterView render
- * conditions: active quote, valid source amount, and quotesLastFetched.
+ * conditions: a valid source amount and a quotesLastFetched timestamp.
  *
  * CV cannot cover these branches: Limit remounts on tab switch and resets
  * the token pair, which clears seeded BridgeController quotes before the
@@ -109,11 +81,15 @@ function buildActiveQuoteState(
   });
 }
 
-function renderFooter(state: DeepPartial<RootState>) {
+function renderFooter(
+  state: DeepPartial<RootState>,
+  props: { onCTAPress?: () => void; ctaDisabled?: boolean } = {},
+) {
   return renderWithProvider(
     <BridgeLimitOrderFooterView
-      onCTAPress={jest.fn()}
+      onCTAPress={props.onCTAPress ?? jest.fn()}
       ctaLabel="Create Order"
+      ctaDisabled={props.ctaDisabled}
     />,
     { state },
   );
@@ -122,37 +98,6 @@ function renderFooter(state: DeepPartial<RootState>) {
 describe('BridgeLimitOrderFooterView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest
-      .mocked(useBridgeQuoteData as unknown as jest.Mock)
-      .mockImplementation(() => mockQuoteDataWithPriceImpact);
-  });
-
-  it('renders nothing when loading without an active quote', () => {
-    jest
-      .mocked(useBridgeQuoteData as unknown as jest.Mock)
-      .mockImplementation(() => ({
-        ...mockUseBridgeQuoteData,
-        isLoading: true,
-        activeQuote: null,
-      }));
-
-    const { queryByTestId } = renderFooter(buildActiveQuoteState());
-
-    expect(queryByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON)).toBeNull();
-  });
-
-  it('renders nothing when there is no active quote', () => {
-    jest
-      .mocked(useBridgeQuoteData as unknown as jest.Mock)
-      .mockImplementation(() => ({
-        ...mockUseBridgeQuoteData,
-        isLoading: false,
-        activeQuote: null,
-      }));
-
-    const { queryByTestId } = renderFooter(buildActiveQuoteState());
-
-    expect(queryByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON)).toBeNull();
   });
 
   it('renders nothing when source amount is missing', () => {
@@ -175,7 +120,7 @@ describe('BridgeLimitOrderFooterView', () => {
     expect(queryByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON)).toBeNull();
   });
 
-  it('renders the confirm button when quote, amount, and last-fetched are set', () => {
+  it('renders an enabled confirm button when ctaDisabled is not set', () => {
     const { getByTestId } = renderFooter(buildActiveQuoteState());
 
     expect(
@@ -187,15 +132,10 @@ describe('BridgeLimitOrderFooterView', () => {
     ).toBeFalsy();
   });
 
-  it('disables the confirm button when the quote has no price data', () => {
-    jest
-      .mocked(useBridgeQuoteData as unknown as jest.Mock)
-      .mockImplementation(() => ({
-        ...mockQuoteDataWithPriceImpact,
-        activeQuote: quoteWithoutPriceImpact,
-      }));
-
-    const { getByTestId } = renderFooter(buildActiveQuoteState());
+  it('disables the confirm button when ctaDisabled is true', () => {
+    const { getByTestId } = renderFooter(buildActiveQuoteState(), {
+      ctaDisabled: true,
+    });
 
     expect(
       getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON).props
@@ -203,37 +143,14 @@ describe('BridgeLimitOrderFooterView', () => {
     ).toBe(true);
   });
 
-  it('disables the confirm button when a selected token has no fiat rate', () => {
-    const { getByTestId } = renderFooter(
-      buildActiveQuoteState({
-        bridgeReducerOverrides: { destToken: unpricedDestToken },
-      }),
-    );
+  it('calls onCTAPress when the confirm button is pressed', () => {
+    const onCTAPress = jest.fn();
 
-    expect(
-      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON).props
-        .accessibilityState?.disabled,
-    ).toBe(true);
-  });
+    const { getByTestId } = renderFooter(buildActiveQuoteState(), {
+      onCTAPress,
+    });
+    fireEvent.press(getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON));
 
-  it('keeps the confirm button enabled while the quote is for a previous token pair', () => {
-    jest
-      .mocked(useBridgeQuoteData as unknown as jest.Mock)
-      .mockImplementation(() => ({
-        ...mockQuoteDataWithPriceImpact,
-        isActiveQuoteForCurrentTokenPair: false,
-        activeQuote: quoteWithoutPriceImpact,
-      }));
-
-    const { getByTestId } = renderFooter(
-      buildActiveQuoteState({
-        bridgeReducerOverrides: { destToken: unpricedDestToken },
-      }),
-    );
-
-    expect(
-      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON).props
-        .accessibilityState?.disabled,
-    ).toBeFalsy();
+    expect(onCTAPress).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.tsx
@@ -16,22 +16,27 @@ import {
 import { SwapsLimitOrderConfirmButton } from '../../../components/SwapsLimitOrderConfirmButton/index.tsx';
 import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
 
-export const BridgeLimitOrderFooterView = () => {
+interface Props {
+  onCTAPress: () => void;
+  ctaDisabled?: boolean;
+  ctaLabel: string;
+}
+
+export const BridgeLimitOrderFooterView = ({
+  onCTAPress,
+  ctaLabel,
+  ctaDisabled,
+}: Props) => {
   const { bottom: bottomInset } = useSafeAreaInsets();
   const sourceAmount = useSelector(selectSourceAmount);
   const sourceToken = useSelector(selectSourceToken);
   const { activeQuote, isLoading, needsNewQuote } = useBridgeQuoteDataContext();
   const { quotesLastFetched } = useSelector(selectBridgeControllerState);
-  const isMissingPrice = useHasMissingQuoteAndAssetsPriceData();
 
   const isValidSourceAmount =
     sourceAmount !== undefined && sourceAmount !== '.' && sourceToken?.decimals;
 
-  if (isLoading && !activeQuote && !needsNewQuote) {
-    return null;
-  }
-
-  if (!activeQuote || !isValidSourceAmount || !quotesLastFetched) {
+  if (!isValidSourceAmount || !quotesLastFetched) {
     return null;
   }
 
@@ -47,10 +52,11 @@ export const BridgeLimitOrderFooterView = () => {
       style={{ paddingBottom: bottomInset }}
     >
       <SwapsLimitOrderConfirmButton
-        onPress={() => 'test'}
-        label="test"
+        onPress={onCTAPress}
+        label={ctaLabel}
         testID={BridgeViewSelectorsIDs.CONFIRM_BUTTON}
-        disabled={isMissingPrice}
+        disabled={ctaDisabled}
+        loading={ctaDisabled}
       />
     </Box>
   );

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.test.tsx
@@ -300,6 +300,7 @@ function buildPriceAdjustMock() {
     onAmountTypeTogglePress: undefined,
     onQuoteUnitPress: jest.fn(),
     quotedSymbol: 'USDC',
+    quotedToken: mockSourceToken,
     secondaryValue: undefined,
     value: '1',
   };

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
@@ -12,7 +12,10 @@ import {
   selectSourceToken,
   setSlippage,
 } from '../../../../../../core/redux/slices/bridge';
-import { BridgeQuoteDataProvider } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import {
+  BridgeQuoteDataProvider,
+  useBridgeQuoteDataContext,
+} from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import type { TokenInputAreaRef } from '../../../components/TokenInputArea';
 import OrdersTabs from '../../../components/OrdersTabs';
 import {
@@ -50,6 +53,19 @@ import {
 import { useSwapsLimitOrderPriceAdjust } from '../../../hooks/useSwapsLimitOrderPriceAdjust';
 import { useSwapsLimitOrderKeypad } from '../../../hooks/useSwapsLimitOrderKeypad';
 import { useHasMissingQuoteAndAssetsPriceData } from '../../../hooks/useHasMissingQuoteAndAssetsPriceData';
+import { useFeeDisclaimer } from '../../../hooks/useFeeDisclaimer';
+import { selectCurrentCurrency } from '../../../../../../selectors/currencyRateController';
+import {
+  formatMinimumReceived,
+  getCurrencySymbol,
+} from '../../../utils/currencyUtils';
+import { formatAmountWithLocaleSeparators } from '../../../utils/formatAmountWithLocaleSeparators';
+import { strings } from '../../../../../../../locales/i18n';
+
+const formatTokenAmountValue = (
+  amount: string | undefined,
+  symbol: string | undefined,
+) => (amount && symbol ? `${formatMinimumReceived(amount)} ${symbol}` : '--');
 
 interface BridgeLimitOrderViewContentProps {
   latestSourceBalance: ReturnType<typeof useLatestBalance>;
@@ -62,6 +78,15 @@ const BridgeLimitOrderViewContent = ({
   const navigation = useNavigation<AppNavigationProp>();
   const dispatch = useDispatch();
   const slippage = useSelector(selectSlippage);
+  const currentCurrency = useSelector(selectCurrentCurrency);
+  const {
+    activeQuote,
+    isActiveQuoteForCurrentTokenPair,
+    isLoading: isQuoteLoading,
+    formattedQuoteData,
+  } = useBridgeQuoteDataContext();
+  const networkFee = formattedQuoteData?.networkFee ?? '-';
+  const { infoText: feeDisclaimer } = useFeeDisclaimer({ activeQuote });
   const inputRef = useRef<TokenInputAreaRef>(null);
   const limitPriceInputRef = useRef<InputSectionRef>(null);
   const customPercentInputRef = useRef<ButtonPricePresetsSectionRef>(null);
@@ -98,6 +123,7 @@ const BridgeLimitOrderViewContent = ({
     onAmountTypeTogglePress,
     onQuoteUnitPress,
     quotedSymbol,
+    quotedToken,
     secondaryValue,
     value,
   } = useSwapsLimitOrderPriceAdjust({
@@ -233,6 +259,47 @@ const BridgeLimitOrderViewContent = ({
     navigation,
   ]);
 
+  const isQuoteActive = Boolean(
+    activeQuote && isActiveQuoteForCurrentTokenPair && !isQuoteLoading,
+  );
+
+  const expiration = getSwapsLimitOrderExpirationLabel(expirationMinutes);
+  const slippageLabel = `${slippage ?? LIMIT_ORDER_DEFAULT_SLIPPAGE}%`;
+  const triggerPrice = `${
+    isLimitFiatMode ? getCurrencySymbol(currentCurrency || 'usd') : ''
+  }${formatAmountWithLocaleSeparators(value)}`;
+
+  const handleCreateOrderPress = useCallback(() => {
+    dismissInputAndKeypad();
+    navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.LIMIT_ORDER_CONFIRMATION_MODAL,
+      params: {
+        sourceToken,
+        destToken,
+        payingAmount: formatTokenAmountValue(sourceAmount, sourceToken?.symbol),
+        triggerPrice,
+        triggerComparison: marketComparison,
+        triggerToken: quotedToken,
+        expiry: expiration,
+        networkFee,
+        feeToken: sourceToken,
+        feeDisclaimer,
+      },
+    });
+  }, [
+    destToken,
+    dismissInputAndKeypad,
+    expiration,
+    feeDisclaimer,
+    marketComparison,
+    navigation,
+    networkFee,
+    quotedToken,
+    sourceAmount,
+    sourceToken,
+    triggerPrice,
+  ]);
+
   return (
     <Box twClassName="flex-1 bg-default">
       <Box
@@ -308,13 +375,11 @@ const BridgeLimitOrderViewContent = ({
 
             <Box twClassName="flex-grow-0" onTouchEnd={dismissInputAndKeypad}>
               <LimitOrderDetails
-                expiration={getSwapsLimitOrderExpirationLabel(
-                  expirationMinutes,
-                )}
+                expiration={expiration}
                 onExpirationPress={handleExpirationPress}
-                slippage={`${slippage ?? LIMIT_ORDER_DEFAULT_SLIPPAGE}%`}
+                slippage={slippageLabel}
                 onPricePress={handleSlippagePress}
-                networkFee="$1.69"
+                networkFee={networkFee}
                 feeToken={sourceToken}
               />
             </Box>
@@ -348,7 +413,11 @@ const BridgeLimitOrderViewContent = ({
           </Box>
         </ScrollView>
 
-        <BridgeLimitOrderFooterView />
+        <BridgeLimitOrderFooterView
+          ctaDisabled={isMissingPrice || !isQuoteActive}
+          onCTAPress={handleCreateOrderPress}
+          ctaLabel={strings('bridge.limit.create_order')}
+        />
 
         <SwapsKeypad
           ref={keypadRef}
@@ -357,10 +426,10 @@ const BridgeLimitOrderViewContent = ({
         >
           {isAmountFocused && sourceAmount && sourceAmount !== '0' ? (
             <SwapsLimitOrderConfirmButton
-              onPress={() => 'test'}
-              label="test"
+              onPress={handleCreateOrderPress}
+              label={strings('bridge.limit.create_order')}
               testID={BridgeViewSelectorsIDs.CONFIRM_BUTTON_KEYPAD}
-              disabled={isMissingPrice}
+              disabled={isMissingPrice || !isQuoteActive}
             />
           ) : isAmountFocused ? (
             <GaslessQuickPickOptions

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/DetailRow/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/DetailRow/index.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { Text } from '@metamask/design-system-react-native';
+import {DetailRow} from './';
+import { DetailRowSelectorsIDs } from './testIds';
+
+describe('DetailRow', () => {
+  it('renders the label and children', () => {
+    const { getByTestId } = render(
+      <DetailRow label="Paying">
+        <Text testID="detail-row-child">0.1 ETH</Text>
+      </DetailRow>,
+    );
+
+    expect(getByTestId(DetailRowSelectorsIDs.CONTAINER)).toBeOnTheScreen();
+    expect(getByTestId(DetailRowSelectorsIDs.LABEL)).toHaveTextContent('Paying');
+    expect(getByTestId('detail-row-child')).toHaveTextContent('0.1 ETH');
+  });
+
+  it('applies a custom testID when provided', () => {
+    const { getByTestId, queryByTestId } = render(
+      <DetailRow label="Paying" testID="custom-detail-row">
+        <Text>0.1 ETH</Text>
+      </DetailRow>,
+    );
+
+    expect(getByTestId('custom-detail-row')).toBeOnTheScreen();
+    expect(queryByTestId(DetailRowSelectorsIDs.CONTAINER)).toBeNull();
+  });
+});

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/DetailRow/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/DetailRow/index.test.tsx
@@ -18,15 +18,4 @@ describe('DetailRow', () => {
     );
     expect(getByTestId('detail-row-child')).toHaveTextContent('0.1 ETH');
   });
-
-  it('applies a custom testID when provided', () => {
-    const { getByTestId, queryByTestId } = render(
-      <DetailRow label="Paying" testID="custom-detail-row">
-        <Text>0.1 ETH</Text>
-      </DetailRow>,
-    );
-
-    expect(getByTestId('custom-detail-row')).toBeOnTheScreen();
-    expect(queryByTestId(DetailRowSelectorsIDs.CONTAINER)).toBeNull();
-  });
 });

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/DetailRow/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/DetailRow/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { Text } from '@metamask/design-system-react-native';
-import {DetailRow} from './';
+import { DetailRow } from './';
 import { DetailRowSelectorsIDs } from './testIds';
 
 describe('DetailRow', () => {
@@ -13,7 +13,9 @@ describe('DetailRow', () => {
     );
 
     expect(getByTestId(DetailRowSelectorsIDs.CONTAINER)).toBeOnTheScreen();
-    expect(getByTestId(DetailRowSelectorsIDs.LABEL)).toHaveTextContent('Paying');
+    expect(getByTestId(DetailRowSelectorsIDs.LABEL)).toHaveTextContent(
+      'Paying',
+    );
     expect(getByTestId('detail-row-child')).toHaveTextContent('0.1 ETH');
   });
 

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/DetailRow/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/DetailRow/index.tsx
@@ -11,10 +11,7 @@ import {
 import { DetailRowSelectorsIDs } from './testIds';
 import type { DetailRowProps } from './types';
 
-export const DetailRow = ({
-  label,
-  children,
-}: DetailRowProps) => (
+export const DetailRow = ({ label, children }: DetailRowProps) => (
   <Box
     flexDirection={BoxFlexDirection.Row}
     alignItems={BoxAlignItems.Center}

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/DetailRow/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/DetailRow/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { DetailRowSelectorsIDs } from './testIds';
+import type { DetailRowProps } from './types';
+
+export const DetailRow = ({
+  label,
+  children,
+}: DetailRowProps) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    justifyContent={BoxJustifyContent.Between}
+    gap={2}
+    paddingHorizontal={4}
+    paddingVertical={1}
+    testID={DetailRowSelectorsIDs.CONTAINER}
+  >
+    <Text
+      variant={TextVariant.BodyMd}
+      color={TextColor.TextAlternative}
+      testID={DetailRowSelectorsIDs.LABEL}
+    >
+      {label}
+    </Text>
+    {children}
+  </Box>
+);

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/DetailRow/testIds.ts
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/DetailRow/testIds.ts
@@ -1,0 +1,4 @@
+export const DetailRowSelectorsIDs = {
+  CONTAINER: 'detail-row',
+  LABEL: 'detail-row-label',
+} as const;

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/DetailRow/types.ts
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/DetailRow/types.ts
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react';
+
+export interface DetailRowProps {
+  label: string;
+  children: ReactNode;
+}

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/LimitOrderConfirmationModal.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/LimitOrderConfirmationModal.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { Hex } from '@metamask/utils';
+import { LimitOrderConfirmationModal } from './LimitOrderConfirmationModal';
+import type { LimitOrderConfirmationModalProps } from './types';
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactModule = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+
+  return {
+    ...actual,
+    BottomSheet: ReactModule.forwardRef(
+      (
+        props: {
+          children: unknown;
+          testID?: string;
+          onClose?: () => void;
+        },
+        ref: React.Ref<{ onCloseBottomSheet: () => void }>,
+      ) => {
+        ReactModule.useImperativeHandle(ref, () => ({
+          onCloseBottomSheet: () => props.onClose?.(),
+        }));
+
+        return (
+          <View testID={props.testID}>{props.children as React.ReactNode}</View>
+        );
+      },
+    ),
+  };
+});
+
+const mockSourceToken = {
+  address: '0x0000000000000000000000000000000000000000',
+  chainId: '0x1' as Hex,
+  decimals: 18,
+  image: '',
+  name: 'Ether',
+  symbol: 'ETH',
+};
+
+const mockDestToken = {
+  address: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
+  chainId: '0xa' as Hex,
+  decimals: 6,
+  image: '',
+  name: 'USD Coin',
+  symbol: 'USDC',
+};
+
+function buildProps(
+  overrides: Partial<LimitOrderConfirmationModalProps> = {},
+): LimitOrderConfirmationModalProps {
+  return {
+    sourceToken: mockSourceToken,
+    destToken: mockDestToken,
+    payingAmount: '0.1 ETH',
+    triggerPrice: '$3,412.20',
+    expiry: '7 days',
+    slippage: '2%',
+    networkFee: '$1.69',
+    feeToken: mockSourceToken,
+    onConfirm: jest.fn(),
+    onEditSlippagePress: jest.fn(),
+    onClose: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('LimitOrderConfirmationModal', () => {
+  it('does not close when re-rendered with the same slippage', () => {
+    const onClose = jest.fn();
+    const props = buildProps({ slippage: '2%', onClose });
+    const { rerender } = render(<LimitOrderConfirmationModal {...props} />);
+
+    rerender(<LimitOrderConfirmationModal {...props} slippage="2%" />);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes the sheet when the slippage changes after mount', () => {
+    const onClose = jest.fn();
+    const props = buildProps({ slippage: '2%', onClose });
+    const { rerender } = render(<LimitOrderConfirmationModal {...props} />);
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    rerender(<LimitOrderConfirmationModal {...props} slippage="0.5%" />);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/LimitOrderConfirmationModal.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/LimitOrderConfirmationModal.tsx
@@ -1,0 +1,179 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import {
+  BottomSheet,
+  BottomSheetFooter,
+  BottomSheetHeader,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  ButtonIcon,
+  ButtonIconSize,
+  IconColor,
+  IconName,
+  Text,
+  TextColor,
+  TextVariant,
+  type BottomSheetRef,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import {DetailRow} from './DetailRow';
+import {TokenAmountValue} from './TokenAmountValue';
+import { LimitOrderConfirmationModalSelectorsIDs } from './testIds';
+import type { LimitOrderConfirmationModalProps } from './types';
+
+export const LimitOrderConfirmationModal = ({
+  sourceToken,
+  destToken,
+  payingAmount,
+  triggerPrice,
+  triggerComparison,
+  triggerToken,
+  expiry,
+  slippage,
+  networkFee,
+  feeToken,
+  feeDisclaimer,
+  onConfirm,
+  onEditSlippagePress,
+  onClose,
+  goBack,
+  testID = LimitOrderConfirmationModalSelectorsIDs.SHEET,
+}: LimitOrderConfirmationModalProps) => {
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const initialSlippageRef = useRef(slippage);
+
+  const closeSheet = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  // If the user edits slippage while this sheet is still mounted, that quote is
+  // stale until a new one is fetched, so close the sheet rather than show
+  // outdated order details.
+  useEffect(() => {
+    if (slippage !== initialSlippageRef.current) {
+      closeSheet();
+    }
+  }, [slippage, closeSheet]);
+
+  const triggerComparisonColor = triggerComparison?.isNegative
+    ? TextColor.ErrorDefault
+    : TextColor.SuccessDefault;
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      testID={testID}
+      goBack={goBack}
+      onClose={onClose}
+    >
+      <BottomSheetHeader
+        onClose={closeSheet}
+        closeButtonProps={{
+          testID: LimitOrderConfirmationModalSelectorsIDs.CLOSE_BUTTON,
+        }}
+      >
+        {strings('bridge.limit.pair', {
+          source: sourceToken?.symbol ?? '',
+          dest: destToken?.symbol ?? '',
+        })}
+      </BottomSheetHeader>
+      <Box paddingBottom={2}>
+        <DetailRow
+          label={strings('bridge.limit.paying')}
+        >
+          <TokenAmountValue amount={payingAmount} token={sourceToken} />
+        </DetailRow>
+        <DetailRow
+          label={strings('bridge.limit.receiving')}
+        >
+          <TokenAmountValue
+            amount={destToken?.symbol ?? '--'}
+            token={destToken}
+          />
+        </DetailRow>
+        <Box twClassName="mx-4 my-2 h-px bg-muted" />
+        <DetailRow
+          label={strings('bridge.limit.trigger_condition')}
+        >
+          <Box alignItems={BoxAlignItems.End} twClassName="shrink">
+            <TokenAmountValue amount={triggerPrice} token={triggerToken} />
+            {triggerComparison ? (
+              <Text
+                variant={TextVariant.BodySm}
+                color={triggerComparisonColor}
+                twClassName="text-right"
+                testID={
+                  LimitOrderConfirmationModalSelectorsIDs.TRIGGER_COMPARISON
+                }
+              >
+                {triggerComparison.label}
+              </Text>
+            ) : null}
+          </Box>
+        </DetailRow>
+        <DetailRow
+          label={strings('bridge.limit.expiry_label')}
+        >
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
+            {expiry}
+          </Text>
+        </DetailRow>
+        <Box twClassName="mx-4 my-2 h-px bg-muted" />
+        <DetailRow
+          label={strings('bridge.slippage')}
+        >
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            gap={1}
+          >
+            <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
+              {slippage}
+            </Text>
+            <ButtonIcon
+              iconName={IconName.Edit}
+              size={ButtonIconSize.Sm}
+              iconProps={{ color: IconColor.IconAlternative }}
+              onPress={onEditSlippagePress}
+              accessibilityLabel={strings('bridge.limit.edit_slippage')}
+              testID={LimitOrderConfirmationModalSelectorsIDs.SLIPPAGE_EDIT}
+            />
+          </Box>
+        </DetailRow>
+        <DetailRow
+          label={strings('bridge.limit.est_network_fee')}
+        >
+          <TokenAmountValue
+            amount={networkFee}
+            token={feeToken}
+            withNetworkBadge
+          />
+        </DetailRow>
+      </Box>
+      <BottomSheetFooter
+        primaryButtonProps={{
+          children: strings('bridge.limit.confirm_order'),
+          onPress: onConfirm,
+          testID: LimitOrderConfirmationModalSelectorsIDs.CONFIRM_BUTTON,
+        }}
+      />
+      {feeDisclaimer ? (
+        <Box
+          alignItems={BoxAlignItems.Center}
+          paddingHorizontal={4}
+          paddingBottom={4}
+          twClassName="pt-1"
+        >
+          <Text
+            variant={TextVariant.BodyXs}
+            color={TextColor.TextAlternative}
+            twClassName="text-center"
+            testID={LimitOrderConfirmationModalSelectorsIDs.FEE_DISCLAIMER}
+          >
+            {feeDisclaimer}
+          </Text>
+        </Box>
+      ) : null}
+    </BottomSheet>
+  );
+};

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/LimitOrderConfirmationModal.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/LimitOrderConfirmationModal.tsx
@@ -16,8 +16,8 @@ import {
   type BottomSheetRef,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
-import {DetailRow} from './DetailRow';
-import {TokenAmountValue} from './TokenAmountValue';
+import { DetailRow } from './DetailRow';
+import { TokenAmountValue } from './TokenAmountValue';
 import { LimitOrderConfirmationModalSelectorsIDs } from './testIds';
 import type { LimitOrderConfirmationModalProps } from './types';
 
@@ -78,23 +78,17 @@ export const LimitOrderConfirmationModal = ({
         })}
       </BottomSheetHeader>
       <Box paddingBottom={2}>
-        <DetailRow
-          label={strings('bridge.limit.paying')}
-        >
+        <DetailRow label={strings('bridge.limit.paying')}>
           <TokenAmountValue amount={payingAmount} token={sourceToken} />
         </DetailRow>
-        <DetailRow
-          label={strings('bridge.limit.receiving')}
-        >
+        <DetailRow label={strings('bridge.limit.receiving')}>
           <TokenAmountValue
             amount={destToken?.symbol ?? '--'}
             token={destToken}
           />
         </DetailRow>
         <Box twClassName="mx-4 my-2 h-px bg-muted" />
-        <DetailRow
-          label={strings('bridge.limit.trigger_condition')}
-        >
+        <DetailRow label={strings('bridge.limit.trigger_condition')}>
           <Box alignItems={BoxAlignItems.End} twClassName="shrink">
             <TokenAmountValue amount={triggerPrice} token={triggerToken} />
             {triggerComparison ? (
@@ -111,17 +105,13 @@ export const LimitOrderConfirmationModal = ({
             ) : null}
           </Box>
         </DetailRow>
-        <DetailRow
-          label={strings('bridge.limit.expiry_label')}
-        >
+        <DetailRow label={strings('bridge.limit.expiry_label')}>
           <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
             {expiry}
           </Text>
         </DetailRow>
         <Box twClassName="mx-4 my-2 h-px bg-muted" />
-        <DetailRow
-          label={strings('bridge.slippage')}
-        >
+        <DetailRow label={strings('bridge.slippage')}>
           <Box
             flexDirection={BoxFlexDirection.Row}
             alignItems={BoxAlignItems.Center}
@@ -140,9 +130,7 @@ export const LimitOrderConfirmationModal = ({
             />
           </Box>
         </DetailRow>
-        <DetailRow
-          label={strings('bridge.limit.est_network_fee')}
-        >
+        <DetailRow label={strings('bridge.limit.est_network_fee')}>
           <TokenAmountValue
             amount={networkFee}
             token={feeToken}

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/LimitOrderConfirmationModalScreen.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/LimitOrderConfirmationModalScreen.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { Hex } from '@metamask/utils';
+import renderWithProvider, {
+  DeepPartial,
+} from '../../../../../util/test/renderWithProvider';
+import type { RootState } from '../../../../../reducers';
+import Routes from '../../../../../constants/navigation/Routes';
+import { useParams } from '../../../../../util/navigation/navUtils';
+import { createBridgeTestState } from '../../testUtils';
+import { LimitOrderConfirmationModalScreen } from './LimitOrderConfirmationModalScreen';
+import { LimitOrderConfirmationModalSelectorsIDs } from './testIds';
+import type { LimitOrderConfirmationModalParams } from './types';
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    goBack: mockGoBack,
+  }),
+}));
+
+jest.mock('../../../../../util/navigation/navUtils', () => ({
+  useParams: jest.fn(),
+}));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactModule = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+
+  return {
+    ...actual,
+    BottomSheet: ReactModule.forwardRef(
+      (
+        props: {
+          children: unknown;
+          testID?: string;
+          onClose?: () => void;
+        },
+        ref: React.Ref<{ onCloseBottomSheet: () => void }>,
+      ) => {
+        ReactModule.useImperativeHandle(ref, () => ({
+          onCloseBottomSheet: () => props.onClose?.(),
+        }));
+
+        return (
+          <View testID={props.testID}>{props.children as React.ReactNode}</View>
+        );
+      },
+    ),
+  };
+});
+
+const mockUseParams = useParams as jest.MockedFunction<typeof useParams>;
+
+const mockSourceToken = {
+  address: '0x0000000000000000000000000000000000000000',
+  chainId: '0x1' as Hex,
+  decimals: 18,
+  image: '',
+  name: 'Ether',
+  symbol: 'ETH',
+};
+
+const mockDestToken = {
+  address: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
+  chainId: '0xa' as Hex,
+  decimals: 6,
+  image: '',
+  name: 'USD Coin',
+  symbol: 'USDC',
+};
+
+const mockParams: LimitOrderConfirmationModalParams = {
+  sourceToken: mockSourceToken,
+  destToken: mockDestToken,
+  payingAmount: '0.1 ETH',
+  triggerPrice: '$3,412.20',
+  triggerToken: mockDestToken,
+  expiry: '7 days',
+  networkFee: '$1.69',
+  feeToken: mockSourceToken,
+};
+
+function renderScreen(state?: DeepPartial<RootState>) {
+  return renderWithProvider(<LimitOrderConfirmationModalScreen />, { state });
+}
+
+describe('LimitOrderConfirmationModalScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseParams.mockReturnValue(mockParams);
+  });
+
+  it('displays the slippage from bridge state', () => {
+    const { getByText } = renderScreen(
+      createBridgeTestState({ bridgeReducerOverrides: { slippage: '0.5' } }),
+    );
+
+    expect(getByText('0.5%')).toBeOnTheScreen();
+  });
+
+  it('displays the default slippage when none is set in bridge state', () => {
+    const { getByText } = renderScreen(
+      createBridgeTestState({
+        bridgeReducerOverrides: { slippage: undefined },
+      }),
+    );
+
+    expect(getByText('2%')).toBeOnTheScreen();
+  });
+
+  it('navigates to the swap default slippage modal when edit is pressed', () => {
+    const { getByTestId } = renderScreen(createBridgeTestState({}));
+
+    fireEvent.press(
+      getByTestId(LimitOrderConfirmationModalSelectorsIDs.SLIPPAGE_EDIT),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.SWAP_DEFAULT_SLIPPAGE_MODAL,
+      params: {
+        sourceChainId: mockSourceToken.chainId,
+        destChainId: mockDestToken.chainId,
+      },
+    });
+  });
+});

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/LimitOrderConfirmationModalScreen.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/LimitOrderConfirmationModalScreen.tsx
@@ -6,7 +6,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { selectSlippage } from '../../../../../core/redux/slices/bridge';
 import { LIMIT_ORDER_DEFAULT_SLIPPAGE } from '../../constants/limitOrders';
-import {LimitOrderConfirmationModal} from './LimitOrderConfirmationModal';
+import { LimitOrderConfirmationModal } from './LimitOrderConfirmationModal';
 import type { LimitOrderConfirmationModalParams } from './types';
 
 export const LimitOrderConfirmationModalScreen = () => {

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/LimitOrderConfirmationModalScreen.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/LimitOrderConfirmationModalScreen.tsx
@@ -1,0 +1,42 @@
+import React, { useCallback } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
+import Routes from '../../../../../constants/navigation/Routes';
+import { useParams } from '../../../../../util/navigation/navUtils';
+import { selectSlippage } from '../../../../../core/redux/slices/bridge';
+import { LIMIT_ORDER_DEFAULT_SLIPPAGE } from '../../constants/limitOrders';
+import {LimitOrderConfirmationModal} from './LimitOrderConfirmationModal';
+import type { LimitOrderConfirmationModalParams } from './types';
+
+export const LimitOrderConfirmationModalScreen = () => {
+  const navigation = useNavigation<AppNavigationProp>();
+  const params = useParams<LimitOrderConfirmationModalParams>();
+  const { sourceToken, destToken } = params;
+  const slippage = useSelector(selectSlippage);
+
+  const handleEditSlippagePress = useCallback(() => {
+    navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.SWAP_DEFAULT_SLIPPAGE_MODAL,
+      params: {
+        sourceChainId: sourceToken?.chainId,
+        destChainId: destToken?.chainId,
+      },
+    });
+  }, [destToken?.chainId, navigation, sourceToken?.chainId]);
+
+  const handleConfirm = useCallback(() => {
+    // STUB FOR LIMIT ORDER CREATION
+    console.warn('Confirm limit order');
+  }, []);
+
+  return (
+    <LimitOrderConfirmationModal
+      {...params}
+      slippage={`${slippage ?? LIMIT_ORDER_DEFAULT_SLIPPAGE}%`}
+      goBack={navigation.goBack}
+      onConfirm={handleConfirm}
+      onEditSlippagePress={handleEditSlippagePress}
+    />
+  );
+};

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAmountValue/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAmountValue/index.test.tsx
@@ -55,13 +55,4 @@ describe('TokenAmountValue', () => {
       getByTestId(TokenAvatarSelectorsIDs.NETWORK_BADGE),
     ).toBeOnTheScreen();
   });
-
-  it('applies a custom testID when provided', () => {
-    const { getByTestId, queryByTestId } = render(
-      <TokenAmountValue amount="0.1 ETH" testID="custom-amount" />,
-    );
-
-    expect(getByTestId('custom-amount')).toHaveTextContent('0.1 ETH');
-    expect(queryByTestId(TokenAmountValueSelectorsIDs.AMOUNT)).toBeNull();
-  });
 });

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAmountValue/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAmountValue/index.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import { createMockTokenWithBalance } from '../../../testUtils';
 import { TokenAvatarSelectorsIDs } from '../TokenAvatar/testIds';
-import {TokenAmountValue} from '.';
+import { TokenAmountValue } from '.';
 import { TokenAmountValueSelectorsIDs } from './testIds';
 
 jest.mock('../../../../../../util/networks', () => ({
@@ -51,7 +51,9 @@ describe('TokenAmountValue', () => {
       <TokenAmountValue amount="$1.69" token={mockToken} withNetworkBadge />,
     );
 
-    expect(getByTestId(TokenAvatarSelectorsIDs.NETWORK_BADGE)).toBeOnTheScreen();
+    expect(
+      getByTestId(TokenAvatarSelectorsIDs.NETWORK_BADGE),
+    ).toBeOnTheScreen();
   });
 
   it('applies a custom testID when provided', () => {

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAmountValue/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAmountValue/index.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { createMockTokenWithBalance } from '../../../testUtils';
+import { TokenAvatarSelectorsIDs } from '../TokenAvatar/testIds';
+import {TokenAmountValue} from '.';
+import { TokenAmountValueSelectorsIDs } from './testIds';
+
+jest.mock('../../../../../../util/networks', () => ({
+  ...jest.requireActual('../../../../../../util/networks'),
+  getNetworkImageSource: jest.fn(() => ({ uri: 'https://network.icon' })),
+}));
+
+jest.mock('../../../utils', () => ({
+  ...jest.requireActual('../../../utils'),
+  getTokenImageSource: jest.fn(() => ({ uri: 'https://token.icon' })),
+}));
+
+const mockToken = createMockTokenWithBalance({
+  symbol: 'ETH',
+  name: 'Ether',
+});
+
+describe('TokenAmountValue', () => {
+  it('renders the amount', () => {
+    const { getByTestId } = render(<TokenAmountValue amount="0.1 ETH" />);
+
+    expect(
+      getByTestId(TokenAmountValueSelectorsIDs.CONTAINER),
+    ).toBeOnTheScreen();
+    expect(getByTestId(TokenAmountValueSelectorsIDs.AMOUNT)).toHaveTextContent(
+      '0.1 ETH',
+    );
+  });
+
+  it('renders the token avatar when a token is provided', () => {
+    const { getByTestId } = render(
+      <TokenAmountValue amount="0.1 ETH" token={mockToken} />,
+    );
+
+    expect(getByTestId(TokenAvatarSelectorsIDs.TOKEN)).toBeOnTheScreen();
+  });
+
+  it('hides the token avatar when no token is provided', () => {
+    const { queryByTestId } = render(<TokenAmountValue amount="0.1 ETH" />);
+
+    expect(queryByTestId(TokenAvatarSelectorsIDs.TOKEN)).toBeNull();
+  });
+
+  it('renders a network badge on the avatar when withNetworkBadge is true', () => {
+    const { getByTestId } = render(
+      <TokenAmountValue amount="$1.69" token={mockToken} withNetworkBadge />,
+    );
+
+    expect(getByTestId(TokenAvatarSelectorsIDs.NETWORK_BADGE)).toBeOnTheScreen();
+  });
+
+  it('applies a custom testID when provided', () => {
+    const { getByTestId, queryByTestId } = render(
+      <TokenAmountValue amount="0.1 ETH" testID="custom-amount" />,
+    );
+
+    expect(getByTestId('custom-amount')).toHaveTextContent('0.1 ETH');
+    expect(queryByTestId(TokenAmountValueSelectorsIDs.AMOUNT)).toBeNull();
+  });
+});

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAmountValue/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAmountValue/index.tsx
@@ -7,7 +7,7 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import {TokenAvatar} from '../TokenAvatar';
+import { TokenAvatar } from '../TokenAvatar';
 import { TokenAmountValueSelectorsIDs } from './testIds';
 import type { TokenAmountValueProps } from './types';
 
@@ -36,4 +36,3 @@ export const TokenAmountValue = ({
     </Text>
   </Box>
 );
-

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAmountValue/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAmountValue/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import {TokenAvatar} from '../TokenAvatar';
+import { TokenAmountValueSelectorsIDs } from './testIds';
+import type { TokenAmountValueProps } from './types';
+
+export const TokenAmountValue = ({
+  amount,
+  token,
+  withNetworkBadge,
+}: TokenAmountValueProps) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    gap={1}
+    twClassName="shrink"
+    testID={TokenAmountValueSelectorsIDs.CONTAINER}
+  >
+    {token ? (
+      <TokenAvatar token={token} withNetworkBadge={withNetworkBadge} />
+    ) : null}
+    <Text
+      variant={TextVariant.BodyMd}
+      color={TextColor.TextDefault}
+      twClassName="text-right"
+      testID={TokenAmountValueSelectorsIDs.AMOUNT}
+    >
+      {amount}
+    </Text>
+  </Box>
+);
+

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAmountValue/testIds.ts
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAmountValue/testIds.ts
@@ -1,0 +1,4 @@
+export const TokenAmountValueSelectorsIDs = {
+  CONTAINER: 'token-amount-value',
+  AMOUNT: 'token-amount-value-amount',
+} as const;

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAmountValue/types.ts
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAmountValue/types.ts
@@ -1,0 +1,7 @@
+import type { BridgeToken } from '../../../types';
+
+export interface TokenAmountValueProps {
+  amount: string;
+  token?: BridgeToken;
+  withNetworkBadge?: boolean;
+}

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/index.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { getNetworkImageSource } from '../../../../../../util/networks';
+import { getTokenImageSource } from '../../../utils';
+import { createMockTokenWithBalance } from '../../../testUtils';
+import TokenAvatar from '.';
+import { TokenAvatarSelectorsIDs } from './testIds';
+
+jest.mock('../../../../../../util/networks', () => ({
+  ...jest.requireActual('../../../../../../util/networks'),
+  getNetworkImageSource: jest.fn(() => ({ uri: 'https://network.icon' })),
+}));
+
+jest.mock('../../../utils', () => ({
+  ...jest.requireActual('../../../utils'),
+  getTokenImageSource: jest.fn(() => ({ uri: 'https://token.icon' })),
+}));
+
+const mockToken = createMockTokenWithBalance({
+  symbol: 'ETH',
+  name: 'Ether',
+});
+
+describe('TokenAvatar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .mocked(getNetworkImageSource)
+      .mockReturnValue({ uri: 'https://network.icon' });
+    jest
+      .mocked(getTokenImageSource)
+      .mockReturnValue({ uri: 'https://token.icon' });
+  });
+
+  it('renders the token avatar without a network badge by default', () => {
+    const { getByTestId, queryByTestId } = render(
+      <TokenAvatar token={mockToken} />,
+    );
+
+    expect(getByTestId(TokenAvatarSelectorsIDs.TOKEN)).toBeOnTheScreen();
+    expect(queryByTestId(TokenAvatarSelectorsIDs.NETWORK_BADGE)).toBeNull();
+  });
+
+  it('renders a network badge when withNetworkBadge is true', () => {
+    const { getByTestId } = render(
+      <TokenAvatar token={mockToken} withNetworkBadge />,
+    );
+
+    expect(getByTestId(TokenAvatarSelectorsIDs.TOKEN)).toBeOnTheScreen();
+    expect(getByTestId(TokenAvatarSelectorsIDs.NETWORK_BADGE)).toBeOnTheScreen();
+    expect(getByTestId(TokenAvatarSelectorsIDs.NETWORK_IMAGE)).toBeOnTheScreen();
+  });
+
+  it('hides the network image when no network image source is available', () => {
+    jest.mocked(getNetworkImageSource).mockReturnValue(undefined);
+
+    const { getByTestId, queryByTestId } = render(
+      <TokenAvatar token={mockToken} withNetworkBadge />,
+    );
+
+    expect(getByTestId(TokenAvatarSelectorsIDs.NETWORK_BADGE)).toBeOnTheScreen();
+    expect(queryByTestId(TokenAvatarSelectorsIDs.NETWORK_IMAGE)).toBeNull();
+  });
+
+  it('applies a custom testID when provided', () => {
+    const { getByTestId, queryByTestId } = render(
+      <TokenAvatar token={mockToken} testID="custom-token-avatar" />,
+    );
+
+    expect(getByTestId('custom-token-avatar')).toBeOnTheScreen();
+    expect(queryByTestId(TokenAvatarSelectorsIDs.TOKEN)).toBeNull();
+  });
+});

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/index.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react-native';
 import { getNetworkImageSource } from '../../../../../../util/networks';
 import { getTokenImageSource } from '../../../utils';
 import { createMockTokenWithBalance } from '../../../testUtils';
-import TokenAvatar from '.';
+import { TokenAvatar } from '.';
 import { TokenAvatarSelectorsIDs } from './testIds';
 
 jest.mock('../../../../../../util/networks', () => ({
@@ -56,7 +56,11 @@ describe('TokenAvatar', () => {
   });
 
   it('hides the network image when no network image source is available', () => {
-    jest.mocked(getNetworkImageSource).mockReturnValue(undefined);
+    jest
+      .mocked(getNetworkImageSource)
+      .mockReturnValue(
+        undefined as unknown as ReturnType<typeof getNetworkImageSource>,
+      );
 
     const { getByTestId, queryByTestId } = render(
       <TokenAvatar token={mockToken} withNetworkBadge />,
@@ -66,14 +70,5 @@ describe('TokenAvatar', () => {
       getByTestId(TokenAvatarSelectorsIDs.NETWORK_BADGE),
     ).toBeOnTheScreen();
     expect(queryByTestId(TokenAvatarSelectorsIDs.NETWORK_IMAGE)).toBeNull();
-  });
-
-  it('applies a custom testID when provided', () => {
-    const { getByTestId, queryByTestId } = render(
-      <TokenAvatar token={mockToken} testID="custom-token-avatar" />,
-    );
-
-    expect(getByTestId('custom-token-avatar')).toBeOnTheScreen();
-    expect(queryByTestId(TokenAvatarSelectorsIDs.TOKEN)).toBeNull();
   });
 });

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/index.test.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/index.test.tsx
@@ -47,8 +47,12 @@ describe('TokenAvatar', () => {
     );
 
     expect(getByTestId(TokenAvatarSelectorsIDs.TOKEN)).toBeOnTheScreen();
-    expect(getByTestId(TokenAvatarSelectorsIDs.NETWORK_BADGE)).toBeOnTheScreen();
-    expect(getByTestId(TokenAvatarSelectorsIDs.NETWORK_IMAGE)).toBeOnTheScreen();
+    expect(
+      getByTestId(TokenAvatarSelectorsIDs.NETWORK_BADGE),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(TokenAvatarSelectorsIDs.NETWORK_IMAGE),
+    ).toBeOnTheScreen();
   });
 
   it('hides the network image when no network image source is available', () => {
@@ -58,7 +62,9 @@ describe('TokenAvatar', () => {
       <TokenAvatar token={mockToken} withNetworkBadge />,
     );
 
-    expect(getByTestId(TokenAvatarSelectorsIDs.NETWORK_BADGE)).toBeOnTheScreen();
+    expect(
+      getByTestId(TokenAvatarSelectorsIDs.NETWORK_BADGE),
+    ).toBeOnTheScreen();
     expect(queryByTestId(TokenAvatarSelectorsIDs.NETWORK_IMAGE)).toBeNull();
   });
 

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/index.tsx
@@ -13,10 +13,7 @@ import { getTokenImageSource } from '../../../utils';
 import { TokenAvatarSelectorsIDs } from './testIds';
 import type { TokenAvatarProps } from './types';
 
-export const TokenAvatar = ({
-  token,
-  withNetworkBadge,
-}: TokenAvatarProps) => {
+export const TokenAvatar = ({ token, withNetworkBadge }: TokenAvatarProps) => {
   const tw = useTailwind();
   const tokenImageSource = getTokenImageSource(
     token.symbol,

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/index.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Image } from 'react-native';
+import {
+  AvatarToken,
+  AvatarTokenSize,
+  BadgeWrapper,
+  BadgeWrapperPosition,
+  Box,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { getNetworkImageSource } from '../../../../../../util/networks';
+import { getTokenImageSource } from '../../../utils';
+import { TokenAvatarSelectorsIDs } from './testIds';
+import type { TokenAvatarProps } from './types';
+
+export const TokenAvatar = ({
+  token,
+  withNetworkBadge,
+}: TokenAvatarProps) => {
+  const tw = useTailwind();
+  const tokenImageSource = getTokenImageSource(
+    token.symbol,
+    token.image,
+    token.address,
+    token.chainId,
+  );
+  const networkImageSource = getNetworkImageSource({ chainId: token.chainId });
+
+  if (!withNetworkBadge) {
+    return (
+      <AvatarToken
+        name={token.symbol}
+        src={tokenImageSource}
+        size={AvatarTokenSize.Xs}
+      />
+    );
+  }
+
+  return (
+    <BadgeWrapper
+      position={BadgeWrapperPosition.BottomRight}
+      twClassName="mt-1"
+      testID={TokenAvatarSelectorsIDs.NETWORK_BADGE}
+      badge={
+        <Box twClassName="overflow-hidden border-2 border-background-default bg-default rounded-[2px] w-[8px] h-[8px]">
+          {networkImageSource ? (
+            <Image
+              source={networkImageSource}
+              style={tw.style('h-full w-full')}
+              testID={TokenAvatarSelectorsIDs.NETWORK_IMAGE}
+            />
+          ) : null}
+        </Box>
+      }
+    >
+      <AvatarToken
+        name={token.symbol}
+        src={tokenImageSource}
+        size={AvatarTokenSize.Xs}
+      />
+    </BadgeWrapper>
+  );
+};

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/index.tsx
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/index.tsx
@@ -29,6 +29,7 @@ export const TokenAvatar = ({ token, withNetworkBadge }: TokenAvatarProps) => {
         name={token.symbol}
         src={tokenImageSource}
         size={AvatarTokenSize.Xs}
+        testID={TokenAvatarSelectorsIDs.TOKEN}
       />
     );
   }
@@ -54,6 +55,7 @@ export const TokenAvatar = ({ token, withNetworkBadge }: TokenAvatarProps) => {
         name={token.symbol}
         src={tokenImageSource}
         size={AvatarTokenSize.Xs}
+        testID={TokenAvatarSelectorsIDs.TOKEN}
       />
     </BadgeWrapper>
   );

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/testIds.ts
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/testIds.ts
@@ -1,0 +1,5 @@
+export const TokenAvatarSelectorsIDs = {
+  TOKEN: 'token-avatar',
+  NETWORK_BADGE: 'token-avatar-network-badge',
+  NETWORK_IMAGE: 'token-avatar-network-image',
+} as const;

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/types.ts
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/TokenAvatar/types.ts
@@ -1,0 +1,6 @@
+import type { BridgeToken } from '../../../types';
+
+export interface TokenAvatarProps {
+  token: BridgeToken;
+  withNetworkBadge?: boolean;
+}

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/testIds.ts
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/testIds.ts
@@ -1,0 +1,14 @@
+export const LimitOrderConfirmationModalSelectorsIDs = {
+  SHEET: 'limit-order-confirmation-modal',
+  CLOSE_BUTTON: 'limit-order-confirmation-modal-close',
+  CONFIRM_BUTTON: 'limit-order-confirmation-modal-confirm',
+  PAYING: 'limit-order-confirmation-modal-paying',
+  RECEIVING: 'limit-order-confirmation-modal-receiving',
+  TRIGGER_CONDITION: 'limit-order-confirmation-modal-trigger-condition',
+  TRIGGER_COMPARISON: 'limit-order-confirmation-modal-trigger-comparison',
+  EXPIRY: 'limit-order-confirmation-modal-expiry',
+  SLIPPAGE: 'limit-order-confirmation-modal-slippage',
+  SLIPPAGE_EDIT: 'limit-order-confirmation-modal-slippage-edit',
+  NETWORK_FEE: 'limit-order-confirmation-modal-network-fee',
+  FEE_DISCLAIMER: 'limit-order-confirmation-modal-fee-disclaimer',
+} as const;

--- a/app/components/UI/Bridge/components/LimitOrderConfirmationModal/types.ts
+++ b/app/components/UI/Bridge/components/LimitOrderConfirmationModal/types.ts
@@ -1,0 +1,85 @@
+import type { BridgeToken } from '../../types';
+
+/**
+ * Market comparison shown under the trigger price, e.g. "(-5% from market)".
+ */
+export interface LimitOrderConfirmationMarketComparison {
+  label: string;
+  isNegative: boolean;
+}
+
+/**
+ * Route params for the limit order confirmation modal. Every value is
+ * pre-formatted by the caller so the sheet itself stays stateless.
+ */
+export interface LimitOrderConfirmationModalParams {
+  /**
+   * Source token, used for the sheet title and the paying row avatar.
+   */
+  sourceToken?: BridgeToken;
+  /**
+   * Destination token, used for the sheet title and the receiving row avatar.
+   */
+  destToken?: BridgeToken;
+  /**
+   * Source amount being paid, including its symbol, e.g. "0.1 ETH".
+   */
+  payingAmount: string;
+  /**
+   * Limit price the order triggers at, e.g. "$3,412.20".
+   */
+  triggerPrice: string;
+  /**
+   * Comparison against the current market price. Omitted while at market.
+   */
+  triggerComparison?: LimitOrderConfirmationMarketComparison;
+  /**
+   * Token the trigger price is quoted in, used for the trigger row avatar.
+   */
+  triggerToken?: BridgeToken;
+  /**
+   * Expiration label, e.g. "7 days".
+   */
+  expiry: string;
+  /**
+   * Estimated network fee, e.g. "$1.69".
+   */
+  networkFee: string;
+  /**
+   * Token the network fee is paid in, used for the network fee row avatar.
+   */
+  feeToken?: BridgeToken;
+  /**
+   * Fee disclaimer shown under the confirm button, e.g. "Includes 0.875% MetaMask fee".
+   */
+  feeDisclaimer?: string;
+}
+
+export interface LimitOrderConfirmationModalProps
+  extends LimitOrderConfirmationModalParams {
+  /**
+   * Slippage label, e.g. "2%". Read from state by the host screen so edits
+   * made in the slippage modal are reflected here.
+   */
+  slippage: string;
+  /**
+   * Fired when the user confirms the order.
+   */
+  onConfirm: () => void;
+  /**
+   * Fired when the user taps the edit icon on the slippage row.
+   */
+  onEditSlippagePress: () => void;
+  /**
+   * Fired when the sheet is dismissed. Used by tests and non-navigation hosts.
+   */
+  onClose?: () => void;
+  /**
+   * Pops the Bridge modal route when the sheet closes.
+   */
+  goBack?: () => void;
+  /**
+   * Optional test ID for the sheet container.
+   */
+  testID?: string;
+}

--- a/app/components/UI/Bridge/constants/limitOrders.ts
+++ b/app/components/UI/Bridge/constants/limitOrders.ts
@@ -8,6 +8,12 @@ export enum LimitOrderExecutionType {
 
 export const LIMIT_ORDER_BUTTON_PRICE_PRESETS = [5, 10];
 
+/**
+ * Upper bound for the custom percent offset a user can type into the custom
+ * preset input. Values above this are clamped on commit.
+ */
+export const LIMIT_ORDER_CUSTOM_PERCENT_MAX = 99;
+
 export const LIMIT_ORDER_DEFAULT_SLIPPAGE = String(
   AppConstants.SWAPS.DEFAULT_SLIPPAGE,
 );

--- a/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.test.ts
@@ -193,6 +193,41 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
     expect(result.current.isCustomActive).toBe(true);
   });
 
+  it('caps a custom percent above the maximum to 99% on commit', () => {
+    const { result } = renderPriceAdjustHook();
+
+    act(() => {
+      result.current.handleCustomPress();
+      result.current.handleCustomValueChange('150');
+    });
+
+    act(() => {
+      result.current.commitCustomPercent();
+    });
+
+    expect(result.current.limitPrice).toBe('0.01');
+    expect(result.current.isCustomActive).toBe(true);
+    expect(result.current.customValue).toBe('99');
+  });
+
+  it('caps a custom percent above the maximum to 99% on commit in sell mode', () => {
+    const { result } = renderPriceAdjustHook();
+
+    act(() => {
+      result.current.onQuoteUnitPress?.();
+      result.current.handleCustomPress();
+      result.current.handleCustomValueChange('250');
+    });
+
+    act(() => {
+      result.current.commitCustomPercent();
+    });
+
+    expect(result.current.limitPrice).toBe('3980');
+    expect(result.current.isCustomActive).toBe(true);
+    expect(result.current.customValue).toBe('99');
+  });
+
   it('exits custom mode without changing the limit price when custom percent is empty', () => {
     const { result } = renderPriceAdjustHook();
 

--- a/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.ts
@@ -13,7 +13,10 @@ import {
   initialLimitOrderPriceAdjustState,
   limitOrderPriceAdjustReducer,
 } from '../../reducers/limitOrderPriceAdjustReducer';
-import { LimitOrderExecutionType } from '../../constants/limitOrders';
+import {
+  LIMIT_ORDER_CUSTOM_PERCENT_MAX,
+  LimitOrderExecutionType,
+} from '../../constants/limitOrders';
 
 interface Params {
   destToken: BridgeToken | undefined;
@@ -100,8 +103,17 @@ export const useSwapsLimitOrderPriceAdjust = ({
       return;
     }
 
+    // Cap the custom percent offset, discarding any larger value the user typed.
+    const cappedMagnitude = magnitude.isGreaterThan(
+      LIMIT_ORDER_CUSTOM_PERCENT_MAX,
+    )
+      ? new BigNumber(LIMIT_ORDER_CUSTOM_PERCENT_MAX)
+      : magnitude;
+
     const nextLimitPrice = getLimitPriceFromSignedPercent(
-      isSell ? magnitude.toNumber() : magnitude.negated().toNumber(),
+      isSell
+        ? cappedMagnitude.toNumber()
+        : cappedMagnitude.negated().toNumber(),
     );
     if (nextLimitPrice === undefined) {
       return;
@@ -111,7 +123,8 @@ export const useSwapsLimitOrderPriceAdjust = ({
     dispatch({
       type: 'commitCustomPercent',
       limitPrice: nextLimitPrice,
-      isTrackingMarket: magnitude.isZero(),
+      isTrackingMarket: cappedMagnitude.isZero(),
+      customValue: cappedMagnitude.toString(),
     });
   }, [customValue, getLimitPriceFromSignedPercent, isCustomActive, isSell]);
 
@@ -225,6 +238,7 @@ export const useSwapsLimitOrderPriceAdjust = ({
       : undefined,
     onQuoteUnitPress: handleQuoteUnitPress,
     quotedSymbol: quotedToken?.symbol,
+    quotedToken,
     secondaryValue,
     value: limitPrice ?? '',
   };

--- a/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.test.ts
+++ b/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.test.ts
@@ -94,6 +94,7 @@ describe('limitOrderPriceAdjustReducer', () => {
         type: 'commitCustomPercent',
         limitPrice: '130',
         isTrackingMarket: false,
+        customValue: '8',
       });
 
       expect(result).toEqual({
@@ -110,12 +111,30 @@ describe('limitOrderPriceAdjustReducer', () => {
         type: 'commitCustomPercent',
         limitPrice: '100',
         isTrackingMarket: true,
+        customValue: '0',
       });
 
       expect(result).toEqual({
         ...modifiedState,
         limitPrice: '100',
         isTrackingMarket: true,
+        customValue: '0',
+      });
+    });
+
+    it('stores the clamped custom value when a capped percent is committed', () => {
+      const result = limitOrderPriceAdjustReducer(modifiedState, {
+        type: 'commitCustomPercent',
+        limitPrice: '199',
+        isTrackingMarket: false,
+        customValue: '99',
+      });
+
+      expect(result).toEqual({
+        ...modifiedState,
+        limitPrice: '199',
+        isTrackingMarket: false,
+        customValue: '99',
       });
     });
   });

--- a/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.ts
+++ b/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.ts
@@ -16,6 +16,7 @@ export type LimitOrderPriceAdjustAction =
       type: 'commitCustomPercent';
       limitPrice: string;
       isTrackingMarket: boolean;
+      customValue: string;
     }
   | { type: 'seedFromMarket'; limitPrice: string }
   | { type: 'enterCustom' }
@@ -67,6 +68,7 @@ export const limitOrderPriceAdjustReducer = (
         ...state,
         isTrackingMarket: action.isTrackingMarket,
         limitPrice: action.limitPrice,
+        customValue: action.customValue,
       };
     case 'seedFromMarket':
       // A market refresh that rounds to the same string is not a state change.

--- a/app/components/UI/Bridge/routes.tsx
+++ b/app/components/UI/Bridge/routes.tsx
@@ -33,6 +33,7 @@ import { BatchSellNetworkFeeInfoModal } from './components/BatchSellNetworkFeeIn
 import { BatchSellMinimumReceivedInfoModal } from './components/BatchSellMinimumReceivedInfoModal';
 import { BatchSellPriceImpactInfoModal } from './components/BatchSellPriceImpactInfoModal';
 import { SwapsLimitOrderExpirationModalScreen } from './components/SwapsLimitOrderExpirationModal/SwapsLimitOrderExpirationModalScreen';
+import { LimitOrderConfirmationModalScreen } from './components/LimitOrderConfirmationModal/LimitOrderConfirmationModalScreen';
 import type {
   BridgeModalsNavigationParamList,
   BridgeScreensStackParamList,
@@ -168,6 +169,10 @@ export const BridgeModalStack = () => (
     <ModalStack.Screen
       name={Routes.BRIDGE.MODALS.SWAPS_LIMIT_ORDER_EXPIRATION_MODAL}
       component={SwapsLimitOrderExpirationModalScreen}
+    />
+    <ModalStack.Screen
+      name={Routes.BRIDGE.MODALS.LIMIT_ORDER_CONFIRMATION_MODAL}
+      component={LimitOrderConfirmationModalScreen}
     />
   </ModalStack.Navigator>
 );

--- a/app/components/UI/Bridge/types/navigation.ts
+++ b/app/components/UI/Bridge/types/navigation.ts
@@ -22,6 +22,7 @@ import type { BatchSellNetworkFeeInfoModalParams } from '../components/BatchSell
 import type { BatchSellMinimumReceivedInfoModalParams } from '../components/BatchSellMinimumReceivedInfoModal/BatchSellMinimumReceivedInfoModal.types';
 import type { NetworkListModalParams } from '../components/BridgeTokenSelector/NetworkListModal';
 import type { SwapsLimitOrderExpirationModalParams } from '../components/SwapsLimitOrderExpirationModal/types';
+import type { LimitOrderConfirmationModalParams } from '../components/LimitOrderConfirmationModal/types';
 
 /**
  * Param list for screens inside the Bridge screen stack (`BridgeScreenStack`).
@@ -69,6 +70,7 @@ export type BridgeModalsNavigationParamList = {
     | undefined;
   BatchSellPriceImpactInfoModal: BatchSellPriceImpactInfoModalParams;
   SwapsLimitOrderExpirationModal: SwapsLimitOrderExpirationModalParams;
+  LimitOrderConfirmationModal: LimitOrderConfirmationModalParams;
 };
 
 /**

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -374,6 +374,7 @@ const Routes = {
         'BatchSellMinimumReceivedInfoModal',
       BATCH_SELL_PRICE_IMPACT_INFO_MODAL: 'BatchSellPriceImpactInfoModal',
       SWAPS_LIMIT_ORDER_EXPIRATION_MODAL: 'SwapsLimitOrderExpirationModal',
+      LIMIT_ORDER_CONFIRMATION_MODAL: 'LimitOrderConfirmationModal',
     },
     BRIDGE_TRANSACTION_DETAILS: 'BridgeTransactionDetails',
   },

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8846,7 +8846,14 @@
         "week": "{{count}} week",
         "month": "{{count}} month"
       },
-      "est_network_fee": "Est. network fee"
+      "est_network_fee": "Est. network fee",
+      "create_order": "Create Order",
+      "paying": "Paying",
+      "receiving": "Receiving",
+      "trigger_condition": "Trigger condition",
+      "expiry_label": "Expiry",
+      "confirm_order": "Confirm order",
+      "edit_slippage": "Edit slippage"
     },
     "recurring": {
       "you_get": "You get",


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Limit orders previously used placeholder CTAs (`"test"`) and a hardcoded network fee, so users could not review the order they were about to place. This change adds a confirmation bottom sheet that summarizes paying amount, destination token, trigger price (with market comparison), expiry, slippage, estimated network fee, and fee disclaimer before the user confirms.

Create Order on the limit-order screen now navigates to that sheet with formatted quote details, and the footer/keypad CTAs stay disabled until a current quote is available. Editing slippage from the sheet opens the existing slippage modal and closes the confirmation sheet so stale quote details are not shown. Confirm remains a stub (`console.warn`) until order submission is wired. Custom percent presets are also clamped to 99% on commit so oversized offsets cannot be applied.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a confirmation bottom sheet that summarizes swaps limit order details before the user confirms

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4907

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Swaps limit order confirmation bottom sheet

  Background:
    Given I am logged into MetaMask Mobile
    And swaps limit orders are available for my account
    And I am on the Swap limit order screen with source and destination tokens selected

  Scenario: user opens the confirmation sheet from Create Order
    Given I have entered a valid source amount
    And a current quote is available

    When user taps "Create Order"

    Then a confirmation bottom sheet should open with the token pair in the header
    And I should see Paying, Receiving, Trigger condition, Expiry, Slippage, and Est. network fee rows
    And the trigger condition should show the limit price and market comparison when not at market
    And the estimated network fee should match the quote (not a hardcoded value)
    And I should see a "Confirm order" button

  Scenario: Create Order stays disabled without a current quote
    Given the quote is loading or price data is missing

    Then the "Create Order" button should be disabled or hidden
    And tapping it should not open the confirmation sheet

  Scenario: user edits slippage from the confirmation sheet
    Given the confirmation bottom sheet is open

    When user taps the slippage edit icon
    Then the slippage modal should open

    When user selects a different slippage value
    Then the confirmation sheet should close so stale quote details are not shown

  Scenario: user dismisses the confirmation sheet
    Given the confirmation bottom sheet is open

    When user taps the close control
    Then the sheet should close
    And I should remain on the limit order screen with my inputs unchanged

  Scenario: custom percent offset above 99% is clamped
    Given I am entering a custom percent offset for the limit price

    When user types a value greater than 99 and commits it
    Then the applied custom percent should be 99
    And the limit price should update from that capped offset

  Scenario: Confirm order is not yet submitting
    Given the confirmation bottom sheet is open

    When user taps "Confirm order"
    Then the order should not be submitted yet (submission is still stubbed)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A — add a recording of opening the confirmation sheet from Create Order before marking Ready for review.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches limit-order UX and navigation with quote-gated CTAs; order submission remains stubbed, so the main risk is incorrect or stale summary data shown before confirm.
> 
> **Overview**
> Replaces placeholder **Create Order** CTAs and a hardcoded network fee on the swaps limit-order flow with a **confirmation bottom sheet** that shows paying/receiving amounts, trigger price (and market comparison), expiry, slippage, estimated network fee, and an optional fee disclaimer.
> 
> **Create Order** (footer and keypad) now navigates to `LimitOrderConfirmationModal` with pre-formatted route params from live quote data; the button stays disabled when price data is missing or there is no active quote for the current pair. `BridgeLimitOrderFooterView` is refactored to accept `onCTAPress`, `ctaLabel`, and `ctaDisabled` from the parent. Limit order details on the main screen use quote-derived **network fee** instead of a stub value.
> 
> The new modal closes automatically if **slippage** changes after open (so stale quote copy is not shown); slippage edit opens the existing default slippage modal. **Confirm order** is still a stub (`console.warn`) until submission is wired.
> 
> Custom limit-price **percent presets** are capped at **99%** on commit, with the reducer persisting the clamped `customValue`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d982f38264444af43ac794ec3c098f0395d79d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->