### PR TITLE
fix(content): capitalize sentence in IPFS gateway banner

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7749,7 +7749,7 @@
   },
   "ipfs_gateway_banner": {
     "ipfs_gateway_banner_title": "IPFS gateway",
-    "ipfs_gateway_banner_content1": "This is an IPFS website. to see this site, you need to turn on",
+    "ipfs_gateway_banner_content1": "This is an IPFS website. To see this site, you need to turn on",
     "ipfs_gateway_banner_content2": "IPFS gateway",
     "ipfs_gateway_banner_content3": "in",
     "ipfs_gateway_banner_content4": "Settings."


### PR DESCRIPTION
## **Description**

The IPFS gateway banner shown in the in-app browser started its second sentence in lowercase: "This is an IPFS website. **to** see this site, you need to turn on IPFS gateway in Settings." This capitalizes it to "To see this site".

Only the `en` locale is changed.

## **Changelog**

CHANGELOG entry: Fixed capitalization in the IPFS gateway banner copy.

## **Related issues**

Fixes: N/A (copy cleanup)

## **Manual testing steps**

```gherkin
Feature: IPFS gateway banner copy

  Scenario: user opens an IPFS website with the IPFS gateway off
    Given the wallet is unlocked
    And IPFS gateway is turned off

    When user opens an IPFS website in the in-app browser
    Then the banner reads "This is an IPFS website. To see this site, you need to turn on IPFS gateway in Settings."
```

## **Screenshots/Recordings**

N/A — capitalization fix in existing banner copy. Verify in Browser → open an IPFS site with IPFS gateway turned off.

### **Before**

`This is an IPFS website. to see this site, you need to turn on IPFS gateway in Settings.`

### **After**

`This is an IPFS website. To see this site, you need to turn on IPFS gateway in Settings.`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

Copy-only change; performance checks are N/A.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single English copy string change with no behavioral, security, or data-handling impact.
> 
> **Overview**
> Fixes a typo in the **English** IPFS gateway in-app browser banner: the second sentence now starts with **"To"** instead of **"to"** (`locales/languages/en.json`, key `ipfs_gateway_banner.ipfs_gateway_banner_content1`).
> 
> No logic or other locales change; the banner still pulls this string from `IpfsBanner`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9edd26c57148cb2b89c4e9bbf0a55620636586e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->