### PR TITLE
fix(content): add missing "to" in Display NFT media copy

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7741,7 +7741,7 @@
   },
   "show_display_nft_media": {
     "show_display_nft_media_title": "Display NFT media",
-    "show_display_nft_media_content_1": "To see an NFT, you need turn on",
+    "show_display_nft_media_content_1": "To see an NFT, you need to turn on",
     "show_display_nft_media_content_2": "Display NFT media.",
     "show_display_nft_media_content_3": "Displaying NFT media and data exposes your IP address to OpenSea or other third parties. NFT autodetection relies on this feature, and won't be available when this is turned off.",
     "show_display_nft_media_content_4": "You can turn off Display NFT media in",


### PR DESCRIPTION
## **Description**

The Display NFT media bottom sheet copy was missing the word "to": it read "To see an NFT, you need turn on **Display NFT media.**". This corrects the English string to "you need to turn on".

Only the `en` locale is changed; translated locales already render their own grammatical form.

## **Changelog**

CHANGELOG entry: Fixed missing word in the Display NFT media sheet copy.

## **Related issues**

Fixes: N/A (copy cleanup)

## **Manual testing steps**

```gherkin
Feature: Display NFT media sheet copy

  Scenario: user opens the Display NFT media sheet
    Given the wallet is unlocked
    And Display NFT media is turned off

    When user opens an NFT that needs media display turned on
    Then the sheet reads "To see an NFT, you need to turn on Display NFT media."
```

## **Screenshots/Recordings**

N/A — single-word copy fix in an existing string. Verify in the Display NFT media bottom sheet (`ShowDisplayNFTMediaSheet`).

### **Before**

`To see an NFT, you need turn on Display NFT media.`

### **After**

`To see an NFT, you need to turn on Display NFT media.`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

Copy-only change; performance checks are N/A.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string English copy fix with no logic, security, or data-handling impact.
> 
> **Overview**
> Fixes a grammar error in the **English** `show_display_nft_media.show_display_nft_media_content_1` string used by the Display NFT media bottom sheet (`ShowDisplayNFTMediaSheet`): it now reads “you need **to** turn on” instead of “you need turn on.”
> 
> No other locales or code paths are updated—only `locales/languages/en.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1236f811f07810023ba253bfea187e53beb5a5c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->