### PR TITLE
fix(content): use "withdrawal" in Predict withdraw error

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3505,7 +3505,7 @@
       "unavailable_description": "For urgent assistance, please contact Customer Service.",
       "unavailable_got_it": "Got it",
       "error_title": "Something went wrong",
-      "error_description": "Failed to proceed with withdraw",
+      "error_description": "Failed to proceed with withdrawal",
       "try_again": "Try again"
     },
     "fee_summary": {


### PR DESCRIPTION
## **Description**

The Predict withdraw error toast read "Failed to proceed with withdraw", using the verb instead of the noun. This changes it to "Failed to proceed with withdrawal", matching the sibling string `predict.withdraw.toast_error_description`, which already reads "withdrawal".

Only the `en` locale is changed.

## **Changelog**

CHANGELOG entry: Fixed wording in the Predict withdrawal error message.

## **Related issues**

Fixes: N/A (copy cleanup)

## **Manual testing steps**

```gherkin
Feature: Predict withdrawal error copy

  Scenario: a withdrawal fails
    Given the wallet is unlocked
    And user has a Predict balance

    When user starts a withdrawal that fails
    Then the error reads "Failed to proceed with withdrawal"
```

## **Screenshots/Recordings**

N/A — one-word copy fix in an existing error string; requires a forced withdrawal failure to surface. Verify in Predict → Withdraw → failed withdrawal toast.

### **Before**

`Failed to proceed with withdraw`

### **After**

`Failed to proceed with withdrawal`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

Copy-only change; performance checks are N/A.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single English locale string change with no logic, security, or data-handling impact.
> 
> **Overview**
> Updates the English Predict withdraw error copy from **"Failed to proceed with withdraw"** to **"Failed to proceed with withdrawal"** so the verb phrase uses the noun form.
> 
> Only `locales/languages/en.json` under `predict.withdraw.error_description` changes, aligning with the existing `toast_error_description` string that already says "withdrawal".
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1031fb4380cba867703c0effbf8ff890b8b7526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->