### PR TITLE
fix(perps): coordinate post-order TP/SL attachment

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -283,6 +283,7 @@ const mockDefaultUsePerpsMaxSlippage = () => ({
   setMaxSlippage: jest.fn(),
 });
 const mockAttachPostOrderTPSL = jest.fn().mockResolvedValue({ success: true });
+let mockIsAttachingPostOrderTPSL = false;
 
 // Mock the hooks module - these will be overridden in beforeEach
 jest.mock('../../hooks', () => ({
@@ -347,6 +348,7 @@ jest.mock('../../hooks', () => ({
   usePerpsOrderExecution: jest.fn(() => mockDefaultUsePerpsOrderExecution()),
   usePerpsPostOrderTPSL: jest.fn(() => ({
     attachPostOrderTPSL: mockAttachPostOrderTPSL,
+    isAttachingPostOrderTPSL: mockIsAttachingPostOrderTPSL,
   })),
   usePerpsOrderDepositTracking: jest.fn(() => ({
     handleDepositConfirm: jest.fn(),
@@ -1114,6 +1116,7 @@ describe('PerpsOrderView', () => {
     mockIsPayQuoteLoading = false;
     mockPayTotals = undefined;
     mockPayRequiredTokens = [];
+    mockIsAttachingPostOrderTPSL = false;
 
     jest.mocked(useAnalytics).mockReturnValue({
       trackEvent: mockTrackEvent,
@@ -1415,14 +1418,9 @@ describe('PerpsOrderView', () => {
     expect(mockSubmitted).toHaveBeenCalled();
   });
 
-  it('waits for the live position before attaching TP/SL to a new market position', async () => {
-    const renderedPosition = {
-      symbol: 'ETH',
-      size: '0.0037',
-    } as Position;
+  it('delegates new-position TP/SL after prompt order execution', async () => {
     const mockExecuteOrder = jest.fn().mockResolvedValue({
       success: true,
-      position: renderedPosition,
     });
     (usePerpsOrderContext as jest.Mock).mockReturnValue({
       ...defaultMockHooks.usePerpsOrderContext,
@@ -1459,15 +1457,13 @@ describe('PerpsOrderView', () => {
     const submittedOrder = mockExecuteOrder.mock.calls[0][0];
     expect(submittedOrder.takeProfitPrice).toBeUndefined();
     expect(submittedOrder.stopLossPrice).toBeUndefined();
-    expect(mockExecuteOrder).toHaveBeenCalledWith(submittedOrder, {
-      waitForPosition: true,
-    });
+    expect(mockExecuteOrder).toHaveBeenCalledWith(submittedOrder);
     expect(mockAttachPostOrderTPSL).toHaveBeenCalledWith(
       expect.objectContaining({
         symbol: 'ETH',
         takeProfitPrice: '3500',
       }),
-      renderedPosition,
+      { positionBaseline: undefined },
     );
   });
 
@@ -1507,7 +1503,9 @@ describe('PerpsOrderView', () => {
       fireEvent.press(placeOrderButton);
     });
 
-    expect(mockAttachPostOrderTPSL.mock.calls[0][1]).toBeUndefined();
+    expect(mockAttachPostOrderTPSL.mock.calls[0][1]).toEqual({
+      positionBaseline: undefined,
+    });
   });
 
   it('includes discovery attribution from route source_section in order trackingData', async () => {
@@ -2342,6 +2340,18 @@ describe('PerpsOrderView', () => {
       render(<PerpsOrderView />, { wrapper: TestWrapper });
 
       // When placing order, button shows loading indicator
+      const placeOrderButton = await screen.findByTestId(
+        PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON,
+      );
+      expect(placeOrderButton).toBeDisabled();
+      expect(placeOrderButton.props.accessibilityState?.busy).toBe(true);
+    });
+
+    it('keeps the button busy while post-order protection is attaching', async () => {
+      mockIsAttachingPostOrderTPSL = true;
+
+      render(<PerpsOrderView />, { wrapper: TestWrapper });
+
       const placeOrderButton = await screen.findByTestId(
         PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON,
       );

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -1462,12 +1462,13 @@ describe('PerpsOrderView', () => {
     expect(mockExecuteOrder).toHaveBeenCalledWith(submittedOrder, {
       waitForPosition: true,
     });
-    expect(mockAttachPostOrderTPSL).toHaveBeenCalledWith({
-      symbol: 'ETH',
-      takeProfitPrice: '3500',
-      stopLossPrice: undefined,
-      position: renderedPosition,
-    });
+    expect(mockAttachPostOrderTPSL).toHaveBeenCalledWith(
+      expect.objectContaining({
+        symbol: 'ETH',
+        takeProfitPrice: '3500',
+      }),
+      renderedPosition,
+    );
   });
 
   it('attempts TP/SL attachment without a rendered position hint', async () => {
@@ -1506,12 +1507,7 @@ describe('PerpsOrderView', () => {
       fireEvent.press(placeOrderButton);
     });
 
-    expect(mockAttachPostOrderTPSL).toHaveBeenCalledWith({
-      symbol: 'ETH',
-      takeProfitPrice: '3500',
-      stopLossPrice: undefined,
-      position: undefined,
-    });
+    expect(mockAttachPostOrderTPSL.mock.calls[0][1]).toBeUndefined();
   });
 
   it('includes discovery attribution from route source_section in order trackingData', async () => {

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -1478,6 +1478,57 @@ describe('PerpsOrderView', () => {
     });
   });
 
+  it('attempts TP/SL attachment without a rendered position hint', async () => {
+    const mockExecuteOrder = jest.fn().mockResolvedValue({
+      success: true,
+    });
+    const mockUpdatePositionTPSL = jest
+      .fn()
+      .mockResolvedValue({ success: true });
+    (usePerpsOrderContext as jest.Mock).mockReturnValue({
+      ...defaultMockHooks.usePerpsOrderContext,
+      orderForm: {
+        asset: 'ETH',
+        amount: '11',
+        leverage: 3,
+        direction: 'long',
+        type: 'market',
+        limitPrice: undefined,
+        takeProfitPrice: '3500',
+        stopLossPrice: undefined,
+        balancePercent: 10,
+      },
+      handleMinAmount: jest.fn(),
+      calculations: {
+        marginRequired: '11',
+        positionSize: '0.0037',
+      },
+    });
+    (usePerpsOrderExecution as jest.Mock).mockReturnValue({
+      placeOrder: mockExecuteOrder,
+      isPlacing: false,
+    });
+    (usePerpsTrading as jest.Mock).mockReturnValue({
+      ...defaultMockHooks.usePerpsTrading,
+      updatePositionTPSL: mockUpdatePositionTPSL,
+    });
+    render(<PerpsOrderView />, { wrapper: TestWrapper });
+    const placeOrderButton = await screen.findByTestId(
+      PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON,
+    );
+
+    await act(async () => {
+      fireEvent.press(placeOrderButton);
+    });
+
+    expect(mockUpdatePositionTPSL).toHaveBeenCalledWith({
+      symbol: 'ETH',
+      takeProfitPrice: '3500',
+      stopLossPrice: undefined,
+      position: undefined,
+    });
+  });
+
   it('includes discovery attribution from route source_section in order trackingData', async () => {
     const mockExecuteOrder = jest.fn().mockResolvedValue({ success: true });
     (useRoute as jest.Mock).mockReturnValue({

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -262,11 +262,6 @@ const mockDefaultUsePerpsToasts = () => ({
         creationFailed: jest.fn(),
       },
     },
-    positionManagement: {
-      tpsl: {
-        updateTPSLError: jest.fn(),
-      },
-    },
     dataFetching: {
       market: {
         error: {
@@ -287,6 +282,7 @@ const mockDefaultUsePerpsMaxSlippage = () => ({
   maxSlippageSource: 'default',
   setMaxSlippage: jest.fn(),
 });
+const mockAttachPostOrderTPSL = jest.fn().mockResolvedValue({ success: true });
 
 // Mock the hooks module - these will be overridden in beforeEach
 jest.mock('../../hooks', () => ({
@@ -349,6 +345,9 @@ jest.mock('../../hooks', () => ({
     validateNow: jest.fn(),
   })),
   usePerpsOrderExecution: jest.fn(() => mockDefaultUsePerpsOrderExecution()),
+  usePerpsPostOrderTPSL: jest.fn(() => ({
+    attachPostOrderTPSL: mockAttachPostOrderTPSL,
+  })),
   usePerpsOrderDepositTracking: jest.fn(() => ({
     handleDepositConfirm: jest.fn(),
   })),
@@ -1425,9 +1424,6 @@ describe('PerpsOrderView', () => {
       success: true,
       position: renderedPosition,
     });
-    const mockUpdatePositionTPSL = jest
-      .fn()
-      .mockResolvedValue({ success: true });
     (usePerpsOrderContext as jest.Mock).mockReturnValue({
       ...defaultMockHooks.usePerpsOrderContext,
       orderForm: {
@@ -1450,10 +1446,6 @@ describe('PerpsOrderView', () => {
     (usePerpsOrderExecution as jest.Mock).mockReturnValue({
       placeOrder: mockExecuteOrder,
       isPlacing: false,
-    });
-    (usePerpsTrading as jest.Mock).mockReturnValue({
-      ...defaultMockHooks.usePerpsTrading,
-      updatePositionTPSL: mockUpdatePositionTPSL,
     });
     render(<PerpsOrderView />, { wrapper: TestWrapper });
 
@@ -1470,7 +1462,7 @@ describe('PerpsOrderView', () => {
     expect(mockExecuteOrder).toHaveBeenCalledWith(submittedOrder, {
       waitForPosition: true,
     });
-    expect(mockUpdatePositionTPSL).toHaveBeenCalledWith({
+    expect(mockAttachPostOrderTPSL).toHaveBeenCalledWith({
       symbol: 'ETH',
       takeProfitPrice: '3500',
       stopLossPrice: undefined,
@@ -1482,9 +1474,6 @@ describe('PerpsOrderView', () => {
     const mockExecuteOrder = jest.fn().mockResolvedValue({
       success: true,
     });
-    const mockUpdatePositionTPSL = jest
-      .fn()
-      .mockResolvedValue({ success: true });
     (usePerpsOrderContext as jest.Mock).mockReturnValue({
       ...defaultMockHooks.usePerpsOrderContext,
       orderForm: {
@@ -1508,10 +1497,6 @@ describe('PerpsOrderView', () => {
       placeOrder: mockExecuteOrder,
       isPlacing: false,
     });
-    (usePerpsTrading as jest.Mock).mockReturnValue({
-      ...defaultMockHooks.usePerpsTrading,
-      updatePositionTPSL: mockUpdatePositionTPSL,
-    });
     render(<PerpsOrderView />, { wrapper: TestWrapper });
     const placeOrderButton = await screen.findByTestId(
       PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON,
@@ -1521,7 +1506,7 @@ describe('PerpsOrderView', () => {
       fireEvent.press(placeOrderButton);
     });
 
-    expect(mockUpdatePositionTPSL).toHaveBeenCalledWith({
+    expect(mockAttachPostOrderTPSL).toHaveBeenCalledWith({
       symbol: 'ETH',
       takeProfitPrice: '3500',
       stopLossPrice: undefined,

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -71,6 +71,7 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
+  type Position,
 } from '@metamask/perps-controller';
 import { PERPS_ANALYTICS_PREVIOUS_LEVERAGE } from '../../constants/perpsAnalytics';
 import PerpsOrderView from './PerpsOrderView';
@@ -1413,6 +1414,68 @@ describe('PerpsOrderView', () => {
       expect(mockShowToast).toHaveBeenCalled();
     });
     expect(mockSubmitted).toHaveBeenCalled();
+  });
+
+  it('waits for the live position before attaching TP/SL to a new market position', async () => {
+    const renderedPosition = {
+      symbol: 'ETH',
+      size: '0.0037',
+    } as Position;
+    const mockExecuteOrder = jest.fn().mockResolvedValue({
+      success: true,
+      position: renderedPosition,
+    });
+    const mockUpdatePositionTPSL = jest
+      .fn()
+      .mockResolvedValue({ success: true });
+    (usePerpsOrderContext as jest.Mock).mockReturnValue({
+      ...defaultMockHooks.usePerpsOrderContext,
+      orderForm: {
+        asset: 'ETH',
+        amount: '11',
+        leverage: 3,
+        direction: 'long',
+        type: 'market',
+        limitPrice: undefined,
+        takeProfitPrice: '3500',
+        stopLossPrice: undefined,
+        balancePercent: 10,
+      },
+      handleMinAmount: jest.fn(),
+      calculations: {
+        marginRequired: '11',
+        positionSize: '0.0037',
+      },
+    });
+    (usePerpsOrderExecution as jest.Mock).mockReturnValue({
+      placeOrder: mockExecuteOrder,
+      isPlacing: false,
+    });
+    (usePerpsTrading as jest.Mock).mockReturnValue({
+      ...defaultMockHooks.usePerpsTrading,
+      updatePositionTPSL: mockUpdatePositionTPSL,
+    });
+    render(<PerpsOrderView />, { wrapper: TestWrapper });
+
+    const placeOrderButton = await screen.findByTestId(
+      PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON,
+    );
+    await act(async () => {
+      fireEvent.press(placeOrderButton);
+    });
+
+    const submittedOrder = mockExecuteOrder.mock.calls[0][0];
+    expect(submittedOrder.takeProfitPrice).toBeUndefined();
+    expect(submittedOrder.stopLossPrice).toBeUndefined();
+    expect(mockExecuteOrder).toHaveBeenCalledWith(submittedOrder, {
+      waitForPosition: true,
+    });
+    expect(mockUpdatePositionTPSL).toHaveBeenCalledWith({
+      symbol: 'ETH',
+      takeProfitPrice: '3500',
+      stopLossPrice: undefined,
+      position: renderedPosition,
+    });
   });
 
   it('includes discovery attribution from route source_section in order trackingData', async () => {

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -112,6 +112,7 @@ import {
   usePerpsOrderDepositTracking,
   usePerpsOrderExecution,
   usePerpsOrderFees,
+  usePerpsPostOrderTPSL,
   usePerpsOrderValidation,
   usePerpsRewards,
   usePerpsToasts,
@@ -318,7 +319,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
   const latestAbandonPropsRef = useRef<Record<string, unknown>>({});
 
   const { isInitialized } = usePerpsConnection();
-  const { subscribeToPrices, updatePositionTPSL } = usePerpsTrading();
+  const { subscribeToPrices } = usePerpsTrading();
+  const { attachPostOrderTPSL } = usePerpsPostOrderTPSL();
   const { account, isInitialLoading: isLoadingAccount } = usePerpsLiveAccount();
 
   // Get order form state from context; balanceForValidation respects custom token amount when set
@@ -1576,23 +1578,12 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
             return;
           }
 
-          const tpslResult = await updatePositionTPSL({
+          await attachPostOrderTPSL({
             symbol: orderForm.asset,
             takeProfitPrice: orderForm.takeProfitPrice,
             stopLossPrice: orderForm.stopLossPrice,
             position: orderResult.position,
           });
-
-          // Show error toast if TP/SL update failed (order succeeded but TP/SL didn't)
-          if (!tpslResult.success) {
-            const errorMessage =
-              tpslResult.error || strings('perps.errors.unknown');
-            showToast(
-              PerpsToastOptions.positionManagement.tpsl.updateTPSLError(
-                errorMessage,
-              ),
-            );
-          }
         } else {
           const orderResult = await executeOrder(orderParams);
           if (!orderResult?.success) {
@@ -1643,12 +1634,11 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
       currentMarketPosition,
       executeOrder,
       showToast,
+      attachPostOrderTPSL,
       updateOrderForm,
       setLimitPrice,
       PerpsToastOptions.formValidation.orderForm,
       PerpsToastOptions.orderManagement,
-      PerpsToastOptions.positionManagement.tpsl,
-      updatePositionTPSL,
       marginRequired,
       feeResults,
       source,

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -320,7 +320,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
 
   const { isInitialized } = usePerpsConnection();
   const { subscribeToPrices } = usePerpsTrading();
-  const { attachPostOrderTPSL } = usePerpsPostOrderTPSL();
+  const { attachPostOrderTPSL, isAttachingPostOrderTPSL } =
+    usePerpsPostOrderTPSL();
   const { account, isInitialLoading: isLoadingAccount } = usePerpsLiveAccount();
 
   // Get order form state from context; balanceForValidation respects custom token amount when set
@@ -1571,14 +1572,14 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
           delete orderWithoutTPSL.takeProfitPrice;
           delete orderWithoutTPSL.stopLossPrice;
 
-          const orderResult = await executeOrder(orderWithoutTPSL, {
-            waitForPosition: true,
-          });
+          const orderResult = await executeOrder(orderWithoutTPSL);
           if (!orderResult?.success) {
             return;
           }
 
-          await attachPostOrderTPSL(orderParams, orderResult.position);
+          await attachPostOrderTPSL(orderParams, {
+            positionBaseline: currentMarketPosition,
+          });
         } else {
           const orderResult = await executeOrder(orderParams);
           if (!orderResult?.success) {
@@ -2199,13 +2200,14 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
               isDisabled={
                 !orderValidation.isValid ||
                 isPlacingOrder ||
+                isAttachingPostOrderTPSL ||
                 doesStopLossRiskLiquidation ||
                 hasInvalidTPSL ||
                 isAtOICap ||
                 shouldBlockBecauseOfFeesLoading ||
                 hasBlockingPayAlerts
               }
-              isLoading={isPlacingOrder}
+              isLoading={isPlacingOrder || isAttachingPostOrderTPSL}
               testID={PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON}
             >
               {placeOrderLabel}
@@ -2219,13 +2221,14 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
               isDisabled={
                 !orderValidation.isValid ||
                 isPlacingOrder ||
+                isAttachingPostOrderTPSL ||
                 doesStopLossRiskLiquidation ||
                 hasInvalidTPSL ||
                 isAtOICap ||
                 shouldBlockBecauseOfFeesLoading ||
                 hasBlockingPayAlerts
               }
-              isLoading={isPlacingOrder}
+              isLoading={isPlacingOrder || isAttachingPostOrderTPSL}
               testID={PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON}
             >
               {placeOrderLabel}

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -1569,16 +1569,24 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
           delete orderWithoutTPSL.takeProfitPrice;
           delete orderWithoutTPSL.stopLossPrice;
 
-          const orderResult = await executeOrder(orderWithoutTPSL);
+          const orderResult = await executeOrder(orderWithoutTPSL, {
+            waitForPosition: true,
+          });
           if (!orderResult?.success) {
             return;
           }
 
-          const tpslResult = await updatePositionTPSL({
-            symbol: orderForm.asset,
-            takeProfitPrice: orderForm.takeProfitPrice,
-            stopLossPrice: orderForm.stopLossPrice,
-          });
+          const tpslResult = orderResult.position
+            ? await updatePositionTPSL({
+                symbol: orderForm.asset,
+                takeProfitPrice: orderForm.takeProfitPrice,
+                stopLossPrice: orderForm.stopLossPrice,
+                position: orderResult.position,
+              })
+            : {
+                success: false,
+                error: strings('perps.errors.position_not_found'),
+              };
 
           // Show error toast if TP/SL update failed (order succeeded but TP/SL didn't)
           if (!tpslResult.success) {

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -1576,17 +1576,12 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
             return;
           }
 
-          const tpslResult = orderResult.position
-            ? await updatePositionTPSL({
-                symbol: orderForm.asset,
-                takeProfitPrice: orderForm.takeProfitPrice,
-                stopLossPrice: orderForm.stopLossPrice,
-                position: orderResult.position,
-              })
-            : {
-                success: false,
-                error: strings('perps.errors.position_not_found'),
-              };
+          const tpslResult = await updatePositionTPSL({
+            symbol: orderForm.asset,
+            takeProfitPrice: orderForm.takeProfitPrice,
+            stopLossPrice: orderForm.stopLossPrice,
+            position: orderResult.position,
+          });
 
           // Show error toast if TP/SL update failed (order succeeded but TP/SL didn't)
           if (!tpslResult.success) {

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -1578,12 +1578,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
             return;
           }
 
-          await attachPostOrderTPSL({
-            symbol: orderForm.asset,
-            takeProfitPrice: orderForm.takeProfitPrice,
-            stopLossPrice: orderForm.stopLossPrice,
-            position: orderResult.position,
-          });
+          await attachPostOrderTPSL(orderParams, orderResult.position);
         } else {
           const orderResult = await executeOrder(orderParams);
           if (!orderResult?.success) {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -3529,6 +3529,28 @@ describe('usePerpsProOrderForm', () => {
       });
     });
 
+    it('attempts TP/SL attachment without a rendered position hint', async () => {
+      // Arrange
+      mockOrderForm.takeProfitPrice = '95000';
+      mockExecuteOrder.mockResolvedValueOnce({
+        success: true,
+      });
+      const { result } = renderProForm();
+
+      // Act
+      await act(async () => {
+        await result.current.onPlaceOrderPress();
+      });
+
+      // Assert
+      expect(mockUpdatePositionTPSL).toHaveBeenCalledWith({
+        symbol: 'BTC',
+        takeProfitPrice: '95000',
+        stopLossPrice: undefined,
+        position: undefined,
+      });
+    });
+
     it('shows an error toast when the separate TP/SL update fails', async () => {
       // Arrange
       const renderedPosition = {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -10,6 +10,7 @@ import {
   formatHyperLiquidPrice,
   type PerpsMarketData,
   type PerpsProviderType,
+  type Position,
   type PositionModifyPreviewResult,
 } from '@metamask/perps-controller';
 import { MetaMetricsEvents } from '../../../../../../../core/Analytics';
@@ -3498,7 +3499,15 @@ describe('usePerpsProOrderForm', () => {
   describe('TP/SL handling', () => {
     it('places the order without TP/SL then updates position TP/SL when flagged', async () => {
       // Arrange: new market position with TP set -> handled separately
+      const renderedPosition = {
+        symbol: 'BTC',
+        size: '1',
+      } as Position;
       mockOrderForm.takeProfitPrice = '95000';
+      mockExecuteOrder.mockResolvedValueOnce({
+        success: true,
+        position: renderedPosition,
+      });
       const { result } = renderProForm();
 
       // Act
@@ -3509,16 +3518,28 @@ describe('usePerpsProOrderForm', () => {
       // Assert
       const params = mockExecuteOrder.mock.calls[0][0];
       expect(params.takeProfitPrice).toBeUndefined();
+      expect(mockExecuteOrder).toHaveBeenCalledWith(params, {
+        waitForPosition: true,
+      });
       expect(mockUpdatePositionTPSL).toHaveBeenCalledWith({
         symbol: 'BTC',
         takeProfitPrice: '95000',
         stopLossPrice: undefined,
+        position: renderedPosition,
       });
     });
 
     it('shows an error toast when the separate TP/SL update fails', async () => {
       // Arrange
+      const renderedPosition = {
+        symbol: 'BTC',
+        size: '1',
+      } as Position;
       mockOrderForm.takeProfitPrice = '95000';
+      mockExecuteOrder.mockResolvedValueOnce({
+        success: true,
+        position: renderedPosition,
+      });
       mockUpdatePositionTPSL.mockResolvedValue({
         success: false,
         error: 'nope',

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -3494,7 +3494,7 @@ describe('usePerpsProOrderForm', () => {
   });
 
   describe('TP/SL handling', () => {
-    it('places the order without TP/SL then updates position TP/SL when flagged', async () => {
+    it('places the order without TP/SL then delegates position attachment', async () => {
       // Arrange: new market position with TP set -> handled separately
       const renderedPosition = {
         symbol: 'BTC',
@@ -3518,12 +3518,13 @@ describe('usePerpsProOrderForm', () => {
       expect(mockExecuteOrder).toHaveBeenCalledWith(params, {
         waitForPosition: true,
       });
-      expect(mockAttachPostOrderTPSL).toHaveBeenCalledWith({
-        symbol: 'BTC',
-        takeProfitPrice: '95000',
-        stopLossPrice: undefined,
-        position: renderedPosition,
-      });
+      expect(mockAttachPostOrderTPSL.mock.calls[0]).toEqual([
+        expect.objectContaining({
+          symbol: 'BTC',
+          takeProfitPrice: '95000',
+        }),
+        renderedPosition,
+      ]);
     });
 
     it('attempts TP/SL attachment without a rendered position hint', async () => {
@@ -3540,12 +3541,7 @@ describe('usePerpsProOrderForm', () => {
       });
 
       // Assert
-      expect(mockAttachPostOrderTPSL).toHaveBeenCalledWith({
-        symbol: 'BTC',
-        takeProfitPrice: '95000',
-        stopLossPrice: undefined,
-        position: undefined,
-      });
+      expect(mockAttachPostOrderTPSL.mock.calls[0][1]).toBeUndefined();
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -53,6 +53,7 @@ const mockHandleAddFunds = jest.fn();
 const mockCloseEligibilityModal = jest.fn();
 const mockShowEligibilityModal = jest.fn();
 const mockAttachPostOrderTPSL = jest.fn().mockResolvedValue({ success: true });
+let mockIsAttachingPostOrderTPSL = false;
 const mockExecuteOrder = jest.fn().mockResolvedValue({ success: true });
 const mockClearPendingTradeConfiguration = jest.fn();
 let mockLiquidationPrice = '80000';
@@ -323,6 +324,7 @@ jest.mock('../../../../hooks', () => ({
   },
   usePerpsPostOrderTPSL: () => ({
     attachPostOrderTPSL: mockAttachPostOrderTPSL,
+    isAttachingPostOrderTPSL: mockIsAttachingPostOrderTPSL,
   }),
 }));
 
@@ -579,6 +581,7 @@ describe('usePerpsProOrderForm', () => {
     mockMarketDataError = null;
     mockMarketData = { szDecimals: 3, maxLeverage: 40 };
     mockIsPlacing = false;
+    mockIsAttachingPostOrderTPSL = false;
     mockIsEligible = true;
     mockComplianceGate.mockImplementation((action: () => Promise<unknown>) =>
       action(),
@@ -3494,16 +3497,20 @@ describe('usePerpsProOrderForm', () => {
   });
 
   describe('TP/SL handling', () => {
-    it('places the order without TP/SL then delegates position attachment', async () => {
+    it('keeps placement disabled while post-order protection is attaching', () => {
+      mockIsAttachingPostOrderTPSL = true;
+
+      const { result } = renderProForm();
+
+      expect(result.current.isPlaceOrderDisabled).toBe(true);
+      expect(result.current.isPlaceOrderLoading).toBe(true);
+    });
+
+    it('places the order without TP/SL then delegates attachment coordination', async () => {
       // Arrange: new market position with TP set -> handled separately
-      const renderedPosition = {
-        symbol: 'BTC',
-        size: '1',
-      } as Position;
       mockOrderForm.takeProfitPrice = '95000';
       mockExecuteOrder.mockResolvedValueOnce({
         success: true,
-        position: renderedPosition,
       });
       const { result } = renderProForm();
 
@@ -3515,16 +3522,33 @@ describe('usePerpsProOrderForm', () => {
       // Assert
       const params = mockExecuteOrder.mock.calls[0][0];
       expect(params.takeProfitPrice).toBeUndefined();
-      expect(mockExecuteOrder).toHaveBeenCalledWith(params, {
-        waitForPosition: true,
-      });
+      expect(mockExecuteOrder).toHaveBeenCalledWith(params);
       expect(mockAttachPostOrderTPSL.mock.calls[0]).toEqual([
         expect.objectContaining({
           symbol: 'BTC',
           takeProfitPrice: '95000',
         }),
-        renderedPosition,
+        { positionBaseline: null },
       ]);
+    });
+
+    it('passes the pre-order position as the flip baseline', async () => {
+      mockExistingPosition = {
+        symbol: 'BTC',
+        size: '-0.0001',
+        leverage: { type: 'isolated', value: 5 },
+      };
+      mockOrderForm.direction = 'long';
+      mockOrderForm.takeProfitPrice = '95000';
+      const { result } = renderProForm();
+
+      await act(async () => {
+        await result.current.onPlaceOrderPress();
+      });
+
+      expect(mockAttachPostOrderTPSL.mock.calls[0][1]).toEqual({
+        positionBaseline: mockExistingPosition,
+      });
     });
 
     it('attempts TP/SL attachment without a rendered position hint', async () => {
@@ -3541,7 +3565,9 @@ describe('usePerpsProOrderForm', () => {
       });
 
       // Assert
-      expect(mockAttachPostOrderTPSL.mock.calls[0][1]).toBeUndefined();
+      expect(mockAttachPostOrderTPSL.mock.calls[0][1]).toEqual({
+        positionBaseline: null,
+      });
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -52,7 +52,7 @@ const mockSetMaxSlippage = jest.fn();
 const mockHandleAddFunds = jest.fn();
 const mockCloseEligibilityModal = jest.fn();
 const mockShowEligibilityModal = jest.fn();
-const mockUpdatePositionTPSL = jest.fn().mockResolvedValue({ success: true });
+const mockAttachPostOrderTPSL = jest.fn().mockResolvedValue({ success: true });
 const mockExecuteOrder = jest.fn().mockResolvedValue({ success: true });
 const mockClearPendingTradeConfiguration = jest.fn();
 let mockLiquidationPrice = '80000';
@@ -220,10 +220,6 @@ const validationError = jest.fn((message: string) => ({
   id: 'validationError',
   message,
 }));
-const updateTPSLError = jest.fn((message: string) => ({
-  id: 'tpslError',
-  message,
-}));
 const limitPriceRequired = { id: 'limitPriceRequired' };
 
 const mockPerpsToastOptions = {
@@ -246,7 +242,6 @@ const mockPerpsToastOptions = {
     },
   },
   formValidation: { orderForm: { validationError, limitPriceRequired } },
-  positionManagement: { tpsl: { updateTPSLError } },
 };
 
 jest.mock('../../../../contexts/PerpsOrderContext', () => ({
@@ -326,7 +321,9 @@ jest.mock('../../../../hooks', () => ({
       error: null,
     };
   },
-  usePerpsTrading: () => ({ updatePositionTPSL: mockUpdatePositionTPSL }),
+  usePerpsPostOrderTPSL: () => ({
+    attachPostOrderTPSL: mockAttachPostOrderTPSL,
+  }),
 }));
 
 jest.mock('../../../../hooks/usePerpsHomeActions', () => ({
@@ -599,7 +596,7 @@ describe('usePerpsProOrderForm', () => {
       mockContextValue.hasBlurredLimitPrice = false;
       mockContextValue.hasBlurredTriggerPrice = false;
     });
-    mockUpdatePositionTPSL.mockResolvedValue({ success: true });
+    mockAttachPostOrderTPSL.mockResolvedValue({ success: true });
     mockExecuteOrder.mockResolvedValue({ success: true });
     mockChaseOrders = [];
     mockGetChaseOrders.mockResolvedValue([]);
@@ -2983,7 +2980,7 @@ describe('usePerpsProOrderForm', () => {
         reduceOnly: true,
       });
       expect(params).not.toHaveProperty('takeProfitPrice');
-      expect(mockUpdatePositionTPSL).not.toHaveBeenCalled();
+      expect(mockAttachPostOrderTPSL).not.toHaveBeenCalled();
       expect(submitted).toHaveBeenCalled();
       expect(mockClearPendingTradeConfiguration).toHaveBeenCalledWith('BTC');
       expect(mockUpdateOrderForm).toHaveBeenCalledWith({
@@ -3403,7 +3400,7 @@ describe('usePerpsProOrderForm', () => {
       expect(playImpact).not.toHaveBeenCalled();
     });
 
-    it('skips updatePositionTPSL and clearPendingConfig when the order fails (shouldHandleTPSLSeparately path)', async () => {
+    it('skips TP/SL attachment and pending-config clearing when the separate order fails', async () => {
       // Arrange: new market position with TP triggers the separate-TP/SL branch;
       // controller returns failure so post-processing must not run
       mockOrderForm.takeProfitPrice = '95000';
@@ -3419,7 +3416,7 @@ describe('usePerpsProOrderForm', () => {
       });
 
       // Assert
-      expect(mockUpdatePositionTPSL).not.toHaveBeenCalled();
+      expect(mockAttachPostOrderTPSL).not.toHaveBeenCalled();
       expect(mockClearPendingTradeConfiguration).not.toHaveBeenCalled();
     });
 
@@ -3521,7 +3518,7 @@ describe('usePerpsProOrderForm', () => {
       expect(mockExecuteOrder).toHaveBeenCalledWith(params, {
         waitForPosition: true,
       });
-      expect(mockUpdatePositionTPSL).toHaveBeenCalledWith({
+      expect(mockAttachPostOrderTPSL).toHaveBeenCalledWith({
         symbol: 'BTC',
         takeProfitPrice: '95000',
         stopLossPrice: undefined,
@@ -3543,38 +3540,12 @@ describe('usePerpsProOrderForm', () => {
       });
 
       // Assert
-      expect(mockUpdatePositionTPSL).toHaveBeenCalledWith({
+      expect(mockAttachPostOrderTPSL).toHaveBeenCalledWith({
         symbol: 'BTC',
         takeProfitPrice: '95000',
         stopLossPrice: undefined,
         position: undefined,
       });
-    });
-
-    it('shows an error toast when the separate TP/SL update fails', async () => {
-      // Arrange
-      const renderedPosition = {
-        symbol: 'BTC',
-        size: '1',
-      } as Position;
-      mockOrderForm.takeProfitPrice = '95000';
-      mockExecuteOrder.mockResolvedValueOnce({
-        success: true,
-        position: renderedPosition,
-      });
-      mockUpdatePositionTPSL.mockResolvedValue({
-        success: false,
-        error: 'nope',
-      });
-      const { result } = renderProForm();
-
-      // Act
-      await act(async () => {
-        await result.current.onPlaceOrderPress();
-      });
-
-      // Assert
-      expect(updateTPSLError).toHaveBeenCalledWith('nope');
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -2699,17 +2699,12 @@ export const usePerpsProOrderForm = ({
           return;
         }
 
-        const tpslResult = orderResult.position
-          ? await updatePositionTPSL({
-              symbol: orderForm.asset,
-              takeProfitPrice: orderForm.takeProfitPrice,
-              stopLossPrice: orderForm.stopLossPrice,
-              position: orderResult.position,
-            })
-          : {
-              success: false,
-              error: strings('perps.errors.position_not_found'),
-            };
+        const tpslResult = await updatePositionTPSL({
+          symbol: orderForm.asset,
+          takeProfitPrice: orderForm.takeProfitPrice,
+          stopLossPrice: orderForm.stopLossPrice,
+          position: orderResult.position,
+        });
 
         if (!tpslResult.success) {
           const errorMessage =

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -2692,16 +2692,24 @@ export const usePerpsProOrderForm = ({
         delete orderWithoutTPSL.takeProfitPrice;
         delete orderWithoutTPSL.stopLossPrice;
 
-        const orderResult = await executeOrder(orderWithoutTPSL);
+        const orderResult = await executeOrder(orderWithoutTPSL, {
+          waitForPosition: true,
+        });
         if (!orderResult?.success) {
           return;
         }
 
-        const tpslResult = await updatePositionTPSL({
-          symbol: orderForm.asset,
-          takeProfitPrice: orderForm.takeProfitPrice,
-          stopLossPrice: orderForm.stopLossPrice,
-        });
+        const tpslResult = orderResult.position
+          ? await updatePositionTPSL({
+              symbol: orderForm.asset,
+              takeProfitPrice: orderForm.takeProfitPrice,
+              stopLossPrice: orderForm.stopLossPrice,
+              position: orderResult.position,
+            })
+          : {
+              success: false,
+              error: strings('perps.errors.position_not_found'),
+            };
 
         if (!tpslResult.success) {
           const errorMessage =

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -2699,12 +2699,7 @@ export const usePerpsProOrderForm = ({
           return;
         }
 
-        await attachPostOrderTPSL({
-          symbol: orderForm.asset,
-          takeProfitPrice: orderForm.takeProfitPrice,
-          stopLossPrice: orderForm.stopLossPrice,
-          position: orderResult.position,
-        });
+        await attachPostOrderTPSL(orderParams, orderResult.position);
       } else {
         const orderResult = await executeOrder(orderParams);
         if (!orderResult?.success) {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -66,9 +66,9 @@ import {
   usePerpsNetwork,
   usePerpsOrderExecution,
   usePerpsOrderFees,
+  usePerpsPostOrderTPSL,
   usePerpsOrderValidation,
   usePerpsToasts,
-  usePerpsTrading,
   getPerpsToastLabels,
 } from '../../../../hooks';
 import { usePerpsHomeActions } from '../../../../hooks/usePerpsHomeActions';
@@ -590,7 +590,7 @@ export const usePerpsProOrderForm = ({
   const { track } = usePerpsEventTracking();
   const { playImpact } = useHaptics();
   const { showToast, PerpsToastOptions } = usePerpsToasts();
-  const { updatePositionTPSL } = usePerpsTrading();
+  const { attachPostOrderTPSL } = usePerpsPostOrderTPSL();
 
   const {
     orderForm,
@@ -2699,22 +2699,12 @@ export const usePerpsProOrderForm = ({
           return;
         }
 
-        const tpslResult = await updatePositionTPSL({
+        await attachPostOrderTPSL({
           symbol: orderForm.asset,
           takeProfitPrice: orderForm.takeProfitPrice,
           stopLossPrice: orderForm.stopLossPrice,
           position: orderResult.position,
         });
-
-        if (!tpslResult.success) {
-          const errorMessage =
-            tpslResult.error || strings('perps.errors.unknown');
-          showToast(
-            PerpsToastOptions.positionManagement.tpsl.updateTPSLError(
-              errorMessage,
-            ),
-          );
-        }
       } else {
         const orderResult = await executeOrder(orderParams);
         if (!orderResult?.success) {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -590,7 +590,8 @@ export const usePerpsProOrderForm = ({
   const { track } = usePerpsEventTracking();
   const { playImpact } = useHaptics();
   const { showToast, PerpsToastOptions } = usePerpsToasts();
-  const { attachPostOrderTPSL } = usePerpsPostOrderTPSL();
+  const { attachPostOrderTPSL, isAttachingPostOrderTPSL } =
+    usePerpsPostOrderTPSL();
 
   const {
     orderForm,
@@ -2692,14 +2693,14 @@ export const usePerpsProOrderForm = ({
         delete orderWithoutTPSL.takeProfitPrice;
         delete orderWithoutTPSL.stopLossPrice;
 
-        const orderResult = await executeOrder(orderWithoutTPSL, {
-          waitForPosition: true,
-        });
+        const orderResult = await executeOrder(orderWithoutTPSL);
         if (!orderResult?.success) {
           return;
         }
 
-        await attachPostOrderTPSL(orderParams, orderResult.position);
+        await attachPostOrderTPSL(orderParams, {
+          positionBaseline: currentMarketPosition,
+        });
       } else {
         const orderResult = await executeOrder(orderParams);
         if (!orderResult?.success) {
@@ -3390,6 +3391,7 @@ export const usePerpsProOrderForm = ({
         chaseProviderId === null)) ||
     isChaseMaxDistanceInvalid ||
     isPlacing ||
+    isAttachingPostOrderTPSL ||
     isAwaitingPositionModifyPreview ||
     isChasePreflightPending ||
     isScalePlacementPending ||
@@ -3840,7 +3842,10 @@ export const usePerpsProOrderForm = ({
     scaleOrder,
     isPlaceOrderDisabled,
     isPlaceOrderLoading:
-      isScalePlacementPending || isChasePreflightPending || isPlacing,
+      isScalePlacementPending ||
+      isChasePreflightPending ||
+      isPlacing ||
+      isAttachingPostOrderTPSL,
     onPlaceOrderPress,
     // Leverage sheet
     isLeverageVisible,

--- a/app/components/UI/Perps/hooks/index.ts
+++ b/app/components/UI/Perps/hooks/index.ts
@@ -89,6 +89,7 @@ export { usePerpsOrderForm } from './usePerpsOrderForm';
 export { usePerpsOrderValidation } from './usePerpsOrderValidation';
 export { usePerpsClosePositionValidation } from './usePerpsClosePositionValidation';
 export { usePerpsOrderExecution } from './usePerpsOrderExecution';
+export { usePerpsPostOrderTPSL } from './usePerpsPostOrderTPSL';
 export { usePerpsOrderDepositTracking } from './usePerpsOrderDepositTracking';
 export { useIsPriceDeviatedAboveThreshold } from './useIsPriceDeviatedAboveThreshold';
 export { usePerpsFirstTimeUser } from './usePerpsFirstTimeUser';

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -1046,6 +1046,52 @@ describe('usePerpsOrderExecution', () => {
       });
     });
 
+    it('returns a late stream position when the caller requires it', async () => {
+      jest.useFakeTimers();
+      try {
+        const onSuccess = jest.fn();
+        mockPlaceOrder.mockResolvedValue({
+          success: true,
+          orderId: 'order123',
+        });
+
+        const { result } = renderHook(() =>
+          usePerpsOrderExecution({ onSuccess }),
+        );
+
+        let placement: ReturnType<typeof result.current.placeOrder> | undefined;
+        await act(async () => {
+          placement = result.current.placeOrder(mockOrderParams, {
+            waitForPosition: true,
+          });
+          await Promise.resolve();
+        });
+
+        await act(async () => {
+          jest.advanceTimersByTime(PERPS_CUF_STREAM_CONFIRM_RACE_MS);
+          await Promise.resolve();
+        });
+        expect(onSuccess).toHaveBeenCalledWith();
+
+        mockGetPositionsSnapshot.mockReturnValue([mockPosition]);
+        act(() => {
+          handlePerpsCufPositionsDelivered([mockPosition]);
+        });
+
+        let placementResult: Awaited<typeof placement>;
+        await act(async () => {
+          placementResult = await placement;
+        });
+        expect(placementResult).toEqual({
+          success: true,
+          orderId: 'order123',
+          position: mockPosition,
+        });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('forwards trackingData to controller on partial fill without client trade analytics', async () => {
       const onSuccess = jest.fn();
       const paramsWithTracking: OrderParams = {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -1,12 +1,8 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { type OrderParams, type Position } from '@metamask/perps-controller';
-import {
-  PERPS_POST_ORDER_POSITION_CONFIRMATION_TIMEOUT_MS,
-  usePerpsOrderExecution,
-} from './usePerpsOrderExecution';
+import { usePerpsOrderExecution } from './usePerpsOrderExecution';
 import { usePerpsTrading } from './usePerpsTrading';
 import {
-  clearPendingPerpsCufTraces,
   handlePerpsCufPositionsDelivered,
   handlePerpsCufOrdersDelivered,
   resetPerpsCufTraceForTests,
@@ -39,52 +35,15 @@ jest.mock('../../../../util/trace', () => {
 const mockEndTrace = endTrace as jest.Mock;
 const mockTrace = trace as jest.Mock;
 const mockLoggerError = jest.mocked(Logger.error);
-const mockGetState = jest.fn(() => ({}));
-const mockSelectedAccountAddress = jest.fn(() => '0xabc');
-const mockSelectedPerpsNetwork = jest.fn(() => 'testnet');
-const mockSelectedPerpsProvider = jest.fn(() => 'hyperliquid');
-const mockStoreSubscribers = new Set<() => void>();
-jest.mock('../../../../store', () => ({
-  store: {
-    getState: () => mockGetState(),
-    subscribe: (callback: () => void) => {
-      mockStoreSubscribers.add(callback);
-      return () => mockStoreSubscribers.delete(callback);
-    },
-  },
-}));
-jest.mock('../selectors/selectedAccountAddress', () => ({
-  selectPerpsSelectedAccountAddress: () => mockSelectedAccountAddress(),
-}));
-jest.mock('../selectors/perpsController', () => ({
-  selectPerpsNetwork: () => mockSelectedPerpsNetwork(),
-  selectPerpsProvider: () => mockSelectedPerpsProvider(),
-}));
 const mockGetPositionsSnapshot = jest.fn();
 const mockGetOrdersSnapshot = jest.fn();
 const mockPositionsLastDeliveredAt = jest.fn(() => null as number | null);
 const mockOrdersLastDeliveredAt = jest.fn(() => null as number | null);
-type PositionsCallback = (positions: Position[] | null) => void;
-const mockPositionSubscribers = new Set<PositionsCallback>();
-const mockSubscribeToPositions = jest.fn(
-  ({ callback }: { callback: PositionsCallback }) => {
-    mockPositionSubscribers.add(callback);
-    const snapshot = mockGetPositionsSnapshot() as Position[] | null;
-    if (snapshot !== null) {
-      callback(snapshot);
-    }
-    return () => mockPositionSubscribers.delete(callback);
-  },
-);
-const notifyStoreChanged = () => {
-  mockStoreSubscribers.forEach((callback) => callback());
-};
 jest.mock('../providers/PerpsStreamManager', () => ({
   usePerpsStream: () => ({
     positions: {
       getSnapshot: mockGetPositionsSnapshot,
       getLastDeliveredAt: mockPositionsLastDeliveredAt,
-      subscribe: mockSubscribeToPositions,
     },
     orders: {
       getSnapshot: mockGetOrdersSnapshot,
@@ -125,21 +84,6 @@ describe('usePerpsOrderExecution', () => {
     mockGetOrdersSnapshot.mockReturnValue([]); // Loaded, no orders by default
     mockPositionsLastDeliveredAt.mockReturnValue(null);
     mockOrdersLastDeliveredAt.mockReturnValue(null);
-    mockSelectedAccountAddress.mockReturnValue('0xabc');
-    mockSelectedPerpsNetwork.mockReturnValue('testnet');
-    mockSelectedPerpsProvider.mockReturnValue('hyperliquid');
-    mockPositionSubscribers.clear();
-    mockStoreSubscribers.clear();
-    mockSubscribeToPositions.mockImplementation(
-      ({ callback }: { callback: PositionsCallback }) => {
-        mockPositionSubscribers.add(callback);
-        const snapshot = mockGetPositionsSnapshot() as Position[] | null;
-        if (snapshot !== null) {
-          callback(snapshot);
-        }
-        return () => mockPositionSubscribers.delete(callback);
-      },
-    );
     (usePerpsTrading as jest.Mock).mockReturnValue({
       placeOrder: mockPlaceOrder,
     });
@@ -191,14 +135,6 @@ describe('usePerpsOrderExecution', () => {
       handlePerpsCufPositionsDelivered([mockPosition]);
       return { success: true, orderId: 'order123', ...result };
     });
-  };
-
-  const deliverPositions = (positions: Position[] | null) => {
-    mockGetPositionsSnapshot.mockReturnValue(positions);
-    if (positions) {
-      handlePerpsCufPositionsDelivered(positions);
-    }
-    mockPositionSubscribers.forEach((callback) => callback(positions));
   };
 
   describe('strategy orders', () => {
@@ -1108,321 +1044,6 @@ describe('usePerpsOrderExecution', () => {
       act(() => {
         handlePerpsCufPositionsDelivered([mockPosition]);
       });
-    });
-
-    it('returns a late stream position when the caller requires it', async () => {
-      jest.useFakeTimers();
-      try {
-        const onSuccess = jest.fn();
-        mockPlaceOrder.mockResolvedValue({
-          success: true,
-          orderId: 'order123',
-        });
-
-        const { result } = renderHook(() =>
-          usePerpsOrderExecution({ onSuccess }),
-        );
-
-        let placement: ReturnType<typeof result.current.placeOrder> | undefined;
-        await act(async () => {
-          placement = result.current.placeOrder(mockOrderParams, {
-            waitForPosition: true,
-          });
-          await Promise.resolve();
-        });
-
-        await act(async () => {
-          jest.advanceTimersByTime(PERPS_CUF_STREAM_CONFIRM_RACE_MS);
-          await Promise.resolve();
-        });
-        expect(onSuccess).toHaveBeenCalledWith();
-
-        act(() => {
-          deliverPositions([mockPosition]);
-        });
-
-        let placementResult: Awaited<typeof placement>;
-        await act(async () => {
-          placementResult = await placement;
-        });
-        expect(placementResult).toEqual({
-          success: true,
-          orderId: 'order123',
-          position: mockPosition,
-        });
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    it('returns a position rendered after the former three-second wait boundary', async () => {
-      jest.useFakeTimers();
-      try {
-        const formerPositionHintWaitTimeoutMs = 3000;
-        mockPlaceOrder.mockResolvedValue({
-          success: true,
-          orderId: 'order123',
-        });
-        const { result } = renderHook(() => usePerpsOrderExecution());
-        let placementResolved = false;
-        let placement: ReturnType<typeof result.current.placeOrder> | undefined;
-
-        await act(async () => {
-          placement = result.current.placeOrder(mockOrderParams, {
-            waitForPosition: true,
-          });
-          placement.then(() => {
-            placementResolved = true;
-          });
-          await Promise.resolve();
-        });
-        await act(async () => {
-          jest.advanceTimersByTime(PERPS_CUF_STREAM_CONFIRM_RACE_MS);
-          await Promise.resolve();
-          await Promise.resolve();
-        });
-        await act(async () => {
-          jest.advanceTimersByTime(formerPositionHintWaitTimeoutMs + 1);
-          await Promise.resolve();
-        });
-
-        expect(placementResolved).toBe(false);
-
-        act(() => {
-          deliverPositions([mockPosition]);
-        });
-        let placementResult: Awaited<typeof placement>;
-        await act(async () => {
-          placementResult = await placement;
-        });
-
-        expect(placementResult).toEqual({
-          success: true,
-          orderId: 'order123',
-          position: mockPosition,
-        });
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    it('clears placing state while post-order position confirmation remains pending', async () => {
-      jest.useFakeTimers();
-      try {
-        mockPlaceOrder.mockResolvedValue({
-          success: true,
-          orderId: 'order123',
-        });
-        const { result } = renderHook(() => usePerpsOrderExecution());
-        let placementResolved = false;
-        let placement: ReturnType<typeof result.current.placeOrder> | undefined;
-
-        await act(async () => {
-          placement = result.current.placeOrder(mockOrderParams, {
-            waitForPosition: true,
-          });
-          placement.then(() => {
-            placementResolved = true;
-          });
-          await Promise.resolve();
-        });
-        await act(async () => {
-          jest.advanceTimersByTime(PERPS_CUF_STREAM_CONFIRM_RACE_MS);
-          await Promise.resolve();
-          await Promise.resolve();
-        });
-
-        expect(result.current.isPlacing).toBe(false);
-        expect(placementResolved).toBe(false);
-
-        act(() => {
-          deliverPositions([mockPosition]);
-        });
-        await act(async () => {
-          await placement;
-        });
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    it('returns the successful order at the position confirmation safety deadline', async () => {
-      jest.useFakeTimers();
-      try {
-        const onError = jest.fn();
-        mockPlaceOrder.mockResolvedValue({
-          success: true,
-          orderId: 'order123',
-        });
-        const { result } = renderHook(() =>
-          usePerpsOrderExecution({ onError }),
-        );
-        let placement: ReturnType<typeof result.current.placeOrder> | undefined;
-
-        await act(async () => {
-          placement = result.current.placeOrder(mockOrderParams, {
-            waitForPosition: true,
-          });
-          await Promise.resolve();
-        });
-        await act(async () => {
-          jest.advanceTimersByTime(PERPS_CUF_STREAM_CONFIRM_RACE_MS);
-          await Promise.resolve();
-          await Promise.resolve();
-        });
-        await act(async () => {
-          jest.advanceTimersByTime(
-            PERPS_POST_ORDER_POSITION_CONFIRMATION_TIMEOUT_MS,
-          );
-          await Promise.resolve();
-        });
-        let placementResult: Awaited<typeof placement>;
-        await act(async () => {
-          placementResult = await placement;
-        });
-
-        expect(placementResult).toEqual({
-          success: true,
-          orderId: 'order123',
-        });
-        expect(onError).not.toHaveBeenCalled();
-        expect(mockLoggerError).not.toHaveBeenCalled();
-        expect(mockPositionSubscribers.size).toBe(0);
-        expect(mockStoreSubscribers.size).toBe(0);
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    it('returns the rendered position after CUF state is cleared', async () => {
-      jest.useFakeTimers();
-      try {
-        const onError = jest.fn();
-        mockPlaceOrder.mockResolvedValue({
-          success: true,
-          orderId: 'order123',
-        });
-        const { result } = renderHook(() =>
-          usePerpsOrderExecution({ onError }),
-        );
-        let placement: ReturnType<typeof result.current.placeOrder> | undefined;
-
-        await act(async () => {
-          placement = result.current.placeOrder(mockOrderParams, {
-            waitForPosition: true,
-          });
-          await Promise.resolve();
-        });
-        await act(async () => {
-          jest.advanceTimersByTime(PERPS_CUF_STREAM_CONFIRM_RACE_MS);
-          await Promise.resolve();
-          await Promise.resolve();
-        });
-        act(() => {
-          clearPendingPerpsCufTraces();
-          deliverPositions([mockPosition]);
-        });
-        let placementResult: Awaited<typeof placement>;
-        await act(async () => {
-          placementResult = await placement;
-        });
-
-        expect(placementResult).toEqual({
-          success: true,
-          orderId: 'order123',
-          position: mockPosition,
-        });
-        expect(onError).not.toHaveBeenCalled();
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    it('stops the position follow-up when the trading context changes', async () => {
-      jest.useFakeTimers();
-      try {
-        const onError = jest.fn();
-        mockPlaceOrder.mockResolvedValue({
-          success: true,
-          orderId: 'order123',
-        });
-        const { result } = renderHook(() =>
-          usePerpsOrderExecution({ onError }),
-        );
-        let placement: ReturnType<typeof result.current.placeOrder> | undefined;
-
-        await act(async () => {
-          placement = result.current.placeOrder(mockOrderParams, {
-            waitForPosition: true,
-          });
-          await Promise.resolve();
-        });
-        await act(async () => {
-          jest.advanceTimersByTime(PERPS_CUF_STREAM_CONFIRM_RACE_MS);
-          await Promise.resolve();
-          await Promise.resolve();
-        });
-        mockSelectedAccountAddress.mockReturnValue('0xdef');
-        act(() => {
-          notifyStoreChanged();
-        });
-        let placementResult: Awaited<typeof placement>;
-        await act(async () => {
-          placementResult = await placement;
-        });
-
-        expect(placementResult).toBeUndefined();
-        expect(onError).not.toHaveBeenCalled();
-        expect(mockPositionSubscribers.size).toBe(0);
-        expect(mockStoreSubscribers.size).toBe(0);
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    it('keeps a position subscription failure out of order error handling', async () => {
-      jest.useFakeTimers();
-      try {
-        const onError = jest.fn();
-        mockPlaceOrder.mockResolvedValue({
-          success: true,
-          orderId: 'order123',
-        });
-        mockSubscribeToPositions.mockImplementationOnce(() => {
-          throw new Error('Position subscription failed');
-        });
-        const { result } = renderHook(() =>
-          usePerpsOrderExecution({ onError }),
-        );
-        let placementResult:
-          | Awaited<ReturnType<typeof result.current.placeOrder>>
-          | undefined;
-
-        let placement: ReturnType<typeof result.current.placeOrder> | undefined;
-        await act(async () => {
-          placement = result.current.placeOrder(mockOrderParams, {
-            waitForPosition: true,
-          });
-          await Promise.resolve();
-        });
-        await act(async () => {
-          jest.advanceTimersByTime(PERPS_CUF_STREAM_CONFIRM_RACE_MS);
-          await Promise.resolve();
-          await Promise.resolve();
-        });
-        await act(async () => {
-          placementResult = await placement;
-        });
-
-        expect(placementResult).toEqual({
-          success: true,
-          orderId: 'order123',
-        });
-        expect(onError).not.toHaveBeenCalled();
-        expect(mockLoggerError).not.toHaveBeenCalled();
-      } finally {
-        jest.useRealTimers();
-      }
     });
 
     it('forwards trackingData to controller on partial fill without client trade analytics', async () => {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { type OrderParams, type Position } from '@metamask/perps-controller';
 import {
-  PERPS_POSITION_HINT_WAIT_TIMEOUT_MS,
+  PERPS_POST_ORDER_POSITION_CONFIRMATION_TIMEOUT_MS,
   usePerpsOrderExecution,
 } from './usePerpsOrderExecution';
 import { usePerpsTrading } from './usePerpsTrading';
@@ -43,9 +43,14 @@ const mockGetState = jest.fn(() => ({}));
 const mockSelectedAccountAddress = jest.fn(() => '0xabc');
 const mockSelectedPerpsNetwork = jest.fn(() => 'testnet');
 const mockSelectedPerpsProvider = jest.fn(() => 'hyperliquid');
+const mockStoreSubscribers = new Set<() => void>();
 jest.mock('../../../../store', () => ({
   store: {
     getState: () => mockGetState(),
+    subscribe: (callback: () => void) => {
+      mockStoreSubscribers.add(callback);
+      return () => mockStoreSubscribers.delete(callback);
+    },
   },
 }));
 jest.mock('../selectors/selectedAccountAddress', () => ({
@@ -71,6 +76,9 @@ const mockSubscribeToPositions = jest.fn(
     return () => mockPositionSubscribers.delete(callback);
   },
 );
+const notifyStoreChanged = () => {
+  mockStoreSubscribers.forEach((callback) => callback());
+};
 jest.mock('../providers/PerpsStreamManager', () => ({
   usePerpsStream: () => ({
     positions: {
@@ -121,6 +129,7 @@ describe('usePerpsOrderExecution', () => {
     mockSelectedPerpsNetwork.mockReturnValue('testnet');
     mockSelectedPerpsProvider.mockReturnValue('hyperliquid');
     mockPositionSubscribers.clear();
+    mockStoreSubscribers.clear();
     mockSubscribeToPositions.mockImplementation(
       ({ callback }: { callback: PositionsCallback }) => {
         mockPositionSubscribers.add(callback);
@@ -1146,7 +1155,58 @@ describe('usePerpsOrderExecution', () => {
       }
     });
 
-    it('clears placing state while the position hint wait remains pending', async () => {
+    it('returns a position rendered after the former three-second wait boundary', async () => {
+      jest.useFakeTimers();
+      try {
+        const formerPositionHintWaitTimeoutMs = 3000;
+        mockPlaceOrder.mockResolvedValue({
+          success: true,
+          orderId: 'order123',
+        });
+        const { result } = renderHook(() => usePerpsOrderExecution());
+        let placementResolved = false;
+        let placement: ReturnType<typeof result.current.placeOrder> | undefined;
+
+        await act(async () => {
+          placement = result.current.placeOrder(mockOrderParams, {
+            waitForPosition: true,
+          });
+          placement.then(() => {
+            placementResolved = true;
+          });
+          await Promise.resolve();
+        });
+        await act(async () => {
+          jest.advanceTimersByTime(PERPS_CUF_STREAM_CONFIRM_RACE_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        await act(async () => {
+          jest.advanceTimersByTime(formerPositionHintWaitTimeoutMs + 1);
+          await Promise.resolve();
+        });
+
+        expect(placementResolved).toBe(false);
+
+        act(() => {
+          deliverPositions([mockPosition]);
+        });
+        let placementResult: Awaited<typeof placement>;
+        await act(async () => {
+          placementResult = await placement;
+        });
+
+        expect(placementResult).toEqual({
+          success: true,
+          orderId: 'order123',
+          position: mockPosition,
+        });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('clears placing state while post-order position confirmation remains pending', async () => {
       jest.useFakeTimers();
       try {
         mockPlaceOrder.mockResolvedValue({
@@ -1186,7 +1246,7 @@ describe('usePerpsOrderExecution', () => {
       }
     });
 
-    it('returns a successful order when the position hint wait times out', async () => {
+    it('returns the successful order at the position confirmation safety deadline', async () => {
       jest.useFakeTimers();
       try {
         const onError = jest.fn();
@@ -1211,7 +1271,9 @@ describe('usePerpsOrderExecution', () => {
           await Promise.resolve();
         });
         await act(async () => {
-          jest.advanceTimersByTime(PERPS_POSITION_HINT_WAIT_TIMEOUT_MS);
+          jest.advanceTimersByTime(
+            PERPS_POST_ORDER_POSITION_CONFIRMATION_TIMEOUT_MS,
+          );
           await Promise.resolve();
         });
         let placementResult: Awaited<typeof placement>;
@@ -1225,6 +1287,8 @@ describe('usePerpsOrderExecution', () => {
         });
         expect(onError).not.toHaveBeenCalled();
         expect(mockLoggerError).not.toHaveBeenCalled();
+        expect(mockPositionSubscribers.size).toBe(0);
+        expect(mockStoreSubscribers.size).toBe(0);
       } finally {
         jest.useRealTimers();
       }
@@ -1300,7 +1364,7 @@ describe('usePerpsOrderExecution', () => {
         });
         mockSelectedAccountAddress.mockReturnValue('0xdef');
         act(() => {
-          deliverPositions([mockPosition]);
+          notifyStoreChanged();
         });
         let placementResult: Awaited<typeof placement>;
         await act(async () => {
@@ -1309,6 +1373,8 @@ describe('usePerpsOrderExecution', () => {
 
         expect(placementResult).toBeUndefined();
         expect(onError).not.toHaveBeenCalled();
+        expect(mockPositionSubscribers.size).toBe(0);
+        expect(mockStoreSubscribers.size).toBe(0);
       } finally {
         jest.useRealTimers();
       }

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -1,8 +1,12 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { type OrderParams, type Position } from '@metamask/perps-controller';
-import { usePerpsOrderExecution } from './usePerpsOrderExecution';
+import {
+  PERPS_POSITION_HINT_WAIT_TIMEOUT_MS,
+  usePerpsOrderExecution,
+} from './usePerpsOrderExecution';
 import { usePerpsTrading } from './usePerpsTrading';
 import {
+  clearPendingPerpsCufTraces,
   handlePerpsCufPositionsDelivered,
   handlePerpsCufOrdersDelivered,
   resetPerpsCufTraceForTests,
@@ -35,15 +39,44 @@ jest.mock('../../../../util/trace', () => {
 const mockEndTrace = endTrace as jest.Mock;
 const mockTrace = trace as jest.Mock;
 const mockLoggerError = jest.mocked(Logger.error);
+const mockGetState = jest.fn(() => ({}));
+const mockSelectedAccountAddress = jest.fn(() => '0xabc');
+const mockSelectedPerpsNetwork = jest.fn(() => 'testnet');
+const mockSelectedPerpsProvider = jest.fn(() => 'hyperliquid');
+jest.mock('../../../../store', () => ({
+  store: {
+    getState: () => mockGetState(),
+  },
+}));
+jest.mock('../selectors/selectedAccountAddress', () => ({
+  selectPerpsSelectedAccountAddress: () => mockSelectedAccountAddress(),
+}));
+jest.mock('../selectors/perpsController', () => ({
+  selectPerpsNetwork: () => mockSelectedPerpsNetwork(),
+  selectPerpsProvider: () => mockSelectedPerpsProvider(),
+}));
 const mockGetPositionsSnapshot = jest.fn();
 const mockGetOrdersSnapshot = jest.fn();
 const mockPositionsLastDeliveredAt = jest.fn(() => null as number | null);
 const mockOrdersLastDeliveredAt = jest.fn(() => null as number | null);
+type PositionsCallback = (positions: Position[] | null) => void;
+const mockPositionSubscribers = new Set<PositionsCallback>();
+const mockSubscribeToPositions = jest.fn(
+  ({ callback }: { callback: PositionsCallback }) => {
+    mockPositionSubscribers.add(callback);
+    const snapshot = mockGetPositionsSnapshot() as Position[] | null;
+    if (snapshot !== null) {
+      callback(snapshot);
+    }
+    return () => mockPositionSubscribers.delete(callback);
+  },
+);
 jest.mock('../providers/PerpsStreamManager', () => ({
   usePerpsStream: () => ({
     positions: {
       getSnapshot: mockGetPositionsSnapshot,
       getLastDeliveredAt: mockPositionsLastDeliveredAt,
+      subscribe: mockSubscribeToPositions,
     },
     orders: {
       getSnapshot: mockGetOrdersSnapshot,
@@ -84,6 +117,20 @@ describe('usePerpsOrderExecution', () => {
     mockGetOrdersSnapshot.mockReturnValue([]); // Loaded, no orders by default
     mockPositionsLastDeliveredAt.mockReturnValue(null);
     mockOrdersLastDeliveredAt.mockReturnValue(null);
+    mockSelectedAccountAddress.mockReturnValue('0xabc');
+    mockSelectedPerpsNetwork.mockReturnValue('testnet');
+    mockSelectedPerpsProvider.mockReturnValue('hyperliquid');
+    mockPositionSubscribers.clear();
+    mockSubscribeToPositions.mockImplementation(
+      ({ callback }: { callback: PositionsCallback }) => {
+        mockPositionSubscribers.add(callback);
+        const snapshot = mockGetPositionsSnapshot() as Position[] | null;
+        if (snapshot !== null) {
+          callback(snapshot);
+        }
+        return () => mockPositionSubscribers.delete(callback);
+      },
+    );
     (usePerpsTrading as jest.Mock).mockReturnValue({
       placeOrder: mockPlaceOrder,
     });
@@ -135,6 +182,14 @@ describe('usePerpsOrderExecution', () => {
       handlePerpsCufPositionsDelivered([mockPosition]);
       return { success: true, orderId: 'order123', ...result };
     });
+  };
+
+  const deliverPositions = (positions: Position[] | null) => {
+    mockGetPositionsSnapshot.mockReturnValue(positions);
+    if (positions) {
+      handlePerpsCufPositionsDelivered(positions);
+    }
+    mockPositionSubscribers.forEach((callback) => callback(positions));
   };
 
   describe('strategy orders', () => {
@@ -1073,9 +1128,8 @@ describe('usePerpsOrderExecution', () => {
         });
         expect(onSuccess).toHaveBeenCalledWith();
 
-        mockGetPositionsSnapshot.mockReturnValue([mockPosition]);
         act(() => {
-          handlePerpsCufPositionsDelivered([mockPosition]);
+          deliverPositions([mockPosition]);
         });
 
         let placementResult: Awaited<typeof placement>;
@@ -1087,6 +1141,219 @@ describe('usePerpsOrderExecution', () => {
           orderId: 'order123',
           position: mockPosition,
         });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('clears placing state while the position hint wait remains pending', async () => {
+      jest.useFakeTimers();
+      try {
+        mockPlaceOrder.mockResolvedValue({
+          success: true,
+          orderId: 'order123',
+        });
+        const { result } = renderHook(() => usePerpsOrderExecution());
+        let placementResolved = false;
+        let placement: ReturnType<typeof result.current.placeOrder> | undefined;
+
+        await act(async () => {
+          placement = result.current.placeOrder(mockOrderParams, {
+            waitForPosition: true,
+          });
+          placement.then(() => {
+            placementResolved = true;
+          });
+          await Promise.resolve();
+        });
+        await act(async () => {
+          jest.advanceTimersByTime(PERPS_CUF_STREAM_CONFIRM_RACE_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+
+        expect(result.current.isPlacing).toBe(false);
+        expect(placementResolved).toBe(false);
+
+        act(() => {
+          deliverPositions([mockPosition]);
+        });
+        await act(async () => {
+          await placement;
+        });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('returns a successful order when the position hint wait times out', async () => {
+      jest.useFakeTimers();
+      try {
+        const onError = jest.fn();
+        mockPlaceOrder.mockResolvedValue({
+          success: true,
+          orderId: 'order123',
+        });
+        const { result } = renderHook(() =>
+          usePerpsOrderExecution({ onError }),
+        );
+        let placement: ReturnType<typeof result.current.placeOrder> | undefined;
+
+        await act(async () => {
+          placement = result.current.placeOrder(mockOrderParams, {
+            waitForPosition: true,
+          });
+          await Promise.resolve();
+        });
+        await act(async () => {
+          jest.advanceTimersByTime(PERPS_CUF_STREAM_CONFIRM_RACE_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        await act(async () => {
+          jest.advanceTimersByTime(PERPS_POSITION_HINT_WAIT_TIMEOUT_MS);
+          await Promise.resolve();
+        });
+        let placementResult: Awaited<typeof placement>;
+        await act(async () => {
+          placementResult = await placement;
+        });
+
+        expect(placementResult).toEqual({
+          success: true,
+          orderId: 'order123',
+        });
+        expect(onError).not.toHaveBeenCalled();
+        expect(mockLoggerError).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('returns the rendered position after CUF state is cleared', async () => {
+      jest.useFakeTimers();
+      try {
+        const onError = jest.fn();
+        mockPlaceOrder.mockResolvedValue({
+          success: true,
+          orderId: 'order123',
+        });
+        const { result } = renderHook(() =>
+          usePerpsOrderExecution({ onError }),
+        );
+        let placement: ReturnType<typeof result.current.placeOrder> | undefined;
+
+        await act(async () => {
+          placement = result.current.placeOrder(mockOrderParams, {
+            waitForPosition: true,
+          });
+          await Promise.resolve();
+        });
+        await act(async () => {
+          jest.advanceTimersByTime(PERPS_CUF_STREAM_CONFIRM_RACE_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        act(() => {
+          clearPendingPerpsCufTraces();
+          deliverPositions([mockPosition]);
+        });
+        let placementResult: Awaited<typeof placement>;
+        await act(async () => {
+          placementResult = await placement;
+        });
+
+        expect(placementResult).toEqual({
+          success: true,
+          orderId: 'order123',
+          position: mockPosition,
+        });
+        expect(onError).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('stops the position follow-up when the trading context changes', async () => {
+      jest.useFakeTimers();
+      try {
+        const onError = jest.fn();
+        mockPlaceOrder.mockResolvedValue({
+          success: true,
+          orderId: 'order123',
+        });
+        const { result } = renderHook(() =>
+          usePerpsOrderExecution({ onError }),
+        );
+        let placement: ReturnType<typeof result.current.placeOrder> | undefined;
+
+        await act(async () => {
+          placement = result.current.placeOrder(mockOrderParams, {
+            waitForPosition: true,
+          });
+          await Promise.resolve();
+        });
+        await act(async () => {
+          jest.advanceTimersByTime(PERPS_CUF_STREAM_CONFIRM_RACE_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        mockSelectedAccountAddress.mockReturnValue('0xdef');
+        act(() => {
+          deliverPositions([mockPosition]);
+        });
+        let placementResult: Awaited<typeof placement>;
+        await act(async () => {
+          placementResult = await placement;
+        });
+
+        expect(placementResult).toBeUndefined();
+        expect(onError).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('keeps a position subscription failure out of order error handling', async () => {
+      jest.useFakeTimers();
+      try {
+        const onError = jest.fn();
+        mockPlaceOrder.mockResolvedValue({
+          success: true,
+          orderId: 'order123',
+        });
+        mockSubscribeToPositions.mockImplementationOnce(() => {
+          throw new Error('Position subscription failed');
+        });
+        const { result } = renderHook(() =>
+          usePerpsOrderExecution({ onError }),
+        );
+        let placementResult:
+          | Awaited<ReturnType<typeof result.current.placeOrder>>
+          | undefined;
+
+        let placement: ReturnType<typeof result.current.placeOrder> | undefined;
+        await act(async () => {
+          placement = result.current.placeOrder(mockOrderParams, {
+            waitForPosition: true,
+          });
+          await Promise.resolve();
+        });
+        await act(async () => {
+          jest.advanceTimersByTime(PERPS_CUF_STREAM_CONFIRM_RACE_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        await act(async () => {
+          placementResult = await placement;
+        });
+
+        expect(placementResult).toEqual({
+          success: true,
+          orderId: 'order123',
+        });
+        expect(onError).not.toHaveBeenCalled();
+        expect(mockLoggerError).not.toHaveBeenCalled();
       } finally {
         jest.useRealTimers();
       }

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -44,7 +44,7 @@ import {
 interface UsePerpsOrderExecutionParams {
   /** Called when the order has been successfully submitted to the exchange. */
   onSubmitted?: () => void;
-  /** Called when the position has rendered via the stream (or, on stream timeout, without it). */
+  /** Called when the order is confirmed, without waiting for post-order work. */
   onSuccess?: (position?: Position) => void;
   onError?: (error: string) => void;
 }
@@ -83,7 +83,12 @@ interface ControllerPlacementHandlers {
 
 type PerpsPositionStream = ReturnType<typeof usePerpsStream>['positions'];
 
-export const PERPS_POSITION_HINT_WAIT_TIMEOUT_MS = 3000;
+/**
+ * Safety deadline for post-order work that requires the resulting position.
+ * The waiter resolves from stream delivery; this deadline only prevents a
+ * failed subscription from retaining resources indefinitely.
+ */
+export const PERPS_POST_ORDER_POSITION_CONFIRMATION_TIMEOUT_MS = 30000;
 
 const getPerpsOrderPositionSnapshot = (
   position?: PerpsOrderPositionSnapshot | null,
@@ -131,6 +136,7 @@ const waitForPositionRendered = (
   return new Promise((resolve) => {
     let settled = false;
     let unsubscribe: (() => void) | undefined;
+    let unsubscribeFromStore: (() => void) | undefined;
     let cancelTimeout = () => {
       // Replaced after the timeout is scheduled.
     };
@@ -141,11 +147,12 @@ const waitForPositionRendered = (
       settled = true;
       cancelTimeout();
       unsubscribe?.();
+      unsubscribeFromStore?.();
       resolve(position);
     };
     const timeout = setTimeout(
       () => settle(),
-      PERPS_POSITION_HINT_WAIT_TIMEOUT_MS,
+      PERPS_POST_ORDER_POSITION_CONFIRMATION_TIMEOUT_MS,
     );
     cancelTimeout = () => clearTimeout(timeout);
 
@@ -171,6 +178,16 @@ const waitForPositionRendered = (
       // its cleanup callback.
       if (settled) {
         unsubscribe();
+      }
+      if (!settled) {
+        unsubscribeFromStore = store.subscribe(() => {
+          if (!isContextCurrent()) {
+            settle();
+          }
+        });
+        if (!isContextCurrent()) {
+          settle();
+        }
       }
     } catch {
       settle();
@@ -417,7 +434,7 @@ export function usePerpsOrderExecution(
       // the span. Once the controller settles, stream-specific waits own the
       // timeout window and this watchdog must not race them.
       let controllerSettled = false;
-      setTimeout(() => {
+      const controllerWatchdog = setTimeout(() => {
         if (!controllerSettled) {
           // Distinct from stream_timeout: the controller request itself never
           // settled, rather than a settled request whose render never arrived.
@@ -431,6 +448,7 @@ export function usePerpsOrderExecution(
       const placementResult = await executeControllerPlacement(orderParams, {
         onSettled: () => {
           controllerSettled = true;
+          clearTimeout(controllerWatchdog);
         },
         onSuccess: async (result) => {
           if (isRestingOrder) {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -34,6 +34,12 @@ import {
 } from '../constants/perpsCufTags';
 import { usePerpsStream } from '../providers/PerpsStreamManager';
 import { usePerpsNetwork } from './usePerpsNetwork';
+import { store } from '../../../../store';
+import { selectPerpsSelectedAccountAddress } from '../selectors/selectedAccountAddress';
+import {
+  selectPerpsNetwork,
+  selectPerpsProvider,
+} from '../selectors/perpsController';
 
 interface UsePerpsOrderExecutionParams {
   /** Called when the order has been successfully submitted to the exchange. */
@@ -69,17 +75,108 @@ type PerpsOrderTrackingValue = string | number | boolean;
 type PerpsOrderPositionSnapshot = Pick<Position, 'size'>;
 
 interface ControllerPlacementHandlers {
-  onSuccess: (
-    result: OrderResult,
-  ) => Position | undefined | Promise<Position | undefined>;
+  onSuccess: (result: OrderResult) => void | Promise<void>;
   onFailure?: () => void;
   onException?: () => void;
   onSettled?: () => void;
 }
 
+type PerpsPositionStream = ReturnType<typeof usePerpsStream>['positions'];
+
+export const PERPS_POSITION_HINT_WAIT_TIMEOUT_MS = 3000;
+
 const getPerpsOrderPositionSnapshot = (
   position?: PerpsOrderPositionSnapshot | null,
 ) => (position ? position.size : undefined);
+
+const getPerpsTradingContextKey = (): string => {
+  const state = store.getState();
+  return JSON.stringify([
+    selectPerpsSelectedAccountAddress(state) ?? '',
+    selectPerpsNetwork(state),
+    selectPerpsProvider(state) ?? '',
+  ]);
+};
+
+const findRenderedPosition = (
+  positions: Position[] | null,
+  symbol: string,
+  baselineSize: string | undefined,
+): Position | undefined => {
+  const position = positions?.find((candidate) => candidate.symbol === symbol);
+  return position && isPerpsFillRendered(position, baselineSize)
+    ? position
+    : undefined;
+};
+
+const waitForPositionRendered = (
+  positionsStream: PerpsPositionStream,
+  symbol: string,
+  baselineSize: string | undefined,
+  isContextCurrent: () => boolean,
+): Promise<Position | undefined> => {
+  if (!isContextCurrent()) {
+    return Promise.resolve(undefined);
+  }
+
+  const renderedPosition = findRenderedPosition(
+    positionsStream.getSnapshot(),
+    symbol,
+    baselineSize,
+  );
+  if (renderedPosition) {
+    return Promise.resolve(renderedPosition);
+  }
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let unsubscribe: (() => void) | undefined;
+    let cancelTimeout = () => {
+      // Replaced after the timeout is scheduled.
+    };
+    const settle = (position?: Position) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cancelTimeout();
+      unsubscribe?.();
+      resolve(position);
+    };
+    const timeout = setTimeout(
+      () => settle(),
+      PERPS_POSITION_HINT_WAIT_TIMEOUT_MS,
+    );
+    cancelTimeout = () => clearTimeout(timeout);
+
+    try {
+      unsubscribe = positionsStream.subscribe({
+        callback: (positions) => {
+          if (!isContextCurrent()) {
+            settle();
+            return;
+          }
+          const position = findRenderedPosition(
+            positions,
+            symbol,
+            baselineSize,
+          );
+          if (position) {
+            settle(position);
+          }
+        },
+        throttleMs: 0,
+      });
+      // subscribe() may synchronously deliver a cached render before returning
+      // its cleanup callback.
+      if (settled) {
+        unsubscribe();
+      }
+    } catch {
+      settle();
+    }
+  });
+};
 
 /**
  * Hook to handle order execution flow
@@ -151,8 +248,8 @@ export function usePerpsOrderExecution(
             'usePerpsOrderExecution: Order placed successfully',
             result,
           );
-          const position = await handlers.onSuccess(result);
-          return position ? { ...result, position } : result;
+          await handlers.onSuccess(result);
+          return result;
         }
 
         handlers.onFailure?.();
@@ -298,6 +395,14 @@ export function usePerpsOrderExecution(
         positionsCache?.find((p) => p.symbol === orderParams.symbol) ?? null;
       const positionBaselineSnapshot =
         getPerpsOrderPositionSnapshot(positionBaseline);
+      const shouldWaitForPosition =
+        options.waitForPosition === true && isMarketOrder;
+      const tradingContextKey = shouldWaitForPosition
+        ? getPerpsTradingContextKey()
+        : undefined;
+      const isTradingContextCurrent = () =>
+        tradingContextKey !== undefined &&
+        getPerpsTradingContextKey() === tradingContextKey;
       if (isMarketOrder) {
         armPerpsPlaceOrderCuf(
           cufOpId,
@@ -323,7 +428,7 @@ export function usePerpsOrderExecution(
         }
       }, PERPS_CUF_STREAM_TIMEOUT_MS);
 
-      return executeControllerPlacement(orderParams, {
+      const placementResult = await executeControllerPlacement(orderParams, {
         onSettled: () => {
           controllerSettled = true;
         },
@@ -423,7 +528,7 @@ export function usePerpsOrderExecution(
               rendered.position,
             );
             onSuccess?.(position);
-            return position;
+            return;
           }
 
           // Stream quiet: unblock the toast now, end the span when the
@@ -433,35 +538,27 @@ export function usePerpsOrderExecution(
           );
           onSuccess?.();
 
-          const waitForLatePosition = waitForPerpsPlaceOrderPositionRendered(
+          waitForPerpsPlaceOrderPositionRendered(
             PERPS_CUF_STREAM_TIMEOUT_MS,
             cufOpId,
-          ).then((late) => {
-            // A newer order owns the span now; this continuation is stale.
-            if (!isPerpsPlaceOrderCufCurrent(cufOpId)) {
-              return undefined;
-            }
-            if (late) {
-              endCufRendered(late.renderedAt, toastShownAt);
-              return stream.positions
-                .getSnapshot()
-                ?.find((p) => p.symbol === orderParams.symbol);
-            }
-            endCuf({
-              [PERPS_CUF_TAG.SUCCESS]: false,
-              [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
+          )
+            .then((late) => {
+              // A newer order owns the span now; this continuation is stale.
+              if (!isPerpsPlaceOrderCufCurrent(cufOpId)) {
+                return;
+              }
+              if (late) {
+                endCufRendered(late.renderedAt, toastShownAt);
+              } else {
+                endCuf({
+                  [PERPS_CUF_TAG.SUCCESS]: false,
+                  [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
+                });
+              }
+            })
+            .catch(() => {
+              // Telemetry failures must never change a successful order result.
             });
-            return undefined;
-          });
-
-          if (options.waitForPosition) {
-            return waitForLatePosition;
-          }
-
-          // Deliberately not awaited: ordinary order callers must not block on
-          // the stream-confirmation span.
-          waitForLatePosition.catch(() => undefined);
-          return undefined;
         },
         onFailure: () => {
           endCuf({
@@ -476,6 +573,25 @@ export function usePerpsOrderExecution(
           });
         },
       });
+
+      if (!placementResult?.success || !shouldWaitForPosition) {
+        return placementResult;
+      }
+      if (!isTradingContextCurrent()) {
+        return undefined;
+      }
+
+      const position = await waitForPositionRendered(
+        stream.positions,
+        orderParams.symbol,
+        positionBaselineSnapshot,
+        isTradingContextCurrent,
+      ).catch(() => undefined);
+      if (!isTradingContextCurrent()) {
+        return undefined;
+      }
+
+      return position ? { ...placementResult, position } : placementResult;
     },
     [executeControllerPlacement, stream, onSuccess],
   );

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -43,8 +43,23 @@ interface UsePerpsOrderExecutionParams {
   onError?: (error: string) => void;
 }
 
+interface PlaceOrderOptions {
+  /**
+   * Continue waiting for the live position after the confirmation-toast race.
+   * Use when a follow-up operation requires the newly rendered position.
+   */
+  waitForPosition?: boolean;
+}
+
+interface PerpsOrderExecutionResult extends OrderResult {
+  position?: Position;
+}
+
 interface UsePerpsOrderExecutionReturn {
-  placeOrder: (params: OrderParams) => Promise<OrderResult | undefined>;
+  placeOrder: (
+    params: OrderParams,
+    options?: PlaceOrderOptions,
+  ) => Promise<PerpsOrderExecutionResult | undefined>;
   isPlacing: boolean;
   lastResult?: OrderResult;
   error?: string;
@@ -54,7 +69,9 @@ type PerpsOrderTrackingValue = string | number | boolean;
 type PerpsOrderPositionSnapshot = Pick<Position, 'size'>;
 
 interface ControllerPlacementHandlers {
-  onSuccess: (result: OrderResult) => void | Promise<void>;
+  onSuccess: (
+    result: OrderResult,
+  ) => Position | undefined | Promise<Position | undefined>;
   onFailure?: () => void;
   onException?: () => void;
   onSettled?: () => void;
@@ -104,7 +121,7 @@ export function usePerpsOrderExecution(
     async (
       orderParams: OrderParams,
       handlers: ControllerPlacementHandlers,
-    ): Promise<OrderResult | undefined> => {
+    ): Promise<PerpsOrderExecutionResult | undefined> => {
       let controllerSettled = false;
       const markControllerSettled = () => {
         if (!controllerSettled) {
@@ -134,15 +151,16 @@ export function usePerpsOrderExecution(
             'usePerpsOrderExecution: Order placed successfully',
             result,
           );
-          await handlers.onSuccess(result);
-        } else {
-          handlers.onFailure?.();
-          const errorMessage =
-            result.error || strings('perps.order.error.unknown');
-          setError(errorMessage);
-          DevLogger.log('usePerpsOrderExecution: Order failed', errorMessage);
-          onError?.(errorMessage);
+          const position = await handlers.onSuccess(result);
+          return position ? { ...result, position } : result;
         }
+
+        handlers.onFailure?.();
+        const errorMessage =
+          result.error || strings('perps.order.error.unknown');
+        setError(errorMessage);
+        DevLogger.log('usePerpsOrderExecution: Order failed', errorMessage);
+        onError?.(errorMessage);
 
         return result;
       } catch (err) {
@@ -196,7 +214,10 @@ export function usePerpsOrderExecution(
   );
 
   const placeOrder = useCallback(
-    async (orderParams: OrderParams): Promise<OrderResult | undefined> => {
+    async (
+      orderParams: OrderParams,
+      options: PlaceOrderOptions = {},
+    ): Promise<PerpsOrderExecutionResult | undefined> => {
       // Market orders measure submit -> position rendered (toast coupled to the
       // same stream render) via PerpsPlaceOrderToPositionRendered. Limit and
       // trigger orders measure submit -> resting order rendered in the orders
@@ -209,7 +230,10 @@ export function usePerpsOrderExecution(
         return executeControllerPlacement(orderParams, {
           // Strategy acceptance starts a schedule; it does not imply that a
           // position or resting child order has rendered yet.
-          onSuccess: () => onSuccess?.(),
+          onSuccess: () => {
+            onSuccess?.();
+            return undefined;
+          },
         });
       }
 
@@ -379,51 +403,65 @@ export function usePerpsOrderExecution(
                 );
               }
             }
-          } else {
-            // Wait briefly for the stream to render the new/changed position so
-            // the confirmation toast fires together with it.
-            const rendered = await waitForPerpsPlaceOrderPositionRendered(
-              PERPS_CUF_STREAM_CONFIRM_RACE_MS,
-              cufOpId,
+            return undefined;
+          }
+
+          // Wait briefly for the stream to render the new/changed position so
+          // the confirmation toast fires together with it.
+          const rendered = await waitForPerpsPlaceOrderPositionRendered(
+            PERPS_CUF_STREAM_CONFIRM_RACE_MS,
+            cufOpId,
+          );
+          const toastShownAt = Date.now();
+          if (rendered) {
+            endCufRendered(rendered.renderedAt, toastShownAt);
+            const position = stream.positions
+              .getSnapshot()
+              ?.find((p) => p.symbol === orderParams.symbol);
+            DevLogger.log(
+              'usePerpsOrderExecution: Position rendered by stream',
+              rendered.position,
             );
-            const toastShownAt = Date.now();
-            if (rendered) {
-              endCufRendered(rendered.renderedAt, toastShownAt);
-              const position = stream.positions
+            onSuccess?.(position);
+            return position;
+          }
+
+          // Stream quiet: unblock the toast now, end the span when the
+          // position finally renders (or record the miss on timeout).
+          DevLogger.log(
+            'usePerpsOrderExecution: Position not rendered yet, toasting without it',
+          );
+          onSuccess?.();
+
+          const waitForLatePosition = waitForPerpsPlaceOrderPositionRendered(
+            PERPS_CUF_STREAM_TIMEOUT_MS,
+            cufOpId,
+          ).then((late) => {
+            // A newer order owns the span now; this continuation is stale.
+            if (!isPerpsPlaceOrderCufCurrent(cufOpId)) {
+              return undefined;
+            }
+            if (late) {
+              endCufRendered(late.renderedAt, toastShownAt);
+              return stream.positions
                 .getSnapshot()
                 ?.find((p) => p.symbol === orderParams.symbol);
-              DevLogger.log(
-                'usePerpsOrderExecution: Position rendered by stream',
-                rendered.position,
-              );
-              onSuccess?.(position);
-            } else {
-              // Stream quiet: unblock the toast now, end the span when the
-              // position finally renders (or record the miss on timeout).
-              DevLogger.log(
-                'usePerpsOrderExecution: Position not rendered yet, toasting without it',
-              );
-              onSuccess?.();
-              // Deliberately not awaited: the caller must not block on the span.
-              waitForPerpsPlaceOrderPositionRendered(
-                PERPS_CUF_STREAM_TIMEOUT_MS,
-                cufOpId,
-              ).then((late) => {
-                // A newer order owns the span now; this continuation is stale.
-                if (!isPerpsPlaceOrderCufCurrent(cufOpId)) {
-                  return;
-                }
-                if (late) {
-                  endCufRendered(late.renderedAt, toastShownAt);
-                } else {
-                  endCuf({
-                    [PERPS_CUF_TAG.SUCCESS]: false,
-                    [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
-                  });
-                }
-              });
             }
+            endCuf({
+              [PERPS_CUF_TAG.SUCCESS]: false,
+              [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
+            });
+            return undefined;
+          });
+
+          if (options.waitForPosition) {
+            return waitForLatePosition;
           }
+
+          // Deliberately not awaited: ordinary order callers must not block on
+          // the stream-confirmation span.
+          waitForLatePosition.catch(() => undefined);
+          return undefined;
         },
         onFailure: () => {
           endCuf({

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -34,12 +34,6 @@ import {
 } from '../constants/perpsCufTags';
 import { usePerpsStream } from '../providers/PerpsStreamManager';
 import { usePerpsNetwork } from './usePerpsNetwork';
-import { store } from '../../../../store';
-import { selectPerpsSelectedAccountAddress } from '../selectors/selectedAccountAddress';
-import {
-  selectPerpsNetwork,
-  selectPerpsProvider,
-} from '../selectors/perpsController';
 
 interface UsePerpsOrderExecutionParams {
   /** Called when the order has been successfully submitted to the exchange. */
@@ -49,23 +43,8 @@ interface UsePerpsOrderExecutionParams {
   onError?: (error: string) => void;
 }
 
-interface PlaceOrderOptions {
-  /**
-   * Continue waiting for the live position after the confirmation-toast race.
-   * Use when a follow-up operation requires the newly rendered position.
-   */
-  waitForPosition?: boolean;
-}
-
-interface PerpsOrderExecutionResult extends OrderResult {
-  position?: Position;
-}
-
 interface UsePerpsOrderExecutionReturn {
-  placeOrder: (
-    params: OrderParams,
-    options?: PlaceOrderOptions,
-  ) => Promise<PerpsOrderExecutionResult | undefined>;
+  placeOrder: (params: OrderParams) => Promise<OrderResult | undefined>;
   isPlacing: boolean;
   lastResult?: OrderResult;
   error?: string;
@@ -81,124 +60,13 @@ interface ControllerPlacementHandlers {
   onSettled?: () => void;
 }
 
-type PerpsPositionStream = ReturnType<typeof usePerpsStream>['positions'];
-
-/**
- * Safety deadline for post-order work that requires the resulting position.
- * The waiter resolves from stream delivery; this deadline only prevents a
- * failed subscription from retaining resources indefinitely.
- */
-export const PERPS_POST_ORDER_POSITION_CONFIRMATION_TIMEOUT_MS = 30000;
-
 const getPerpsOrderPositionSnapshot = (
   position?: PerpsOrderPositionSnapshot | null,
 ) => (position ? position.size : undefined);
 
-const getPerpsTradingContextKey = (): string => {
-  const state = store.getState();
-  return JSON.stringify([
-    selectPerpsSelectedAccountAddress(state) ?? '',
-    selectPerpsNetwork(state),
-    selectPerpsProvider(state) ?? '',
-  ]);
-};
-
-const findRenderedPosition = (
-  positions: Position[] | null,
-  symbol: string,
-  baselineSize: string | undefined,
-): Position | undefined => {
-  const position = positions?.find((candidate) => candidate.symbol === symbol);
-  return position && isPerpsFillRendered(position, baselineSize)
-    ? position
-    : undefined;
-};
-
-const waitForPositionRendered = (
-  positionsStream: PerpsPositionStream,
-  symbol: string,
-  baselineSize: string | undefined,
-  isContextCurrent: () => boolean,
-): Promise<Position | undefined> => {
-  if (!isContextCurrent()) {
-    return Promise.resolve(undefined);
-  }
-
-  const renderedPosition = findRenderedPosition(
-    positionsStream.getSnapshot(),
-    symbol,
-    baselineSize,
-  );
-  if (renderedPosition) {
-    return Promise.resolve(renderedPosition);
-  }
-
-  return new Promise((resolve) => {
-    let settled = false;
-    let unsubscribe: (() => void) | undefined;
-    let unsubscribeFromStore: (() => void) | undefined;
-    let cancelTimeout = () => {
-      // Replaced after the timeout is scheduled.
-    };
-    const settle = (position?: Position) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      cancelTimeout();
-      unsubscribe?.();
-      unsubscribeFromStore?.();
-      resolve(position);
-    };
-    const timeout = setTimeout(
-      () => settle(),
-      PERPS_POST_ORDER_POSITION_CONFIRMATION_TIMEOUT_MS,
-    );
-    cancelTimeout = () => clearTimeout(timeout);
-
-    try {
-      unsubscribe = positionsStream.subscribe({
-        callback: (positions) => {
-          if (!isContextCurrent()) {
-            settle();
-            return;
-          }
-          const position = findRenderedPosition(
-            positions,
-            symbol,
-            baselineSize,
-          );
-          if (position) {
-            settle(position);
-          }
-        },
-        throttleMs: 0,
-      });
-      // subscribe() may synchronously deliver a cached render before returning
-      // its cleanup callback.
-      if (settled) {
-        unsubscribe();
-      }
-      if (!settled) {
-        unsubscribeFromStore = store.subscribe(() => {
-          if (!isContextCurrent()) {
-            settle();
-          }
-        });
-        if (!isContextCurrent()) {
-          settle();
-        }
-      }
-    } catch {
-      settle();
-    }
-  });
-};
-
 /**
  * Hook to handle order execution flow
- * Manages loading states, success/error handling, and stream-confirmed
- * position rendering.
+ * Manages loading states, success/error handling, and confirmation telemetry.
  *
  * Trade transaction analytics (submitted + terminal) are emitted by
  * `@metamask/perps-controller` TradingService — do not re-emit
@@ -235,7 +103,7 @@ export function usePerpsOrderExecution(
     async (
       orderParams: OrderParams,
       handlers: ControllerPlacementHandlers,
-    ): Promise<PerpsOrderExecutionResult | undefined> => {
+    ): Promise<OrderResult | undefined> => {
       let controllerSettled = false;
       const markControllerSettled = () => {
         if (!controllerSettled) {
@@ -328,10 +196,7 @@ export function usePerpsOrderExecution(
   );
 
   const placeOrder = useCallback(
-    async (
-      orderParams: OrderParams,
-      options: PlaceOrderOptions = {},
-    ): Promise<PerpsOrderExecutionResult | undefined> => {
+    async (orderParams: OrderParams): Promise<OrderResult | undefined> => {
       // Market orders measure submit -> position rendered (toast coupled to the
       // same stream render) via PerpsPlaceOrderToPositionRendered. Limit and
       // trigger orders measure submit -> resting order rendered in the orders
@@ -412,14 +277,6 @@ export function usePerpsOrderExecution(
         positionsCache?.find((p) => p.symbol === orderParams.symbol) ?? null;
       const positionBaselineSnapshot =
         getPerpsOrderPositionSnapshot(positionBaseline);
-      const shouldWaitForPosition =
-        options.waitForPosition === true && isMarketOrder;
-      const tradingContextKey = shouldWaitForPosition
-        ? getPerpsTradingContextKey()
-        : undefined;
-      const isTradingContextCurrent = () =>
-        tradingContextKey !== undefined &&
-        getPerpsTradingContextKey() === tradingContextKey;
       if (isMarketOrder) {
         armPerpsPlaceOrderCuf(
           cufOpId,
@@ -445,7 +302,7 @@ export function usePerpsOrderExecution(
         }
       }, PERPS_CUF_STREAM_TIMEOUT_MS);
 
-      const placementResult = await executeControllerPlacement(orderParams, {
+      return executeControllerPlacement(orderParams, {
         onSettled: () => {
           controllerSettled = true;
           clearTimeout(controllerWatchdog);
@@ -591,25 +448,6 @@ export function usePerpsOrderExecution(
           });
         },
       });
-
-      if (!placementResult?.success || !shouldWaitForPosition) {
-        return placementResult;
-      }
-      if (!isTradingContextCurrent()) {
-        return undefined;
-      }
-
-      const position = await waitForPositionRendered(
-        stream.positions,
-        orderParams.symbol,
-        positionBaselineSnapshot,
-        isTradingContextCurrent,
-      ).catch(() => undefined);
-      if (!isTradingContextCurrent()) {
-        return undefined;
-      }
-
-      return position ? { ...placementResult, position } : placementResult;
     },
     [executeControllerPlacement, stream, onSuccess],
   );

--- a/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.test.ts
@@ -49,11 +49,13 @@ describe('usePerpsPostOrderTPSL', () => {
     const { result } = renderHook(() => usePerpsPostOrderTPSL());
 
     await act(async () => {
-      await result.current.attachPostOrderTPSL({
-        symbol: 'ETH',
-        takeProfitPrice: '3500',
+      await result.current.attachPostOrderTPSL(
+        {
+          symbol: 'ETH',
+          takeProfitPrice: '3500',
+        },
         position,
-      });
+      );
     });
 
     expect(mockUpdatePositionTPSL).toHaveBeenCalledWith({
@@ -68,11 +70,13 @@ describe('usePerpsPostOrderTPSL', () => {
     const { result } = renderHook(() => usePerpsPostOrderTPSL());
 
     await act(async () => {
-      await result.current.attachPostOrderTPSL({
-        symbol: 'ETH',
-        stopLossPrice: '2500',
-        position: undefined,
-      });
+      await result.current.attachPostOrderTPSL(
+        {
+          symbol: 'ETH',
+          stopLossPrice: '2500',
+        },
+        undefined,
+      );
     });
 
     expect(mockUpdatePositionTPSL).toHaveBeenCalledWith({

--- a/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.test.ts
@@ -1,11 +1,35 @@
 import { act, renderHook } from '@testing-library/react-native';
-import type { OrderResult, Position } from '@metamask/perps-controller';
+import {
+  PERPS_ERROR_CODES,
+  type OrderResult,
+  type Position,
+} from '@metamask/perps-controller';
 import Logger from '../../../../util/Logger';
-import { usePerpsPostOrderTPSL } from './usePerpsPostOrderTPSL';
+import {
+  POST_ORDER_TPSL_RETRY_OFFSETS_MS,
+  usePerpsPostOrderTPSL,
+} from './usePerpsPostOrderTPSL';
 
 const mockUpdatePositionTPSL = jest.fn();
 const mockShowToast = jest.fn();
 const mockPostOrderAttachmentFailed = { id: 'post-order-attachment-failed' };
+const mockGetPositionsSnapshot = jest.fn<Position[] | null, []>();
+type PositionsCallback = (positions: Position[] | null) => void;
+const mockPositionSubscribers = new Set<PositionsCallback>();
+const mockStoreSubscribers = new Set<() => void>();
+const mockSelectedAccountAddress = jest.fn(() => '0xabc');
+const mockSelectedPerpsNetwork = jest.fn(() => 'testnet');
+const mockSelectedPerpsProvider = jest.fn(() => 'hyperliquid');
+const mockSubscribeToPositions = jest.fn(
+  ({ callback }: { callback: PositionsCallback }) => {
+    mockPositionSubscribers.add(callback);
+    const snapshot = mockGetPositionsSnapshot();
+    if (snapshot !== null) {
+      callback(snapshot);
+    }
+    return () => mockPositionSubscribers.delete(callback);
+  },
+);
 
 jest.mock('./usePerpsTrading', () => ({
   usePerpsTrading: () => ({
@@ -27,6 +51,34 @@ jest.mock('./usePerpsToasts', () => ({
   }),
 }));
 
+jest.mock('../providers/PerpsStreamManager', () => ({
+  usePerpsStream: () => ({
+    positions: {
+      getSnapshot: mockGetPositionsSnapshot,
+      subscribe: mockSubscribeToPositions,
+    },
+  }),
+}));
+
+jest.mock('../../../../store', () => ({
+  store: {
+    getState: () => ({}),
+    subscribe: (callback: () => void) => {
+      mockStoreSubscribers.add(callback);
+      return () => mockStoreSubscribers.delete(callback);
+    },
+  },
+}));
+
+jest.mock('../selectors/selectedAccountAddress', () => ({
+  selectPerpsSelectedAccountAddress: () => mockSelectedAccountAddress(),
+}));
+
+jest.mock('../selectors/perpsController', () => ({
+  selectPerpsNetwork: () => mockSelectedPerpsNetwork(),
+  selectPerpsProvider: () => mockSelectedPerpsProvider(),
+}));
+
 jest.mock('../../../../util/Logger', () => ({
   __esModule: true,
   default: {
@@ -39,86 +91,210 @@ describe('usePerpsPostOrderTPSL', () => {
     symbol: 'ETH',
     size: '0.1',
   } as Position;
+  const flippedPosition = {
+    ...position,
+    size: '-0.2',
+  };
+  const order = {
+    symbol: 'ETH',
+    takeProfitPrice: '3500',
+    stopLossPrice: '2500',
+  };
+  const positionNotFoundResult: OrderResult = {
+    success: false,
+    error: PERPS_ERROR_CODES.POSITION_NOT_FOUND,
+  };
+
+  const flushPromises = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  const deliverPositions = (positions: Position[]) => {
+    mockGetPositionsSnapshot.mockReturnValue(positions);
+    mockPositionSubscribers.forEach((callback) => callback(positions));
+  };
+
+  const notifyStoreChanged = () => {
+    mockStoreSubscribers.forEach((callback) => callback());
+  };
 
   beforeEach(() => {
+    jest.useFakeTimers();
     jest.clearAllMocks();
+    mockPositionSubscribers.clear();
+    mockStoreSubscribers.clear();
+    mockGetPositionsSnapshot.mockReturnValue([]);
+    mockSelectedAccountAddress.mockReturnValue('0xabc');
+    mockSelectedPerpsNetwork.mockReturnValue('testnet');
+    mockSelectedPerpsProvider.mockReturnValue('hyperliquid');
+    mockSubscribeToPositions.mockImplementation(
+      ({ callback }: { callback: PositionsCallback }) => {
+        mockPositionSubscribers.add(callback);
+        const snapshot = mockGetPositionsSnapshot();
+        if (snapshot !== null) {
+          callback(snapshot);
+        }
+        return () => mockPositionSubscribers.delete(callback);
+      },
+    );
     mockUpdatePositionTPSL.mockResolvedValue({ success: true });
   });
 
-  it('passes the rendered position to the controller', async () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('attaches protection immediately for a new position', async () => {
     const { result } = renderHook(() => usePerpsPostOrderTPSL());
+    let attachmentResult: OrderResult | undefined;
 
     await act(async () => {
-      await result.current.attachPostOrderTPSL(
-        {
-          symbol: 'ETH',
-          takeProfitPrice: '3500',
-        },
-        position,
-      );
+      attachmentResult = await result.current.attachPostOrderTPSL(order);
     });
 
     expect(mockUpdatePositionTPSL).toHaveBeenCalledWith({
-      symbol: 'ETH',
-      takeProfitPrice: '3500',
+      ...order,
+      position: undefined,
+    });
+    expect(attachmentResult).toEqual({ success: true });
+    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(result.current.isAttachingPostOrderTPSL).toBe(false);
+  });
+
+  it('retries as soon as the position stream renders', async () => {
+    mockUpdatePositionTPSL
+      .mockResolvedValueOnce(positionNotFoundResult)
+      .mockResolvedValueOnce({ success: true });
+    const { result } = renderHook(() => usePerpsPostOrderTPSL());
+    let attachment: Promise<OrderResult | undefined>;
+
+    act(() => {
+      attachment = result.current.attachPostOrderTPSL(order);
+    });
+    await act(flushPromises);
+
+    expect(mockUpdatePositionTPSL).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deliverPositions([position]);
+      await attachment;
+    });
+
+    expect(mockUpdatePositionTPSL).toHaveBeenCalledTimes(2);
+    expect(mockUpdatePositionTPSL).toHaveBeenLastCalledWith({
+      ...order,
       position,
     });
     expect(mockShowToast).not.toHaveBeenCalled();
   });
 
-  it('allows the controller fallback when the stream provides no position', async () => {
+  it('finds controller HTTP readiness on the two-second retry', async () => {
+    mockUpdatePositionTPSL
+      .mockResolvedValueOnce(positionNotFoundResult)
+      .mockResolvedValueOnce(positionNotFoundResult)
+      .mockResolvedValueOnce({ success: true });
     const { result } = renderHook(() => usePerpsPostOrderTPSL());
+    let attachment: Promise<OrderResult | undefined>;
 
+    act(() => {
+      attachment = result.current.attachPostOrderTPSL(order);
+    });
+    await act(flushPromises);
     await act(async () => {
-      await result.current.attachPostOrderTPSL(
-        {
-          symbol: 'ETH',
-          stopLossPrice: '2500',
-        },
-        undefined,
-      );
+      jest.advanceTimersByTime(500);
+      await flushPromises();
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1500);
+      await attachment;
     });
 
-    expect(mockUpdatePositionTPSL).toHaveBeenCalledWith({
-      symbol: 'ETH',
-      stopLossPrice: '2500',
-      position: undefined,
-    });
+    expect(mockUpdatePositionTPSL).toHaveBeenCalledTimes(3);
     expect(mockShowToast).not.toHaveBeenCalled();
   });
 
-  it('warns that the open position has no protection when attachment fails', async () => {
-    mockUpdatePositionTPSL.mockResolvedValue({
-      success: false,
-      error: 'No position found for ETH',
-    });
+  it('warns once after position-not-found retries are exhausted', async () => {
+    mockUpdatePositionTPSL.mockResolvedValue(positionNotFoundResult);
     const { result } = renderHook(() => usePerpsPostOrderTPSL());
+    let attachment: Promise<OrderResult | undefined>;
 
+    act(() => {
+      attachment = result.current.attachPostOrderTPSL(order);
+    });
+    await act(flushPromises);
+    for (
+      let index = 1;
+      index < POST_ORDER_TPSL_RETRY_OFFSETS_MS.length;
+      index += 1
+    ) {
+      const elapsed =
+        POST_ORDER_TPSL_RETRY_OFFSETS_MS[index] -
+        POST_ORDER_TPSL_RETRY_OFFSETS_MS[index - 1];
+      await act(async () => {
+        jest.advanceTimersByTime(elapsed);
+        await flushPromises();
+      });
+    }
     let attachmentResult: OrderResult | undefined;
     await act(async () => {
-      attachmentResult = await result.current.attachPostOrderTPSL({
-        symbol: 'ETH',
-        takeProfitPrice: '3500',
-      });
+      attachmentResult = await attachment;
     });
 
-    expect(attachmentResult).toEqual({
+    expect(attachmentResult).toEqual(positionNotFoundResult);
+    expect(mockUpdatePositionTPSL).toHaveBeenCalledTimes(4);
+    expect(mockShowToast).toHaveBeenCalledTimes(1);
+    expect(mockShowToast).toHaveBeenCalledWith(mockPostOrderAttachmentFailed);
+    expect(mockPositionSubscribers.size).toBe(0);
+    expect(mockStoreSubscribers.size).toBe(0);
+  });
+
+  it('fails immediately for a terminal controller result', async () => {
+    const terminalResult = {
       success: false,
-      error: 'No position found for ETH',
+      error: PERPS_ERROR_CODES.ORDER_TPSL_SIZE_INVALID,
+    };
+    mockUpdatePositionTPSL.mockResolvedValue(terminalResult);
+    const { result } = renderHook(() => usePerpsPostOrderTPSL());
+    let attachmentResult: OrderResult | undefined;
+
+    await act(async () => {
+      attachmentResult = await result.current.attachPostOrderTPSL(order);
     });
+
+    expect(attachmentResult).toEqual(terminalResult);
+    expect(mockUpdatePositionTPSL).toHaveBeenCalledTimes(1);
     expect(mockShowToast).toHaveBeenCalledWith(mockPostOrderAttachmentFailed);
   });
 
-  it('normalizes a rejected attachment as an unprotected position', async () => {
+  it('retries a rejected typed position-not-found error', async () => {
+    mockUpdatePositionTPSL
+      .mockRejectedValueOnce(new Error(PERPS_ERROR_CODES.POSITION_NOT_FOUND))
+      .mockResolvedValueOnce({ success: true });
+    const { result } = renderHook(() => usePerpsPostOrderTPSL());
+    let attachment: Promise<OrderResult | undefined>;
+
+    act(() => {
+      attachment = result.current.attachPostOrderTPSL(order);
+    });
+    await act(flushPromises);
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+      await attachment;
+    });
+
+    expect(mockUpdatePositionTPSL).toHaveBeenCalledTimes(2);
+    expect(Logger.error).not.toHaveBeenCalled();
+    expect(mockShowToast).not.toHaveBeenCalled();
+  });
+
+  it('normalizes a rejected terminal error as an unprotected position', async () => {
     mockUpdatePositionTPSL.mockRejectedValue(new Error('Network unavailable'));
     const { result } = renderHook(() => usePerpsPostOrderTPSL());
-
     let attachmentResult: OrderResult | undefined;
+
     await act(async () => {
-      attachmentResult = await result.current.attachPostOrderTPSL({
-        symbol: 'ETH',
-        takeProfitPrice: '3500',
-      });
+      attachmentResult = await result.current.attachPostOrderTPSL(order);
     });
 
     expect(attachmentResult).toEqual({
@@ -130,5 +306,127 @@ describe('usePerpsPostOrderTPSL', () => {
       'usePerpsPostOrderTPSL: Failed to attach protection',
     );
     expect(mockShowToast).toHaveBeenCalledWith(mockPostOrderAttachmentFailed);
+  });
+
+  it('aborts without a warning when the trading context changes', async () => {
+    mockUpdatePositionTPSL.mockResolvedValue(positionNotFoundResult);
+    const { result } = renderHook(() => usePerpsPostOrderTPSL());
+    let attachment: Promise<OrderResult | undefined>;
+
+    act(() => {
+      attachment = result.current.attachPostOrderTPSL(order);
+    });
+    await act(flushPromises);
+    mockSelectedAccountAddress.mockReturnValue('0xdef');
+    let attachmentResult: OrderResult | undefined;
+    await act(async () => {
+      notifyStoreChanged();
+      attachmentResult = await attachment;
+    });
+
+    expect(attachmentResult).toBeUndefined();
+    expect(mockUpdatePositionTPSL).toHaveBeenCalledTimes(1);
+    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockPositionSubscribers.size).toBe(0);
+    expect(mockStoreSubscribers.size).toBe(0);
+  });
+
+  it('uses timer retries when the stream subscription fails', async () => {
+    mockSubscribeToPositions.mockImplementationOnce(() => {
+      throw new Error('Position subscription failed');
+    });
+    mockUpdatePositionTPSL
+      .mockResolvedValueOnce(positionNotFoundResult)
+      .mockResolvedValueOnce({ success: true });
+    const { result } = renderHook(() => usePerpsPostOrderTPSL());
+    let attachment: Promise<OrderResult | undefined>;
+
+    act(() => {
+      attachment = result.current.attachPostOrderTPSL(order);
+    });
+    await act(flushPromises);
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+      await attachment;
+    });
+
+    expect(mockUpdatePositionTPSL).toHaveBeenCalledTimes(2);
+    expect(mockShowToast).not.toHaveBeenCalled();
+  });
+
+  it('returns the active attachment for a duplicate call', async () => {
+    let resolveUpdate: ((result: OrderResult) => void) | undefined;
+    mockUpdatePositionTPSL.mockReturnValue(
+      new Promise<OrderResult>((resolve) => {
+        resolveUpdate = resolve;
+      }),
+    );
+    const { result } = renderHook(() => usePerpsPostOrderTPSL());
+    let firstAttachment!: Promise<OrderResult | undefined>;
+    let secondAttachment!: Promise<OrderResult | undefined>;
+
+    act(() => {
+      firstAttachment = result.current.attachPostOrderTPSL(order);
+      secondAttachment = result.current.attachPostOrderTPSL(order);
+    });
+
+    expect(firstAttachment).toBe(secondAttachment);
+    expect(mockUpdatePositionTPSL).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveUpdate?.({ success: true });
+      await firstAttachment;
+    });
+  });
+
+  it('waits for a flipped position before attaching protection', async () => {
+    mockGetPositionsSnapshot.mockReturnValue([position]);
+    const { result } = renderHook(() => usePerpsPostOrderTPSL());
+    let attachment: Promise<OrderResult | undefined>;
+
+    act(() => {
+      attachment = result.current.attachPostOrderTPSL(order, {
+        positionBaseline: position,
+      });
+    });
+    await act(flushPromises);
+
+    expect(mockUpdatePositionTPSL).not.toHaveBeenCalled();
+
+    await act(async () => {
+      deliverPositions([flippedPosition]);
+      await attachment;
+    });
+
+    expect(mockUpdatePositionTPSL).toHaveBeenCalledWith({
+      ...order,
+      position: flippedPosition,
+    });
+  });
+
+  it('fails closed when a flipped position never renders', async () => {
+    mockGetPositionsSnapshot.mockReturnValue([position]);
+    const { result } = renderHook(() => usePerpsPostOrderTPSL());
+    let attachment: Promise<OrderResult | undefined>;
+
+    act(() => {
+      attachment = result.current.attachPostOrderTPSL(order, {
+        positionBaseline: position,
+      });
+    });
+    await act(flushPromises);
+    let attachmentResult: OrderResult | undefined;
+    await act(async () => {
+      jest.advanceTimersByTime(
+        POST_ORDER_TPSL_RETRY_OFFSETS_MS[
+          POST_ORDER_TPSL_RETRY_OFFSETS_MS.length - 1
+        ],
+      );
+      attachmentResult = await attachment;
+    });
+
+    expect(attachmentResult).toEqual(positionNotFoundResult);
+    expect(mockUpdatePositionTPSL).not.toHaveBeenCalled();
+    expect(mockShowToast).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.test.ts
@@ -1,0 +1,130 @@
+import { act, renderHook } from '@testing-library/react-native';
+import type { OrderResult, Position } from '@metamask/perps-controller';
+import Logger from '../../../../util/Logger';
+import { usePerpsPostOrderTPSL } from './usePerpsPostOrderTPSL';
+
+const mockUpdatePositionTPSL = jest.fn();
+const mockShowToast = jest.fn();
+const mockPostOrderAttachmentFailed = { id: 'post-order-attachment-failed' };
+
+jest.mock('./usePerpsTrading', () => ({
+  usePerpsTrading: () => ({
+    updatePositionTPSL: mockUpdatePositionTPSL,
+  }),
+}));
+
+jest.mock('./usePerpsToasts', () => ({
+  __esModule: true,
+  default: () => ({
+    showToast: mockShowToast,
+    PerpsToastOptions: {
+      positionManagement: {
+        tpsl: {
+          postOrderAttachmentFailed: mockPostOrderAttachmentFailed,
+        },
+      },
+    },
+  }),
+}));
+
+jest.mock('../../../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+  },
+}));
+
+describe('usePerpsPostOrderTPSL', () => {
+  const position = {
+    symbol: 'ETH',
+    size: '0.1',
+  } as Position;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpdatePositionTPSL.mockResolvedValue({ success: true });
+  });
+
+  it('passes the rendered position to the controller', async () => {
+    const { result } = renderHook(() => usePerpsPostOrderTPSL());
+
+    await act(async () => {
+      await result.current.attachPostOrderTPSL({
+        symbol: 'ETH',
+        takeProfitPrice: '3500',
+        position,
+      });
+    });
+
+    expect(mockUpdatePositionTPSL).toHaveBeenCalledWith({
+      symbol: 'ETH',
+      takeProfitPrice: '3500',
+      position,
+    });
+    expect(mockShowToast).not.toHaveBeenCalled();
+  });
+
+  it('allows the controller fallback when the stream provides no position', async () => {
+    const { result } = renderHook(() => usePerpsPostOrderTPSL());
+
+    await act(async () => {
+      await result.current.attachPostOrderTPSL({
+        symbol: 'ETH',
+        stopLossPrice: '2500',
+        position: undefined,
+      });
+    });
+
+    expect(mockUpdatePositionTPSL).toHaveBeenCalledWith({
+      symbol: 'ETH',
+      stopLossPrice: '2500',
+      position: undefined,
+    });
+    expect(mockShowToast).not.toHaveBeenCalled();
+  });
+
+  it('warns that the open position has no protection when attachment fails', async () => {
+    mockUpdatePositionTPSL.mockResolvedValue({
+      success: false,
+      error: 'No position found for ETH',
+    });
+    const { result } = renderHook(() => usePerpsPostOrderTPSL());
+
+    let attachmentResult: OrderResult | undefined;
+    await act(async () => {
+      attachmentResult = await result.current.attachPostOrderTPSL({
+        symbol: 'ETH',
+        takeProfitPrice: '3500',
+      });
+    });
+
+    expect(attachmentResult).toEqual({
+      success: false,
+      error: 'No position found for ETH',
+    });
+    expect(mockShowToast).toHaveBeenCalledWith(mockPostOrderAttachmentFailed);
+  });
+
+  it('normalizes a rejected attachment as an unprotected position', async () => {
+    mockUpdatePositionTPSL.mockRejectedValue(new Error('Network unavailable'));
+    const { result } = renderHook(() => usePerpsPostOrderTPSL());
+
+    let attachmentResult: OrderResult | undefined;
+    await act(async () => {
+      attachmentResult = await result.current.attachPostOrderTPSL({
+        symbol: 'ETH',
+        takeProfitPrice: '3500',
+      });
+    });
+
+    expect(attachmentResult).toEqual({
+      success: false,
+      error: 'Network unavailable',
+    });
+    expect(Logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Network unavailable' }),
+      'usePerpsPostOrderTPSL: Failed to attach protection',
+    );
+    expect(mockShowToast).toHaveBeenCalledWith(mockPostOrderAttachmentFailed);
+  });
+});

--- a/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.test.ts
@@ -417,11 +417,7 @@ describe('usePerpsPostOrderTPSL', () => {
     await act(flushPromises);
     let attachmentResult: OrderResult | undefined;
     await act(async () => {
-      jest.advanceTimersByTime(
-        POST_ORDER_TPSL_RETRY_OFFSETS_MS[
-          POST_ORDER_TPSL_RETRY_OFFSETS_MS.length - 1
-        ],
-      );
+      jest.advanceTimersByTime(POST_ORDER_TPSL_RETRY_OFFSETS_MS.at(-1) ?? 0);
       attachmentResult = await attachment;
     });
 

--- a/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.ts
+++ b/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.ts
@@ -102,6 +102,44 @@ const findRenderedPosition = (
     : undefined;
 };
 
+const subscribeToRenderedPosition = (
+  positionsStream: PerpsPositionStream,
+  symbol: string,
+  baselineSize: string | undefined,
+  isContextCurrent: () => boolean,
+  isSettled: () => boolean,
+  settle: (wakeResult: AttachmentWakeResult) => void,
+): (() => void) | undefined => {
+  try {
+    const unsubscribe = positionsStream.subscribe({
+      callback: (positions) => {
+        if (!isContextCurrent()) {
+          settle({ type: 'context-changed' });
+          return;
+        }
+        const position = findRenderedPosition(positions, symbol, baselineSize);
+        if (position) {
+          settle({ type: 'position', position });
+        }
+      },
+      throttleMs: 0,
+      symbols: [symbol],
+    });
+
+    // The stream may synchronously deliver cached data before subscribe()
+    // returns its cleanup callback.
+    if (isSettled()) {
+      unsubscribe();
+      return undefined;
+    }
+    return unsubscribe;
+  } catch {
+    // The controller retry schedule remains available when the stream cannot
+    // subscribe. The timer and context listener still settle this wait.
+    return undefined;
+  }
+};
+
 const waitForPositionOrDelay = (
   positionsStream: PerpsPositionStream,
   symbol: string,
@@ -124,7 +162,7 @@ const waitForPositionOrDelay = (
 
   return new Promise((resolve) => {
     let settled = false;
-    let unsubscribeFromPositions: (() => void) | undefined;
+    let unsubscribeFromPositions: () => void = () => undefined;
     let cancelDelay: () => void = () => undefined;
     let unsubscribeFromStore: () => void = () => undefined;
     const settle = (wakeResult: AttachmentWakeResult) => {
@@ -133,7 +171,7 @@ const waitForPositionOrDelay = (
       }
       settled = true;
       cancelDelay();
-      unsubscribeFromPositions?.();
+      unsubscribeFromPositions();
       unsubscribeFromStore();
       resolve(wakeResult);
     };
@@ -146,34 +184,15 @@ const waitForPositionOrDelay = (
       }
     });
 
-    try {
-      unsubscribeFromPositions = positionsStream.subscribe({
-        callback: (positions) => {
-          if (!isContextCurrent()) {
-            settle({ type: 'context-changed' });
-            return;
-          }
-          const position = findRenderedPosition(
-            positions,
-            symbol,
-            baselineSize,
-          );
-          if (position) {
-            settle({ type: 'position', position });
-          }
-        },
-        throttleMs: 0,
-        symbols: [symbol],
-      });
-      // The stream may synchronously deliver cached data before subscribe()
-      // returns its cleanup callback.
-      if (settled) {
-        unsubscribeFromPositions();
-      }
-    } catch {
-      // The controller retry schedule remains available when the stream cannot
-      // subscribe. The timer and context listener still settle this wait.
-    }
+    unsubscribeFromPositions =
+      subscribeToRenderedPosition(
+        positionsStream,
+        symbol,
+        baselineSize,
+        isContextCurrent,
+        () => settled,
+        settle,
+      ) ?? (() => undefined);
 
     if (!isContextCurrent()) {
       settle({ type: 'context-changed' });

--- a/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.ts
+++ b/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.ts
@@ -1,23 +1,37 @@
 import { useCallback } from 'react';
 import type {
+  OrderParams,
   OrderResult,
-  UpdatePositionTPSLParams,
+  Position,
 } from '@metamask/perps-controller';
 import { ensureError } from '../../../../util/errorUtils';
 import Logger from '../../../../util/Logger';
 import usePerpsToasts from './usePerpsToasts';
 import { usePerpsTrading } from './usePerpsTrading';
 
+type PostOrderTPSLSource = Pick<
+  OrderParams,
+  'symbol' | 'takeProfitPrice' | 'stopLossPrice'
+>;
+
 export function usePerpsPostOrderTPSL() {
   const { updatePositionTPSL } = usePerpsTrading();
   const { showToast, PerpsToastOptions } = usePerpsToasts();
 
   const attachPostOrderTPSL = useCallback(
-    async (params: UpdatePositionTPSLParams): Promise<OrderResult> => {
+    async (
+      order: PostOrderTPSLSource,
+      position?: Position,
+    ): Promise<OrderResult> => {
       let result: OrderResult;
 
       try {
-        result = await updatePositionTPSL(params);
+        result = await updatePositionTPSL({
+          symbol: order.symbol,
+          takeProfitPrice: order.takeProfitPrice,
+          stopLossPrice: order.stopLossPrice,
+          position,
+        });
       } catch (error) {
         const normalizedError = ensureError(
           error,

--- a/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.ts
+++ b/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.ts
@@ -4,6 +4,7 @@ import {
   type OrderParams,
   type OrderResult,
   type Position,
+  type UpdatePositionTPSLParams,
 } from '@metamask/perps-controller';
 import { ensureError } from '../../../../util/errorUtils';
 import Logger from '../../../../util/Logger';
@@ -35,7 +36,51 @@ type AttachmentWakeResult =
   | { type: 'delay' }
   | { type: 'context-changed' };
 
+interface AttachmentPositionState {
+  position?: Position;
+  waitBaselineSize?: string;
+}
+
+type AttachmentOutcome =
+  | { type: 'success'; result: OrderResult }
+  | { type: 'failure'; result: OrderResult; rejectedError?: Error }
+  | { type: 'context-changed' };
+
+type AttachmentPositionOutcome =
+  | { type: 'ready'; state: AttachmentPositionState }
+  | Extract<AttachmentOutcome, { type: 'failure' | 'context-changed' }>;
+
+type AttachmentPreparationOutcome =
+  | { type: 'ready'; state: AttachmentPositionState }
+  | Extract<AttachmentOutcome, { type: 'context-changed' }>;
+
+type PreparedAttachmentOutcome =
+  | {
+      type: 'attempted';
+      outcome: Extract<AttachmentOutcome, { type: 'failure' | 'success' }>;
+      state: AttachmentPositionState;
+    }
+  | Extract<AttachmentOutcome, { type: 'context-changed' }>;
+
+type UpdatePositionTPSL = (
+  params: UpdatePositionTPSLParams,
+) => Promise<OrderResult>;
+
+interface AttachmentCoordinatorParams {
+  order: PostOrderTPSLSource;
+  positionsStream: PerpsPositionStream;
+  updatePositionTPSL: UpdatePositionTPSL;
+  isContextCurrent: () => boolean;
+  startedAt: number;
+  initialBaselineSize?: string;
+}
+
 export const POST_ORDER_TPSL_RETRY_OFFSETS_MS = [0, 500, 2000, 4000] as const;
+
+const createPositionNotFoundResult = (): OrderResult => ({
+  success: false,
+  error: PERPS_ERROR_CODES.POSITION_NOT_FOUND,
+});
 
 const getPerpsTradingContextKey = (): string => {
   const state = store.getState();
@@ -136,6 +181,191 @@ const waitForPositionOrDelay = (
   });
 };
 
+const resolveInitialAttachmentPosition = async ({
+  positionsStream,
+  order,
+  initialBaselineSize,
+  isContextCurrent,
+}: AttachmentCoordinatorParams): Promise<AttachmentPositionOutcome> => {
+  if (initialBaselineSize === undefined) {
+    return {
+      type: 'ready',
+      state: { waitBaselineSize: initialBaselineSize },
+    };
+  }
+
+  const wakeResult = await waitForPositionOrDelay(
+    positionsStream,
+    order.symbol,
+    initialBaselineSize,
+    POST_ORDER_TPSL_RETRY_OFFSETS_MS.at(-1) ?? 0,
+    isContextCurrent,
+  );
+  if (wakeResult.type === 'context-changed') {
+    return wakeResult;
+  }
+  if (wakeResult.type !== 'position') {
+    return { type: 'failure', result: createPositionNotFoundResult() };
+  }
+
+  return {
+    type: 'ready',
+    state: {
+      position: wakeResult.position,
+      waitBaselineSize: wakeResult.position.size,
+    },
+  };
+};
+
+const prepareAttachmentAttempt = async (
+  attemptIndex: number,
+  state: AttachmentPositionState,
+  {
+    positionsStream,
+    order,
+    startedAt,
+    isContextCurrent,
+  }: AttachmentCoordinatorParams,
+): Promise<AttachmentPreparationOutcome> => {
+  const targetOffset = POST_ORDER_TPSL_RETRY_OFFSETS_MS[attemptIndex];
+  const elapsedMs = Date.now() - startedAt;
+  const wakeResult = await waitForPositionOrDelay(
+    positionsStream,
+    order.symbol,
+    state.waitBaselineSize,
+    Math.max(0, targetOffset - elapsedMs),
+    isContextCurrent,
+  );
+  if (wakeResult.type === 'context-changed') {
+    return wakeResult;
+  }
+  if (wakeResult.type !== 'position') {
+    return { type: 'ready', state };
+  }
+
+  return {
+    type: 'ready',
+    state: {
+      position: wakeResult.position,
+      waitBaselineSize: wakeResult.position.size,
+    },
+  };
+};
+
+const executeAttachmentAttempt = async (
+  updatePositionTPSL: UpdatePositionTPSL,
+  order: PostOrderTPSLSource,
+  position?: Position,
+): Promise<Extract<AttachmentOutcome, { type: 'failure' | 'success' }>> => {
+  try {
+    const result = await updatePositionTPSL({
+      symbol: order.symbol,
+      takeProfitPrice: order.takeProfitPrice,
+      stopLossPrice: order.stopLossPrice,
+      position,
+    });
+    return result.success
+      ? { type: 'success', result }
+      : { type: 'failure', result };
+  } catch (error) {
+    const rejectedError = ensureError(
+      error,
+      'usePerpsPostOrderTPSL.attachPostOrderTPSL',
+    );
+    return {
+      type: 'failure',
+      result: {
+        success: false,
+        error: rejectedError.message,
+      },
+      rejectedError,
+    };
+  }
+};
+
+const executePreparedAttachmentAttempt = async (
+  attemptIndex: number,
+  state: AttachmentPositionState,
+  params: AttachmentCoordinatorParams,
+): Promise<PreparedAttachmentOutcome> => {
+  let preparedState = state;
+  if (attemptIndex > 0) {
+    const preparedAttempt = await prepareAttachmentAttempt(
+      attemptIndex,
+      state,
+      params,
+    );
+    if (preparedAttempt.type !== 'ready') {
+      return preparedAttempt;
+    }
+    preparedState = preparedAttempt.state;
+  }
+
+  const outcome = await executeAttachmentAttempt(
+    params.updatePositionTPSL,
+    params.order,
+    preparedState.position,
+  );
+  return { type: 'attempted', outcome, state: preparedState };
+};
+
+const isRetryableAttachmentFailure = (
+  outcome: Extract<AttachmentOutcome, { type: 'failure' }>,
+  attemptIndex: number,
+): boolean =>
+  isPerpsErrorCode(
+    outcome.result.error,
+    PERPS_ERROR_CODES.POSITION_NOT_FOUND,
+  ) && attemptIndex < POST_ORDER_TPSL_RETRY_OFFSETS_MS.length - 1;
+
+const runPostOrderTPSLAttachment = async (
+  params: AttachmentCoordinatorParams,
+): Promise<AttachmentOutcome> => {
+  let initialPosition: AttachmentPositionOutcome = {
+    type: 'ready',
+    state: { waitBaselineSize: params.initialBaselineSize },
+  };
+  if (params.initialBaselineSize !== undefined) {
+    initialPosition = await resolveInitialAttachmentPosition(params);
+  }
+  if (initialPosition.type !== 'ready') {
+    return initialPosition;
+  }
+
+  let state = initialPosition.state;
+  for (
+    let attemptIndex = 0;
+    attemptIndex < POST_ORDER_TPSL_RETRY_OFFSETS_MS.length;
+    attemptIndex += 1
+  ) {
+    if (!params.isContextCurrent()) {
+      return { type: 'context-changed' };
+    }
+
+    const preparedAttempt = await executePreparedAttachmentAttempt(
+      attemptIndex,
+      state,
+      params,
+    );
+    if (preparedAttempt.type === 'context-changed') {
+      return preparedAttempt;
+    }
+    state = preparedAttempt.state;
+    const { outcome } = preparedAttempt;
+    if (!params.isContextCurrent()) {
+      return { type: 'context-changed' };
+    }
+    if (outcome.type === 'success') {
+      return outcome;
+    }
+    if (!isRetryableAttachmentFailure(outcome, attemptIndex)) {
+      return outcome;
+    }
+  }
+
+  return { type: 'failure', result: createPositionNotFoundResult() };
+};
+
 export function usePerpsPostOrderTPSL() {
   const { updatePositionTPSL } = usePerpsTrading();
   const { showToast, PerpsToastOptions } = usePerpsToasts();
@@ -173,126 +403,38 @@ export function usePerpsPostOrderTPSL() {
         setIsAttachingPostOrderTPSL(true);
       }
 
-      const attachment = (async (): Promise<OrderResult | undefined> => {
-        let position: Position | undefined;
-        let waitBaselineSize = initialBaselineSize;
-
-        if (initialBaselineSize !== undefined) {
-          const wakeResult = await waitForPositionOrDelay(
-            stream.positions,
-            order.symbol,
-            initialBaselineSize,
-            POST_ORDER_TPSL_RETRY_OFFSETS_MS[
-              POST_ORDER_TPSL_RETRY_OFFSETS_MS.length - 1
-            ],
-            isContextCurrent,
-          );
-          if (wakeResult.type === 'context-changed') {
+      const attachment = runPostOrderTPSLAttachment({
+        order,
+        positionsStream: stream.positions,
+        updatePositionTPSL,
+        isContextCurrent,
+        startedAt,
+        initialBaselineSize,
+      })
+        .then((outcome): OrderResult | undefined => {
+          if (outcome.type === 'context-changed') {
             return undefined;
           }
-          if (wakeResult.type !== 'position') {
-            const result = {
-              success: false,
-              error: PERPS_ERROR_CODES.POSITION_NOT_FOUND,
-            };
+          if (outcome.type === 'failure') {
+            if (outcome.rejectedError) {
+              Logger.error(
+                outcome.rejectedError,
+                'usePerpsPostOrderTPSL: Failed to attach protection',
+              );
+            }
             showToast(
               PerpsToastOptions.positionManagement.tpsl
                 .postOrderAttachmentFailed,
             );
-            return result;
           }
-          position = wakeResult.position;
-          waitBaselineSize = position.size;
-        }
-
-        let lastResult: OrderResult = {
-          success: false,
-          error: PERPS_ERROR_CODES.POSITION_NOT_FOUND,
-        };
-
-        for (
-          let attemptIndex = 0;
-          attemptIndex < POST_ORDER_TPSL_RETRY_OFFSETS_MS.length;
-          attemptIndex += 1
-        ) {
-          if (!isContextCurrent()) {
-            return undefined;
+          return outcome.result;
+        })
+        .finally(() => {
+          activeAttachmentRef.current = undefined;
+          if (isMountedRef.current) {
+            setIsAttachingPostOrderTPSL(false);
           }
-
-          if (attemptIndex > 0) {
-            const targetOffset = POST_ORDER_TPSL_RETRY_OFFSETS_MS[attemptIndex];
-            const elapsedMs = Date.now() - startedAt;
-            const wakeResult = await waitForPositionOrDelay(
-              stream.positions,
-              order.symbol,
-              waitBaselineSize,
-              Math.max(0, targetOffset - elapsedMs),
-              isContextCurrent,
-            );
-            if (wakeResult.type === 'context-changed') {
-              return undefined;
-            }
-            if (wakeResult.type === 'position') {
-              position = wakeResult.position;
-              waitBaselineSize = position.size;
-            }
-          }
-
-          let rejectedError: Error | undefined;
-          try {
-            lastResult = await updatePositionTPSL({
-              symbol: order.symbol,
-              takeProfitPrice: order.takeProfitPrice,
-              stopLossPrice: order.stopLossPrice,
-              position,
-            });
-          } catch (error) {
-            rejectedError = ensureError(
-              error,
-              'usePerpsPostOrderTPSL.attachPostOrderTPSL',
-            );
-            lastResult = {
-              success: false,
-              error: rejectedError.message,
-            };
-          }
-
-          if (!isContextCurrent()) {
-            return undefined;
-          }
-          if (lastResult.success) {
-            return lastResult;
-          }
-
-          const isPositionNotFound = isPerpsErrorCode(
-            lastResult.error,
-            PERPS_ERROR_CODES.POSITION_NOT_FOUND,
-          );
-          const hasMoreAttempts =
-            attemptIndex < POST_ORDER_TPSL_RETRY_OFFSETS_MS.length - 1;
-          if (isPositionNotFound && hasMoreAttempts) {
-            continue;
-          }
-
-          if (rejectedError) {
-            Logger.error(
-              rejectedError,
-              'usePerpsPostOrderTPSL: Failed to attach protection',
-            );
-          }
-          showToast(
-            PerpsToastOptions.positionManagement.tpsl.postOrderAttachmentFailed,
-          );
-          return lastResult;
-        }
-
-        return lastResult;
-      })().finally(() => {
-        activeAttachmentRef.current = undefined;
-        if (isMountedRef.current) {
-          setIsAttachingPostOrderTPSL(false);
-        }
-      });
+        });
 
       activeAttachmentRef.current = attachment;
       return attachment;

--- a/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.ts
+++ b/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.ts
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+import type {
+  OrderResult,
+  UpdatePositionTPSLParams,
+} from '@metamask/perps-controller';
+import { ensureError } from '../../../../util/errorUtils';
+import Logger from '../../../../util/Logger';
+import usePerpsToasts from './usePerpsToasts';
+import { usePerpsTrading } from './usePerpsTrading';
+
+export function usePerpsPostOrderTPSL() {
+  const { updatePositionTPSL } = usePerpsTrading();
+  const { showToast, PerpsToastOptions } = usePerpsToasts();
+
+  const attachPostOrderTPSL = useCallback(
+    async (params: UpdatePositionTPSLParams): Promise<OrderResult> => {
+      let result: OrderResult;
+
+      try {
+        result = await updatePositionTPSL(params);
+      } catch (error) {
+        const normalizedError = ensureError(
+          error,
+          'usePerpsPostOrderTPSL.attachPostOrderTPSL',
+        );
+        Logger.error(
+          normalizedError,
+          'usePerpsPostOrderTPSL: Failed to attach protection',
+        );
+        result = {
+          success: false,
+          error: normalizedError.message,
+        };
+      }
+
+      if (!result.success) {
+        showToast(
+          PerpsToastOptions.positionManagement.tpsl.postOrderAttachmentFailed,
+        );
+      }
+
+      return result;
+    },
+    [
+      PerpsToastOptions.positionManagement.tpsl.postOrderAttachmentFailed,
+      showToast,
+      updatePositionTPSL,
+    ],
+  );
+
+  return { attachPostOrderTPSL };
+}

--- a/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.ts
+++ b/app/components/UI/Perps/hooks/usePerpsPostOrderTPSL.ts
@@ -1,11 +1,21 @@
-import { useCallback } from 'react';
-import type {
-  OrderParams,
-  OrderResult,
-  Position,
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  PERPS_ERROR_CODES,
+  type OrderParams,
+  type OrderResult,
+  type Position,
 } from '@metamask/perps-controller';
 import { ensureError } from '../../../../util/errorUtils';
 import Logger from '../../../../util/Logger';
+import { store } from '../../../../store';
+import { usePerpsStream } from '../providers/PerpsStreamManager';
+import { selectPerpsSelectedAccountAddress } from '../selectors/selectedAccountAddress';
+import {
+  selectPerpsNetwork,
+  selectPerpsProvider,
+} from '../selectors/perpsController';
+import { isPerpsFillRendered } from '../utils/perpsCufTrace';
+import { isPerpsErrorCode } from '../utils/translatePerpsError';
 import usePerpsToasts from './usePerpsToasts';
 import { usePerpsTrading } from './usePerpsTrading';
 
@@ -14,53 +24,286 @@ type PostOrderTPSLSource = Pick<
   'symbol' | 'takeProfitPrice' | 'stopLossPrice'
 >;
 
+interface PostOrderTPSLAttachmentOptions {
+  positionBaseline?: Pick<Position, 'size'> | null;
+}
+
+type PerpsPositionStream = ReturnType<typeof usePerpsStream>['positions'];
+
+type AttachmentWakeResult =
+  | { type: 'position'; position: Position }
+  | { type: 'delay' }
+  | { type: 'context-changed' };
+
+export const POST_ORDER_TPSL_RETRY_OFFSETS_MS = [0, 500, 2000, 4000] as const;
+
+const getPerpsTradingContextKey = (): string => {
+  const state = store.getState();
+  return JSON.stringify([
+    selectPerpsSelectedAccountAddress(state) ?? '',
+    selectPerpsNetwork(state),
+    selectPerpsProvider(state) ?? '',
+  ]);
+};
+
+const findRenderedPosition = (
+  positions: Position[] | null,
+  symbol: string,
+  baselineSize: string | undefined,
+): Position | undefined => {
+  const position = positions?.find((candidate) => candidate.symbol === symbol);
+  return position && isPerpsFillRendered(position, baselineSize)
+    ? position
+    : undefined;
+};
+
+const waitForPositionOrDelay = (
+  positionsStream: PerpsPositionStream,
+  symbol: string,
+  baselineSize: string | undefined,
+  delayMs: number,
+  isContextCurrent: () => boolean,
+): Promise<AttachmentWakeResult> => {
+  if (!isContextCurrent()) {
+    return Promise.resolve({ type: 'context-changed' });
+  }
+
+  const renderedPosition = findRenderedPosition(
+    positionsStream.getSnapshot(),
+    symbol,
+    baselineSize,
+  );
+  if (renderedPosition) {
+    return Promise.resolve({ type: 'position', position: renderedPosition });
+  }
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let unsubscribeFromPositions: (() => void) | undefined;
+    let cancelDelay: () => void = () => undefined;
+    let unsubscribeFromStore: () => void = () => undefined;
+    const settle = (wakeResult: AttachmentWakeResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cancelDelay();
+      unsubscribeFromPositions?.();
+      unsubscribeFromStore();
+      resolve(wakeResult);
+    };
+    const delay = setTimeout(() => settle({ type: 'delay' }), delayMs);
+    cancelDelay = () => clearTimeout(delay);
+
+    unsubscribeFromStore = store.subscribe(() => {
+      if (!isContextCurrent()) {
+        settle({ type: 'context-changed' });
+      }
+    });
+
+    try {
+      unsubscribeFromPositions = positionsStream.subscribe({
+        callback: (positions) => {
+          if (!isContextCurrent()) {
+            settle({ type: 'context-changed' });
+            return;
+          }
+          const position = findRenderedPosition(
+            positions,
+            symbol,
+            baselineSize,
+          );
+          if (position) {
+            settle({ type: 'position', position });
+          }
+        },
+        throttleMs: 0,
+        symbols: [symbol],
+      });
+      // The stream may synchronously deliver cached data before subscribe()
+      // returns its cleanup callback.
+      if (settled) {
+        unsubscribeFromPositions();
+      }
+    } catch {
+      // The controller retry schedule remains available when the stream cannot
+      // subscribe. The timer and context listener still settle this wait.
+    }
+
+    if (!isContextCurrent()) {
+      settle({ type: 'context-changed' });
+    }
+  });
+};
+
 export function usePerpsPostOrderTPSL() {
   const { updatePositionTPSL } = usePerpsTrading();
   const { showToast, PerpsToastOptions } = usePerpsToasts();
+  const stream = usePerpsStream();
+  const [isAttachingPostOrderTPSL, setIsAttachingPostOrderTPSL] =
+    useState(false);
+  const isMountedRef = useRef(true);
+  const activeAttachmentRef = useRef<
+    Promise<OrderResult | undefined> | undefined
+  >(undefined);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const attachPostOrderTPSL = useCallback(
-    async (
+    (
       order: PostOrderTPSLSource,
-      position?: Position,
-    ): Promise<OrderResult> => {
-      let result: OrderResult;
+      options: PostOrderTPSLAttachmentOptions = {},
+    ): Promise<OrderResult | undefined> => {
+      if (activeAttachmentRef.current) {
+        return activeAttachmentRef.current;
+      }
 
-      try {
-        result = await updatePositionTPSL({
-          symbol: order.symbol,
-          takeProfitPrice: order.takeProfitPrice,
-          stopLossPrice: order.stopLossPrice,
-          position,
-        });
-      } catch (error) {
-        const normalizedError = ensureError(
-          error,
-          'usePerpsPostOrderTPSL.attachPostOrderTPSL',
-        );
-        Logger.error(
-          normalizedError,
-          'usePerpsPostOrderTPSL: Failed to attach protection',
-        );
-        result = {
+      const tradingContextKey = getPerpsTradingContextKey();
+      const isContextCurrent = () =>
+        getPerpsTradingContextKey() === tradingContextKey;
+      const startedAt = Date.now();
+      const initialBaselineSize = options.positionBaseline?.size;
+
+      if (isMountedRef.current) {
+        setIsAttachingPostOrderTPSL(true);
+      }
+
+      const attachment = (async (): Promise<OrderResult | undefined> => {
+        let position: Position | undefined;
+        let waitBaselineSize = initialBaselineSize;
+
+        if (initialBaselineSize !== undefined) {
+          const wakeResult = await waitForPositionOrDelay(
+            stream.positions,
+            order.symbol,
+            initialBaselineSize,
+            POST_ORDER_TPSL_RETRY_OFFSETS_MS[
+              POST_ORDER_TPSL_RETRY_OFFSETS_MS.length - 1
+            ],
+            isContextCurrent,
+          );
+          if (wakeResult.type === 'context-changed') {
+            return undefined;
+          }
+          if (wakeResult.type !== 'position') {
+            const result = {
+              success: false,
+              error: PERPS_ERROR_CODES.POSITION_NOT_FOUND,
+            };
+            showToast(
+              PerpsToastOptions.positionManagement.tpsl
+                .postOrderAttachmentFailed,
+            );
+            return result;
+          }
+          position = wakeResult.position;
+          waitBaselineSize = position.size;
+        }
+
+        let lastResult: OrderResult = {
           success: false,
-          error: normalizedError.message,
+          error: PERPS_ERROR_CODES.POSITION_NOT_FOUND,
         };
-      }
 
-      if (!result.success) {
-        showToast(
-          PerpsToastOptions.positionManagement.tpsl.postOrderAttachmentFailed,
-        );
-      }
+        for (
+          let attemptIndex = 0;
+          attemptIndex < POST_ORDER_TPSL_RETRY_OFFSETS_MS.length;
+          attemptIndex += 1
+        ) {
+          if (!isContextCurrent()) {
+            return undefined;
+          }
 
-      return result;
+          if (attemptIndex > 0) {
+            const targetOffset = POST_ORDER_TPSL_RETRY_OFFSETS_MS[attemptIndex];
+            const elapsedMs = Date.now() - startedAt;
+            const wakeResult = await waitForPositionOrDelay(
+              stream.positions,
+              order.symbol,
+              waitBaselineSize,
+              Math.max(0, targetOffset - elapsedMs),
+              isContextCurrent,
+            );
+            if (wakeResult.type === 'context-changed') {
+              return undefined;
+            }
+            if (wakeResult.type === 'position') {
+              position = wakeResult.position;
+              waitBaselineSize = position.size;
+            }
+          }
+
+          let rejectedError: Error | undefined;
+          try {
+            lastResult = await updatePositionTPSL({
+              symbol: order.symbol,
+              takeProfitPrice: order.takeProfitPrice,
+              stopLossPrice: order.stopLossPrice,
+              position,
+            });
+          } catch (error) {
+            rejectedError = ensureError(
+              error,
+              'usePerpsPostOrderTPSL.attachPostOrderTPSL',
+            );
+            lastResult = {
+              success: false,
+              error: rejectedError.message,
+            };
+          }
+
+          if (!isContextCurrent()) {
+            return undefined;
+          }
+          if (lastResult.success) {
+            return lastResult;
+          }
+
+          const isPositionNotFound = isPerpsErrorCode(
+            lastResult.error,
+            PERPS_ERROR_CODES.POSITION_NOT_FOUND,
+          );
+          const hasMoreAttempts =
+            attemptIndex < POST_ORDER_TPSL_RETRY_OFFSETS_MS.length - 1;
+          if (isPositionNotFound && hasMoreAttempts) {
+            continue;
+          }
+
+          if (rejectedError) {
+            Logger.error(
+              rejectedError,
+              'usePerpsPostOrderTPSL: Failed to attach protection',
+            );
+          }
+          showToast(
+            PerpsToastOptions.positionManagement.tpsl.postOrderAttachmentFailed,
+          );
+          return lastResult;
+        }
+
+        return lastResult;
+      })().finally(() => {
+        activeAttachmentRef.current = undefined;
+        if (isMountedRef.current) {
+          setIsAttachingPostOrderTPSL(false);
+        }
+      });
+
+      activeAttachmentRef.current = attachment;
+      return attachment;
     },
     [
       PerpsToastOptions.positionManagement.tpsl.postOrderAttachmentFailed,
       showToast,
+      stream.positions,
       updatePositionTPSL,
     ],
   );
 
-  return { attachPostOrderTPSL };
+  return { attachPostOrderTPSL, isAttachingPostOrderTPSL };
 }

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -1328,6 +1328,30 @@ describe('usePerpsToasts', () => {
         ]);
       });
 
+      it('describes the position as open when post-order attachment fails', () => {
+        const { result } = renderHook(() => usePerpsToasts());
+
+        const config =
+          result.current.PerpsToastOptions.positionManagement.tpsl
+            .postOrderAttachmentFailed;
+
+        expect(config).toMatchObject({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Warning,
+          hapticsType: NotificationMoment.Error,
+          hasNoTimeout: false,
+        });
+        expect(config.labelOptions).toEqual([
+          { label: 'Position opened without TP/SL', isBold: true },
+          { label: '\n', isBold: false },
+          {
+            label:
+              'Add take profit or stop loss from the position card to protect this trade.',
+            isBold: false,
+          },
+        ]);
+      });
+
       it('returns update TPSL error configuration with custom error', () => {
         const { result } = renderHook(() => usePerpsToasts());
         const customError = 'Network connection failed';

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -221,6 +221,7 @@ export interface PerpsToastOptionsConfig {
     tpsl: {
       updateTPSLSuccess: PerpsToastOptions;
       updateTPSLError: (error?: string) => PerpsToastOptions;
+      postOrderAttachmentFailed: PerpsToastOptions;
     };
     margin: {
       addSuccess: (assetSymbol: string, amount: string) => PerpsToastOptions;
@@ -1160,6 +1161,15 @@ const usePerpsToasts = (): {
               error || strings('perps.errors.tpslUpdateFailed'),
             ),
           }),
+          postOrderAttachmentFailed: {
+            ...perpsBaseToastOptions.error,
+            labelOptions: getPerpsToastLabels(
+              strings('perps.position.tpsl.post_order_attachment_failed'),
+              strings(
+                'perps.position.tpsl.post_order_attachment_failed_description',
+              ),
+            ),
+          },
         },
         margin: {
           addSuccess: (assetSymbol: string, amount: string) => ({

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2367,7 +2367,9 @@
       },
       "tpsl": {
         "update_success": "TP/SL updated successfully",
-        "update_failed": "Failed to update TP/SL"
+        "update_failed": "Failed to update TP/SL",
+        "post_order_attachment_failed": "Position opened without TP/SL",
+        "post_order_attachment_failed_description": "Add take profit or stop loss from the position card to protect this trade."
       },
       "margin": {
         "add_success": "Added ${{amount}} margin to {{asset}} position",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Opening a new Perps market position with TP/SL could place the trade successfully and then fail to attach protection with `No position found`. This was first reported in the 8.10 Lite flow, but the underlying race predates that release: new positions and flips are submitted without TP/SL, followed immediately by a separate position-bound TP/SL update.

The root cause was a missing synchronization contract between those operations. `placeOrder` resolves when HyperLiquid acknowledges the market order, but that acknowledgement does not guarantee that `clearinghouseState` or the positions stream already contains the resulting position. When Mobile called `updatePositionTPSL` during that propagation window, the controller queried the previous position snapshot, could not find the symbol, and returned `POSITION_NOT_FOUND`. Pro inherited the same two-step behavior and could expose the race under different stream and rendering timing.

Two separate TP/SL bugs surfaced during the same 8.10 release cycle. Controller v13 misread HyperLiquid’s normal waitingForTrigger response as a failure, even though TP/SL had been created. The resulting investigation and repeated TP/SL testing exposed an older Lite race: Mobile sometimes tried to attach TP/SL before the new position appeared, causing No position found. V13 did not create that race, it made TP/SL failures much more visible this week. Pro had inherited the same race and later reproduced it under different timing.

This change keeps order confirmation responsive and moves eventual-consistency handling into a shared post-order TP/SL coordinator. It races stream delivery with a bounded serialized retry schedule (`0`, `500`, `2000`, and `4000` ms), retries only typed `POSITION_NOT_FOUND` failures, fails immediately for terminal errors, and aborts silently if the account, network, or provider changes. Lite and Pro remain disabled/loading while protection is being attached; if retries are exhausted, the successful trade remains successful and a dedicated warning tells the trader that the position opened without TP/SL.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed TP/SL attachment failures after opening Perps positions

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3916

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Attach TP/SL when opening a Perps position

  Scenario Outline: User opens a new market position with TP/SL
    Given the user has no open position for ETH
    And the user is on the <mode> ETH trade screen
    And the user configures a valid take-profit or stop-loss price

    When the user submits a market order
    Then the order success feedback appears promptly
    And the market position is opened successfully
    And the configured TP/SL appears on the position card
    And no "No position found" TP/SL error toast is shown

    Examples:
      | mode |
      | Lite |
      | Pro  |

  Scenario: TP/SL cannot be attached after the position opens
    Given the user submits a valid market order with TP/SL configured
    And the position opens successfully

    When TP/SL attachment reaches a terminal failure
    Then the successful order is not presented as failed
    And a warning states that the position opened without TP/SL
    And the warning directs the user to add protection from the position card
```

Local iOS verification: Passed.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — timing and controller-data fix with no visual layout changes.

### **After**

N/A — timing and controller-data fix with no visual layout changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

N/A — this logic-only fix reuses the existing stream and CUF instrumentation; Android-specific, power-user, and new performance instrumentation work is not applicable.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches order placement and TP/SL timing on a critical trading path; mitigated by bounded retries, context aborts, and broad unit test coverage.
> 
> **Overview**
> Fixes a race where opening a market position with TP/SL could succeed on the trade but fail protection with **No position found** because `updatePositionTPSL` ran before the position appeared in the stream or controller state.
> 
> Introduces **`usePerpsPostOrderTPSL`**, shared by Lite (`PerpsOrderView`) and Pro (`usePerpsProOrderForm`). The flow still places the order **without** TP/SL, then calls `attachPostOrderTPSL`, which waits on the positions stream (with flip **position baseline** when relevant), retries only **`POSITION_NOT_FOUND`** on a bounded schedule (0/500/2000/4000 ms), aborts silently on account/network/provider change, and surfaces a dedicated warning toast if attachment ultimately fails while leaving the fill successful.
> 
> **Place order** CTAs stay disabled/loading during `isAttachingPostOrderTPSL`. Inline TP/SL error toasts in the order views are removed in favor of the coordinator’s `postOrderAttachmentFailed` messaging. **`usePerpsOrderExecution`** is adjusted so successful placements return promptly (confirmation not blocked on post-order work) and the controller timeout watchdog is cleared when the controller settles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f317f4f742e72f9d4830bb39e0c26263d8b36f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->