### PR TITLE
fix: remove extra space in token minimal unit error message

### DIFF
--- a/app/util/number/bigint.ts
+++ b/app/util/number/bigint.ts
@@ -250,7 +250,7 @@ export function toTokenMinimalUnit(
     throw new Error(
       '[number] while converting number ' +
         tokenValue +
-        ' to token minimal util,  too many decimal points',
+        ' to token minimal util, too many decimal points',
     );
   }
   let whole = comps[0],

--- a/app/util/number/index.js
+++ b/app/util/number/index.js
@@ -212,7 +212,7 @@ export function toTokenMinimalUnit(tokenValue, decimals) {
     throw new Error(
       '[number] while converting number ' +
         tokenValue +
-        ' to token minimal util,  too many decimal points',
+        ' to token minimal util, too many decimal points',
     );
   }
   let whole = comps[0],


### PR DESCRIPTION
## **Description**

The error thrown when converting a number with too many decimal points to token minimal units had a double space after the comma: "to token minimal util,  too many decimal points". This removes the extra space in both implementations (`app/util/number/index.js` and `app/util/number/bigint.ts`).

No test asserts this message, so no test changes were needed.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (message cleanup)

## **Manual testing steps**

```gherkin
Feature: Token minimal unit conversion error message

  Scenario: a value with multiple decimal points is converted
    Given a token amount string containing more than one decimal point

    When toTokenMinimalUnit is called with that value
    Then the thrown error message contains "to token minimal util, too many decimal points" with a single space
```

## **Screenshots/Recordings**

N/A — internal thrown-error message, not rendered as UI copy.

### **Before**

`[number] while converting number <value> to token minimal util,  too many decimal points`

### **After**

`[number] while converting number <value> to token minimal util, too many decimal points`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

String-only change; performance checks are N/A.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only change to an internal error message with no behavior or test assertion impact.
> 
> **Overview**
> Fixes a typo in the thrown error when `toTokenMinimalUnit` rejects a value with more than one decimal point: the message after the comma had **two spaces** (`util,  too`) and now uses a **single space** (`util, too`).
> 
> The same string is updated in both the legacy `app/util/number/index.js` implementation and `app/util/number/bigint.ts`. Conversion logic and when the error is thrown are unchanged; this is copy-only inside the `comps.length > 2` branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 516bd329d78dad49ccc1d2738dae610b6258b098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->