### PR TITLE
test: AI Analyzer #51 risk-mode integration

### DIFF
--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: MetaMask/ai-analyzer
-          ref: f9a82c6ae0bfdadb352b9b736d26174705fe6348
+          ref: aa4456db29d531a2bb4ce046ca0d57f6bc80e0b9
           path: .ai-analyzer-action
           token: ${{ secrets.AI_ANALYZER_TOKEN }}
 

--- a/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
+++ b/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
@@ -14,7 +14,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { MAINNET } from '../../../../constants/network';
 import ActionModal from '../../../UI/ActionModal';
 import { clearHistory } from '../../../../actions/browser';
-import { SIMULATION_DETALS_ARTICLE_URL } from '../../../../constants/urls';
+import { SIMULATION_DETAILS_ARTICLE_URL } from '../../../../constants/urls';
 import { strings } from '../../../../../locales/i18n';
 import Engine from '../../../../core/Engine';
 import { SEED_PHRASE_HINTS } from '../../../../constants/storage';
@@ -311,11 +311,11 @@ const Settings: React.FC = () => {
             size={OldButtonSize.Auto}
             labelTextVariant={LibraryTextVariant.BodySMMedium}
             onPress={() => {
-              Linking.openURL(SIMULATION_DETALS_ARTICLE_URL);
+              Linking.openURL(SIMULATION_DETAILS_ARTICLE_URL);
               trackExternalLinkClicked(trackEvent, createEventBuilder, {
                 location: 'app_settings',
                 text: strings('app_settings.simulation_details_learn_more'),
-                url_domain: SIMULATION_DETALS_ARTICLE_URL,
+                url_domain: SIMULATION_DETAILS_ARTICLE_URL,
               });
             }}
             label={strings('app_settings.simulation_details_learn_more')}

--- a/app/constants/urls.ts
+++ b/app/constants/urls.ts
@@ -18,7 +18,7 @@ export const PASSWORD_GUIDE_URL = `https://support.metamask.io/configure/wallet/
 export const LEARN_MORE_URL = `https://support.metamask.io/privacy-and-security/basic-safety-and-security-tips-for-metamask/${MOBILE_UTM}`;
 export const WHY_TRANSACTION_TAKE_TIME_URL =
   'https://community.metamask.io/t/what-is-gas-why-do-transactions-take-so-long/3172';
-export const SIMULATION_DETALS_ARTICLE_URL = `https://support.metamask.io/transactions-and-gas/transactions/simulations/${MOBILE_UTM}`;
+export const SIMULATION_DETAILS_ARTICLE_URL = `https://support.metamask.io/transactions-and-gas/transactions/simulations/${MOBILE_UTM}`;
 
 export const TOKEN_APPROVAL_SPENDING_CAP = `https://support.metamask.io/privacy-and-security/how-to-customize-token-approvals-with-a-spending-cap/${MOBILE_UTM}`;
 export const CONNECTING_TO_A_DECEPTIVE_SITE = `https://support.metamask.io/troubleshooting/deceptive-site-ahead-when-trying-to-connect-to-a-site/${MOBILE_UTM}`;


### PR DESCRIPTION
## Summary
Temporary integration smoke for [MetaMask/ai-analyzer#51](https://github.com/MetaMask/ai-analyzer/pull/51) (mode-owned skills / gates / finalize).

- Pins `.github/workflows/ai-pr-risk-analysis.yml` to analyzer SHA `aa4456db29d531a2bb4ce046ca0d57f6bc80e0b9` (`feat/mode-owned-runtime-contract`)
- **No** Mobile mode/config/prompt changes — validates unchanged consumer inputs
- Builtin `pr-risk-analysis` already declares `gate.name: AI PR Analyzer / Gate` on #51; Mobile does not need a gate overlay

## Test plan
- [ ] `AI PR risk analysis / Analyze` completes on this PR
- [ ] Check run `AI PR Analyzer / Gate` is posted (same name as today)
- [ ] Risk label applied; JSON still has `merge_safe` / `risk_level` / `summary`
- [ ] Close after results are recorded on analyzer #51

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI pin is temporary test wiring; the URL rename is a typo fix with no behavior change beyond the constant identifier.
> 
> **Overview**
> This PR bumps the **AI PR risk analysis** workflow to checkout **MetaMask/ai-analyzer** at commit `aa4456db29d531a2bb4ce046ca0d57f6bc80e0b9` (replacing `f9a82c6…`) so Mobile can smoke-test the mode-owned runtime contract from [ai-analyzer#51](https://github.com/MetaMask/ai-analyzer/pull/51). Workflow inputs (`mode: pr-risk-analysis`, labels, tokens) are unchanged.
> 
> Separately, it renames the support article constant from `SIMULATION_DETALS_ARTICLE_URL` to **`SIMULATION_DETAILS_ARTICLE_URL`** in `urls.ts` and updates **Security Settings** imports and the simulation “Learn more” link/analytics `url_domain` to match. The URL string is the same; only the export name is corrected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1284843dada7e6f2235a4e1b32d8bfd508981f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->