### PR TITLE
fix(content): remove trailing period in notifications accounts copy

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4338,7 +4338,7 @@
       "select_all": "Select all",
       "deselect_all": "Deselect all",
       "select_accounts_title": "Accounts",
-      "select_accounts_desc": "Choose which accounts you'd like to get notifications for.",
+      "select_accounts_desc": "Choose which accounts you'd like to get notifications for",
       "wallet_activity_title": "Wallet activity",
       "wallet_activity_desc": "Buy, sells, transfers, swaps",
       "perps_title": "Trading activity",


### PR DESCRIPTION
## **Description**

Removes the trailing period from the Notifications settings helper under Accounts. The English copy currently reads "Choose which accounts you'd like to get notifications for."

That period does not follow the copy pattern used by the other pages in the same `NotificationsSettings` directory. Sibling section descriptions on this flow are written as labels without a terminal period, for example:

- Wallet activity: "Buy, sells, transfers, swaps"
- Trading activity: "Perps position changes, liquidations, funding rates, and margin updates"
- Trading signals: "Updates from traders and assets you follow, plus curated market news"
- Updates and rewards: "Product updates, feature announcements, and new releases"
- Price alerts: "Get notified based on the alerts you've set for a token's price"

Only the `en` locale is changed. The string is rendered in `NotificationSettingsSectionContent`.

## **Changelog**

CHANGELOG entry: Removed the trailing period from the Notifications accounts helper copy.

## **Related issues**

Fixes: N/A (copy cleanup)

## **Manual testing steps**

```gherkin
Feature: Notifications accounts helper copy

  Scenario: user reads the Accounts helper on Notifications settings
    Given the wallet is unlocked

    When user opens Settings
    And user opens Notifications
    Then the Accounts helper reads "Choose which accounts you'd like to get notifications for" without a trailing period
```

## **Screenshots/Recordings**

### **Before**

Settings → Notifications → Accounts:
<img width="590" height="1278" alt="IMG_0377" src="https://github.com/user-attachments/assets/efa186a0-4f4f-4835-bdfe-6d0343af7cc3" />

`Choose which accounts you'd like to get notifications for.`

### **After**

`Choose which accounts you'd like to get notifications for`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

Copy-only change; performance checks are N/A.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single English locale string change with no logic, security, or data-handling impact.
> 
> **Overview**
> Updates the English **Accounts** helper on Notifications settings so it no longer ends with a period, aligning that line with the other sentence-style labels on the same screen.
> 
> Only `locales/languages/en.json` changes (`notifications_opts.select_accounts_desc`); the string is shown from `NotificationSettingsSectionContent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16750df4c0391b802dfd208fb46cf75c63551f84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->