### PR TITLE
fix(content): use "Personalized alerts are on/off" in toasts

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6518,11 +6518,11 @@
         "button_not_now": "Not now",
         "toast": {
           "personalized_alerts_on": {
-            "title": "Personalized alerts is on",
+            "title": "Personalized alerts are on",
             "description": "Manage this anytime in Settings."
           },
           "personalized_alerts_off": {
-            "title": "Personalized alerts is off",
+            "title": "Personalized alerts are off",
             "description": "Turn it on anytime in Settings."
           }
         }


### PR DESCRIPTION
## **Description**

The toasts shown after the personalized alerts onboarding for existing users read "Personalized alerts **is** on" / "Personalized alerts **is** off". The subject is plural, so this changes both titles to "are on" / "are off".

Only the `en` locale is changed.

## **Changelog**

CHANGELOG entry: Fixed grammar in the personalized alerts confirmation toasts.

## **Related issues**

Fixes: N/A (copy cleanup)

## **Manual testing steps**

```gherkin
Feature: Personalized alerts toast copy

  Scenario: existing user completes the personalized alerts onboarding
    Given the wallet is unlocked
    And the personalized alerts onboarding is shown for an existing user

    When user confirms with the toggle on
    Then the toast title reads "Personalized alerts are on"

    When user confirms with the toggle off
    Then the toast title reads "Personalized alerts are off"
```

## **Screenshots/Recordings**

N/A — one-word grammar fix in existing toast titles. Verify in the push notification onboarding for existing users (`PushNotificationOnboarding`).

### **Before**

`Personalized alerts is on` / `Personalized alerts is off`

### **After**

`Personalized alerts are on` / `Personalized alerts are off`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

Copy-only change; performance checks are N/A.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
