### PR TITLE
fix(agentic): handle Fabric UI targets reliably

### DIFF
--- a/app/dev-tools/AgenticService/AgenticService.test.ts
+++ b/app/dev-tools/AgenticService/AgenticService.test.ts
@@ -3,6 +3,7 @@ import AgenticService, {
   findFiberByTestId,
   walkFiberRoots,
   tryScroll,
+  findMeasurableStateNode,
   toAccountSummary,
   getFixtureMnemonicCount,
   getFixtureAccountNames,
@@ -254,14 +255,21 @@ function makeFiber(
   overrides: Partial<FiberNode> & {
     testID?: string;
     onPress?: () => void;
+    disabled?: boolean;
+    isDisabled?: boolean;
+    accessibilityState?: { disabled?: boolean };
   } = {},
 ): FiberNode {
-  const { testID, onPress, ...rest } = overrides;
+  const { testID, onPress, disabled, isDisabled, accessibilityState, ...rest } =
+    overrides;
   return {
     child: null,
     sibling: null,
     return: null,
-    memoizedProps: testID || onPress ? { testID, onPress } : null,
+    memoizedProps:
+      testID || onPress
+        ? { testID, onPress, disabled, isDisabled, accessibilityState }
+        : null,
     stateNode: null,
     ...rest,
   };
@@ -336,6 +344,35 @@ describe('findFiberByTestId', () => {
   it('returns null when testID not found', () => {
     const root = makeFiber({ child: makeFiber({ testID: 'other' }) });
     expect(findFiberByTestId(root, 'missing')).toBeNull();
+  });
+});
+
+describe('findMeasurableStateNode', () => {
+  it('resolves the public instance from a Fabric host state node', () => {
+    const publicInstance = {
+      measureInWindow: jest.fn(),
+    } as FiberNode['stateNode'];
+    const fabricHost = makeFiber({
+      stateNode: {
+        canonical: { publicInstance },
+      } as FiberNode['stateNode'],
+    });
+
+    const result = findMeasurableStateNode(fabricHost);
+
+    expect(result).toBe(publicInstance);
+  });
+
+  it('uses a measurable ancestor for a flattened host node', () => {
+    const measurableParent = makeFiber({
+      stateNode: { measureInWindow: jest.fn() } as FiberNode['stateNode'],
+    });
+    const flattenedHost = makeFiber({ stateNode: null });
+    flattenedHost.return = measurableParent;
+
+    const result = findMeasurableStateNode(flattenedHost);
+
+    expect(result).toBe(measurableParent.stateNode);
   });
 });
 
@@ -710,6 +747,23 @@ describe('AgenticService.install', () => {
       expect(result.error).toContain('no-press');
     });
 
+    it.each([
+      { disabled: true },
+      { isDisabled: true },
+      { accessibilityState: { disabled: true } },
+    ])('does not press a disabled component', (disabledProps) => {
+      const onPress = jest.fn();
+      installFiberHook(
+        makeFiber({ testID: 'disabled-button', onPress, ...disabledProps }),
+      );
+
+      const result = bridge().pressTestId('disabled-button');
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('disabled');
+      expect(onPress).not.toHaveBeenCalled();
+    });
+
     it('handles deeply nested components', () => {
       const onPress = jest.fn();
       const deep = makeFiber({ testID: 'deep', onPress });
@@ -760,8 +814,11 @@ describe('AgenticService.install', () => {
 
     it('scrolls near a testID anchor', () => {
       const scrollTo = jest.fn();
+      const publicInstance = { scrollTo } as FiberNode['stateNode'];
       const scrollChild = makeFiber({
-        stateNode: { scrollTo } as FiberNode['stateNode'],
+        stateNode: {
+          canonical: { publicInstance },
+        } as FiberNode['stateNode'],
       });
       const anchor = makeFiber({
         testID: 'my-list',
@@ -777,6 +834,28 @@ describe('AgenticService.install', () => {
 
       expect(result.ok).toBe(true);
       expect(scrollTo).toHaveBeenCalledWith({ y: 100, animated: false });
+    });
+
+    it('scrolls the nearest ancestor of a testID anchor', () => {
+      const scrollTo = jest.fn();
+      const publicInstance = { scrollTo } as FiberNode['stateNode'];
+      const anchor = makeFiber({ testID: 'list-row' });
+      const scrollParent = makeFiber({
+        child: anchor,
+        stateNode: {
+          canonical: { publicInstance },
+        } as FiberNode['stateNode'],
+      });
+      anchor.return = scrollParent;
+      installFiberHook(makeFiber({ child: scrollParent }));
+
+      const result = bridge().scrollView({
+        testId: 'list-row',
+        offset: 500,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(scrollTo).toHaveBeenCalledWith({ y: 500, animated: false });
     });
 
     it('returns error when no scrollable found', () => {

--- a/app/dev-tools/AgenticService/AgenticService.test.ts
+++ b/app/dev-tools/AgenticService/AgenticService.test.ts
@@ -399,6 +399,24 @@ describe('findMeasurableStateNode', () => {
     expect(result).toBe(publicInstance);
   });
 
+  it('keeps a measurable Fabric public instance when its child is flattened', () => {
+    const publicInstance = {
+      measureInWindow: jest.fn(),
+    } as FiberNode['stateNode'];
+    const flattenedChild = makeFiber({ stateNode: null });
+    const fabricHost = makeFiber({
+      stateNode: {
+        canonical: { publicInstance },
+      } as FiberNode['stateNode'],
+      child: flattenedChild,
+    });
+    flattenedChild.return = fabricHost;
+
+    const result = findMeasurableStateNode(fabricHost);
+
+    expect(result).toBe(publicInstance);
+  });
+
   it('uses a measurable ancestor for a flattened host node', () => {
     const measurableParent = makeFiber({
       stateNode: { measureInWindow: jest.fn() } as FiberNode['stateNode'],

--- a/app/dev-tools/AgenticService/AgenticService.test.ts
+++ b/app/dev-tools/AgenticService/AgenticService.test.ts
@@ -258,17 +258,35 @@ function makeFiber(
     disabled?: boolean;
     isDisabled?: boolean;
     accessibilityState?: { disabled?: boolean };
+    activityState?: number;
+    style?: unknown;
   } = {},
 ): FiberNode {
-  const { testID, onPress, disabled, isDisabled, accessibilityState, ...rest } =
-    overrides;
+  const {
+    testID,
+    onPress,
+    disabled,
+    isDisabled,
+    accessibilityState,
+    activityState,
+    style,
+    ...rest
+  } = overrides;
   return {
     child: null,
     sibling: null,
     return: null,
     memoizedProps:
-      testID || onPress
-        ? { testID, onPress, disabled, isDisabled, accessibilityState }
+      testID || onPress || activityState !== undefined || style !== undefined
+        ? {
+            testID,
+            onPress,
+            disabled,
+            isDisabled,
+            accessibilityState,
+            activityState,
+            style,
+          }
         : null,
     stateNode: null,
     ...rest,
@@ -345,6 +363,24 @@ describe('findFiberByTestId', () => {
     const root = makeFiber({ child: makeFiber({ testID: 'other' }) });
     expect(findFiberByTestId(root, 'missing')).toBeNull();
   });
+
+  it('finds the active duplicate outside a retained hidden route', () => {
+    const hiddenTarget = makeFiber({ testID: 'shared-button' });
+    const hiddenRoute = makeFiber({
+      activityState: 0,
+      child: hiddenTarget,
+    });
+    const activeTarget = makeFiber({ testID: 'shared-button' });
+    const root = makeFiber({ child: hiddenRoute });
+    hiddenTarget.return = hiddenRoute;
+    hiddenRoute.return = root;
+    hiddenRoute.sibling = activeTarget;
+    activeTarget.return = root;
+
+    const result = findFiberByTestId(root, 'shared-button');
+
+    expect(result).toBe(activeTarget);
+  });
 });
 
 describe('findMeasurableStateNode', () => {
@@ -373,6 +409,18 @@ describe('findMeasurableStateNode', () => {
     const result = findMeasurableStateNode(flattenedHost);
 
     expect(result).toBe(measurableParent.stateNode);
+  });
+
+  it('does not use a measurable sibling outside the target subtree', () => {
+    const measurableStateNode = {
+      measureInWindow: jest.fn(),
+    } as FiberNode['stateNode'];
+    const target = makeFiber();
+    target.sibling = makeFiber({ stateNode: measurableStateNode });
+
+    const result = findMeasurableStateNode(target, false);
+
+    expect(result).toBeNull();
   });
 });
 
@@ -705,43 +753,43 @@ describe('AgenticService.install', () => {
   });
 
   describe('pressTestId', () => {
-    it('presses a component found by testID', () => {
+    it('presses a component found by testID', async () => {
       const onPress = jest.fn();
       const fiber = makeFiber({
         child: makeFiber({ testID: 'my-btn', onPress }),
       });
       installFiberHook(fiber);
 
-      const result = bridge().pressTestId('my-btn');
+      const result = await bridge().pressTestId('my-btn');
 
       expect(result).toEqual({ ok: true, testId: 'my-btn' });
       expect(onPress).toHaveBeenCalledTimes(1);
     });
 
-    it('returns error when testID not found', () => {
+    it('returns error when testID not found', async () => {
       installFiberHook(makeFiber());
 
-      const result = bridge().pressTestId('missing');
+      const result = await bridge().pressTestId('missing');
 
       expect(result.ok).toBe(false);
       expect(result.error).toContain('missing');
     });
 
-    it('returns error when hook is not installed', () => {
+    it('returns error when hook is not installed', async () => {
       globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__ = undefined;
 
-      const result = bridge().pressTestId('any');
+      const result = await bridge().pressTestId('any');
 
       expect(result.ok).toBe(false);
     });
 
-    it('returns error when component has no onPress', () => {
+    it('returns error when component has no onPress', async () => {
       const fiber = makeFiber({
         child: makeFiber({ testID: 'no-press' }),
       });
       installFiberHook(fiber);
 
-      const result = bridge().pressTestId('no-press');
+      const result = await bridge().pressTestId('no-press');
 
       expect(result.ok).toBe(false);
       expect(result.error).toContain('no-press');
@@ -751,30 +799,216 @@ describe('AgenticService.install', () => {
       { disabled: true },
       { isDisabled: true },
       { accessibilityState: { disabled: true } },
-    ])('does not press a disabled component', (disabledProps) => {
+    ])('does not press a disabled component', async (disabledProps) => {
       const onPress = jest.fn();
       installFiberHook(
         makeFiber({ testID: 'disabled-button', onPress, ...disabledProps }),
       );
 
-      const result = bridge().pressTestId('disabled-button');
+      const result = await bridge().pressTestId('disabled-button');
 
       expect(result.ok).toBe(false);
       expect(result.error).toContain('disabled');
       expect(onPress).not.toHaveBeenCalled();
     });
 
-    it('handles deeply nested components', () => {
+    it('handles deeply nested components', async () => {
       const onPress = jest.fn();
       const deep = makeFiber({ testID: 'deep', onPress });
       const mid = makeFiber({ child: deep });
       const root = makeFiber({ child: mid });
       installFiberHook(root);
 
-      const result = bridge().pressTestId('deep');
+      const result = await bridge().pressTestId('deep');
 
       expect(result).toEqual({ ok: true, testId: 'deep' });
       expect(onPress).toHaveBeenCalled();
+    });
+
+    it('presses the active duplicate outside a retained hidden route', async () => {
+      const hiddenPress = jest.fn();
+      const activePress = jest.fn();
+      const hiddenTarget = makeFiber({
+        testID: 'shared-button',
+        onPress: hiddenPress,
+      });
+      const hiddenRoute = makeFiber({
+        style: { display: 'none' },
+        child: hiddenTarget,
+      });
+      const activeTarget = makeFiber({
+        testID: 'shared-button',
+        onPress: activePress,
+      });
+      const root = makeFiber({ child: hiddenRoute });
+      hiddenTarget.return = hiddenRoute;
+      hiddenRoute.return = root;
+      hiddenRoute.sibling = activeTarget;
+      activeTarget.return = root;
+      installFiberHook(root);
+
+      const result = await bridge().pressTestId('shared-button');
+
+      expect(result).toEqual({ ok: true, testId: 'shared-button' });
+      expect(hiddenPress).not.toHaveBeenCalled();
+      expect(activePress).toHaveBeenCalledTimes(1);
+    });
+
+    it('presses the viewport-visible duplicate in the active route', async () => {
+      const hiddenPress = jest.fn();
+      const visiblePress = jest.fn();
+      const hiddenTarget = makeFiber({
+        testID: 'shared-button',
+        onPress: hiddenPress,
+        stateNode: {
+          measureInWindow: (callback) => callback(0, 0, 0, 0),
+        } as FiberNode['stateNode'],
+      });
+      const visibleTarget = makeFiber({
+        testID: 'shared-button',
+        onPress: visiblePress,
+        stateNode: {
+          measureInWindow: (callback) => callback(10, 10, 40, 40),
+        } as FiberNode['stateNode'],
+      });
+      const root = makeFiber({ child: hiddenTarget });
+      hiddenTarget.return = root;
+      hiddenTarget.sibling = visibleTarget;
+      visibleTarget.return = root;
+      installFiberHook(root);
+
+      const result = await bridge().pressTestId('shared-button');
+
+      expect(result).toEqual({ ok: true, testId: 'shared-button' });
+      expect(hiddenPress).not.toHaveBeenCalled();
+      expect(visiblePress).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not borrow a visible frame from a duplicate sibling', async () => {
+      const unmeasurablePress = jest.fn();
+      const visiblePress = jest.fn();
+      const unmeasurableTarget = makeFiber({
+        testID: 'shared-button',
+        onPress: unmeasurablePress,
+      });
+      const visibleTarget = makeFiber({
+        testID: 'shared-button',
+        onPress: visiblePress,
+        stateNode: {
+          measureInWindow: (callback) => callback(10, 10, 40, 40),
+        } as FiberNode['stateNode'],
+      });
+      const root = makeFiber({ child: unmeasurableTarget });
+      unmeasurableTarget.return = root;
+      unmeasurableTarget.sibling = visibleTarget;
+      visibleTarget.return = root;
+      installFiberHook(root);
+
+      const result = await bridge().pressTestId('shared-button');
+
+      expect(result).toEqual({ ok: true, testId: 'shared-button' });
+      expect(unmeasurablePress).not.toHaveBeenCalled();
+      expect(visiblePress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('pressText', () => {
+    it('presses an enabled component by text', () => {
+      const onPress = jest.fn();
+      installFiberHook(
+        makeFiber({ memoizedProps: { children: 'Place order', onPress } }),
+      );
+
+      const result = bridge().pressText('Place order');
+
+      expect(result).toEqual({ ok: true, text: 'Place order' });
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      { disabled: true },
+      { isDisabled: true },
+      { accessibilityState: { disabled: true } },
+    ])('does not press text on a disabled component', (disabledProps) => {
+      const onPress = jest.fn();
+      installFiberHook(
+        makeFiber({
+          memoizedProps: {
+            children: 'Place order',
+            onPress,
+            ...disabledProps,
+          },
+        }),
+      );
+
+      const result = bridge().pressText('Place order');
+
+      expect(result).toEqual({
+        ok: false,
+        text: 'Place order',
+        error: 'Pressable for text="Place order" is disabled',
+      });
+      expect(onPress).not.toHaveBeenCalled();
+    });
+
+    it('presses active text outside a retained hidden route', () => {
+      const hiddenPress = jest.fn();
+      const activePress = jest.fn();
+      const hiddenTarget = makeFiber({
+        memoizedProps: { children: 'Place order', onPress: hiddenPress },
+      });
+      const hiddenRoute = makeFiber({
+        activityState: 0,
+        child: hiddenTarget,
+      });
+      const activeTarget = makeFiber({
+        memoizedProps: { children: 'Place order', onPress: activePress },
+      });
+      const root = makeFiber({ child: hiddenRoute });
+      hiddenTarget.return = hiddenRoute;
+      hiddenRoute.return = root;
+      hiddenRoute.sibling = activeTarget;
+      activeTarget.return = root;
+      installFiberHook(root);
+
+      const result = bridge().pressText('Place order');
+
+      expect(result).toEqual({ ok: true, text: 'Place order' });
+      expect(hiddenPress).not.toHaveBeenCalled();
+      expect(activePress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('queryUiTarget', () => {
+    it('measures the active duplicate outside a retained hidden route', async () => {
+      const hiddenTarget = makeFiber({ testID: 'shared-target' });
+      const hiddenRoute = makeFiber({
+        activityState: 0,
+        child: hiddenTarget,
+      });
+      const activeTarget = makeFiber({
+        testID: 'shared-target',
+        stateNode: {
+          measureInWindow: (callback) => callback(10, 10, 40, 40),
+        } as FiberNode['stateNode'],
+      });
+      const root = makeFiber({ child: hiddenRoute });
+      hiddenTarget.return = hiddenRoute;
+      hiddenRoute.return = root;
+      hiddenRoute.sibling = activeTarget;
+      activeTarget.return = root;
+      installFiberHook(root);
+
+      const result = await bridge().queryUiTarget({
+        testId: 'shared-target',
+        visibility: 'viewport',
+      });
+
+      expect(result).toMatchObject({
+        present: true,
+        visible: true,
+        rect: { x: 10, y: 10, width: 40, height: 40 },
+      });
     });
   });
 

--- a/app/dev-tools/AgenticService/AgenticService.ts
+++ b/app/dev-tools/AgenticService/AgenticService.ts
@@ -887,8 +887,9 @@ function findMeasurableStateNode(
 
   let result = fiber ? resolveMeasurableStateNode(fiber) : null;
   walkFiber(fiber?.child ?? null, (node) => {
-    result = resolveMeasurableStateNode(node);
-    if (result) {
+    const descendant = resolveMeasurableStateNode(node);
+    if (descendant) {
+      result = descendant;
       return true;
     }
     return false;

--- a/app/dev-tools/AgenticService/AgenticService.ts
+++ b/app/dev-tools/AgenticService/AgenticService.ts
@@ -65,9 +65,15 @@ interface FiberNode {
     testID?: string;
     onPress?: (...args: unknown[]) => unknown;
     onChangeText?: (text: string) => void;
+    disabled?: boolean;
+    isDisabled?: boolean;
+    accessibilityState?: { disabled?: boolean };
     [key: string]: unknown;
   } | null;
   stateNode: {
+    canonical?: {
+      publicInstance?: FiberNode['stateNode'];
+    };
     scrollTo?: (opts: { y: number; animated: boolean }) => void;
     scrollToOffset?: (opts: { offset: number; animated: boolean }) => void;
     measure?: (
@@ -776,7 +782,8 @@ function tryScroll(
 ): boolean {
   let current: FiberNode | null = start;
   while (current) {
-    const sn = current.stateNode;
+    const sn =
+      current.stateNode?.canonical?.publicInstance ?? current.stateNode;
     if (sn) {
       if (typeof sn.scrollTo === 'function') {
         sn.scrollTo({ y: offset, animated });
@@ -828,19 +835,30 @@ function findUiTargetFiber(
 function findMeasurableStateNode(
   fiber: FiberNode | null,
 ): FiberNode['stateNode'] | null {
+  const resolveMeasurableStateNode = (node: FiberNode) => {
+    const stateNode = node.stateNode;
+    const publicInstance = stateNode?.canonical?.publicInstance ?? stateNode;
+    return publicInstance &&
+      (typeof publicInstance.measureInWindow === 'function' ||
+        typeof publicInstance.measure === 'function')
+      ? publicInstance
+      : null;
+  };
+
   let result: FiberNode['stateNode'] | null = null;
   walkFiber(fiber, (node) => {
-    const sn = node.stateNode;
-    if (
-      sn &&
-      (typeof sn.measureInWindow === 'function' ||
-        typeof sn.measure === 'function')
-    ) {
-      result = sn;
+    result = resolveMeasurableStateNode(node);
+    if (result) {
       return true;
     }
     return false;
   });
+
+  let ancestor = fiber?.return ?? null;
+  while (!result && ancestor) {
+    result = resolveMeasurableStateNode(ancestor);
+    ancestor = ancestor.return;
+  }
   return result;
 }
 
@@ -1144,18 +1162,31 @@ const AgenticService = {
         ),
       pressTestId: (testId: string) => {
         try {
+          let disabled = false;
           const found = walkFiberRoots((rootFiber) =>
             walkFiber(rootFiber, (f) => {
               if (
                 f.memoizedProps?.testID === testId &&
                 typeof f.memoizedProps?.onPress === 'function'
               ) {
+                disabled =
+                  f.memoizedProps.disabled === true ||
+                  f.memoizedProps.isDisabled === true ||
+                  f.memoizedProps.accessibilityState?.disabled === true;
+                if (disabled) return true;
                 f.memoizedProps.onPress();
                 return true;
               }
               return false;
             }),
           );
+          if (found && disabled) {
+            return {
+              ok: false,
+              testId,
+              error: `Component with testID="${testId}" is disabled`,
+            };
+          }
           if (found) return { ok: true, testId };
           return {
             ok: false,
@@ -1225,7 +1256,23 @@ const AgenticService = {
             if (scrollTestId) {
               const anchor = findFiberByTestId(rootFiber, scrollTestId);
               if (!anchor) return false;
-              return tryScroll(anchor, offset, animated, false);
+              if (tryScroll(anchor, offset, animated, false)) return true;
+              let ancestor = anchor.return;
+              while (ancestor) {
+                const stateNode =
+                  ancestor.stateNode?.canonical?.publicInstance ??
+                  ancestor.stateNode;
+                if (typeof stateNode?.scrollTo === 'function') {
+                  stateNode.scrollTo({ y: offset, animated });
+                  return true;
+                }
+                if (typeof stateNode?.scrollToOffset === 'function') {
+                  stateNode.scrollToOffset({ offset, animated });
+                  return true;
+                }
+                ancestor = ancestor.return;
+              }
+              return false;
             }
             return tryScroll(rootFiber, offset, animated);
           });
@@ -1655,6 +1702,7 @@ export {
   findFiberByTestId,
   walkFiberRoots,
   tryScroll,
+  findMeasurableStateNode,
   toAccountSummary,
 };
 export type { FiberNode, FiberRoot, ReactDevToolsHook, AgenticBridge };

--- a/app/dev-tools/AgenticService/AgenticService.ts
+++ b/app/dev-tools/AgenticService/AgenticService.ts
@@ -124,11 +124,11 @@ interface AgenticBridge {
   goBack: () => void;
   listAccounts: () => { id: string; address: string; name: string }[];
   getSelectedAccount: () => { id: string; address: string; name: string };
-  pressTestId: (testId: string) => {
+  pressTestId: (testId: string) => Promise<{
     ok: boolean;
     testId?: string;
     error?: string;
-  };
+  }>;
   pressText: (
     text: string,
     options?: { requiredTexts?: string[]; maxTexts?: number },
@@ -316,6 +316,39 @@ function walkFiber(
   return false;
 }
 
+/** Return true when React Navigation retains a fiber under a hidden route. */
+function isFiberInactive(fiber: FiberNode): boolean {
+  let current: FiberNode | null = fiber;
+  while (current) {
+    const props = current.memoizedProps;
+    const styles = Array.isArray(props?.style) ? props.style : [props?.style];
+    if (
+      props?.activityState === 0 ||
+      styles.some(
+        (style) =>
+          typeof style === 'object' &&
+          style !== null &&
+          'display' in style &&
+          style.display === 'none',
+      )
+    ) {
+      return true;
+    }
+    current = current.return;
+  }
+  return false;
+}
+
+/** Return true when a pressable fiber declares any supported disabled state. */
+function isFiberDisabled(fiber: FiberNode): boolean {
+  const props = fiber.memoizedProps;
+  return (
+    props?.disabled === true ||
+    props?.isDisabled === true ||
+    props?.accessibilityState?.disabled === true
+  );
+}
+
 /**
  * Find the first fiber node whose `testID` prop matches.
  */
@@ -325,7 +358,7 @@ function findFiberByTestId(
 ): FiberNode | null {
   let result: FiberNode | null = null;
   walkFiber(fiber, (f) => {
-    if (f.memoizedProps?.testID === testId) {
+    if (f.memoizedProps?.testID === testId && !isFiberInactive(f)) {
       result = f;
       return true;
     }
@@ -774,6 +807,23 @@ async function materializeFixtureAccounts(
  * traversed — useful when starting from a testId anchor whose siblings
  * are unrelated components.
  */
+function tryScrollStateNode(
+  stateNode: FiberNode['stateNode'],
+  offset: number,
+  animated: boolean,
+): boolean {
+  const publicInstance = stateNode?.canonical?.publicInstance ?? stateNode;
+  if (typeof publicInstance?.scrollTo === 'function') {
+    publicInstance.scrollTo({ y: offset, animated });
+    return true;
+  }
+  if (typeof publicInstance?.scrollToOffset === 'function') {
+    publicInstance.scrollToOffset({ offset, animated });
+    return true;
+  }
+  return false;
+}
+
 function tryScroll(
   start: FiberNode | null,
   offset: number,
@@ -782,18 +832,7 @@ function tryScroll(
 ): boolean {
   let current: FiberNode | null = start;
   while (current) {
-    const sn =
-      current.stateNode?.canonical?.publicInstance ?? current.stateNode;
-    if (sn) {
-      if (typeof sn.scrollTo === 'function') {
-        sn.scrollTo({ y: offset, animated });
-        return true;
-      }
-      if (typeof sn.scrollToOffset === 'function') {
-        sn.scrollToOffset({ offset, animated });
-        return true;
-      }
-    }
+    if (tryScrollStateNode(current.stateNode, offset, animated)) return true;
     if (tryScroll(current.child, offset, animated)) return true;
     current = walkSiblings ? current.sibling : null;
   }
@@ -823,7 +862,7 @@ function findUiTargetFiber(
 ): FiberNode | null {
   let result: FiberNode | null = null;
   walkFiber(rootFiber, (fiber) => {
-    if (targetMatches(fiber, options)) {
+    if (targetMatches(fiber, options) && !isFiberInactive(fiber)) {
       result = fiber;
       return true;
     }
@@ -834,6 +873,7 @@ function findUiTargetFiber(
 
 function findMeasurableStateNode(
   fiber: FiberNode | null,
+  includeAncestors = true,
 ): FiberNode['stateNode'] | null {
   const resolveMeasurableStateNode = (node: FiberNode) => {
     const stateNode = node.stateNode;
@@ -845,8 +885,8 @@ function findMeasurableStateNode(
       : null;
   };
 
-  let result: FiberNode['stateNode'] | null = null;
-  walkFiber(fiber, (node) => {
+  let result = fiber ? resolveMeasurableStateNode(fiber) : null;
+  walkFiber(fiber?.child ?? null, (node) => {
     result = resolveMeasurableStateNode(node);
     if (result) {
       return true;
@@ -854,7 +894,7 @@ function findMeasurableStateNode(
     return false;
   });
 
-  let ancestor = fiber?.return ?? null;
+  let ancestor = includeAncestors ? (fiber?.return ?? null) : null;
   while (!result && ancestor) {
     result = resolveMeasurableStateNode(ancestor);
     ancestor = ancestor.return;
@@ -1160,38 +1200,64 @@ const AgenticService = {
         toAccountSummary(
           Engine.context.AccountsController.getSelectedAccount(),
         ),
-      pressTestId: (testId: string) => {
+      pressTestId: async (testId: string) => {
         try {
-          let disabled = false;
-          const found = walkFiberRoots((rootFiber) =>
-            walkFiber(rootFiber, (f) => {
+          const candidates: FiberNode[] = [];
+          walkFiberRoots((rootFiber) => {
+            walkFiber(rootFiber, (fiber) => {
               if (
-                f.memoizedProps?.testID === testId &&
-                typeof f.memoizedProps?.onPress === 'function'
+                fiber.memoizedProps?.testID === testId &&
+                typeof fiber.memoizedProps?.onPress === 'function' &&
+                !isFiberInactive(fiber)
               ) {
-                disabled =
-                  f.memoizedProps.disabled === true ||
-                  f.memoizedProps.isDisabled === true ||
-                  f.memoizedProps.accessibilityState?.disabled === true;
-                if (disabled) return true;
-                f.memoizedProps.onPress();
-                return true;
+                candidates.push(fiber);
               }
               return false;
-            }),
+            });
+            return false;
+          });
+          const viewport = Dimensions.get('window');
+          const measuredCandidates = await Promise.all(
+            candidates.map(async (fiber) => ({
+              fiber,
+              rect: await measureStateNode(
+                findMeasurableStateNode(fiber, false),
+              ),
+            })),
           );
-          if (found && disabled) {
+          const visibleCandidate = measuredCandidates.find(({ rect }) =>
+            Boolean(
+              rect &&
+                rect.width > 0 &&
+                rect.height > 0 &&
+                rect.x < viewport.width &&
+                rect.y < viewport.height &&
+                rect.x + rect.width > 0 &&
+                rect.y + rect.height > 0,
+            ),
+          )?.fiber;
+          const candidate =
+            visibleCandidate ??
+            (candidates.length === 1 ? candidates[0] : null);
+          if (!candidate) {
+            return {
+              ok: false,
+              testId,
+              error:
+                candidates.length > 1
+                  ? `No visible component with testID="${testId}" found among duplicate matches`
+                  : `No component with testID="${testId}" found or no onPress prop`,
+            };
+          }
+          if (isFiberDisabled(candidate)) {
             return {
               ok: false,
               testId,
               error: `Component with testID="${testId}" is disabled`,
             };
           }
-          if (found) return { ok: true, testId };
-          return {
-            ok: false,
-            error: `No component with testID="${testId}" found or no onPress prop`,
-          };
+          candidate.memoizedProps?.onPress?.();
+          return { ok: true, testId };
         } catch (e) {
           return { ok: false, error: String(e) };
         }
@@ -1206,7 +1272,10 @@ const AgenticService = {
           let bestTextCount = Number.POSITIVE_INFINITY;
           walkFiberRoots((rootFiber) =>
             walkFiber(rootFiber, (fiber) => {
-              if (typeof fiber.memoizedProps?.onPress !== 'function') {
+              if (
+                typeof fiber.memoizedProps?.onPress !== 'function' ||
+                isFiberInactive(fiber)
+              ) {
                 return false;
               }
               const texts = collectFiberTexts(fiber);
@@ -1228,6 +1297,13 @@ const AgenticService = {
           );
           const matched = bestMatch as FiberNode | null;
           if (matched && typeof matched.memoizedProps?.onPress === 'function') {
+            if (isFiberDisabled(matched)) {
+              return {
+                ok: false,
+                text,
+                error: `Pressable for text="${text}" is disabled`,
+              };
+            }
             matched.memoizedProps.onPress();
             return { ok: true, text };
           }
@@ -1259,15 +1335,7 @@ const AgenticService = {
               if (tryScroll(anchor, offset, animated, false)) return true;
               let ancestor = anchor.return;
               while (ancestor) {
-                const stateNode =
-                  ancestor.stateNode?.canonical?.publicInstance ??
-                  ancestor.stateNode;
-                if (typeof stateNode?.scrollTo === 'function') {
-                  stateNode.scrollTo({ y: offset, animated });
-                  return true;
-                }
-                if (typeof stateNode?.scrollToOffset === 'function') {
-                  stateNode.scrollToOffset({ offset, animated });
+                if (tryScrollStateNode(ancestor.stateNode, offset, animated)) {
                   return true;
                 }
                 ancestor = ancestor.return;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.
-->

## **Description**

Makes the dev-only AgenticService interact with React Native Fabric hosts through their real public instances. Visibility and scrolling can now fall back to measurable or scrollable ancestors, while press actions fail closed for `disabled`, `isDisabled`, and accessibility-disabled controls.

This does not override component or application state. It prevents recipe automation from performing an action that a user cannot perform.

Retained hidden routes are ignored, and duplicate test IDs resolve only to a viewport-visible target.

<!-- mms-check: type=text required=true -->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: [TAT-3919](https://consensyssoftware.atlassian.net/browse/TAT-3919)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: truthful AgenticService UI interaction

  Scenario: reject a disabled control
    Given a React Native control exposes a disabled state and an onPress handler
    When the agentic bridge attempts to press its test ID
    Then the bridge returns an error without invoking the handler

  Scenario: locate a Fabric UI target
    Given a target or scroll host exposes canonical.publicInstance
    When the bridge measures or scrolls to the target
    Then it uses the real native public instance or nearest valid ancestor
```

Focused validation: `AgenticService.test.ts` passed 90/90 tests. ESLint reported no errors; seven unchanged deprecation warnings remain in this pre-existing dev-tools file.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — dev-only bridge behavior with no user-visible UI change.

### **After**

N/A — covered by focused unit tests.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed MetaMask Contributor Docs and Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability.
- [x] I've included tests if applicable.
- [x] I've documented code using JSDoc where applicable.
- [x] I've applied the right labels on the PR.
- [x] I've considered Android performance testing; this dev-only bridge change is not performance-sensitive.
- [x] I've considered a power-user scenario; it is not applicable to this bridge correction.
- [x] I've considered Sentry tracing; no production operation was added.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR.
- [ ] I confirm that this PR addresses its stated behavior and includes the necessary testing evidence.

<!-- Generated with the help of the pr-description AI skill -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to `__DEV__` AgenticService and test automation; `pressTestId` is now async, which external recipe runners must await.
> 
> **Overview**
> Hardens the **dev-only** `__AGENTIC__` fiber bridge so recipe automation targets real, user-actionable UI on React Native **Fabric** and retained navigation stacks.
> 
> **Targeting and measurement** now skip fibers under inactive routes (`activityState === 0` or `display: 'none'`), resolve scroll/measure through `stateNode.canonical.publicInstance`, and use **`findMeasurableStateNode`** with descendant and ancestor fallbacks (without borrowing a sibling’s frame). **`scrollView`** with a testID anchor can scroll the nearest scrollable ancestor when the anchor itself is not scrollable.
> 
> **Press behavior** is stricter: **`pressTestId`** is **async**, gathers all matching pressables, prefers a **viewport-visible** duplicate when testIDs collide, and returns an error instead of firing **`onPress`** when the control is disabled via `disabled`, `isDisabled`, or `accessibilityState.disabled`. **`pressText`** applies the same inactive/disabled rules.
> 
> Unit tests cover Fabric public instances, hidden routes, duplicate testIDs, and disabled controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3deea81fd693bc9692e9bee91091d74780eae32c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





[TAT-3919]: https://consensyssoftware.atlassian.net/browse/TAT-3919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ