### PR TITLE
ci: retry Namespace artifact uploads in ci.yml (INFRA-3902)

### DIFF
--- a/.github/actions/dual-upload-e2e-artifact/action.yml
+++ b/.github/actions/dual-upload-e2e-artifact/action.yml
@@ -18,8 +18,15 @@ inputs:
     description: 'Name of the artifact to upload.'
     required: true
   path:
-    description: 'A file, directory or wildcard pattern that describes what to upload.'
+    description: 'A file, directory or wildcard pattern that describes what to upload to the Namespace store (and GitHub when github-path is unset).'
     required: true
+  github-path:
+    description: >
+      Optional path for the GitHub store upload. When unset, GitHub uses `path`.
+      Use when Namespace needs a full directory but GitHub API consumers need a
+      subset under the same artifact name (e.g. ci.yml coverage shards).
+    required: false
+    default: ''
   if-no-files-found:
     description: 'Behavior if no files are found (`warn`, `error`, or `ignore`).'
     required: false
@@ -105,7 +112,7 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.name }}
-        path: ${{ inputs.path }}
+        path: ${{ contains(inputs.runner-provider, 'namespace') && inputs.github-path != '' && inputs.github-path || inputs.path }}
         if-no-files-found: ${{ inputs.if-no-files-found }}
         retention-days: ${{ inputs.retention-days }}
         overwrite: true

--- a/.github/actions/dual-upload-e2e-artifact/dual-upload-e2e-artifact.test.ts
+++ b/.github/actions/dual-upload-e2e-artifact/dual-upload-e2e-artifact.test.ts
@@ -109,6 +109,18 @@ describe('dual-upload-e2e-artifact', () => {
       name: 'Upload to GitHub',
       if: "${{ inputs.skip-github != 'true' || !contains(inputs.runner-provider, 'namespace') }}",
     });
+    expect(githubUploadSteps[0]?.with?.path).toBe(
+      "${{ contains(inputs.runner-provider, 'namespace') && inputs.github-path != '' && inputs.github-path || inputs.path }}",
+    );
+  });
+
+  it('exposes github-path as an optional input defaulting to empty', () => {
+    const actionMetadata = loadActionMetadata();
+
+    expect(actionMetadata.inputs['github-path']).toMatchObject({
+      required: false,
+    });
+    expect(actionMetadata.inputs['github-path'].default).toBe('');
   });
 
   it('exposes skip-github as an optional input defaulting to false', () => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,20 +708,13 @@ jobs:
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${COMMIT_SHA}" \
             -d "$BODY"
 
-      - name: Upload iOS bundle (Namespace)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
-        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
+      - name: Upload iOS bundle (artifact stores)
+        uses: ./.github/actions/dual-upload-e2e-artifact
         with:
           name: ios-bundle
           path: ios/main.jsbundle
           retention-days: 7
-      - name: Upload iOS bundle (current)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios-bundle
-          path: ios/main.jsbundle
-          retention-days: 7
+          runner-provider: ${{ env.RESOLVED_RUNNER_PROVIDER }}
 
   ship-js-bundle-size-check:
     name: Ship JS bundle size check
@@ -936,32 +929,17 @@ jobs:
           cp tests/results/unit-test-results-${{ matrix.shard }}.json ./tests/coverage/jest-results.json
           count=$(jq '(.numPassedTests // 0) + (.numFailedTests // 0)' tests/results/unit-test-results-${{ matrix.shard }}.json)
           echo "{\"count\": $count}" > ./tests/coverage/count.json
-      - name: Upload coverage unit shard (Namespace)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
-        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
+      # Namespace stores the full shard dir for merge; GitHub gets jest-results.json
+      # only so qa-stats can read it via the GitHub API.
+      - name: Upload coverage unit shard (artifact stores)
+        uses: ./.github/actions/dual-upload-e2e-artifact
         with:
           name: coverage-unit-${{ matrix.shard }}
           path: ./tests/coverage/
+          github-path: ./tests/coverage/jest-results.json
           if-no-files-found: error
           retention-days: 7
-      # QA Stats reads artifacts through the GitHub API, which cannot see
-      # artifacts stored by namespace-actions/upload-artifact.
-      - name: Upload unit test results for QA Stats (GitHub)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-unit-${{ matrix.shard }}
-          path: ./tests/coverage/jest-results.json
-          if-no-files-found: error
-          retention-days: 7
-      - name: Upload coverage unit shard (current)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-unit-${{ matrix.shard }}
-          path: ./tests/coverage/
-          if-no-files-found: error
-          retention-days: 7
+          runner-provider: ${{ env.RESOLVED_RUNNER_PROVIDER }}
       - name: Require clean working directory
         shell: bash
         run: |
@@ -1098,155 +1076,87 @@ jobs:
           find ./tests/coverage/coverage-* -name 'coverage-*.json' -exec mv {} ./tests/coverage/ \;
       - run: yarn test:merge-coverage
       - run: yarn test:validate-coverage
-      - name: Upload lcov.info (Namespace)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
-        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
+      - name: Upload lcov.info (artifact stores)
+        uses: ./.github/actions/dual-upload-e2e-artifact
         with:
           name: lcov.info
           path: ./tests/merged-coverage/lcov.info
           if-no-files-found: error
           retention-days: 7
-      - name: Upload lcov.info (current)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: lcov.info
-          path: ./tests/merged-coverage/lcov.info
-          if-no-files-found: error
-          retention-days: 7
-      - name: Upload cv-test-stats (Namespace)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
-        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
+          runner-provider: ${{ env.RESOLVED_RUNNER_PROVIDER }}
+      - name: Upload cv-test-stats (artifact stores)
+        uses: ./.github/actions/dual-upload-e2e-artifact
         with:
           name: cv-test-stats
           path: ./cv-test-stats.json
           if-no-files-found: error
           retention-days: 7
-      - name: Upload cv-test-stats (current)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: cv-test-stats
-          path: ./cv-test-stats.json
-          if-no-files-found: error
-          retention-days: 7
-      - name: Upload integration-test-stats (Namespace)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
-        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
+          runner-provider: ${{ env.RESOLVED_RUNNER_PROVIDER }}
+      - name: Upload integration-test-stats (artifact stores)
+        uses: ./.github/actions/dual-upload-e2e-artifact
         with:
           name: integration-test-stats
           path: ./integration-test-stats.json
           if-no-files-found: error
           retention-days: 7
-      - name: Upload integration-test-stats (current)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: integration-test-stats
-          path: ./integration-test-stats.json
-          if-no-files-found: error
-          retention-days: 7
-      - name: Upload unit-test-stats (Namespace)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
-        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
+          runner-provider: ${{ env.RESOLVED_RUNNER_PROVIDER }}
+      - name: Upload unit-test-stats (artifact stores)
+        uses: ./.github/actions/dual-upload-e2e-artifact
         with:
           name: unit-test-stats
           path: ./unit-test-stats.json
           if-no-files-found: error
           retention-days: 7
-      - name: Upload unit-test-stats (current)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-test-stats
-          path: ./unit-test-stats.json
-          if-no-files-found: error
-          retention-days: 7
+          runner-provider: ${{ env.RESOLVED_RUNNER_PROVIDER }}
       - name: Generate CV test coverage report
         run: yarn nyc report --temp-dir ./tests/coverage-cv-merged --report-dir ./tests/coverage-cv-lcov --reporter html --reporter json-summary
-      - name: Upload cv-test-coverage-html (Namespace)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
-        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
+      - name: Upload cv-test-coverage-html (artifact stores)
+        uses: ./.github/actions/dual-upload-e2e-artifact
         with:
           name: cv-test-coverage-html
           path: ./tests/coverage-cv-lcov/
           if-no-files-found: error
           retention-days: 7
-      - name: Upload cv-test-coverage-html (current)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: cv-test-coverage-html
-          path: ./tests/coverage-cv-lcov/
-          if-no-files-found: error
-          retention-days: 7
-      - name: Upload cv-test-coverage-summary (Namespace)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
-        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
+          runner-provider: ${{ env.RESOLVED_RUNNER_PROVIDER }}
+      - name: Upload cv-test-coverage-summary (artifact stores)
+        uses: ./.github/actions/dual-upload-e2e-artifact
         with:
           name: cv-test-coverage-summary
           path: ./tests/coverage-cv-lcov/coverage-summary.json
           if-no-files-found: error
           retention-days: 7
-      - name: Upload cv-test-coverage-summary (GitHub)
-        uses: actions/upload-artifact@v4
-        with:
-          name: cv-test-coverage-summary
-          path: ./tests/coverage-cv-lcov/coverage-summary.json
-          if-no-files-found: error
-          retention-days: 7
+          runner-provider: ${{ env.RESOLVED_RUNNER_PROVIDER }}
       - name: Generate integration test coverage report
         if: ${{ steps.aggregate-coverage.outputs.has_integration_coverage == 'true' }}
         run: yarn nyc report --temp-dir ./tests/coverage-integration-merged --report-dir ./tests/coverage-integration-lcov --reporter html --reporter json-summary
-      - name: Upload integration-test-coverage-html (Namespace)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' && steps.aggregate-coverage.outputs.has_integration_coverage == 'true' }}
-        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
-        with:
-          name: integration-test-coverage-html
-          path: ./tests/coverage-integration-lcov/
-          if-no-files-found: error
-          retention-days: 7
-      - name: Upload integration-test-coverage-html (current)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' && steps.aggregate-coverage.outputs.has_integration_coverage == 'true' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: integration-test-coverage-html
-          path: ./tests/coverage-integration-lcov/
-          if-no-files-found: error
-          retention-days: 7
-      - name: Upload integration-test-coverage-summary (Namespace)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' && steps.aggregate-coverage.outputs.has_integration_coverage == 'true' }}
-        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
-        with:
-          name: integration-test-coverage-summary
-          path: ./tests/coverage-integration-lcov/coverage-summary.json
-          if-no-files-found: error
-          retention-days: 7
-      - name: Upload integration-test-coverage-summary (GitHub)
+      - name: Upload integration-test-coverage-html (artifact stores)
         if: ${{ steps.aggregate-coverage.outputs.has_integration_coverage == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/dual-upload-e2e-artifact
+        with:
+          name: integration-test-coverage-html
+          path: ./tests/coverage-integration-lcov/
+          if-no-files-found: error
+          retention-days: 7
+          runner-provider: ${{ env.RESOLVED_RUNNER_PROVIDER }}
+      - name: Upload integration-test-coverage-summary (artifact stores)
+        if: ${{ steps.aggregate-coverage.outputs.has_integration_coverage == 'true' }}
+        uses: ./.github/actions/dual-upload-e2e-artifact
         with:
           name: integration-test-coverage-summary
           path: ./tests/coverage-integration-lcov/coverage-summary.json
           if-no-files-found: error
           retention-days: 7
+          runner-provider: ${{ env.RESOLVED_RUNNER_PROVIDER }}
       - name: Generate unit test coverage summary
         run: yarn nyc report --temp-dir ./tests/coverage-unit-merged --report-dir ./tests/coverage-unit-lcov --reporter json-summary
-      - name: Upload unit-test-coverage-summary (Namespace)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
-        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
+      - name: Upload unit-test-coverage-summary (artifact stores)
+        uses: ./.github/actions/dual-upload-e2e-artifact
         with:
           name: unit-test-coverage-summary
           path: ./tests/coverage-unit-lcov/coverage-summary.json
           if-no-files-found: error
           retention-days: 7
-      - name: Upload unit-test-coverage-summary (GitHub)
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-test-coverage-summary
-          path: ./tests/coverage-unit-lcov/coverage-summary.json
-          if-no-files-found: error
-          retention-days: 7
+          runner-provider: ${{ env.RESOLVED_RUNNER_PROVIDER }}
       - name: Require clean working directory
         shell: bash
         run: |
@@ -1315,30 +1225,15 @@ jobs:
           cp tests/results/cv-test-results-${{ matrix.shard }}.json ./tests/coverage/jest-results.json
           count=$(jq '(.numPassedTests // 0) + (.numFailedTests // 0)' tests/results/cv-test-results-${{ matrix.shard }}.json)
           echo "{\"count\": $count}" > ./tests/coverage/count.json
-      - name: Upload coverage CV shard (Namespace)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
-        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
+      - name: Upload coverage CV shard (artifact stores)
+        uses: ./.github/actions/dual-upload-e2e-artifact
         with:
           name: coverage-cv-${{ matrix.shard }}
           path: ./tests/coverage/
+          github-path: ./tests/coverage/jest-results.json
           if-no-files-found: error
           retention-days: 7
-      - name: Upload component view test results for QA Stats (GitHub)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-cv-${{ matrix.shard }}
-          path: ./tests/coverage/jest-results.json
-          if-no-files-found: error
-          retention-days: 7
-      - name: Upload coverage CV shard (current)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-cv-${{ matrix.shard }}
-          path: ./tests/coverage/
-          if-no-files-found: error
-          retention-days: 7
+          runner-provider: ${{ env.RESOLVED_RUNNER_PROVIDER }}
 
   # Integration tests are optional for the PR gate — they feed coverage into
   # merge → Sonar but are not listed in check-all-jobs-pass needs.
@@ -1416,30 +1311,15 @@ jobs:
           cp tests/results/integration-test-results-${{ matrix.shard }}.json ./tests/coverage/jest-results.json
           count=$(jq '(.numPassedTests // 0) + (.numFailedTests // 0)' tests/results/integration-test-results-${{ matrix.shard }}.json)
           echo "{\"count\": $count}" > ./tests/coverage/count.json
-      - name: Upload coverage integration shard (Namespace)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
-        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
+      - name: Upload coverage integration shard (artifact stores)
+        uses: ./.github/actions/dual-upload-e2e-artifact
         with:
           name: coverage-integration-${{ matrix.shard }}
           path: ./tests/coverage/
+          github-path: ./tests/coverage/jest-results.json
           if-no-files-found: error
           retention-days: 7
-      - name: Upload integration test results for QA Stats (GitHub)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-integration-${{ matrix.shard }}
-          path: ./tests/coverage/jest-results.json
-          if-no-files-found: error
-          retention-days: 7
-      - name: Upload coverage integration shard (current)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-integration-${{ matrix.shard }}
-          path: ./tests/coverage/
-          if-no-files-found: error
-          retention-days: 7
+          runner-provider: ${{ env.RESOLVED_RUNNER_PROVIDER }}
 
   smart-e2e-selection:
     name: 'Smart E2E Selection'


### PR DESCRIPTION
## **Description**

Namespace → GitHub `CreateArtifact` calls intermittently fail with `ECONNREFUSED` after tests pass. PR #35349 introduced `dual-upload-e2e-artifact` with 3 retries and 15s backoff for Appium E2E workflows, but `ci.yml` still called `namespace-actions/upload-artifact` directly (13 steps).

This PR:
1. Extends `dual-upload-e2e-artifact` with an optional `github-path` input so coverage shards can upload the full directory to Namespace while qa-stats still receives only `jest-results.json` on GitHub.
2. Migrates all 13 Namespace artifact upload steps in `ci.yml` to the retrying composite action.

Complements #35669, which covers the remaining E2E build/api-spec workflows.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: [INFRA-3902](https://consensyssoftware.atlassian.net/browse/INFRA-3902)

## **Manual testing steps**

N/A — CI-only change. Unit tests added for `github-path` input and GitHub path expression in `dual-upload-e2e-artifact.test.ts`.

## **Screenshots/Recordings**

N/A — no UI changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable (N/A — workflow YAML and composite action metadata only)
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android (N/A — CI-only change)
- [x] I've tested with a power user scenario (N/A — CI-only change)
- [x] I've instrumented key operations with Sentry traces for production performance metrics (N/A — CI-only change)

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[INFRA-3902]: https://consensyssoftware.atlassian.net/browse/INFRA-3902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ