### PR TITLE
fix(content): remove extra space in onboarding analytics alert

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -310,7 +310,7 @@
     "new_to_metamask": "New to MetaMask?",
     "already_have_wallet": "Already have a wallet?",
     "optin_back_title": "Heads up!",
-    "optin_back_desc": "Please agree or disagree to the usage of data analytics.  You can also update this option in settings.",
+    "optin_back_desc": "Please agree or disagree to the usage of data analytics. You can also update this option in settings.",
     "warning_title": "Warning",
     "warning_text_1": "Your current wallet and accounts will be",
     "warning_text_2": "removed",


### PR DESCRIPTION
## **Description**

The "Heads up!" alert shown when a user tries to leave the onboarding analytics opt-in screen had two spaces between the two sentences of its body copy. This removes the extra space.

Only the `en` locale is changed.

## **Changelog**

CHANGELOG entry: Fixed extra space in the onboarding analytics opt-in alert copy.

## **Related issues**

Fixes: N/A (copy cleanup)

## **Manual testing steps**

```gherkin
Feature: Onboarding analytics opt-in alert copy

  Scenario: user tries to go back from the analytics opt-in screen
    Given the app is in onboarding on the analytics opt-in screen

    When user presses back
    Then the "Heads up!" alert body has a single space between its two sentences
```

## **Screenshots/Recordings**

N/A — one-character spacing fix in existing alert copy. Verify in onboarding → analytics opt-in screen → press back.

### **Before**

`Please agree or disagree to the usage of data analytics.  You can also update this option in settings.`

### **After**

`Please agree or disagree to the usage of data analytics. You can also update this option in settings.`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

Copy-only change; performance checks are N/A.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only English locale tweak with no logic, security, or data-handling impact.
> 
> **Overview**
> Fixes a **double space** in the English `onboarding.optin_back_desc` string shown in the **“Heads up!”** alert when users try to leave the onboarding analytics opt-in screen (via `OptinMetrics`). The body copy now uses a single space between the two sentences; only **`locales/languages/en.json`** is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82766359f066bb22d7a2d4067ba8db5fa1f228c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->