### PR TITLE
fix(assets): restore hide token from token details (ASSETS-3478)

### DIFF
--- a/app/components/UI/TokenDetails/components/useAssetVisibility.test.ts
+++ b/app/components/UI/TokenDetails/components/useAssetVisibility.test.ts
@@ -318,11 +318,16 @@ describe('useAssetVisibility', () => {
       ).not.toHaveBeenCalled();
     });
 
-    it('does nothing when accountId is undefined', () => {
+    it('calls hideAsset when accountId is undefined', () => {
       setupSelectors({ globalAccountId: undefined as unknown as string });
       const { result } = renderHook(() => useAssetVisibility(evmToken()));
       act(() => result.current.handleHideToken());
-      expect(Engine.context.AssetsController.hideAsset).not.toHaveBeenCalled();
+      expect(Engine.context.AssetsController.hideAsset).toHaveBeenCalledWith(
+        EVM_ASSET_ID,
+      );
+      expect(
+        Engine.context.AssetsController.removeCustomAsset,
+      ).not.toHaveBeenCalled();
     });
 
     it('calls unhideAsset when the EVM token is hidden via assetPreferences', () => {
@@ -368,7 +373,7 @@ describe('useAssetVisibility', () => {
       ).not.toHaveBeenCalled();
     });
 
-    it('calls removeCustomAsset only when custom asset has no balance entry', () => {
+    it('calls removeCustomAsset and hideAsset when custom asset has no balance entry', () => {
       setupSelectors({
         customAssets: { [ACCOUNT_ID]: [EVM_ASSET_ID] },
       });
@@ -377,7 +382,9 @@ describe('useAssetVisibility', () => {
       expect(
         Engine.context.AssetsController.removeCustomAsset,
       ).toHaveBeenCalledWith(ACCOUNT_ID, EVM_ASSET_ID);
-      expect(Engine.context.AssetsController.hideAsset).not.toHaveBeenCalled();
+      expect(Engine.context.AssetsController.hideAsset).toHaveBeenCalledWith(
+        EVM_ASSET_ID,
+      );
     });
 
     it('calls removeCustomAsset and hideAsset when custom asset also has balance', () => {
@@ -443,13 +450,15 @@ describe('useAssetVisibility', () => {
       ).not.toHaveBeenCalled();
     });
 
-    it('does nothing when token is not hidden, not custom, and has no balance', () => {
+    it('calls hideAsset when token is not hidden, not custom, and has no balance', () => {
       const { result } = renderHook(() => useAssetVisibility(evmToken()));
       act(() => result.current.handleHideToken());
       expect(
         Engine.context.AssetsController.unhideAsset,
       ).not.toHaveBeenCalled();
-      expect(Engine.context.AssetsController.hideAsset).not.toHaveBeenCalled();
+      expect(Engine.context.AssetsController.hideAsset).toHaveBeenCalledWith(
+        EVM_ASSET_ID,
+      );
       expect(
         Engine.context.AssetsController.removeCustomAsset,
       ).not.toHaveBeenCalled();

--- a/app/components/UI/TokenDetails/components/useAssetVisibility.ts
+++ b/app/components/UI/TokenDetails/components/useAssetVisibility.ts
@@ -45,8 +45,8 @@ export interface UseAssetVisibilityReturn {
   /**
    * Calls the correct AssetsController method based on the token's current state:
    * - already hidden → unhideAsset   (checked first: hideAsset keeps the balance entry)
-   * - not hidden + custom → removeCustomAsset
-   * - not hidden + balance entry → hideAsset (runs in addition to removeCustomAsset when both apply)
+   * - not hidden + custom → removeCustomAsset (when accountId is known)
+   * - not hidden → hideAsset (always; unified wallet lists filter on assetPreferences)
    */
   handleHideToken: () => void;
   /**
@@ -153,7 +153,7 @@ const useAssetVisibility = (asset?: TokenI): UseAssetVisibilityReturn => {
   );
 
   const handleHideToken = useCallback(() => {
-    if (!assetId || !accountId) return;
+    if (!assetId) return;
 
     const { AssetsController, MultichainAssetsController } = Engine.context;
 
@@ -166,19 +166,20 @@ const useAssetVisibility = (asset?: TokenI): UseAssetVisibilityReturn => {
         AssetsController.unhideAsset(assetId);
         // For non-EVM tokens the hidden state also lives in
         // MultichainAssetsController.allIgnoredAssets; addAssets restores it.
-        if (allIgnoredNonEvmAssets[accountId]?.includes(assetId)) {
+        if (accountId && allIgnoredNonEvmAssets[accountId]?.includes(assetId)) {
           MultichainAssetsController.addAssets([assetId], accountId);
         }
       } else {
         // Custom-added tokens typically also have an assetsBalance entry once
         // unified assets state hydrated the balance; removing only from
         // customAssets would leave a visible detected token unless we hide too.
-        if (isCustomAsset) {
+        if (isCustomAsset && accountId) {
           AssetsController.removeCustomAsset(accountId, assetId);
         }
-        if (isInAssetsBalance) {
-          AssetsController.hideAsset(assetId);
-        }
+        // hideAsset is global (assetPreferences) and is what unified wallet
+        // selectors use to filter the token list. Always call it when hiding so
+        // token-details hide works even if balance/custom lookups miss the entry.
+        AssetsController.hideAsset(assetId);
       }
     } catch (err) {
       Logger.log(err, 'useAssetVisibility: Failed to update token visibility');
@@ -187,7 +188,6 @@ const useAssetVisibility = (asset?: TokenI): UseAssetVisibilityReturn => {
     assetId,
     accountId,
     isCustomAsset,
-    isInAssetsBalance,
     isHidden,
     allIgnoredNonEvmAssets,
   ]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

With `assetsUnifyState` enabled, the wallet token list reads hidden state from `AssetsController.assetPreferences`. The token-details **Remove token** flow (three-dot menu → Hide confirmation) calls `handleHideToken` from `useAssetVisibility`, but that hook only invoked `AssetsController.hideAsset` when the token had a matching `assetsBalance` entry. For many visible tokens the hide path was a no-op while legacy `TokensController.ignoreTokens` no longer affects the unified list.

This change always calls `AssetsController.hideAsset` when hiding (after optionally removing a custom asset), so token-details hide matches Manage tokens / wallet-list hide behavior.

## **Changelog**

CHANGELOG entry: Fixed hiding a token from token details not removing it from the wallet token list.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/43391 https://consensyssoftware.atlassian.net/browse/ASSETS-3478

## **Manual testing steps**

```gherkin
Feature: Hide token from token details

  Scenario: user hides a token from token details on a popular network
    Given assetsUnifyState is enabled and the wallet shows an ERC-20 token with balance
    When the user opens token details, opens the three-dot menu, taps Remove token, and confirms Hide
    Then the token no longer appears in the wallet token list
```

Unit tests: `yarn jest app/components/UI/TokenDetails/components/useAssetVisibility.test.ts --coverage=false`

## **Screenshots/Recordings**

N/A — logic fix validated by unit tests; UI flow unchanged.

### **Before**

Hide confirmation appeared but the token remained in the wallet list (see ASSETS-3478 recording).

### **After**

N/A — not captured in this environment.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33e038ae-f6f4-4243-9ef4-54a6638ee172?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33e038ae-f6f4-4243-9ef4-54a6638ee172&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

