### PR TITLE
feat(card): move redeem withdrawal and receipt monitoring into CardController

### DIFF
--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -3132,7 +3132,7 @@ describe('CardController — data pass-throughs', () => {
   }
 
   function wireRedeemNetworkMessenger(
-    messenger: { call: jest.Mock },
+    messenger: { call: unknown },
     providerRequest: jest.Mock = jest.fn().mockResolvedValue({ status: '0x1' }),
     options: { missingProvider?: boolean } = {},
   ) {
@@ -4603,27 +4603,31 @@ describe('CardController — data pass-throughs', () => {
       ['50', '10-100'],
       ['250', '100-1000'],
       ['1500', '1000+'],
-    ])('logs amount bucket %s as %s on successful submit', async (amount) => {
-      const provider = buildMockProvider({
-        withdrawCashback: jest.fn().mockResolvedValue({ txHash: '0xabc' }),
-        getCashbackWithdrawEstimation: jest
-          .fn()
-          .mockResolvedValue(lineaEstimation),
-      });
-      const { controller, messenger } = buildAuthenticatedController(provider);
-      wireRedeemNetworkMessenger(messenger);
-      jest.spyOn(controller, 'fetchCardHomeData').mockResolvedValue();
-      jest.mocked(Logger.log).mockClear();
+    ])(
+      'logs amount bucket %s as %s on successful submit',
+      async (amount, expectedBucket) => {
+        const provider = buildMockProvider({
+          withdrawCashback: jest.fn().mockResolvedValue({ txHash: '0xabc' }),
+          getCashbackWithdrawEstimation: jest
+            .fn()
+            .mockResolvedValue(lineaEstimation),
+        });
+        const { controller, messenger } =
+          buildAuthenticatedController(provider);
+        wireRedeemNetworkMessenger(messenger);
+        jest.spyOn(controller, 'fetchCardHomeData').mockResolvedValue();
+        jest.mocked(Logger.log).mockClear();
 
-      await controller.withdrawCashback({ amount });
+        await controller.withdrawCashback({ amount });
 
-      expect(Logger.log).toHaveBeenCalledWith(
-        'Card redeem withdraw submitted',
-        expect.objectContaining({
-          amountBucket: expect.any(String),
-        }),
-      );
-    });
+        expect(Logger.log).toHaveBeenCalledWith(
+          'Card redeem withdraw submitted',
+          expect.objectContaining({
+            amountBucket: expectedBucket,
+          }),
+        );
+      },
+    );
 
     it('fails with network reason when provider returns a network error', async () => {
       const provider = buildMockProvider({
@@ -4679,7 +4683,7 @@ describe('CardController — data pass-throughs', () => {
       });
     });
 
-    it('classifies CardApiError status codes when submit throws one', async () => {
+    it('classifies CardApiError 5xx submit failures as server_error', async () => {
       const provider = buildMockProvider({
         withdrawCashback: jest
           .fn()
@@ -4710,8 +4714,8 @@ describe('CardController — data pass-throughs', () => {
       });
     });
 
-    it('classifies CardApiError network (status 0) and client failures', async () => {
-      const networkProvider = buildMockProvider({
+    it('classifies CardApiError status 0 submit failures as network', async () => {
+      const provider = buildMockProvider({
         withdrawCashback: jest
           .fn()
           .mockRejectedValue(
@@ -4721,18 +4725,19 @@ describe('CardController — data pass-throughs', () => {
           .fn()
           .mockResolvedValue(lineaEstimation),
       });
-      const { controller: networkController, messenger: networkMessenger } =
-        buildAuthenticatedController(networkProvider);
-      wireRedeemNetworkMessenger(networkMessenger);
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      wireRedeemNetworkMessenger(messenger);
 
       await expect(
-        networkController.withdrawCashback({ amount: '5' }),
+        controller.withdrawCashback({ amount: '5' }),
       ).rejects.toBeInstanceOf(CardApiError);
-      expect(networkController.state.redeemWithdrawal).toMatchObject({
+      expect(controller.state.redeemWithdrawal).toMatchObject({
         error: { reason: 'network', statusCode: 0 },
       });
+    });
 
-      const clientProvider = buildMockProvider({
+    it('classifies CardApiError 4xx submit failures as submit_failed', async () => {
+      const provider = buildMockProvider({
         withdrawCashback: jest
           .fn()
           .mockRejectedValue(
@@ -4742,20 +4747,19 @@ describe('CardController — data pass-throughs', () => {
           .fn()
           .mockResolvedValue(lineaEstimation),
       });
-      const { controller: clientController, messenger: clientMessenger } =
-        buildAuthenticatedController(clientProvider);
-      wireRedeemNetworkMessenger(clientMessenger);
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      wireRedeemNetworkMessenger(messenger);
 
       await expect(
-        clientController.withdrawCashback({ amount: '5' }),
+        controller.withdrawCashback({ amount: '5' }),
       ).rejects.toBeInstanceOf(CardApiError);
-      expect(clientController.state.redeemWithdrawal).toMatchObject({
+      expect(controller.state.redeemWithdrawal).toMatchObject({
         error: { reason: 'submit_failed', statusCode: 400 },
       });
     });
 
-    it('classifies unknown errors and in-progress errors from submit', async () => {
-      const unknownProvider = buildMockProvider({
+    it('classifies unknown submit errors as unknown', async () => {
+      const provider = buildMockProvider({
         withdrawCashback: jest
           .fn()
           .mockRejectedValue(
@@ -4765,18 +4769,19 @@ describe('CardController — data pass-throughs', () => {
           .fn()
           .mockResolvedValue(lineaEstimation),
       });
-      const { controller: unknownController, messenger: unknownMessenger } =
-        buildAuthenticatedController(unknownProvider);
-      wireRedeemNetworkMessenger(unknownMessenger);
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      wireRedeemNetworkMessenger(messenger);
 
       await expect(
-        unknownController.withdrawCashback({ amount: '5' }),
+        controller.withdrawCashback({ amount: '5' }),
       ).rejects.toMatchObject({ name: 'WeirdError' });
-      expect(unknownController.state.redeemWithdrawal).toMatchObject({
+      expect(controller.state.redeemWithdrawal).toMatchObject({
         error: { reason: 'unknown', code: 'WeirdError' },
       });
+    });
 
-      const inProgressProvider = buildMockProvider({
+    it('classifies in-progress submit errors as in_progress', async () => {
+      const provider = buildMockProvider({
         withdrawCashback: jest
           .fn()
           .mockRejectedValue(new CardRedeemWithdrawalInProgressError()),
@@ -4784,16 +4789,13 @@ describe('CardController — data pass-throughs', () => {
           .fn()
           .mockResolvedValue(lineaEstimation),
       });
-      const {
-        controller: inProgressController,
-        messenger: inProgressMessenger,
-      } = buildAuthenticatedController(inProgressProvider);
-      wireRedeemNetworkMessenger(inProgressMessenger);
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      wireRedeemNetworkMessenger(messenger);
 
       await expect(
-        inProgressController.withdrawCashback({ amount: '5' }),
+        controller.withdrawCashback({ amount: '5' }),
       ).rejects.toBeInstanceOf(CardRedeemWithdrawalInProgressError);
-      expect(inProgressController.state.redeemWithdrawal).toMatchObject({
+      expect(controller.state.redeemWithdrawal).toMatchObject({
         error: { reason: 'in_progress' },
       });
     });

--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -4485,9 +4485,14 @@ describe('CardController — data pass-throughs', () => {
       expect(controller.state.redeemWithdrawal).toMatchObject({
         status: 'success',
       });
+      // Success is a terminal lock for the mounted UI only — a later submit
+      // clears it and starts a new withdrawal.
       await expect(
         controller.withdrawCashback({ amount: '1' }),
-      ).rejects.toBeInstanceOf(CardRedeemWithdrawalInProgressError);
+      ).resolves.toEqual({ txHash: '0xabc' });
+      expect(controller.state.redeemWithdrawal).toMatchObject({
+        status: 'success',
+      });
     });
 
     it('abandons monitoring and leaves state cleared when the session ends mid-withdrawal', async () => {

--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -36,6 +36,7 @@ import {
 } from '../../../../util/trace';
 import type { ImmersveService } from './services/ImmersveService';
 import type { ImmersveProviderConfig } from './services/immersve-config';
+import Logger from '../../../../util/Logger';
 
 jest.mock('./CardTokenStore');
 jest.mock('./CardOnboardingStore');
@@ -3130,6 +3131,47 @@ describe('CardController — data pass-throughs', () => {
     });
   }
 
+  function wireRedeemNetworkMessenger(
+    messenger: { call: jest.Mock },
+    providerRequest: jest.Mock = jest.fn().mockResolvedValue({ status: '0x1' }),
+    options: { missingProvider?: boolean } = {},
+  ) {
+    (messenger.call as jest.Mock).mockImplementation((action: string) => {
+      if (action === 'AccountsController:getState') {
+        return {
+          internalAccounts: {
+            accounts: {
+              'id-1': {
+                address: '0xabc',
+                type: 'eip155:eoa',
+                scopes: ['eip155:0'],
+              },
+            },
+            selectedAccount: 'id-1',
+          },
+        };
+      }
+      if (action === 'NetworkController:findNetworkClientIdByChainId') {
+        return 'linea-client';
+      }
+      if (action === 'NetworkController:getNetworkClientById') {
+        if (options.missingProvider) {
+          return { provider: undefined };
+        }
+        return { provider: { request: providerRequest } };
+      }
+      return undefined;
+    });
+    return providerRequest;
+  }
+
+  const lineaEstimation = {
+    wei: '1',
+    eth: '0.001',
+    price: '0.5',
+    network: 'linea',
+  };
+
   describe('refreshCardStatus', () => {
     it('delegates to provider.getCardDetails', async () => {
       const provider = buildMockProvider();
@@ -4556,6 +4598,315 @@ describe('CardController — data pass-throughs', () => {
         force: true,
       });
     });
+
+    it.each([
+      ['50', '10-100'],
+      ['250', '100-1000'],
+      ['1500', '1000+'],
+    ])('logs amount bucket %s as %s on successful submit', async (amount) => {
+      const provider = buildMockProvider({
+        withdrawCashback: jest.fn().mockResolvedValue({ txHash: '0xabc' }),
+        getCashbackWithdrawEstimation: jest
+          .fn()
+          .mockResolvedValue(lineaEstimation),
+      });
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      wireRedeemNetworkMessenger(messenger);
+      jest.spyOn(controller, 'fetchCardHomeData').mockResolvedValue();
+      jest.mocked(Logger.log).mockClear();
+
+      await controller.withdrawCashback({ amount });
+
+      expect(Logger.log).toHaveBeenCalledWith(
+        'Card redeem withdraw submitted',
+        expect.objectContaining({
+          amountBucket: expect.any(String),
+        }),
+      );
+    });
+
+    it('fails with network reason when provider returns a network error', async () => {
+      const provider = buildMockProvider({
+        withdrawCashback: jest
+          .fn()
+          .mockRejectedValue(
+            new CardProviderError(CardProviderErrorCode.Network, 'offline', 0),
+          ),
+        getCashbackWithdrawEstimation: jest
+          .fn()
+          .mockResolvedValue(lineaEstimation),
+      });
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      wireRedeemNetworkMessenger(messenger);
+
+      await expect(
+        controller.withdrawCashback({ amount: '5' }),
+      ).rejects.toMatchObject({ code: CardProviderErrorCode.Network });
+      expect(controller.state.redeemWithdrawal).toMatchObject({
+        status: 'failed',
+        error: { reason: 'network', code: CardProviderErrorCode.Network },
+      });
+    });
+
+    it('fails with server_error when provider returns a server error', async () => {
+      const provider = buildMockProvider({
+        withdrawCashback: jest
+          .fn()
+          .mockRejectedValue(
+            new CardProviderError(
+              CardProviderErrorCode.ServerError,
+              'boom',
+              503,
+            ),
+          ),
+        getCashbackWithdrawEstimation: jest
+          .fn()
+          .mockResolvedValue(lineaEstimation),
+      });
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      wireRedeemNetworkMessenger(messenger);
+
+      await expect(
+        controller.withdrawCashback({ amount: '5' }),
+      ).rejects.toMatchObject({ code: CardProviderErrorCode.ServerError });
+      expect(controller.state.redeemWithdrawal).toMatchObject({
+        status: 'failed',
+        error: {
+          reason: 'server_error',
+          code: CardProviderErrorCode.ServerError,
+          statusCode: 503,
+        },
+      });
+    });
+
+    it('classifies CardApiError status codes when submit throws one', async () => {
+      const provider = buildMockProvider({
+        withdrawCashback: jest
+          .fn()
+          .mockRejectedValue(
+            new CardApiError(
+              502,
+              '/v1/wallet/reward/withdraw',
+              '{"errorCode":"upstream"}',
+            ),
+          ),
+        getCashbackWithdrawEstimation: jest
+          .fn()
+          .mockResolvedValue(lineaEstimation),
+      });
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      wireRedeemNetworkMessenger(messenger);
+
+      await expect(
+        controller.withdrawCashback({ amount: '5' }),
+      ).rejects.toBeInstanceOf(CardApiError);
+      expect(controller.state.redeemWithdrawal).toMatchObject({
+        status: 'failed',
+        error: {
+          reason: 'server_error',
+          code: 'upstream',
+          statusCode: 502,
+        },
+      });
+    });
+
+    it('classifies CardApiError network (status 0) and client failures', async () => {
+      const networkProvider = buildMockProvider({
+        withdrawCashback: jest
+          .fn()
+          .mockRejectedValue(
+            new CardApiError(0, '/v1/wallet/reward/withdraw', ''),
+          ),
+        getCashbackWithdrawEstimation: jest
+          .fn()
+          .mockResolvedValue(lineaEstimation),
+      });
+      const { controller: networkController, messenger: networkMessenger } =
+        buildAuthenticatedController(networkProvider);
+      wireRedeemNetworkMessenger(networkMessenger);
+
+      await expect(
+        networkController.withdrawCashback({ amount: '5' }),
+      ).rejects.toBeInstanceOf(CardApiError);
+      expect(networkController.state.redeemWithdrawal).toMatchObject({
+        error: { reason: 'network', statusCode: 0 },
+      });
+
+      const clientProvider = buildMockProvider({
+        withdrawCashback: jest
+          .fn()
+          .mockRejectedValue(
+            new CardApiError(400, '/v1/wallet/reward/withdraw', ''),
+          ),
+        getCashbackWithdrawEstimation: jest
+          .fn()
+          .mockResolvedValue(lineaEstimation),
+      });
+      const { controller: clientController, messenger: clientMessenger } =
+        buildAuthenticatedController(clientProvider);
+      wireRedeemNetworkMessenger(clientMessenger);
+
+      await expect(
+        clientController.withdrawCashback({ amount: '5' }),
+      ).rejects.toBeInstanceOf(CardApiError);
+      expect(clientController.state.redeemWithdrawal).toMatchObject({
+        error: { reason: 'submit_failed', statusCode: 400 },
+      });
+    });
+
+    it('classifies unknown errors and in-progress errors from submit', async () => {
+      const unknownProvider = buildMockProvider({
+        withdrawCashback: jest
+          .fn()
+          .mockRejectedValue(
+            Object.assign(new Error('boom'), { name: 'WeirdError' }),
+          ),
+        getCashbackWithdrawEstimation: jest
+          .fn()
+          .mockResolvedValue(lineaEstimation),
+      });
+      const { controller: unknownController, messenger: unknownMessenger } =
+        buildAuthenticatedController(unknownProvider);
+      wireRedeemNetworkMessenger(unknownMessenger);
+
+      await expect(
+        unknownController.withdrawCashback({ amount: '5' }),
+      ).rejects.toMatchObject({ name: 'WeirdError' });
+      expect(unknownController.state.redeemWithdrawal).toMatchObject({
+        error: { reason: 'unknown', code: 'WeirdError' },
+      });
+
+      const inProgressProvider = buildMockProvider({
+        withdrawCashback: jest
+          .fn()
+          .mockRejectedValue(new CardRedeemWithdrawalInProgressError()),
+        getCashbackWithdrawEstimation: jest
+          .fn()
+          .mockResolvedValue(lineaEstimation),
+      });
+      const {
+        controller: inProgressController,
+        messenger: inProgressMessenger,
+      } = buildAuthenticatedController(inProgressProvider);
+      wireRedeemNetworkMessenger(inProgressMessenger);
+
+      await expect(
+        inProgressController.withdrawCashback({ amount: '5' }),
+      ).rejects.toBeInstanceOf(CardRedeemWithdrawalInProgressError);
+      expect(inProgressController.state.redeemWithdrawal).toMatchObject({
+        error: { reason: 'in_progress' },
+      });
+    });
+
+    it('fails with tx_reverted when the receipt status is 0', async () => {
+      const provider = buildMockProvider({
+        withdrawCashback: jest.fn().mockResolvedValue({ txHash: '0xrev' }),
+        getCashbackWithdrawEstimation: jest
+          .fn()
+          .mockResolvedValue(lineaEstimation),
+      });
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      wireRedeemNetworkMessenger(
+        messenger,
+        jest.fn().mockResolvedValue({ status: '0x0' }),
+      );
+
+      await expect(
+        controller.withdrawCashback({ amount: '5' }),
+      ).rejects.toMatchObject({ name: 'ExternalTransactionRevertedError' });
+      expect(controller.state.redeemWithdrawal).toMatchObject({
+        status: 'failed',
+        error: { reason: 'tx_reverted' },
+      });
+    });
+
+    it('fails with tx_timeout when receipt polling times out', async () => {
+      jest.useFakeTimers();
+      try {
+        const provider = buildMockProvider({
+          withdrawCashback: jest.fn().mockResolvedValue({ txHash: '0xtime' }),
+          getCashbackWithdrawEstimation: jest
+            .fn()
+            .mockResolvedValue(lineaEstimation),
+        });
+        const { controller, messenger } =
+          buildAuthenticatedController(provider);
+        // Hung receipt never resolves — raceWithTimeout fires.
+        wireRedeemNetworkMessenger(
+          messenger,
+          jest.fn().mockReturnValue(new Promise(() => undefined)),
+        );
+
+        const withdrawal = controller.withdrawCashback({ amount: '5' });
+        withdrawal.catch(() => undefined);
+        await jest.advanceTimersByTimeAsync(3 * 60 * 1000 + 1000);
+
+        await expect(withdrawal).rejects.toMatchObject({
+          name: 'ExternalTransactionReceiptTimeoutError',
+        });
+        expect(controller.state.redeemWithdrawal).toMatchObject({
+          status: 'failed',
+          error: { reason: 'tx_timeout' },
+        });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('fails monitoring when no network provider is available', async () => {
+      const provider = buildMockProvider({
+        withdrawCashback: jest.fn().mockResolvedValue({ txHash: '0xnop' }),
+        getCashbackWithdrawEstimation: jest
+          .fn()
+          .mockResolvedValue(lineaEstimation),
+      });
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      wireRedeemNetworkMessenger(messenger, jest.fn(), {
+        missingProvider: true,
+      });
+
+      await expect(
+        controller.withdrawCashback({ amount: '5' }),
+      ).rejects.toMatchObject({ code: CardProviderErrorCode.Network });
+      expect(controller.state.redeemWithdrawal).toMatchObject({
+        status: 'failed',
+        error: { reason: 'network' },
+      });
+    });
+
+    it('logs refresh failures after a successful withdraw without failing the withdraw', async () => {
+      const provider = buildMockProvider({
+        withdrawCashback: jest.fn().mockResolvedValue({ txHash: '0xok' }),
+        getCashbackWithdrawEstimation: jest
+          .fn()
+          .mockResolvedValue(lineaEstimation),
+      });
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      wireRedeemNetworkMessenger(messenger);
+      jest
+        .spyOn(controller, 'fetchCardHomeData')
+        .mockRejectedValue(new Error('refresh failed'));
+      jest.mocked(Logger.error).mockClear();
+
+      await expect(
+        controller.withdrawCashback({ amount: '5' }),
+      ).resolves.toEqual({ txHash: '0xok' });
+      expect(controller.state.redeemWithdrawal).toMatchObject({
+        status: 'success',
+      });
+
+      await Promise.resolve();
+      expect(Logger.error).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          context: expect.objectContaining({
+            data: expect.objectContaining({
+              step: 'post_withdraw_refresh',
+            }),
+          }),
+        }),
+      );
+    });
   });
 
   describe('getCreditWallet', () => {
@@ -4632,6 +4983,97 @@ describe('CardController — data pass-throughs', () => {
         mode: 'credit',
         status: 'success',
         txHash: '0xcredit',
+      });
+    });
+
+    it('logs and rethrows getCreditWithdrawEstimation failures', async () => {
+      const provider = buildMockProvider({
+        getCreditWithdrawEstimation: jest
+          .fn()
+          .mockRejectedValue(
+            new CardApiError(
+              500,
+              '/v1/wallet/credit/withdraw-estimation',
+              '{"errorCode":"est_down"}',
+            ),
+          ),
+      });
+      const { controller } = buildAuthenticatedController(provider);
+      jest.mocked(Logger.error).mockClear();
+
+      await expect(
+        controller.getCreditWithdrawEstimation(),
+      ).rejects.toBeInstanceOf(CardApiError);
+      expect(Logger.error).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          context: expect.objectContaining({
+            data: expect.objectContaining({
+              method: 'getCreditWithdrawEstimation',
+              step: 'estimation',
+              code: 'est_down',
+              statusCode: 500,
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('logs credit submit failures via #submitCreditWithdraw', async () => {
+      const provider = buildMockProvider({
+        withdrawCredit: jest
+          .fn()
+          .mockRejectedValue(
+            new CardProviderError(
+              CardProviderErrorCode.Unknown,
+              'credit submit failed',
+            ),
+          ),
+        getCreditWithdrawEstimation: jest
+          .fn()
+          .mockResolvedValue(lineaEstimation),
+      });
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      wireRedeemNetworkMessenger(messenger);
+      jest.mocked(Logger.error).mockClear();
+
+      await expect(
+        controller.withdrawCredit({ amount: '3' }),
+      ).rejects.toMatchObject({ message: 'credit submit failed' });
+      expect(Logger.error).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          context: expect.objectContaining({
+            data: expect.objectContaining({
+              method: 'withdrawCredit',
+              step: 'submit',
+            }),
+          }),
+        }),
+      );
+      expect(controller.state.redeemWithdrawal).toMatchObject({
+        mode: 'credit',
+        status: 'failed',
+        error: { reason: 'submit_failed' },
+      });
+    });
+
+    it('throws when credit withdrawal is unsupported', async () => {
+      const provider = buildMockProvider({
+        withdrawCredit: undefined,
+        getCreditWithdrawEstimation: jest
+          .fn()
+          .mockResolvedValue(lineaEstimation),
+      });
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      wireRedeemNetworkMessenger(messenger);
+
+      await expect(controller.withdrawCredit({ amount: '3' })).rejects.toThrow(
+        'Credit withdrawal not supported',
+      );
+      expect(controller.state.redeemWithdrawal).toMatchObject({
+        status: 'failed',
+        error: { reason: 'submit_failed' },
       });
     });
   });

--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -10,6 +10,7 @@ import {
 } from './types';
 import {
   CardLinkageInProgressError,
+  CardRedeemWithdrawalInProgressError,
   CardProviderError,
   CardProviderErrorCode,
   CardProviderIds,
@@ -324,6 +325,7 @@ describe('CardController', () => {
       cardHomeDataError: null,
       cardHomeDataFetchedThisSession: false,
       moneyAccountCardLinkInProgress: false,
+      redeemWithdrawal: null,
     });
   });
 
@@ -766,6 +768,28 @@ describe('CardController — auth methods', () => {
       expect(controller.state.cardHomeData).toBeNull();
       expect(controller.state.cardHomeDataStatus).toBe('idle');
       expect(controller.state.cardHomeDataError).toBeNull();
+    });
+
+    it('clears redeem withdrawal state on logout', async () => {
+      const provider = buildMockProvider();
+      provider.logout.mockResolvedValue(undefined);
+      mockTokenStore.get.mockResolvedValue(mockTokenSet);
+      mockTokenStore.remove.mockResolvedValue(true);
+      const controller = buildController(provider, {
+        isAuthenticated: true,
+        redeemWithdrawal: {
+          mode: 'cashback',
+          status: 'monitoring',
+          txHash: '0x123',
+          chainId: '0xe708',
+          submittedAt: 1,
+          error: null,
+        } as unknown as Record<string, null>,
+      });
+
+      await controller.logout();
+
+      expect(controller.state.redeemWithdrawal).toBeNull();
     });
   });
 
@@ -4294,28 +4318,316 @@ describe('CardController — data pass-throughs', () => {
   });
 
   describe('withdrawCashback', () => {
-    it('delegates to provider', async () => {
+    it('submits, monitors receipt, and refreshes card home', async () => {
       const resp = { txHash: '0x123' };
       const mockWithdraw = jest.fn().mockResolvedValue(resp);
+      const mockEstimation = jest.fn().mockResolvedValue({
+        wei: '1',
+        eth: '0.001',
+        price: '0.5',
+        network: 'linea',
+      });
       const provider = buildMockProvider({
         withdrawCashback: mockWithdraw,
+        getCashbackWithdrawEstimation: mockEstimation,
       });
-      const { controller } = buildAuthenticatedController(provider);
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      const providerRequest = jest.fn().mockResolvedValue({ status: '0x1' });
+      (messenger.call as jest.Mock).mockImplementation((action: string) => {
+        if (action === 'AccountsController:getState') {
+          return {
+            internalAccounts: {
+              accounts: {
+                'id-1': {
+                  address: '0xabc',
+                  type: 'eip155:eoa',
+                  scopes: ['eip155:0'],
+                },
+              },
+              selectedAccount: 'id-1',
+            },
+          };
+        }
+        if (action === 'NetworkController:findNetworkClientIdByChainId') {
+          return 'linea-client';
+        }
+        if (action === 'NetworkController:getNetworkClientById') {
+          return { provider: { request: providerRequest } };
+        }
+        return undefined;
+      });
+      jest.spyOn(controller, 'fetchCardHomeData').mockResolvedValue();
 
-      const result = await controller.withdrawCashback({
-        amount: '5',
-        walletAddress: '0xaddr',
-      } as never);
+      const result = await controller.withdrawCashback({ amount: '5' });
+
       expect(result).toStrictEqual(resp);
+      expect(mockEstimation).toHaveBeenCalled();
+      expect(mockWithdraw).toHaveBeenCalledWith({ amount: '5' }, mockTokenSet);
+      expect(controller.state.redeemWithdrawal).toMatchObject({
+        mode: 'cashback',
+        status: 'success',
+        txHash: '0x123',
+      });
+      expect(controller.fetchCardHomeData).toHaveBeenCalledWith({
+        force: true,
+      });
     });
 
     it('throws when unsupported', async () => {
-      const provider = buildMockProvider({ withdrawCashback: undefined });
+      const provider = buildMockProvider({
+        withdrawCashback: undefined,
+        getCashbackWithdrawEstimation: jest.fn().mockResolvedValue({
+          wei: '1',
+          eth: '0.001',
+          price: '0.5',
+          network: 'linea',
+        }),
+      });
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      (messenger.call as jest.Mock).mockImplementation((action: string) => {
+        if (action === 'AccountsController:getState') {
+          return {
+            internalAccounts: {
+              accounts: {
+                'id-1': {
+                  address: '0xabc',
+                  type: 'eip155:eoa',
+                  scopes: ['eip155:0'],
+                },
+              },
+              selectedAccount: 'id-1',
+            },
+          };
+        }
+        return undefined;
+      });
+
+      await expect(
+        controller.withdrawCashback({ amount: '5' }),
+      ).rejects.toThrow('Cashback withdrawal not supported');
+      expect(controller.state.redeemWithdrawal).toMatchObject({
+        status: 'failed',
+        error: { reason: 'submit_failed' },
+      });
+    });
+
+    it('fails with no_polling_chain when estimation network is unknown', async () => {
+      const provider = buildMockProvider({
+        withdrawCashback: jest.fn(),
+        getCashbackWithdrawEstimation: jest.fn().mockResolvedValue({
+          wei: '1',
+          eth: '0.001',
+          price: '0.5',
+          network: 'unknown-network',
+        }),
+      });
       const { controller } = buildAuthenticatedController(provider);
 
       await expect(
-        controller.withdrawCashback({ amount: '5' } as never),
-      ).rejects.toThrow('Cashback withdrawal not supported');
+        controller.withdrawCashback({ amount: '5' }),
+      ).rejects.toThrow('Unable to resolve withdrawal network for monitoring');
+      expect(controller.state.redeemWithdrawal).toMatchObject({
+        status: 'failed',
+        error: { reason: 'no_polling_chain' },
+      });
+      expect(provider.withdrawCashback).not.toHaveBeenCalled();
+    });
+
+    it('rejects concurrent withdrawals', async () => {
+      let resolveEstimation!: (value: unknown) => void;
+      const provider = buildMockProvider({
+        withdrawCashback: jest.fn().mockResolvedValue({ txHash: '0xabc' }),
+        getCashbackWithdrawEstimation: jest.fn().mockReturnValue(
+          new Promise((resolve) => {
+            resolveEstimation = resolve;
+          }),
+        ),
+      });
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      const providerRequest = jest.fn().mockResolvedValue({ status: '0x1' });
+      (messenger.call as jest.Mock).mockImplementation((action: string) => {
+        if (action === 'AccountsController:getState') {
+          return {
+            internalAccounts: {
+              accounts: {
+                'id-1': {
+                  address: '0xabc',
+                  type: 'eip155:eoa',
+                  scopes: ['eip155:0'],
+                },
+              },
+              selectedAccount: 'id-1',
+            },
+          };
+        }
+        if (action === 'NetworkController:findNetworkClientIdByChainId') {
+          return 'linea-client';
+        }
+        if (action === 'NetworkController:getNetworkClientById') {
+          return { provider: { request: providerRequest } };
+        }
+        return undefined;
+      });
+      jest.spyOn(controller, 'fetchCardHomeData').mockResolvedValue();
+
+      const first = controller.withdrawCashback({ amount: '5' });
+      await expect(
+        controller.withdrawCashback({ amount: '1' }),
+      ).rejects.toBeInstanceOf(CardRedeemWithdrawalInProgressError);
+
+      resolveEstimation({
+        wei: '1',
+        eth: '0.001',
+        price: '0.5',
+        network: 'linea',
+      });
+      await first;
+      expect(controller.state.redeemWithdrawal).toMatchObject({
+        status: 'success',
+      });
+      await expect(
+        controller.withdrawCashback({ amount: '1' }),
+      ).rejects.toBeInstanceOf(CardRedeemWithdrawalInProgressError);
+    });
+
+    it('abandons monitoring and leaves state cleared when the session ends mid-withdrawal', async () => {
+      let resolveSubmit!: (value: unknown) => void;
+      const provider = buildMockProvider({
+        withdrawCashback: jest.fn().mockReturnValue(
+          new Promise((resolve) => {
+            resolveSubmit = resolve;
+          }),
+        ),
+        getCashbackWithdrawEstimation: jest.fn().mockResolvedValue({
+          wei: '1',
+          eth: '0.001',
+          price: '0.5',
+          network: 'linea',
+        }),
+      });
+      provider.logout.mockResolvedValue(undefined);
+      mockTokenStore.get.mockResolvedValue(mockTokenSet);
+      mockTokenStore.remove.mockResolvedValue(true);
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      const providerRequest = jest.fn().mockResolvedValue(null);
+      (messenger.call as jest.Mock).mockImplementation((action: string) => {
+        if (action === 'AccountsController:getState') {
+          return {
+            internalAccounts: {
+              accounts: {
+                'id-1': {
+                  address: '0xabc',
+                  type: 'eip155:eoa',
+                  scopes: ['eip155:0'],
+                },
+              },
+              selectedAccount: 'id-1',
+            },
+          };
+        }
+        if (action === 'NetworkController:findNetworkClientIdByChainId') {
+          return 'linea-client';
+        }
+        if (action === 'NetworkController:getNetworkClientById') {
+          return { provider: { request: providerRequest } };
+        }
+        return undefined;
+      });
+      jest.spyOn(controller, 'fetchCardHomeData').mockResolvedValue();
+
+      const withdrawal = controller.withdrawCashback({ amount: '5' });
+      withdrawal.catch(() => undefined);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      await controller.logout();
+      resolveSubmit({ txHash: '0xabc' });
+
+      await expect(withdrawal).rejects.toMatchObject({
+        name: 'ExternalTransactionMonitorCancelledError',
+      });
+      expect(controller.state.redeemWithdrawal).toBeNull();
+      expect(providerRequest).not.toHaveBeenCalled();
+      expect(controller.fetchCardHomeData).not.toHaveBeenCalledWith({
+        force: true,
+      });
+    });
+  });
+
+  describe('getCreditWallet', () => {
+    it('delegates to provider', async () => {
+      const wallet = {
+        id: 'w1',
+        balance: '10',
+        currency: 'usdc',
+        isWithdrawable: true,
+        type: 'credit',
+      };
+      const mockGet = jest.fn().mockResolvedValue(wallet);
+      const provider = buildMockProvider({ getCreditWallet: mockGet });
+      const { controller } = buildAuthenticatedController(provider);
+
+      const result = await controller.getCreditWallet();
+      expect(result).toStrictEqual(wallet);
+    });
+
+    it('throws when unsupported', async () => {
+      const provider = buildMockProvider({ getCreditWallet: undefined });
+      const { controller } = buildAuthenticatedController(provider);
+
+      await expect(controller.getCreditWallet()).rejects.toThrow(
+        'Credit not supported',
+      );
+    });
+  });
+
+  describe('withdrawCredit', () => {
+    it('submits, monitors receipt, and refreshes card home', async () => {
+      const resp = { txHash: '0xcredit' };
+      const mockWithdraw = jest.fn().mockResolvedValue(resp);
+      const provider = buildMockProvider({
+        withdrawCredit: mockWithdraw,
+        getCreditWithdrawEstimation: jest.fn().mockResolvedValue({
+          wei: '1',
+          eth: '0.001',
+          price: '0.5',
+          network: 'linea',
+        }),
+      });
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      const providerRequest = jest.fn().mockResolvedValue({ status: '0x1' });
+      (messenger.call as jest.Mock).mockImplementation((action: string) => {
+        if (action === 'AccountsController:getState') {
+          return {
+            internalAccounts: {
+              accounts: {
+                'id-1': {
+                  address: '0xabc',
+                  type: 'eip155:eoa',
+                  scopes: ['eip155:0'],
+                },
+              },
+              selectedAccount: 'id-1',
+            },
+          };
+        }
+        if (action === 'NetworkController:findNetworkClientIdByChainId') {
+          return 'linea-client';
+        }
+        if (action === 'NetworkController:getNetworkClientById') {
+          return { provider: { request: providerRequest } };
+        }
+        return undefined;
+      });
+      jest.spyOn(controller, 'fetchCardHomeData').mockResolvedValue();
+
+      const result = await controller.withdrawCredit({ amount: '3' });
+
+      expect(result).toStrictEqual(resp);
+      expect(controller.state.redeemWithdrawal).toMatchObject({
+        mode: 'credit',
+        status: 'success',
+        txHash: '0xcredit',
+      });
     });
   });
 

--- a/app/core/Engine/controllers/card-controller/CardController.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.ts
@@ -22,11 +22,18 @@ import {
   type CardControllerState,
   type CardHomeDataError,
   type CardHomeDataErrorReason,
+  type CardRedeemWithdrawal,
+  type CardRedeemWithdrawalError,
+  type CardRedeemWithdrawalErrorReason,
   type FetchCardHomeDataOptions,
 } from './types';
-import type { CardLocation } from '../../../../components/UI/Card/types';
+import type {
+  CardLocation,
+  CardNetwork,
+} from '../../../../components/UI/Card/types';
 import {
   CardLinkageInProgressError,
+  CardRedeemWithdrawalInProgressError,
   CardProviderError,
   CardProviderErrorCode,
   CardStatus,
@@ -65,6 +72,7 @@ import {
   isCardAuthTokenError,
   CardProviderIds,
   type CardProviderId,
+  type RedeemWalletMode,
   type UserResponse,
 } from './provider-types';
 import { CardTokenStore } from './CardTokenStore';
@@ -77,6 +85,12 @@ import {
   awaitTransactionConfirmed,
   type AwaitTransactionConfirmedMessenger,
 } from './utils/awaitTransactionConfirmed';
+import {
+  awaitExternalTransactionReceipt,
+  ExternalTransactionMonitorCancelledError,
+  ExternalTransactionReceiptTimeoutError,
+  ExternalTransactionRevertedError,
+} from './utils/awaitExternalTransactionReceipt';
 import { resolveMoneyAccountCardToken } from './utils/moneyAccountCardToken';
 import {
   MONEY_ACCOUNT_DELEGATION_NETWORK,
@@ -99,10 +113,29 @@ import {
 import { CardService } from './services/CardService';
 import { CardApiError } from './services/BaanxService';
 import type { CardApiSupportedRegionsResponse } from './services/card-supported-regions.types';
+import { cardNetworkInfos } from '../../../../components/UI/Card/constants';
+import { safeFormatChainIdToHex } from '../../../../components/UI/Card/util/safeFormatChainIdToHex';
 
 const CARDHOLDER_BATCH_SIZE = 50;
 const CARDHOLDER_MAX_BATCHES = 3;
 const CARD_HOME_DATA_FRESH_MS = 1000 * 60;
+
+const bucketRedeemAmount = (amount: string): string => {
+  const n = parseFloat(amount);
+  if (!Number.isFinite(n) || n <= 0) return '0';
+  if (n < 1) return '<1';
+  if (n < 10) return '1-10';
+  if (n < 100) return '10-100';
+  if (n < 1000) return '100-1000';
+  return '1000+';
+};
+
+const resolveRedeemPollingChainId = (network?: string): string | undefined => {
+  const info = network ? cardNetworkInfos[network as CardNetwork] : undefined;
+  return info?.caipChainId
+    ? safeFormatChainIdToHex(info.caipChainId)
+    : undefined;
+};
 
 const metadata: StateMetadata<CardControllerState> = {
   selectedCountry: {
@@ -183,6 +216,12 @@ const metadata: StateMetadata<CardControllerState> = {
     includeInStateLogs: false,
     usedInUi: true,
   },
+  redeemWithdrawal: {
+    persist: false,
+    includeInDebugSnapshot: false,
+    includeInStateLogs: true,
+    usedInUi: true,
+  },
 };
 
 export const defaultCardControllerState: CardControllerState = {
@@ -199,6 +238,7 @@ export const defaultCardControllerState: CardControllerState = {
   cardHomeDataError: null,
   cardHomeDataFetchedThisSession: false,
   moneyAccountCardLinkInProgress: false,
+  redeemWithdrawal: null,
 };
 
 /**
@@ -221,6 +261,7 @@ export class CardController extends BaseController<
   #cardholderCheckTimer: ReturnType<typeof setTimeout> | undefined;
   private fetchCardHomeDataPromise: Promise<void> | null = null;
   private fetchGeneration = 0;
+  private redeemGeneration = 0;
   private previousEvmAddress: string | null = null;
   private resetInProgress = false;
   #lastFetchedAt = 0;
@@ -840,6 +881,15 @@ export class CardController extends BaseController<
     this.#lastFetchedAt = 0;
   }
 
+  /**
+   * Increments the redeem generation, which stops an in-flight withdrawal
+   * monitor from polling and blocks it from writing state. Call this before
+   * clearing the redeem slice so an abandoned withdrawal cannot resurrect it.
+   */
+  #invalidateRedeemWithdrawal(): void {
+    this.redeemGeneration++;
+  }
+
   #getSelectedEvmAddress(): string | null {
     const { internalAccounts } = this.messenger.call(
       'AccountsController:getState',
@@ -987,6 +1037,7 @@ export class CardController extends BaseController<
     this.currentSession = null;
     await this.clearTokens();
     this.invalidateFetch();
+    this.#invalidateRedeemWithdrawal();
     this.update((s) => {
       s.isAuthenticated = false;
       s.providerUserId = null;
@@ -995,6 +1046,7 @@ export class CardController extends BaseController<
       s.cardHomeDataAddress = null;
       s.cardHomeDataStatus = 'idle';
       s.cardHomeDataError = null;
+      s.redeemWithdrawal = null;
       if (pid) {
         (s.providerData as unknown as Record<string, Record<string, string>>)[
           pid
@@ -1062,6 +1114,7 @@ export class CardController extends BaseController<
       this.currentSession = null;
       this.refreshPromise = null;
       this.invalidateFetch();
+      this.#invalidateRedeemWithdrawal();
       if (this.#cardholderCheckTimer !== undefined) {
         clearTimeout(this.#cardholderCheckTimer);
         this.#cardholderCheckTimer = undefined;
@@ -1972,85 +2025,524 @@ export class CardController extends BaseController<
   // -- Cashback --
 
   async getCashbackWallet(): Promise<CashbackWalletResponse> {
-    const provider = this.getActiveProvider();
-    const getCashbackWallet = provider.getCashbackWallet?.bind(provider);
-    if (!getCashbackWallet) {
-      throw new CardProviderError(
-        CardProviderErrorCode.Unknown,
-        'Cashback not supported',
-      );
+    try {
+      const provider = this.getActiveProvider();
+      const getCashbackWallet = provider.getCashbackWallet?.bind(provider);
+      if (!getCashbackWallet) {
+        throw new CardProviderError(
+          CardProviderErrorCode.Unknown,
+          'Cashback not supported',
+        );
+      }
+      return await this.#withAuthRetry((tokens) => getCashbackWallet(tokens));
+    } catch (error) {
+      this.#logRedeemError(error, {
+        method: 'getCashbackWallet',
+        mode: 'cashback',
+        step: 'wallet_fetch',
+      });
+      throw error;
     }
-    return this.#withAuthRetry((tokens) => getCashbackWallet(tokens));
   }
 
   async getCashbackWithdrawEstimation(): Promise<CashbackWithdrawEstimationResponse> {
-    const provider = this.getActiveProvider();
-    const getCashbackWithdrawEstimation =
-      provider.getCashbackWithdrawEstimation?.bind(provider);
-    if (!getCashbackWithdrawEstimation) {
-      throw new CardProviderError(
-        CardProviderErrorCode.Unknown,
-        'Cashback not supported',
+    try {
+      const provider = this.getActiveProvider();
+      const getCashbackWithdrawEstimation =
+        provider.getCashbackWithdrawEstimation?.bind(provider);
+      if (!getCashbackWithdrawEstimation) {
+        throw new CardProviderError(
+          CardProviderErrorCode.Unknown,
+          'Cashback not supported',
+        );
+      }
+      return await this.#withAuthRetry((tokens) =>
+        getCashbackWithdrawEstimation(tokens),
       );
+    } catch (error) {
+      this.#logRedeemError(error, {
+        method: 'getCashbackWithdrawEstimation',
+        mode: 'cashback',
+        step: 'estimation',
+      });
+      throw error;
     }
-    return this.#withAuthRetry((tokens) =>
-      getCashbackWithdrawEstimation(tokens),
-    );
   }
 
   async withdrawCashback(
     params: CashbackWithdrawParams,
   ): Promise<CashbackWithdrawResponse> {
-    const provider = this.getActiveProvider();
-    const withdrawCashback = provider.withdrawCashback?.bind(provider);
-    if (!withdrawCashback) {
-      throw new CardProviderError(
-        CardProviderErrorCode.Unknown,
-        'Cashback withdrawal not supported',
-      );
-    }
-    return this.#withAuthRetry((tokens) => withdrawCashback(params, tokens));
+    return this.withdrawRedeemable({ mode: 'cashback', amount: params.amount });
   }
 
   // -- Credit --
 
   async getCreditWallet(): Promise<CreditWalletResponse> {
-    const provider = this.getActiveProvider();
-    const getCreditWallet = provider.getCreditWallet?.bind(provider);
-    if (!getCreditWallet) {
-      throw new CardProviderError(
-        CardProviderErrorCode.Unknown,
-        'Credit not supported',
-      );
+    try {
+      const provider = this.getActiveProvider();
+      const getCreditWallet = provider.getCreditWallet?.bind(provider);
+      if (!getCreditWallet) {
+        throw new CardProviderError(
+          CardProviderErrorCode.Unknown,
+          'Credit not supported',
+        );
+      }
+      return await this.#withAuthRetry((tokens) => getCreditWallet(tokens));
+    } catch (error) {
+      this.#logRedeemError(error, {
+        method: 'getCreditWallet',
+        mode: 'credit',
+        step: 'wallet_fetch',
+      });
+      throw error;
     }
-    return this.#withAuthRetry((tokens) => getCreditWallet(tokens));
   }
 
   async getCreditWithdrawEstimation(): Promise<CreditWithdrawEstimationResponse> {
-    const provider = this.getActiveProvider();
-    const getCreditWithdrawEstimation =
-      provider.getCreditWithdrawEstimation?.bind(provider);
-    if (!getCreditWithdrawEstimation) {
-      throw new CardProviderError(
-        CardProviderErrorCode.Unknown,
-        'Credit not supported',
+    try {
+      const provider = this.getActiveProvider();
+      const getCreditWithdrawEstimation =
+        provider.getCreditWithdrawEstimation?.bind(provider);
+      if (!getCreditWithdrawEstimation) {
+        throw new CardProviderError(
+          CardProviderErrorCode.Unknown,
+          'Credit not supported',
+        );
+      }
+      return await this.#withAuthRetry((tokens) =>
+        getCreditWithdrawEstimation(tokens),
       );
+    } catch (error) {
+      this.#logRedeemError(error, {
+        method: 'getCreditWithdrawEstimation',
+        mode: 'credit',
+        step: 'estimation',
+      });
+      throw error;
     }
-    return this.#withAuthRetry((tokens) => getCreditWithdrawEstimation(tokens));
   }
 
   async withdrawCredit(
     params: CreditWithdrawParams,
   ): Promise<CreditWithdrawResponse> {
-    const provider = this.getActiveProvider();
-    const withdrawCredit = provider.withdrawCredit?.bind(provider);
-    if (!withdrawCredit) {
-      throw new CardProviderError(
-        CardProviderErrorCode.Unknown,
-        'Credit withdrawal not supported',
-      );
+    return this.withdrawRedeemable({ mode: 'credit', amount: params.amount });
+  }
+
+  /**
+   * Submits a credit / mUSD Back withdrawal and monitors the returned txHash
+   * until confirmed or failed. State lives on the controller so navigating
+   * away from the redeem screen does not lose the outcome.
+   */
+  async withdrawRedeemable(params: {
+    mode: RedeemWalletMode;
+    amount: string;
+  }): Promise<CreditWithdrawResponse | CashbackWithdrawResponse> {
+    const { mode, amount } = params;
+    const existing = this.#getRedeemWithdrawal();
+    if (
+      existing &&
+      (existing.status === 'submitting' ||
+        existing.status === 'monitoring' ||
+        existing.status === 'success')
+    ) {
+      throw new CardRedeemWithdrawalInProgressError();
     }
-    return this.#withAuthRetry((tokens) => withdrawCredit(params, tokens));
+
+    const submittedAt = Date.now();
+    const generation = ++this.redeemGeneration;
+    this.#setRedeemWithdrawal(
+      {
+        mode,
+        status: 'submitting',
+        txHash: null,
+        chainId: null,
+        submittedAt,
+        error: null,
+      },
+      generation,
+    );
+
+    return await trace(
+      {
+        name: TraceName.CardRedeemWithdraw,
+        op: TraceOperation.CardDataFetch,
+        tags: { mode },
+      },
+      async (context) => {
+        try {
+          const estimation =
+            mode === 'credit'
+              ? await this.getCreditWithdrawEstimation()
+              : await this.getCashbackWithdrawEstimation();
+          const chainId = resolveRedeemPollingChainId(estimation.network);
+          if (!chainId) {
+            const error = new CardProviderError(
+              CardProviderErrorCode.Unknown,
+              'Unable to resolve withdrawal network for monitoring',
+            );
+            Logger.error(error, {
+              tags: { feature: 'card', mode },
+              context: {
+                name: 'CardController',
+                data: {
+                  method: 'withdrawRedeemable',
+                  step: 'no_polling_chain',
+                  estimationNetwork: estimation.network ?? null,
+                  hasEstimation: true,
+                },
+              },
+            });
+            this.#failRedeemWithdrawal('no_polling_chain', error, generation);
+            annotateTrace(context, {
+              success: false,
+              reason: 'no_polling_chain',
+            });
+            throw error;
+          }
+
+          const submitResult =
+            mode === 'credit'
+              ? await this.#submitCreditWithdraw({ amount })
+              : await this.#submitCashbackWithdraw({ amount });
+
+          Logger.log('Card redeem withdraw submitted', {
+            mode,
+            network: estimation.network,
+            amountBucket: bucketRedeemAmount(amount),
+            chainId,
+          });
+
+          this.#setRedeemWithdrawal(
+            {
+              mode,
+              status: 'monitoring',
+              txHash: submitResult.txHash,
+              chainId,
+              submittedAt,
+              error: null,
+            },
+            generation,
+          );
+
+          await this.#monitorRedeemTx({
+            mode,
+            txHash: submitResult.txHash,
+            chainId,
+            generation,
+          });
+
+          this.#setRedeemWithdrawal(
+            {
+              mode,
+              status: 'success',
+              txHash: submitResult.txHash,
+              chainId,
+              submittedAt,
+              error: null,
+            },
+            generation,
+          );
+
+          // Refresh card home so headline balance / credit banner update.
+          if (generation === this.redeemGeneration) {
+            this.fetchCardHomeData({ force: true }).catch((refreshError) => {
+              Logger.error(refreshError as Error, {
+                tags: { feature: 'card', mode },
+                context: {
+                  name: 'CardController',
+                  data: {
+                    method: 'withdrawRedeemable',
+                    step: 'post_withdraw_refresh',
+                  },
+                },
+              });
+            });
+          }
+
+          annotateTrace(context, { success: true });
+          return submitResult;
+        } catch (error) {
+          if (error instanceof ExternalTransactionMonitorCancelledError) {
+            annotateTrace(context, { success: false, reason: 'cancelled' });
+            throw error;
+          }
+          if (
+            !(
+              this.#getRedeemWithdrawal()?.status === 'failed' &&
+              this.#getRedeemWithdrawal()?.error
+            )
+          ) {
+            const reason = this.#classifyRedeemError(error);
+            this.#failRedeemWithdrawal(reason, error, generation);
+          }
+          const classified = this.#getRedeemWithdrawal()?.error;
+          annotateTrace(context, {
+            success: false,
+            error_name: (error as Error)?.name ?? 'unknown',
+            reason: classified?.reason ?? 'unknown',
+            code: classified?.code != null ? classified.code : 'none',
+            statusCode:
+              classified?.statusCode != null ? classified.statusCode : -1,
+          });
+          throw error;
+        }
+      },
+    );
+  }
+
+  clearRedeemWithdrawal(): void {
+    this.#invalidateRedeemWithdrawal();
+    this.update((state) => {
+      state.redeemWithdrawal = null;
+    });
+  }
+
+  #getRedeemWithdrawal(): CardRedeemWithdrawal | null {
+    return this.state.redeemWithdrawal as CardRedeemWithdrawal | null;
+  }
+
+  /** No-ops when the withdrawal was cleared or superseded while awaiting. */
+  #setRedeemWithdrawal(value: CardRedeemWithdrawal, generation: number): void {
+    if (generation !== this.redeemGeneration) return;
+    this.update((s) => {
+      (s as unknown as CardControllerState).redeemWithdrawal =
+        value as unknown as CardControllerState['redeemWithdrawal'];
+    });
+  }
+
+  #failRedeemWithdrawal(
+    reason: CardRedeemWithdrawalErrorReason,
+    error: unknown,
+    generation: number,
+  ): void {
+    if (generation !== this.redeemGeneration) return;
+    const current = this.#getRedeemWithdrawal();
+    const mapped: CardRedeemWithdrawalError = {
+      reason,
+      code:
+        error instanceof CardProviderError
+          ? error.code
+          : error instanceof CardApiError
+            ? (error.errorCode ?? null)
+            : ((error as Error)?.name ?? null),
+      statusCode:
+        error instanceof CardProviderError || error instanceof CardApiError
+          ? (error.statusCode ?? null)
+          : null,
+    };
+    this.#setRedeemWithdrawal(
+      {
+        mode: current?.mode ?? 'cashback',
+        status: 'failed',
+        txHash: current?.txHash ?? null,
+        chainId: current?.chainId ?? null,
+        submittedAt: current?.submittedAt ?? Date.now(),
+        error: mapped,
+      },
+      generation,
+    );
+  }
+
+  #classifyRedeemError(error: unknown): CardRedeemWithdrawalErrorReason {
+    if (error instanceof CardRedeemWithdrawalInProgressError) {
+      return 'in_progress';
+    }
+    if (error instanceof ExternalTransactionRevertedError) {
+      return 'tx_reverted';
+    }
+    if (error instanceof ExternalTransactionReceiptTimeoutError) {
+      return 'tx_timeout';
+    }
+    if (error instanceof CardProviderError) {
+      if (error.code === CardProviderErrorCode.Network) return 'network';
+      if (error.code === CardProviderErrorCode.ServerError)
+        return 'server_error';
+      return 'submit_failed';
+    }
+    if (error instanceof CardApiError) {
+      if (error.statusCode === 0) return 'network';
+      if (error.statusCode >= 500) return 'server_error';
+      return 'submit_failed';
+    }
+    return 'unknown';
+  }
+
+  #logRedeemError(
+    error: unknown,
+    data: {
+      method: string;
+      mode: RedeemWalletMode;
+      step: string;
+    },
+  ): void {
+    if (isCardAuthTokenError(error)) return;
+    const code =
+      error instanceof CardProviderError
+        ? error.code
+        : error instanceof CardApiError
+          ? (error.errorCode ?? null)
+          : null;
+    const statusCode =
+      error instanceof CardProviderError || error instanceof CardApiError
+        ? (error.statusCode ?? null)
+        : null;
+    Logger.error(error as Error, {
+      tags: {
+        feature: 'card',
+        mode: data.mode,
+        provider: this.state.activeProviderId ?? undefined,
+      },
+      context: {
+        name: 'CardController',
+        data: {
+          method: data.method,
+          step: data.step,
+          code,
+          statusCode,
+        },
+      },
+    });
+  }
+
+  async #submitCashbackWithdraw(
+    params: CashbackWithdrawParams,
+  ): Promise<CashbackWithdrawResponse> {
+    try {
+      const provider = this.getActiveProvider();
+      const withdrawCashback = provider.withdrawCashback?.bind(provider);
+      if (!withdrawCashback) {
+        throw new CardProviderError(
+          CardProviderErrorCode.Unknown,
+          'Cashback withdrawal not supported',
+        );
+      }
+      return await this.#withAuthRetry((tokens) =>
+        withdrawCashback(params, tokens),
+      );
+    } catch (error) {
+      this.#logRedeemError(error, {
+        method: 'withdrawCashback',
+        mode: 'cashback',
+        step: 'submit',
+      });
+      throw error;
+    }
+  }
+
+  async #submitCreditWithdraw(
+    params: CreditWithdrawParams,
+  ): Promise<CreditWithdrawResponse> {
+    try {
+      const provider = this.getActiveProvider();
+      const withdrawCredit = provider.withdrawCredit?.bind(provider);
+      if (!withdrawCredit) {
+        throw new CardProviderError(
+          CardProviderErrorCode.Unknown,
+          'Credit withdrawal not supported',
+        );
+      }
+      return await this.#withAuthRetry((tokens) =>
+        withdrawCredit(params, tokens),
+      );
+    } catch (error) {
+      this.#logRedeemError(error, {
+        method: 'withdrawCredit',
+        mode: 'credit',
+        step: 'submit',
+      });
+      throw error;
+    }
+  }
+
+  async #monitorRedeemTx(params: {
+    mode: RedeemWalletMode;
+    txHash: string;
+    chainId: string;
+    generation: number;
+  }): Promise<void> {
+    const { mode, txHash, chainId, generation } = params;
+    try {
+      const networkClientId = this.messenger.call(
+        'NetworkController:findNetworkClientIdByChainId',
+        chainId as `0x${string}`,
+      );
+      const networkClient = this.messenger.call(
+        'NetworkController:getNetworkClientById',
+        networkClientId,
+      );
+      const provider = networkClient?.provider;
+      if (!provider) {
+        throw new CardProviderError(
+          CardProviderErrorCode.Network,
+          'No network provider for redeem monitoring',
+        );
+      }
+
+      const result = await awaitExternalTransactionReceipt({
+        txHash,
+        shouldContinue: () => generation === this.redeemGeneration,
+        getReceipt: async () => {
+          const receipt = (await provider.request({
+            method: 'eth_getTransactionReceipt',
+            params: [txHash],
+          })) as { status?: string | number } | null;
+          return receipt;
+        },
+      });
+
+      Logger.log('Card redeem withdraw confirmed', {
+        mode,
+        chainId,
+        elapsedMs: result.elapsedMs,
+        pollAttempts: result.pollAttempts,
+      });
+    } catch (error) {
+      if (error instanceof ExternalTransactionMonitorCancelledError) {
+        Logger.log('Card redeem monitoring abandoned', { mode, chainId });
+        throw error;
+      }
+      if (error instanceof ExternalTransactionRevertedError) {
+        Logger.error(error, {
+          tags: { feature: 'card', mode },
+          context: {
+            name: 'CardController',
+            data: {
+              method: 'withdrawRedeemable',
+              step: 'tx_reverted',
+              chainId,
+              // txHash is on-chain public data; truncate for log volume.
+              txHashPrefix: txHash.slice(0, 10),
+            },
+          },
+        });
+        this.#failRedeemWithdrawal('tx_reverted', error, generation);
+        throw error;
+      }
+      if (error instanceof ExternalTransactionReceiptTimeoutError) {
+        Logger.error(error, {
+          tags: { feature: 'card', mode },
+          context: {
+            name: 'CardController',
+            data: {
+              method: 'withdrawRedeemable',
+              step: 'tx_timeout',
+              chainId,
+              pollAttempts: error.pollAttempts,
+              lastPollErrorCode: error.lastPollErrorCode,
+              elapsedMs: error.elapsedMs,
+            },
+          },
+        });
+        this.#failRedeemWithdrawal('tx_timeout', error, generation);
+        throw error;
+      }
+      this.#logRedeemError(error, {
+        method: 'withdrawRedeemable',
+        mode,
+        step: 'monitor',
+      });
+      throw error;
+    }
   }
 
   // -- Transactions --

--- a/app/core/Engine/controllers/card-controller/CardController.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.ts
@@ -121,7 +121,7 @@ const CARDHOLDER_MAX_BATCHES = 3;
 const CARD_HOME_DATA_FRESH_MS = 1000 * 60;
 
 const bucketRedeemAmount = (amount: string): string => {
-  const n = parseFloat(amount);
+  const n = Number.parseFloat(amount);
   if (!Number.isFinite(n) || n <= 0) return '0';
   if (n < 1) return '<1';
   if (n < 10) return '1-10';
@@ -2320,14 +2320,17 @@ export class CardController extends BaseController<
   ): void {
     if (generation !== this.redeemGeneration) return;
     const current = this.#getRedeemWithdrawal();
+    let code: string | null;
+    if (error instanceof CardProviderError) {
+      code = error.code;
+    } else if (error instanceof CardApiError) {
+      code = error.errorCode ?? null;
+    } else {
+      code = (error as Error)?.name ?? null;
+    }
     const mapped: CardRedeemWithdrawalError = {
       reason,
-      code:
-        error instanceof CardProviderError
-          ? error.code
-          : error instanceof CardApiError
-            ? (error.errorCode ?? null)
-            : ((error as Error)?.name ?? null),
+      code,
       statusCode:
         error instanceof CardProviderError || error instanceof CardApiError
           ? (error.statusCode ?? null)
@@ -2379,12 +2382,14 @@ export class CardController extends BaseController<
     },
   ): void {
     if (isCardAuthTokenError(error)) return;
-    const code =
-      error instanceof CardProviderError
-        ? error.code
-        : error instanceof CardApiError
-          ? (error.errorCode ?? null)
-          : null;
+    let code: string | null;
+    if (error instanceof CardProviderError) {
+      code = error.code;
+    } else if (error instanceof CardApiError) {
+      code = error.errorCode ?? null;
+    } else {
+      code = null;
+    }
     const statusCode =
       error instanceof CardProviderError || error instanceof CardApiError
         ? (error.statusCode ?? null)

--- a/app/core/Engine/controllers/card-controller/CardController.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.ts
@@ -2139,11 +2139,14 @@ export class CardController extends BaseController<
   }): Promise<CreditWithdrawResponse | CashbackWithdrawResponse> {
     const { mode, amount } = params;
     const existing = this.#getRedeemWithdrawal();
-    if (
+    // Terminal states are stale once the user leaves the redeem UI — allow a
+    // fresh submit. The view keeps the button locked through `success` while
+    // still mounted for the toast/navigation gap.
+    if (existing?.status === 'success' || existing?.status === 'failed') {
+      this.clearRedeemWithdrawal();
+    } else if (
       existing &&
-      (existing.status === 'submitting' ||
-        existing.status === 'monitoring' ||
-        existing.status === 'success')
+      (existing.status === 'submitting' || existing.status === 'monitoring')
     ) {
       throw new CardRedeemWithdrawalInProgressError();
     }

--- a/app/core/Engine/controllers/card-controller/provider-types.ts
+++ b/app/core/Engine/controllers/card-controller/provider-types.ts
@@ -59,6 +59,39 @@ export class CardLinkageInProgressError extends Error {
   }
 }
 
+export class CardRedeemWithdrawalInProgressError extends Error {
+  constructor(message = 'A Card redeem withdrawal is already in progress') {
+    super(message);
+    this.name = 'CardRedeemWithdrawalInProgressError';
+  }
+}
+
+/** Shared redeemable wallet response (credit refund balance / mUSD Back). */
+export type RedeemWalletMode = 'credit' | 'cashback';
+
+export interface RedeemWalletResponse {
+  id: string;
+  balance: string;
+  currency: string;
+  isWithdrawable: boolean;
+  type: string;
+}
+
+export interface RedeemWithdrawEstimationResponse {
+  wei: string;
+  eth: string;
+  price: string;
+  network: string;
+}
+
+export interface RedeemWithdrawParams {
+  amount: string;
+}
+
+export interface RedeemWithdrawResponse {
+  txHash: string;
+}
+
 // -- Provider Identity --
 
 export const CardProviderIds = {
@@ -298,45 +331,24 @@ export interface DelegationChallengeResponse {
 
 // -- Cashback --
 
-export interface CashbackWalletResponse {
-  id: string;
-  balance: string;
-  currency: string;
-  isWithdrawable: boolean;
-  type: string;
-}
+export type CashbackWalletResponse = RedeemWalletResponse;
 
-export interface CashbackWithdrawEstimationResponse {
-  wei: string;
-  eth: string;
-  price: string;
-  network: string;
-}
+export type CashbackWithdrawEstimationResponse =
+  RedeemWithdrawEstimationResponse;
 
-export interface CashbackWithdrawParams {
-  amount: string;
-}
+export type CashbackWithdrawParams = RedeemWithdrawParams;
 
-export interface CashbackWithdrawResponse {
-  txHash: string;
-}
+export type CashbackWithdrawResponse = RedeemWithdrawResponse;
 
 // -- Credit --
 
-export interface CreditWalletResponse {
-  id: string;
-  balance: string;
-  currency: string;
-  isWithdrawable: boolean;
-  type: string;
-}
+export type CreditWalletResponse = RedeemWalletResponse;
 
-export type CreditWithdrawEstimationResponse =
-  CashbackWithdrawEstimationResponse;
+export type CreditWithdrawEstimationResponse = RedeemWithdrawEstimationResponse;
 
-export type CreditWithdrawParams = CashbackWithdrawParams;
+export type CreditWithdrawParams = RedeemWithdrawParams;
 
-export type CreditWithdrawResponse = CashbackWithdrawResponse;
+export type CreditWithdrawResponse = RedeemWithdrawResponse;
 
 // -- Push Provisioning --
 

--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.test.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.test.ts
@@ -19,6 +19,7 @@ import {
 import { encodeCardCursor } from '../utils/transactionCursor';
 import { BaanxProvider } from './BaanxProvider';
 import type { CardFeatureFlag } from '../../../../../selectors/featureFlagController/card';
+import Logger from '../../../../../util/Logger';
 
 jest.mock('axios');
 jest.mock('../../../../../util/Logger');
@@ -669,6 +670,345 @@ describe('BaanxProvider', () => {
         name: 'CardProviderError',
         code: CardProviderErrorCode.InvalidCredentials,
         statusCode: 401,
+      });
+    });
+  });
+
+  describe('cashback and credit wallet APIs', () => {
+    const tokens: CardAuthTokens = {
+      accessToken: 'at',
+      refreshToken: 'rt',
+      accessTokenExpiresAt: 1,
+      refreshTokenExpiresAt: 2,
+      location: 'international',
+    };
+
+    beforeEach(() => {
+      jest.mocked(Logger.error).mockClear();
+    });
+
+    describe('getCashbackWallet', () => {
+      it('returns the reward wallet from GET /v1/wallet/reward', async () => {
+        const wallet = {
+          id: 'w1',
+          balance: '10',
+          currency: 'musd',
+          isWithdrawable: true,
+          type: 'reward',
+        };
+        const get = jest.fn().mockResolvedValue(wallet);
+        const provider = new BaanxProvider({
+          service: { get, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(provider.getCashbackWallet(tokens)).resolves.toEqual(
+          wallet,
+        );
+        expect(get).toHaveBeenCalledWith('/v1/wallet/reward', tokens);
+      });
+
+      it('logs and maps non-auth failures', async () => {
+        const get = jest
+          .fn()
+          .mockRejectedValue(new CardApiError(500, '/v1/wallet/reward', ''));
+        const provider = new BaanxProvider({
+          service: { get, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(provider.getCashbackWallet(tokens)).rejects.toMatchObject({
+          name: 'CardProviderError',
+          code: CardProviderErrorCode.ServerError,
+        });
+        expect(Logger.error).toHaveBeenCalled();
+      });
+
+      it('does not log auth failures', async () => {
+        const get = jest
+          .fn()
+          .mockRejectedValue(new CardApiError(401, '/v1/wallet/reward', ''));
+        const provider = new BaanxProvider({
+          service: { get, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(provider.getCashbackWallet(tokens)).rejects.toMatchObject({
+          code: CardProviderErrorCode.InvalidCredentials,
+        });
+        expect(Logger.error).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('getCashbackWithdrawEstimation', () => {
+      it('returns estimation from GET withdraw-estimation', async () => {
+        const estimation = {
+          wei: '1',
+          eth: '0.001',
+          price: '0.5',
+          network: 'linea',
+        };
+        const get = jest.fn().mockResolvedValue(estimation);
+        const provider = new BaanxProvider({
+          service: { get, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(
+          provider.getCashbackWithdrawEstimation(tokens),
+        ).resolves.toEqual(estimation);
+        expect(get).toHaveBeenCalledWith(
+          '/v1/wallet/reward/withdraw-estimation',
+          tokens,
+        );
+      });
+
+      it('logs and maps non-auth failures', async () => {
+        const get = jest
+          .fn()
+          .mockRejectedValue(
+            new CardApiError(500, '/v1/wallet/reward/withdraw-estimation', ''),
+          );
+        const provider = new BaanxProvider({
+          service: { get, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(
+          provider.getCashbackWithdrawEstimation(tokens),
+        ).rejects.toMatchObject({
+          code: CardProviderErrorCode.ServerError,
+        });
+        expect(Logger.error).toHaveBeenCalled();
+      });
+
+      it('does not log auth failures', async () => {
+        const get = jest
+          .fn()
+          .mockRejectedValue(
+            new CardApiError(401, '/v1/wallet/reward/withdraw-estimation', ''),
+          );
+        const provider = new BaanxProvider({
+          service: { get, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(
+          provider.getCashbackWithdrawEstimation(tokens),
+        ).rejects.toMatchObject({
+          code: CardProviderErrorCode.InvalidCredentials,
+        });
+        expect(Logger.error).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('withdrawCashback', () => {
+      it('posts the withdraw request', async () => {
+        const resp = { txHash: '0xabc' };
+        const post = jest.fn().mockResolvedValue(resp);
+        const provider = new BaanxProvider({
+          service: { post, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(
+          provider.withdrawCashback({ amount: '5' }, tokens),
+        ).resolves.toEqual(resp);
+        expect(post).toHaveBeenCalledWith(
+          '/v1/wallet/reward/withdraw',
+          { amount: '5' },
+          tokens,
+        );
+      });
+
+      it('logs and maps non-auth failures', async () => {
+        const post = jest
+          .fn()
+          .mockRejectedValue(
+            new CardApiError(500, '/v1/wallet/reward/withdraw', ''),
+          );
+        const provider = new BaanxProvider({
+          service: { post, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(
+          provider.withdrawCashback({ amount: '5' }, tokens),
+        ).rejects.toMatchObject({
+          code: CardProviderErrorCode.ServerError,
+        });
+        expect(Logger.error).toHaveBeenCalled();
+      });
+
+      it('does not log auth failures', async () => {
+        const post = jest
+          .fn()
+          .mockRejectedValue(
+            new CardApiError(401, '/v1/wallet/reward/withdraw', ''),
+          );
+        const provider = new BaanxProvider({
+          service: { post, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(
+          provider.withdrawCashback({ amount: '5' }, tokens),
+        ).rejects.toMatchObject({
+          code: CardProviderErrorCode.InvalidCredentials,
+        });
+        expect(Logger.error).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('getCreditWallet', () => {
+      it('returns the credit wallet from GET /v1/wallet/credit', async () => {
+        const wallet = {
+          id: 'w1',
+          balance: '10',
+          currency: 'usdc',
+          isWithdrawable: true,
+          type: 'credit',
+        };
+        const get = jest.fn().mockResolvedValue(wallet);
+        const provider = new BaanxProvider({
+          service: { get, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(provider.getCreditWallet(tokens)).resolves.toEqual(wallet);
+        expect(get).toHaveBeenCalledWith('/v1/wallet/credit', tokens);
+      });
+
+      it('logs and maps non-auth failures', async () => {
+        const get = jest
+          .fn()
+          .mockRejectedValue(new CardApiError(500, '/v1/wallet/credit', ''));
+        const provider = new BaanxProvider({
+          service: { get, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(provider.getCreditWallet(tokens)).rejects.toMatchObject({
+          code: CardProviderErrorCode.ServerError,
+        });
+        expect(Logger.error).toHaveBeenCalled();
+      });
+
+      it('does not log auth failures', async () => {
+        const get = jest
+          .fn()
+          .mockRejectedValue(new CardApiError(401, '/v1/wallet/credit', ''));
+        const provider = new BaanxProvider({
+          service: { get, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(provider.getCreditWallet(tokens)).rejects.toMatchObject({
+          code: CardProviderErrorCode.InvalidCredentials,
+        });
+        expect(Logger.error).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('getCreditWithdrawEstimation', () => {
+      it('returns estimation from GET credit withdraw-estimation', async () => {
+        const estimation = {
+          wei: '1',
+          eth: '0.001',
+          price: '0.5',
+          network: 'linea',
+        };
+        const get = jest.fn().mockResolvedValue(estimation);
+        const provider = new BaanxProvider({
+          service: { get, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(
+          provider.getCreditWithdrawEstimation(tokens),
+        ).resolves.toEqual(estimation);
+        expect(get).toHaveBeenCalledWith(
+          '/v1/wallet/credit/withdraw-estimation',
+          tokens,
+        );
+      });
+
+      it('logs and maps non-auth failures', async () => {
+        const get = jest
+          .fn()
+          .mockRejectedValue(
+            new CardApiError(500, '/v1/wallet/credit/withdraw-estimation', ''),
+          );
+        const provider = new BaanxProvider({
+          service: { get, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(
+          provider.getCreditWithdrawEstimation(tokens),
+        ).rejects.toMatchObject({
+          code: CardProviderErrorCode.ServerError,
+        });
+        expect(Logger.error).toHaveBeenCalled();
+      });
+
+      it('does not log auth failures', async () => {
+        const get = jest
+          .fn()
+          .mockRejectedValue(
+            new CardApiError(401, '/v1/wallet/credit/withdraw-estimation', ''),
+          );
+        const provider = new BaanxProvider({
+          service: { get, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(
+          provider.getCreditWithdrawEstimation(tokens),
+        ).rejects.toMatchObject({
+          code: CardProviderErrorCode.InvalidCredentials,
+        });
+        expect(Logger.error).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('withdrawCredit', () => {
+      it('posts the credit withdraw request', async () => {
+        const resp = { txHash: '0xcredit' };
+        const post = jest.fn().mockResolvedValue(resp);
+        const provider = new BaanxProvider({
+          service: { post, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(
+          provider.withdrawCredit({ amount: '3' }, tokens),
+        ).resolves.toEqual(resp);
+        expect(post).toHaveBeenCalledWith(
+          '/v1/wallet/credit/withdraw',
+          { amount: '3' },
+          tokens,
+        );
+      });
+
+      it('logs and maps non-auth failures', async () => {
+        const post = jest
+          .fn()
+          .mockRejectedValue(
+            new CardApiError(500, '/v1/wallet/credit/withdraw', ''),
+          );
+        const provider = new BaanxProvider({
+          service: { post, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(
+          provider.withdrawCredit({ amount: '3' }, tokens),
+        ).rejects.toMatchObject({
+          code: CardProviderErrorCode.ServerError,
+        });
+        expect(Logger.error).toHaveBeenCalled();
+      });
+
+      it('does not log auth failures', async () => {
+        const post = jest
+          .fn()
+          .mockRejectedValue(
+            new CardApiError(401, '/v1/wallet/credit/withdraw', ''),
+          );
+        const provider = new BaanxProvider({
+          service: { post, apiKey: 'k' } as unknown as BaanxService,
+        });
+
+        await expect(
+          provider.withdrawCredit({ amount: '3' }, tokens),
+        ).rejects.toMatchObject({
+          code: CardProviderErrorCode.InvalidCredentials,
+        });
+        expect(Logger.error).not.toHaveBeenCalled();
       });
     });
   });

--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
@@ -1045,56 +1045,107 @@ export class BaanxProvider implements ICardProvider {
   async getCashbackWallet(
     tokens: CardAuthTokens,
   ): Promise<CashbackWalletResponse> {
-    return this.service.get<CashbackWalletResponse>(
-      '/v1/wallet/reward',
-      tokens,
-    );
+    try {
+      return await this.service.get<CashbackWalletResponse>(
+        '/v1/wallet/reward',
+        tokens,
+      );
+    } catch (error) {
+      if (!isCardAuthTokenError(error)) {
+        Logger.error(error as Error, getErrorContext('getCashbackWallet'));
+      }
+      throw mapApiError(error, 'getCashbackWallet');
+    }
   }
 
   async getCashbackWithdrawEstimation(
     tokens: CardAuthTokens,
   ): Promise<CashbackWithdrawEstimationResponse> {
-    return this.service.get<CashbackWithdrawEstimationResponse>(
-      '/v1/wallet/reward/withdraw-estimation',
-      tokens,
-    );
+    try {
+      return await this.service.get<CashbackWithdrawEstimationResponse>(
+        '/v1/wallet/reward/withdraw-estimation',
+        tokens,
+      );
+    } catch (error) {
+      if (!isCardAuthTokenError(error)) {
+        Logger.error(
+          error as Error,
+          getErrorContext('getCashbackWithdrawEstimation'),
+        );
+      }
+      throw mapApiError(error, 'getCashbackWithdrawEstimation');
+    }
   }
 
   async withdrawCashback(
     params: CashbackWithdrawParams,
     tokens: CardAuthTokens,
   ): Promise<CashbackWithdrawResponse> {
-    return this.service.post<CashbackWithdrawResponse>(
-      '/v1/wallet/reward/withdraw',
-      params,
-      tokens,
-    );
+    try {
+      return await this.service.post<CashbackWithdrawResponse>(
+        '/v1/wallet/reward/withdraw',
+        params,
+        tokens,
+      );
+    } catch (error) {
+      if (!isCardAuthTokenError(error)) {
+        Logger.error(error as Error, getErrorContext('withdrawCashback'));
+      }
+      throw mapApiError(error, 'withdrawCashback');
+    }
   }
 
   // -- Credit --
 
   async getCreditWallet(tokens: CardAuthTokens): Promise<CreditWalletResponse> {
-    return this.service.get<CreditWalletResponse>('/v1/wallet/credit', tokens);
+    try {
+      return await this.service.get<CreditWalletResponse>(
+        '/v1/wallet/credit',
+        tokens,
+      );
+    } catch (error) {
+      if (!isCardAuthTokenError(error)) {
+        Logger.error(error as Error, getErrorContext('getCreditWallet'));
+      }
+      throw mapApiError(error, 'getCreditWallet');
+    }
   }
 
   async getCreditWithdrawEstimation(
     tokens: CardAuthTokens,
   ): Promise<CreditWithdrawEstimationResponse> {
-    return this.service.get<CreditWithdrawEstimationResponse>(
-      '/v1/wallet/credit/withdraw-estimation',
-      tokens,
-    );
+    try {
+      return await this.service.get<CreditWithdrawEstimationResponse>(
+        '/v1/wallet/credit/withdraw-estimation',
+        tokens,
+      );
+    } catch (error) {
+      if (!isCardAuthTokenError(error)) {
+        Logger.error(
+          error as Error,
+          getErrorContext('getCreditWithdrawEstimation'),
+        );
+      }
+      throw mapApiError(error, 'getCreditWithdrawEstimation');
+    }
   }
 
   async withdrawCredit(
     params: CreditWithdrawParams,
     tokens: CardAuthTokens,
   ): Promise<CreditWithdrawResponse> {
-    return this.service.post<CreditWithdrawResponse>(
-      '/v1/wallet/credit/withdraw',
-      params,
-      tokens,
-    );
+    try {
+      return await this.service.post<CreditWithdrawResponse>(
+        '/v1/wallet/credit/withdraw',
+        params,
+        tokens,
+      );
+    } catch (error) {
+      if (!isCardAuthTokenError(error)) {
+        Logger.error(error as Error, getErrorContext('withdrawCredit'));
+      }
+      throw mapApiError(error, 'withdrawCredit');
+    }
   }
 
   // -- On-Chain (unauthenticated) --

--- a/app/core/Engine/controllers/card-controller/types.ts
+++ b/app/core/Engine/controllers/card-controller/types.ts
@@ -17,7 +17,10 @@ import type {
   RemoteFeatureFlagControllerGetStateAction,
   RemoteFeatureFlagControllerStateChangeEvent,
 } from '@metamask/remote-feature-flag-controller';
-import type { NetworkControllerFindNetworkClientIdByChainIdAction } from '@metamask/network-controller';
+import type {
+  NetworkControllerFindNetworkClientIdByChainIdAction,
+  NetworkControllerGetNetworkClientByIdAction,
+} from '@metamask/network-controller';
 import type {
   TransactionControllerAddTransactionAction,
   TransactionControllerAddTransactionBatchAction,
@@ -53,6 +56,43 @@ export interface CardHomeDataError {
   code: string | null;
   statusCode: number | null;
   at: number;
+}
+
+export type CardRedeemWithdrawalStatus =
+  | 'submitting'
+  | 'monitoring'
+  | 'success'
+  | 'failed';
+
+export type CardRedeemWithdrawalErrorReason =
+  | 'no_polling_chain'
+  | 'submit_failed'
+  | 'tx_reverted'
+  | 'tx_timeout'
+  | 'in_progress'
+  | 'network'
+  | 'server_error'
+  | 'unknown';
+
+/** PII-free: state logs ship this field verbatim. */
+export interface CardRedeemWithdrawalError {
+  reason: CardRedeemWithdrawalErrorReason;
+  code: string | null;
+  statusCode: number | null;
+}
+
+/**
+ * In-flight / terminal redeem withdrawal. Not persisted — survives UI unmount
+ * via controller state so monitoring continues after navigating away.
+ * Typed as Record fields where needed for StateConstraint.
+ */
+export interface CardRedeemWithdrawal {
+  mode: 'credit' | 'cashback';
+  status: CardRedeemWithdrawalStatus;
+  txHash: string | null;
+  chainId: string | null;
+  submittedAt: number;
+  error: CardRedeemWithdrawalError | null;
 }
 
 export interface FetchCardHomeDataOptions {
@@ -98,6 +138,11 @@ export type CardControllerState = {
   cardHomeDataFetchedThisSession: boolean;
   /** True while `linkMoneyAccountCard` is in flight. Not persisted. */
   moneyAccountCardLinkInProgress: boolean;
+  /**
+   * Active / last redeem withdrawal (credit / mUSD Back). Not persisted.
+   * Typed as Record<string, Json> for StateConstraint; cast at read sites.
+   */
+  redeemWithdrawal: Record<string, Json> | null;
 };
 
 export type CardControllerActions = ControllerGetStateAction<
@@ -116,6 +161,7 @@ type CardControllerAllowedActions =
   | RemoteFeatureFlagControllerGetStateAction
   | KeyringControllerSignPersonalMessageAction
   | NetworkControllerFindNetworkClientIdByChainIdAction
+  | NetworkControllerGetNetworkClientByIdAction
   | TransactionControllerAddTransactionAction
   | TransactionControllerAddTransactionBatchAction
   | TransactionControllerGetStateAction;

--- a/app/core/Engine/controllers/card-controller/utils/awaitExternalTransactionReceipt.test.ts
+++ b/app/core/Engine/controllers/card-controller/utils/awaitExternalTransactionReceipt.test.ts
@@ -1,0 +1,90 @@
+import { awaitExternalTransactionReceipt } from './awaitExternalTransactionReceipt';
+
+describe('awaitExternalTransactionReceipt', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('resolves when receipt status is success', async () => {
+    const getReceipt = jest.fn().mockResolvedValue({ status: '0x1' });
+
+    const resultPromise = awaitExternalTransactionReceipt({
+      txHash: '0xabc',
+      getReceipt,
+      intervalMs: 1000,
+      timeoutMs: 5000,
+    });
+
+    const result = await resultPromise;
+    expect(result.pollAttempts).toBe(1);
+    expect(getReceipt).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws ExternalTransactionRevertedError when status is 0', async () => {
+    const getReceipt = jest.fn().mockResolvedValue({ status: '0x0' });
+
+    await expect(
+      awaitExternalTransactionReceipt({
+        txHash: '0xabc',
+        getReceipt,
+        intervalMs: 1000,
+        timeoutMs: 5000,
+      }),
+    ).rejects.toMatchObject({ name: 'ExternalTransactionRevertedError' });
+  });
+
+  it('times out with pollAttempts and lastPollErrorCode', async () => {
+    const getReceipt = jest
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error('rpc down'), { name: 'RpcError' }),
+      );
+
+    const resultPromise = awaitExternalTransactionReceipt({
+      txHash: '0xabc',
+      getReceipt,
+      intervalMs: 1000,
+      timeoutMs: 2500,
+    });
+    // Prevent unhandled rejection noise while timers advance.
+    resultPromise.catch(() => undefined);
+
+    await jest.advanceTimersByTimeAsync(3000);
+
+    await expect(resultPromise).rejects.toMatchObject({
+      name: 'ExternalTransactionReceiptTimeoutError',
+      lastPollErrorCode: 'RpcError',
+      elapsedMs: expect.any(Number),
+    });
+  });
+
+  it('stops polling when shouldContinue returns false', async () => {
+    const getReceipt = jest.fn().mockResolvedValue(null);
+    let cancelled = false;
+
+    const resultPromise = awaitExternalTransactionReceipt({
+      txHash: '0xabc',
+      getReceipt,
+      shouldContinue: () => !cancelled,
+      intervalMs: 1000,
+      timeoutMs: 60000,
+    });
+    // Prevent unhandled rejection noise while timers advance.
+    resultPromise.catch(() => undefined);
+
+    await jest.advanceTimersByTimeAsync(1000);
+    cancelled = true;
+    await jest.advanceTimersByTimeAsync(1000);
+
+    await expect(resultPromise).rejects.toMatchObject({
+      name: 'ExternalTransactionMonitorCancelledError',
+    });
+    const attemptsAtCancel = getReceipt.mock.calls.length;
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(getReceipt).toHaveBeenCalledTimes(attemptsAtCancel);
+  });
+});

--- a/app/core/Engine/controllers/card-controller/utils/awaitExternalTransactionReceipt.test.ts
+++ b/app/core/Engine/controllers/card-controller/utils/awaitExternalTransactionReceipt.test.ts
@@ -82,6 +82,26 @@ describe('awaitExternalTransactionReceipt', () => {
     expect(getReceipt).toHaveBeenCalledTimes(1);
   });
 
+  it('times out when remaining budget is exhausted after a pending poll', async () => {
+    jest.setSystemTime(0);
+    const getReceipt = jest.fn().mockImplementation(() => {
+      jest.setSystemTime(Date.now() + 2500);
+      return Promise.resolve(null);
+    });
+
+    await expect(
+      awaitExternalTransactionReceipt({
+        txHash: '0xabc',
+        getReceipt,
+        intervalMs: 1000,
+        timeoutMs: 2500,
+      }),
+    ).rejects.toMatchObject({
+      name: 'ExternalTransactionReceiptTimeoutError',
+      pollAttempts: 1,
+    });
+  });
+
   it('stops polling when shouldContinue returns false', async () => {
     const getReceipt = jest.fn().mockResolvedValue(null);
     let cancelled = false;

--- a/app/core/Engine/controllers/card-controller/utils/awaitExternalTransactionReceipt.test.ts
+++ b/app/core/Engine/controllers/card-controller/utils/awaitExternalTransactionReceipt.test.ts
@@ -62,6 +62,26 @@ describe('awaitExternalTransactionReceipt', () => {
     });
   });
 
+  it('times out when getReceipt never resolves', async () => {
+    const getReceipt = jest.fn().mockReturnValue(new Promise(() => undefined));
+
+    const resultPromise = awaitExternalTransactionReceipt({
+      txHash: '0xabc',
+      getReceipt,
+      intervalMs: 1000,
+      timeoutMs: 2500,
+    });
+    resultPromise.catch(() => undefined);
+
+    await jest.advanceTimersByTimeAsync(2500);
+
+    await expect(resultPromise).rejects.toMatchObject({
+      name: 'ExternalTransactionReceiptTimeoutError',
+      pollAttempts: 1,
+    });
+    expect(getReceipt).toHaveBeenCalledTimes(1);
+  });
+
   it('stops polling when shouldContinue returns false', async () => {
     const getReceipt = jest.fn().mockResolvedValue(null);
     let cancelled = false;

--- a/app/core/Engine/controllers/card-controller/utils/awaitExternalTransactionReceipt.ts
+++ b/app/core/Engine/controllers/card-controller/utils/awaitExternalTransactionReceipt.ts
@@ -50,6 +50,34 @@ export interface AwaitExternalTransactionReceiptResult {
   pollAttempts: number;
 }
 
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Race `promise` against a timer so a hung RPC call cannot stall forever.
+ * Rejects with `onTimeout()` when the timer fires first.
+ */
+const raceWithTimeout = <T>(
+  promise: Promise<T>,
+  ms: number,
+  onTimeout: () => Error,
+): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(onTimeout());
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+
 /**
  * Polls for an externally-submitted transaction receipt (e.g. a Card provider
  * withdrawal that returns a txHash rather than going through
@@ -73,14 +101,43 @@ export const awaitExternalTransactionReceipt = async (
   let pollAttempts = 0;
   let lastPollErrorCode: string | null = null;
 
+  const remainingMs = () => Math.max(0, timeoutMs - (Date.now() - startedAt));
+
+  const throwTimeout = () => {
+    throw new ExternalTransactionReceiptTimeoutError(
+      timeoutMs,
+      Date.now() - startedAt,
+      pollAttempts,
+      lastPollErrorCode,
+    );
+  };
+
   // Immediate first attempt, then interval polling.
   for (;;) {
     if (shouldContinue && !shouldContinue()) {
       throw new ExternalTransactionMonitorCancelledError(txHash);
     }
+
+    const budgetMs = remainingMs();
+    if (budgetMs === 0) {
+      throwTimeout();
+    }
+
     pollAttempts += 1;
+    const attempt = pollAttempts;
+    const lastErrorAtAttempt = lastPollErrorCode;
     try {
-      const receipt = await getReceipt();
+      const receipt = await raceWithTimeout(
+        getReceipt(),
+        budgetMs,
+        () =>
+          new ExternalTransactionReceiptTimeoutError(
+            timeoutMs,
+            Date.now() - startedAt,
+            attempt,
+            lastErrorAtAttempt,
+          ),
+      );
       if (receipt) {
         const status =
           typeof receipt.status === 'string'
@@ -95,6 +152,9 @@ export const awaitExternalTransactionReceipt = async (
         throw new ExternalTransactionRevertedError(txHash);
       }
     } catch (error) {
+      if (error instanceof ExternalTransactionReceiptTimeoutError) {
+        throw error;
+      }
       if (error instanceof ExternalTransactionRevertedError) {
         throw error;
       }
@@ -103,16 +163,11 @@ export const awaitExternalTransactionReceipt = async (
       // Continue polling on transient RPC errors.
     }
 
-    const elapsedMs = Date.now() - startedAt;
-    if (elapsedMs > timeoutMs) {
-      throw new ExternalTransactionReceiptTimeoutError(
-        timeoutMs,
-        elapsedMs,
-        pollAttempts,
-        lastPollErrorCode,
-      );
+    if (remainingMs() === 0) {
+      throwTimeout();
     }
 
-    await new Promise<void>((resolve) => setTimeout(resolve, intervalMs));
+    const sleepMs = Math.min(intervalMs, remainingMs());
+    await delay(sleepMs);
   }
 };

--- a/app/core/Engine/controllers/card-controller/utils/awaitExternalTransactionReceipt.ts
+++ b/app/core/Engine/controllers/card-controller/utils/awaitExternalTransactionReceipt.ts
@@ -50,6 +50,10 @@ export interface AwaitExternalTransactionReceiptResult {
   pollAttempts: number;
 }
 
+interface Receipt {
+  status?: string | number;
+}
+
 const delay = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -77,6 +81,44 @@ const raceWithTimeout = <T>(
       },
     );
   });
+
+const assertShouldContinue = (
+  shouldContinue: (() => boolean) | undefined,
+  txHash: string,
+): void => {
+  if (shouldContinue && !shouldContinue()) {
+    throw new ExternalTransactionMonitorCancelledError(txHash);
+  }
+};
+
+const isReceiptSuccess = (receipt: Receipt): boolean => {
+  const status =
+    typeof receipt.status === 'string'
+      ? Number.parseInt(receipt.status, 16)
+      : receipt.status;
+  return status === 1;
+};
+
+/**
+ * Returns true when a receipt confirms success. Throws on revert.
+ * Returns false while the receipt is still pending (null).
+ */
+const evaluateReceipt = (receipt: Receipt | null, txHash: string): boolean => {
+  if (!receipt) {
+    return false;
+  }
+  if (isReceiptSuccess(receipt)) {
+    return true;
+  }
+  throw new ExternalTransactionRevertedError(txHash);
+};
+
+const isTerminalPollError = (error: unknown): boolean =>
+  error instanceof ExternalTransactionReceiptTimeoutError ||
+  error instanceof ExternalTransactionRevertedError;
+
+const toPollErrorCode = (error: unknown): string =>
+  error instanceof Error ? error.name || 'Error' : 'unknown';
 
 /**
  * Polls for an externally-submitted transaction receipt (e.g. a Card provider
@@ -114,9 +156,7 @@ export const awaitExternalTransactionReceipt = async (
 
   // Immediate first attempt, then interval polling.
   while (true) {
-    if (shouldContinue && !shouldContinue()) {
-      throw new ExternalTransactionMonitorCancelledError(txHash);
-    }
+    assertShouldContinue(shouldContinue, txHash);
 
     const budgetMs = remainingMs();
     if (budgetMs === 0) {
@@ -138,28 +178,17 @@ export const awaitExternalTransactionReceipt = async (
             lastErrorAtAttempt,
           ),
       );
-      if (receipt) {
-        const status =
-          typeof receipt.status === 'string'
-            ? parseInt(receipt.status, 16)
-            : receipt.status;
-        if (status === 1) {
-          return {
-            elapsedMs: Date.now() - startedAt,
-            pollAttempts,
-          };
-        }
-        throw new ExternalTransactionRevertedError(txHash);
+      if (evaluateReceipt(receipt, txHash)) {
+        return {
+          elapsedMs: Date.now() - startedAt,
+          pollAttempts,
+        };
       }
     } catch (error) {
-      if (error instanceof ExternalTransactionReceiptTimeoutError) {
+      if (isTerminalPollError(error)) {
         throw error;
       }
-      if (error instanceof ExternalTransactionRevertedError) {
-        throw error;
-      }
-      lastPollErrorCode =
-        error instanceof Error ? error.name || 'Error' : 'unknown';
+      lastPollErrorCode = toPollErrorCode(error);
       // Continue polling on transient RPC errors.
     }
 

--- a/app/core/Engine/controllers/card-controller/utils/awaitExternalTransactionReceipt.ts
+++ b/app/core/Engine/controllers/card-controller/utils/awaitExternalTransactionReceipt.ts
@@ -113,7 +113,7 @@ export const awaitExternalTransactionReceipt = async (
   };
 
   // Immediate first attempt, then interval polling.
-  for (;;) {
+  while (true) {
     if (shouldContinue && !shouldContinue()) {
       throw new ExternalTransactionMonitorCancelledError(txHash);
     }

--- a/app/core/Engine/controllers/card-controller/utils/awaitExternalTransactionReceipt.ts
+++ b/app/core/Engine/controllers/card-controller/utils/awaitExternalTransactionReceipt.ts
@@ -1,0 +1,118 @@
+const DEFAULT_INTERVAL_MS = 5000;
+const DEFAULT_TIMEOUT_MS = 3 * 60 * 1000;
+
+export class ExternalTransactionReceiptTimeoutError extends Error {
+  readonly elapsedMs: number;
+  readonly pollAttempts: number;
+  readonly lastPollErrorCode: string | null;
+
+  constructor(
+    timeoutMs: number,
+    elapsedMs: number,
+    pollAttempts: number,
+    lastPollErrorCode: string | null,
+  ) {
+    super(`External transaction receipt timed out after ${timeoutMs}ms`);
+    this.name = 'ExternalTransactionReceiptTimeoutError';
+    this.elapsedMs = elapsedMs;
+    this.pollAttempts = pollAttempts;
+    this.lastPollErrorCode = lastPollErrorCode;
+  }
+}
+
+export class ExternalTransactionRevertedError extends Error {
+  constructor(txHash: string) {
+    super(`External transaction reverted on-chain: ${txHash}`);
+    this.name = 'ExternalTransactionRevertedError';
+  }
+}
+
+export class ExternalTransactionMonitorCancelledError extends Error {
+  constructor(txHash: string) {
+    super(`External transaction monitoring cancelled: ${txHash}`);
+    this.name = 'ExternalTransactionMonitorCancelledError';
+  }
+}
+
+export interface AwaitExternalTransactionReceiptArgs {
+  /** Hex transaction hash returned by the provider. */
+  txHash: string;
+  /** Fetch eth_getTransactionReceipt for the hash. Return null while pending. */
+  getReceipt: () => Promise<{ status?: string | number } | null>;
+  /** Checked before each poll. Return false to abandon monitoring. */
+  shouldContinue?: () => boolean;
+  intervalMs?: number;
+  timeoutMs?: number;
+}
+
+export interface AwaitExternalTransactionReceiptResult {
+  elapsedMs: number;
+  pollAttempts: number;
+}
+
+/**
+ * Polls for an externally-submitted transaction receipt (e.g. a Card provider
+ * withdrawal that returns a txHash rather than going through
+ * TransactionController).
+ *
+ * Unlike `awaitTransactionConfirmed`, this does not listen for messenger
+ * events — the wallet did not submit the transaction.
+ */
+export const awaitExternalTransactionReceipt = async (
+  args: AwaitExternalTransactionReceiptArgs,
+): Promise<AwaitExternalTransactionReceiptResult> => {
+  const {
+    txHash,
+    getReceipt,
+    shouldContinue,
+    intervalMs = DEFAULT_INTERVAL_MS,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  } = args;
+
+  const startedAt = Date.now();
+  let pollAttempts = 0;
+  let lastPollErrorCode: string | null = null;
+
+  // Immediate first attempt, then interval polling.
+  for (;;) {
+    if (shouldContinue && !shouldContinue()) {
+      throw new ExternalTransactionMonitorCancelledError(txHash);
+    }
+    pollAttempts += 1;
+    try {
+      const receipt = await getReceipt();
+      if (receipt) {
+        const status =
+          typeof receipt.status === 'string'
+            ? parseInt(receipt.status, 16)
+            : receipt.status;
+        if (status === 1) {
+          return {
+            elapsedMs: Date.now() - startedAt,
+            pollAttempts,
+          };
+        }
+        throw new ExternalTransactionRevertedError(txHash);
+      }
+    } catch (error) {
+      if (error instanceof ExternalTransactionRevertedError) {
+        throw error;
+      }
+      lastPollErrorCode =
+        error instanceof Error ? error.name || 'Error' : 'unknown';
+      // Continue polling on transient RPC errors.
+    }
+
+    const elapsedMs = Date.now() - startedAt;
+    if (elapsedMs > timeoutMs) {
+      throw new ExternalTransactionReceiptTimeoutError(
+        timeoutMs,
+        elapsedMs,
+        pollAttempts,
+        lastPollErrorCode,
+      );
+    }
+
+    await new Promise<void>((resolve) => setTimeout(resolve, intervalMs));
+  }
+};

--- a/app/core/Engine/messengers/card-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/card-controller-messenger/index.ts
@@ -33,6 +33,7 @@ export function getCardControllerMessenger(
       'RemoteFeatureFlagController:getState',
       'KeyringController:signPersonalMessage',
       'NetworkController:findNetworkClientIdByChainId',
+      'NetworkController:getNetworkClientById',
       'TransactionController:addTransaction',
       'TransactionController:addTransactionBatch',
       'TransactionController:getState',

--- a/app/selectors/cardController.test.ts
+++ b/app/selectors/cardController.test.ts
@@ -27,6 +27,7 @@ import {
   selectCardResidencyRegion,
   selectIsCardResidencyBlocked,
   selectCardRedemptionDestinationIsMoneyAccount,
+  selectCardRedeemWithdrawal,
 } from './cardController';
 import { selectPrimaryMoneyAccount } from './moneyAccountController';
 import type { CardControllerState } from '../core/Engine/controllers/card-controller/types';
@@ -151,6 +152,33 @@ const createMockRootState = (
   }) as unknown as RootState;
 
 describe('CardController selectors', () => {
+  describe('selectCardRedeemWithdrawal', () => {
+    it('returns null when CardController state is undefined', () => {
+      const state = {
+        engine: { backgroundState: {} },
+      } as unknown as RootState;
+      expect(selectCardRedeemWithdrawal(state)).toBeNull();
+    });
+
+    it('returns null when redeemWithdrawal is null', () => {
+      const state = createMockRootState({ redeemWithdrawal: null });
+      expect(selectCardRedeemWithdrawal(state)).toBeNull();
+    });
+
+    it('returns the redeemWithdrawal state', () => {
+      const redeemWithdrawal = {
+        mode: 'cashback' as const,
+        status: 'monitoring' as const,
+        txHash: '0xabc',
+        chainId: '0xe708',
+        submittedAt: 1,
+        error: null,
+      };
+      const state = createMockRootState({ redeemWithdrawal });
+      expect(selectCardRedeemWithdrawal(state)).toEqual(redeemWithdrawal);
+    });
+  });
+
   describe('selectIsMoneyAccountCardLinkInProgress', () => {
     it('returns false when CardController state is undefined', () => {
       const state = {

--- a/app/selectors/cardController.ts
+++ b/app/selectors/cardController.ts
@@ -12,6 +12,7 @@ import {
   type CardControllerState,
   type CardHomeDataError,
   type CardHomeDataStatus,
+  type CardRedeemWithdrawal,
 } from '../core/Engine/controllers/card-controller/types';
 import {
   FundingAssetStatus,
@@ -132,6 +133,12 @@ export const selectIsMoneyAccountCardLinkInProgress = createSelector(
   selectCardControllerState,
   (cardState: CardControllerState | undefined) =>
     cardState?.moneyAccountCardLinkInProgress ?? false,
+);
+
+export const selectCardRedeemWithdrawal = createSelector(
+  selectCardControllerState,
+  (cardState: CardControllerState | undefined) =>
+    (cardState?.redeemWithdrawal as CardRedeemWithdrawal | null) ?? null,
 );
 
 export const selectCardholderAccounts = createSelector(

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -770,7 +770,8 @@
     "cardholderAccounts": [],
     "providerData": {},
     "moneyAccountCardLinkInProgress": false,
-    "lastUnauthenticatedReason": null
+    "lastUnauthenticatedReason": null,
+    "redeemWithdrawal": null
   },
   "ConfigRegistryController": {
     "configs": {

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -297,6 +297,7 @@ export enum TraceName {
   // Money Home Data Fetches
   MoneyActivityFetch = 'Money Activity Fetch',
   CardHomeDataFetch = 'Card Home Data Fetch',
+  CardRedeemWithdraw = 'Card Redeem Withdraw',
   // Rewards
   /** Tap Rewards tab → onboarding content or enrolled dashboard shell. */
   RewardsTabTimeToContent = 'Rewards Tab Time To Content',

--- a/tests/framework/fixtures/json/default-fixture.json
+++ b/tests/framework/fixtures/json/default-fixture.json
@@ -161,6 +161,7 @@
           "moneyAccountCardLinkInProgress": false,
           "providerData": {},
           "providerUserId": null,
+          "redeemWithdrawal": null,
           "selectedCountry": null
         },
         "ClaimsController": {


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

**Reason for the change:** Credit and cashback redeem withdrawals were submitted through `CardController`, but receipt monitoring and in-flight locking lived in UI hooks. Leaving the redeem screen (or opening the other redeem mode) could lose monitoring state, allow duplicate submits, or show inconsistent progress.

**Improvement/solution:** This is PR 1 of 3 in a stacked series. Move the redeem withdrawal lifecycle into `CardController` so hooks/views share one source of truth:

- Route `withdrawCashback` / `withdrawCredit` through shared `withdrawRedeemable`, which fetches estimation, submits via the provider, then polls `eth_getTransactionReceipt` until success, revert, timeout, or cancellation.
- Persist a non-persisted `redeemWithdrawal` slice (`submitting` → `monitoring` → `success` / `failed`) and throw `CardRedeemWithdrawalInProgressError` for concurrent attempts, including while status is still `success` until cleared.
- Add `awaitExternalTransactionReceipt`, `clearRedeemWithdrawal`, `selectCardRedeemWithdrawal`, and `TraceName.CardRedeemWithdraw`.
- Unify provider redeem types under shared aliases so existing `Cashback*` / `Credit*` consumers still compile.
- Wire `NetworkController:getNetworkClientById` on the card controller messenger for monitoring RPC.

Follow-ups: #35740 (hooks/queries), #35741 (destination resolution + view locking).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
Refs: stacked card redeem work (controller foundation; no tracked GitHub issue)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: CardController redeem withdrawal monitoring

  Scenario: controller owns a successful cashback withdraw lifecycle
    Given I am authenticated with a withdrawable cashback balance
    And CardController redeemWithdrawal is idle

    When withdrawCashback is called with a valid amount
    Then redeemWithdrawal status progresses submitting then monitoring
    And once the receipt succeeds status becomes success
    And a second withdraw attempt throws CardRedeemWithdrawalInProgressError until clearRedeemWithdrawal

  Scenario: abandoned monitors cannot write after logout
    Given a redeem withdrawal is monitoring
    When the card session is cleared or the user logs out
    Then the monitor generation is bumped
    And the abandoned monitor does not update redeemWithdrawal or refresh card home
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — controller/internal change only

### **After**

N/A — controller/internal change only

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches card fund movement (cashback/credit withdraw), on-chain receipt polling, and session teardown; mistakes could allow duplicate submits or wrong balance UI, though generation guards and extensive tests mitigate this.
> 
> **Overview**
> **Card cashback and credit withdrawals** now run through a shared **`withdrawRedeemable`** path in `CardController` instead of stopping at provider submit. The controller fetches withdraw estimation, resolves the polling chain from estimation network, submits via the provider, then polls **`eth_getTransactionReceipt`** through a new **`awaitExternalTransactionReceipt`** helper until success, revert, timeout, or cancellation.
> 
> **In-flight state** lives in a non-persisted **`redeemWithdrawal`** slice (`submitting` → `monitoring` → `success` / `failed`) with **`selectCardRedeemWithdrawal`** for UI. Concurrent submits while `submitting`/`monitoring` throw **`CardRedeemWithdrawalInProgressError`**; a **`redeemGeneration`** guard plus **`clearRedeemWithdrawal`** / logout teardown prevent abandoned monitors from updating state or refreshing card home. Successful redeems trigger a best-effort forced **`fetchCardHomeData`**; failures are classified (network, server, revert, timeout, etc.) with structured logging and **`TraceName.CardRedeemWithdraw`**.
> 
> **Supporting changes:** shared redeem wallet/withdraw types and **`CardRedeemWithdrawalInProgressError`** in `provider-types`; **`NetworkController:getNetworkClientById`** on the card messenger; Baanx cashback/credit wallet APIs wrapped with **`mapApiError`** / logging; broad unit tests for controller, Baanx provider, and receipt polling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 120096558dac058f70c8348599c7d41acec80ddd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->