### PR TITLE
fix(assets): skip Token API requests for unsupported networks (ASSETS-3434)

### DIFF
--- a/app/components/UI/Tokens/util/tokenSecurityBadgeBatch.test.ts
+++ b/app/components/UI/Tokens/util/tokenSecurityBadgeBatch.test.ts
@@ -14,6 +14,12 @@ jest.mock('@metamask/assets-controllers', () => ({
   fetchTokenAssets: jest.fn(),
 }));
 
+jest.mock('../../../../util/tokenApi/supportedNetworks', () => ({
+  filterTokenApiSupportedCaipAssetIds: jest.fn(async (assetIds: string[]) =>
+    assetIds.filter((id) => !id.includes('11155111')),
+  ),
+}));
+
 const mockFetchTokenAssets = jest.mocked(fetchTokenAssets);
 
 function tokenAssetFixture(
@@ -146,6 +152,18 @@ describe('requestTokenSecurityForAsset', () => {
 
     await expect(pUsdc).resolves.toEqual({ resultType: 'Verified' });
     await expect(pDai).resolves.toEqual({ resultType: 'Warning' });
+  });
+
+  it('resolves null without calling fetchTokenAssets for unsupported networks', async () => {
+    const sepoliaUsdc =
+      'eip155:11155111/erc20:0x7b79995e5f793a07b53987d39fffc615e1f0fbbb' as CaipAssetType;
+
+    const p = requestTokenSecurityForAsset(sepoliaUsdc);
+
+    await waitForBatchFlush();
+
+    expect(mockFetchTokenAssets).not.toHaveBeenCalled();
+    await expect(p).resolves.toBeNull();
   });
 
   it('resolves null when fetchTokenAssets throws', async () => {

--- a/app/components/UI/Tokens/util/tokenSecurityBadgeBatch.ts
+++ b/app/components/UI/Tokens/util/tokenSecurityBadgeBatch.ts
@@ -8,6 +8,7 @@ import {
   toCaipAssetType,
   type CaipAssetType,
 } from '@metamask/utils';
+import { filterTokenApiSupportedCaipAssetIds } from '../../../../util/tokenApi/supportedNetworks';
 
 export function normalizeCaipAssetIdForTokenApi(
   assetId: CaipAssetType,
@@ -73,6 +74,8 @@ async function flush() {
 
   const assetIds = [...snapshot.keys()];
 
+  const supportedAssetIds = await filterTokenApiSupportedCaipAssetIds(assetIds);
+
   const resolveAll = (
     getter: (id: CaipAssetType) => TokenSecurityData | null,
   ) => {
@@ -83,9 +86,14 @@ async function flush() {
     }
   };
 
+  if (supportedAssetIds.length === 0) {
+    resolveAll(() => null);
+    return;
+  }
+
   const byAssetId = new Map<CaipAssetType, TokenSecurityData | null>();
   try {
-    for (const chunk of chunkArray(assetIds, MAX_ASSETS_PER_REQUEST)) {
+    for (const chunk of chunkArray(supportedAssetIds, MAX_ASSETS_PER_REQUEST)) {
       try {
         const assets = await fetchTokenAssets(chunk, {
           includeTokenSecurityData: true,

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import {
   CodefiTokenPricesServiceV2,
-  TokenListService,
+  type TokenListService,
 } from '@metamask/assets-controllers';
 import { AccountsController } from '@metamask/accounts-controller';
 import {
@@ -115,6 +115,7 @@ import {
 } from '../../selectors/assets/assets-migration';
 import { getGlobalChainId } from '../../util/networks/global-network';
 import { logEngineCreation } from './utils/logger';
+import { createTokenListService } from './utils/createTokenListService';
 import { initMessengerClients } from './utils';
 import { accountTreeControllerInit } from '../../multichain-accounts/controllers/account-tree-controller';
 import { bridgeControllerInit } from './controllers/bridge-controller/bridge-controller-init';
@@ -290,7 +291,7 @@ export class Engine {
     });
 
     const codefiTokenApiV2 = new CodefiTokenPricesServiceV2();
-    const tokenListService = new TokenListService();
+    const tokenListService = createTokenListService();
     this.tokenListService = tokenListService;
 
     const initRequest = {

--- a/app/core/Engine/utils/createTokenListService.test.ts
+++ b/app/core/Engine/utils/createTokenListService.test.ts
@@ -1,0 +1,62 @@
+import { TokenListService } from '@metamask/assets-controllers';
+import { createTokenListService } from './createTokenListService';
+import { isTokenApiChainSupported } from '../../../util/tokenApi/supportedNetworks';
+
+jest.mock('@metamask/assets-controllers', () => ({
+  TokenListService: jest.fn(),
+}));
+
+jest.mock('../../../util/tokenApi/supportedNetworks', () => ({
+  isTokenApiChainSupported: jest.fn(),
+}));
+
+const MockTokenListService = TokenListService as jest.MockedClass<
+  typeof TokenListService
+>;
+const mockIsTokenApiChainSupported = jest.mocked(isTokenApiChainSupported);
+
+describe('createTokenListService', () => {
+  const fetchTokensByChainId = jest.fn();
+  const destroy = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockTokenListService.mockImplementation(
+      () =>
+        ({
+          fetchTokensByChainId,
+          destroy,
+        }) as unknown as TokenListService,
+    );
+  });
+
+  it('returns an empty map without calling the inner service for unsupported chains', async () => {
+    mockIsTokenApiChainSupported.mockResolvedValue(false);
+    const service = createTokenListService();
+
+    const result = await service.fetchTokensByChainId('0xaa36a7');
+
+    expect(result).toEqual({});
+    expect(fetchTokensByChainId).not.toHaveBeenCalled();
+  });
+
+  it('delegates to the inner service for supported chains', async () => {
+    mockIsTokenApiChainSupported.mockResolvedValue(true);
+    const tokenListMap = { '0xabc': { symbol: 'TST' } };
+    fetchTokensByChainId.mockResolvedValue(tokenListMap);
+    const service = createTokenListService();
+
+    const result = await service.fetchTokensByChainId('0x1');
+
+    expect(result).toBe(tokenListMap);
+    expect(fetchTokensByChainId).toHaveBeenCalledWith('0x1');
+  });
+
+  it('forwards destroy to the inner service', () => {
+    const service = createTokenListService();
+
+    service.destroy();
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/core/Engine/utils/createTokenListService.ts
+++ b/app/core/Engine/utils/createTokenListService.ts
@@ -1,0 +1,27 @@
+import {
+  TokenListService,
+  type TokenListMap,
+} from '@metamask/assets-controllers';
+import type { Hex } from '@metamask/utils';
+import { isTokenApiChainSupported } from '../../../util/tokenApi/supportedNetworks';
+
+/**
+ * Shared TokenListService instance that skips `/tokens/{chainId}` requests for
+ * networks absent from Token API `/v2/supportedNetworks` (e.g. Sepolia).
+ */
+export function createTokenListService(): TokenListService {
+  const inner = new TokenListService();
+
+  return {
+    async fetchTokensByChainId(chainId: Hex): Promise<TokenListMap> {
+      if (!(await isTokenApiChainSupported(chainId))) {
+        return {};
+      }
+
+      return inner.fetchTokensByChainId(chainId);
+    },
+    destroy(): void {
+      inner.destroy();
+    },
+  } as TokenListService;
+}

--- a/app/util/tokenApi/supportedNetworks.test.ts
+++ b/app/util/tokenApi/supportedNetworks.test.ts
@@ -1,0 +1,76 @@
+import { handleFetch } from '@metamask/controller-utils';
+import {
+  filterTokenApiSupportedCaipAssetIds,
+  getTokenApiSupportedChainIds,
+  hexChainIdToCaipChainId,
+  isTokenApiChainSupported,
+  resetTokenApiSupportedNetworksCacheForTesting,
+  TOKEN_API_SUPPORTED_NETWORKS_URL,
+} from './supportedNetworks';
+
+jest.mock('@metamask/controller-utils', () => ({
+  ...jest.requireActual('@metamask/controller-utils'),
+  handleFetch: jest.fn(),
+}));
+
+const mockHandleFetch = handleFetch as jest.Mock;
+
+const SUPPORTED_NETWORKS_RESPONSE = {
+  fullSupport: ['eip155:1', 'eip155:137'],
+  partialSupport: ['eip155:8453'],
+};
+
+describe('tokenApi/supportedNetworks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetTokenApiSupportedNetworksCacheForTesting();
+  });
+
+  it('fetches and caches supported chain IDs', async () => {
+    mockHandleFetch.mockResolvedValue(SUPPORTED_NETWORKS_RESPONSE);
+
+    const first = await getTokenApiSupportedChainIds();
+    const second = await getTokenApiSupportedChainIds();
+
+    expect(first).toEqual(new Set(['eip155:1', 'eip155:137', 'eip155:8453']));
+    expect(second).toEqual(first);
+    expect(mockHandleFetch).toHaveBeenCalledTimes(1);
+    expect(mockHandleFetch).toHaveBeenCalledWith(
+      TOKEN_API_SUPPORTED_NETWORKS_URL,
+    );
+  });
+
+  it('converts hex chain IDs to CAIP format', () => {
+    expect(hexChainIdToCaipChainId('0xaa36a7')).toBe('eip155:11155111');
+    expect(hexChainIdToCaipChainId('0x1')).toBe('eip155:1');
+  });
+
+  it('returns false for unsupported networks such as Sepolia', async () => {
+    mockHandleFetch.mockResolvedValue(SUPPORTED_NETWORKS_RESPONSE);
+
+    await expect(isTokenApiChainSupported('0xaa36a7')).resolves.toBe(false);
+    await expect(isTokenApiChainSupported('0x1')).resolves.toBe(true);
+  });
+
+  it('filters asset IDs to supported networks only', async () => {
+    mockHandleFetch.mockResolvedValue(SUPPORTED_NETWORKS_RESPONSE);
+
+    const filtered = await filterTokenApiSupportedCaipAssetIds([
+      'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      'eip155:11155111/erc20:0x7b79995e5f793a07b53987d39fffc615e1f0fbbb',
+    ]);
+
+    expect(filtered).toEqual([
+      'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    ]);
+  });
+
+  it('returns an empty set when the supported-networks fetch fails', async () => {
+    mockHandleFetch.mockRejectedValue(new Error('network error'));
+
+    const supported = await getTokenApiSupportedChainIds();
+
+    expect(supported).toEqual(new Set());
+    await expect(isTokenApiChainSupported('0x1')).resolves.toBe(false);
+  });
+});

--- a/app/util/tokenApi/supportedNetworks.ts
+++ b/app/util/tokenApi/supportedNetworks.ts
@@ -1,0 +1,124 @@
+import { handleFetch, convertHexToDecimal } from '@metamask/controller-utils';
+import { parseCaipAssetType, type Hex } from '@metamask/utils';
+
+export const TOKEN_API_SUPPORTED_NETWORKS_URL =
+  'https://token.api.cx.metamask.io/v2/supportedNetworks';
+
+const SUPPORTED_NETWORKS_CACHE_TTL_MS = 60 * 60 * 1000;
+
+interface SupportedNetworksResponse {
+  fullSupport?: string[];
+  partialSupport?: string[];
+}
+
+let supportedChainIdsCache: Set<string> | undefined;
+let supportedChainIdsCachedAt = 0;
+let supportedChainIdsRefreshPromise: Promise<Set<string>> | undefined;
+
+function normalizeSupportedNetworksResponse(
+  response: SupportedNetworksResponse,
+): Set<string> {
+  return new Set([
+    ...(response.fullSupport ?? []),
+    ...(response.partialSupport ?? []),
+  ]);
+}
+
+async function refreshSupportedChainIds(now: number): Promise<Set<string>> {
+  if (supportedChainIdsRefreshPromise) {
+    return supportedChainIdsRefreshPromise;
+  }
+
+  supportedChainIdsRefreshPromise = (async () => {
+    try {
+      const response = (await handleFetch(
+        TOKEN_API_SUPPORTED_NETWORKS_URL,
+      )) as SupportedNetworksResponse;
+
+      if (
+        response &&
+        typeof response === 'object' &&
+        (Array.isArray(response.fullSupport) ||
+          Array.isArray(response.partialSupport))
+      ) {
+        supportedChainIdsCache = normalizeSupportedNetworksResponse(response);
+        supportedChainIdsCachedAt = now;
+      }
+    } catch {
+      // Leave cache unchanged on failure; callers treat missing cache as unsupported.
+    } finally {
+      supportedChainIdsRefreshPromise = undefined;
+    }
+
+    return supportedChainIdsCache ?? new Set();
+  })();
+
+  return supportedChainIdsRefreshPromise;
+}
+
+/**
+ * Returns CAIP chain IDs supported by the Token API (`/v2/supportedNetworks`).
+ * Results are cached in memory for one hour.
+ */
+export async function getTokenApiSupportedChainIds(): Promise<Set<string>> {
+  const now = Date.now();
+  if (
+    supportedChainIdsCache &&
+    now - supportedChainIdsCachedAt < SUPPORTED_NETWORKS_CACHE_TTL_MS
+  ) {
+    return supportedChainIdsCache;
+  }
+
+  return refreshSupportedChainIds(now);
+}
+
+export function hexChainIdToCaipChainId(chainId: Hex | string): string {
+  const normalized = chainId.startsWith('0x')
+    ? chainId
+    : (`0x${chainId}` as Hex);
+  return `eip155:${convertHexToDecimal(normalized)}`;
+}
+
+/**
+ * Whether the Token API supports token-list / asset requests for `chainId`.
+ * Returns `false` when the network is absent from `/v2/supportedNetworks`.
+ */
+export async function isTokenApiChainSupported(
+  chainId: Hex | string,
+): Promise<boolean> {
+  const supportedChainIds = await getTokenApiSupportedChainIds();
+  return supportedChainIds.has(hexChainIdToCaipChainId(chainId));
+}
+
+function getCaipChainIdFromAssetId(assetId: string): string | null {
+  try {
+    const { chain } = parseCaipAssetType(assetId);
+    return `${chain.namespace}:${chain.reference}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Filters CAIP-19 asset IDs to those on Token API supported networks.
+ */
+export async function filterTokenApiSupportedCaipAssetIds(
+  assetIds: readonly string[],
+): Promise<string[]> {
+  if (assetIds.length === 0) {
+    return [];
+  }
+
+  const supportedChainIds = await getTokenApiSupportedChainIds();
+  return assetIds.filter((assetId) => {
+    const chainId = getCaipChainIdFromAssetId(assetId);
+    return chainId != null && supportedChainIds.has(chainId);
+  });
+}
+
+/** Clears the in-memory supported-networks cache. For unit tests only. */
+export function resetTokenApiSupportedNetworksCacheForTesting(): void {
+  supportedChainIdsCache = undefined;
+  supportedChainIdsCachedAt = 0;
+  supportedChainIdsRefreshPromise = undefined;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [ASSETS-3434](https://consensyssoftware.atlassian.net/browse/ASSETS-3434): switching to Sepolia caused a `400 Bad Request` from `token.api.cx.metamask.io/tokens/11155111` because the Token API does not support that chain.

## Root cause

After recent security-related token fetching changes, `TokenListService` and token security badge batching called the Token API for every chain without checking `/v2/supportedNetworks`. Sepolia (`11155111`) is not in that list, so the request fails with HTTP 400.

## Solution

- Add a module-level cache of `GET https://token.api.cx.metamask.io/v2/supportedNetworks` (1h TTL, deduped in-flight fetch).
- Wrap `TokenListService` so `fetchTokensByChainId` returns `{}` immediately for unsupported chains (covers `TokenDetectionController`, `TokensController`, etc.).
- Filter unsupported CAIP asset IDs in `tokenSecurityBadgeBatch` before calling `fetchTokenAssets`.

## Testing

- `yarn jest app/util/tokenApi/supportedNetworks.test.ts`
- `yarn jest app/core/Engine/utils/createTokenListService.test.ts`
- `yarn jest app/components/UI/Tokens/util/tokenSecurityBadgeBatch.test.ts`

All three suites pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f04a9b0-caf9-4b12-82bf-eb92a34fb97c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f04a9b0-caf9-4b12-82bf-eb92a34fb97c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[ASSETS-3434]: https://consensyssoftware.atlassian.net/browse/ASSETS-3434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ