### PR TITLE
feat(accounts): add ManageAccountsView 

### DIFF
--- a/app/components/Views/ManageAccounts/ManageAccounts.testIds.ts
+++ b/app/components/Views/ManageAccounts/ManageAccounts.testIds.ts
@@ -13,6 +13,7 @@ export const ManageAccountsViewSelectorsIDs = {
 } as const;
 
 const ROW_ID_PREFIX = 'manage-accounts-row-';
+const ROW_CELL_ID_PREFIX = 'manage-accounts-row-cell-';
 const ROW_EYE_TOGGLE_ID_PREFIX = 'manage-accounts-row-eye-toggle-';
 const ROW_EYE_ICON_ID_PREFIX = 'manage-accounts-row-eye-icon-';
 const ROW_REMOVE_ID_PREFIX = 'manage-accounts-row-remove-';
@@ -29,6 +30,10 @@ const toTestIdSlug = (value: string): string =>
 /** Test ID for the management row of a single account group. */
 export const getManageAccountRowId = (groupId: string): string =>
   `${ROW_ID_PREFIX}${groupId}`;
+
+/** Test ID for the account-cell wrapper inside a management row. */
+export const getManageAccountRowCellId = (groupId: string): string =>
+  `${ROW_CELL_ID_PREFIX}${groupId}`;
 
 /** Test ID for the eye toggle (hide/unhide) on a management row. */
 export const getManageAccountRowEyeToggleId = (groupId: string): string =>

--- a/app/components/Views/ManageAccounts/ManageAccountsView.tsx
+++ b/app/components/Views/ManageAccounts/ManageAccountsView.tsx
@@ -18,56 +18,34 @@ import {
   getManageAccountAddAccountFooterId,
 } from './ManageAccounts.testIds';
 
-/**
- * One wallet section of the management list.
- *
- * The view layer decides each row's trailing-action variant from account
- * type (entropy/HD → hide; hardware → hide + remove; imported → remove;
- * snap → none) and injects it per group — the row only renders what it's
- * given.
- */
+/** One wallet section of the management list. */
 export interface ManageAccountsSection {
   /** Wallet display name, rendered as the section header. */
   walletName: string;
   /** Account groups belonging to this wallet, in display order. */
   groups: AccountGroupObject[];
-  /**
-   * Account-wallet ID backing this section. Required for the "Add account"
-   * footer (the footer resolves the keyring from the wallets map by this ID).
-   */
+  /** Wallet ID used by the "Add account" footer to resolve the keyring. */
   walletId?: string;
   /**
-   * Trailing-action variant per group ID of this section. Groups without an
-   * entry fall back to the hide toggle (Phase 1 behavior) — the wiring lane
-   * owns the account-type → variant mapping and should map every group
-   * explicitly (entropy/HD → Hide, hardware → HideAndRemove, imported →
-   * Remove, snap → None).
+   * Trailing-action variant per group ID. Groups without an entry
+   * fall back to the hide toggle.
    */
   rowVariantByGroupId?: Partial<
     Record<AccountGroupId, ManageAccountRowVariant>
   >;
-  /** Whether the wallet's entropy is locked (renders the Locked header state). */
+  /** Whether the wallet is locked (renders the Locked header state). */
   isLocked?: boolean;
-  /**
-   * Optional wallet-level remove handler. When provided, the section header
-   * renders its Remove control (hardware-section use). Omit for unlocked
-   * entropy wallets (design-TBD) and imported sections (no wallet-level
-   * removal in Figma).
-   */
+  /** When provided, the section header renders its Remove control. */
   onRemoveWallet?: () => void;
   /**
-   * Whether to render the "Add account" footer for this section
-   * (entropy / hardware wallets only — spec §6 keeps it out of
-   * imported-accounts-only sections). Requires `walletId`.
+   * Whether to render the "Add account" footer for this section.
+   * Requires `walletId`.
    */
   showsAddAccountFooter?: boolean;
 }
 
 export interface ManageAccountsViewProps {
-  /**
-   * Wallet sections in display order. Arrives pre-computed from the
-   * integration lane (selectors own the pinned/wallet section model).
-   */
+  /** Wallet sections in display order. */
   sections: ManageAccountsSection[];
   /** Hidden flag per account group ID; missing key means visible. */
   isHiddenByGroupId: Partial<Record<AccountGroupId, boolean>>;
@@ -76,37 +54,27 @@ export interface ManageAccountsViewProps {
    * (`true` = hide, `false` = unhide).
    */
   onToggleHidden: (groupId: AccountGroupId, nextHidden: boolean) => void;
-  /**
-   * Optional row-level remove handler, forwarded to rows whose variant
-   * includes the remove affordance.
-   */
+  /** Row-level remove handler, used when the row variant includes remove. */
   onRemoveAccount?: (groupId: AccountGroupId) => void;
   /**
-   * Optional "Add account" handler. Its existence gates the per-section
-   * "Add account" footers (entropy / hardware sections only — imported
-   * sections never opt in, spec §6). The reused `AccountListFooter` owns the
-   * creation flow itself; this callback is invoked with the section's wallet
-   * name when the footer reports a newly created account group.
+   * Called with the wallet name after a new account is created.
+   * Required for the per-section "Add account" footer to render.
    */
   onAddAccount?: (walletName: string) => void;
-  /** Optional Add-wallet CTA handler. Renders the button only when provided. */
+  /** Add-wallet CTA handler. Renders the button only when provided. */
   onAddWallet?: () => void;
   /** User's avatar preference, forwarded to every row. */
   avatarAccountType: AccountAvatarVariant;
-  /** Back action (wired to `navigation.goBack()` by the integration lane). */
+  /** Back action. */
   onBack: () => void;
   testID?: string;
 }
 
-/**
- * Manage accounts screen — visuals only.
- *
- * Visual host: sections, hidden flags, trailing-action variants and handlers
- * are injected via props (no Engine, no Redux, no route registration here).
- * Every new affordance (add-account footer, add-wallet CTA, remove controls)
- * renders only when its callback/flag is supplied, so the wiring lane can
- * adopt them incrementally.
- */
+const shouldShowSectionDivider = (
+  sectionIndex: number,
+  sectionCount: number,
+): boolean => sectionIndex < sectionCount - 1;
+
 const ManageAccountsView = ({
   sections,
   isHiddenByGroupId,
@@ -174,11 +142,9 @@ const ManageAccountsView = ({
                 />
               </Box>
             ) : null}
-            {/* Section divider (spec token: border-muted). Rendered between
-                wallet blocks only, matching the Figma rhythm. */}
-            {sectionIndex < sections.length - 1 ? (
+            {shouldShowSectionDivider(sectionIndex, sections.length) && (
               <Box twClassName="mx-4 my-2 h-px bg-border-muted" />
-            ) : null}
+            )}
           </Box>
         ))}
       </ScrollView>

--- a/app/components/Views/ManageAccounts/ManageAccountsView.tsx
+++ b/app/components/Views/ManageAccounts/ManageAccountsView.tsx
@@ -6,6 +6,7 @@ import { Box, HeaderStandard } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
 import type { AccountGroupObject } from '@metamask/account-tree-controller';
+import { strings } from '../../../../locales/i18n';
 import type { AccountAvatarVariant } from '../../../component-library/components-temp/MultichainAccounts/avatarAccountVariant';
 import AccountListFooter from '../../../component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter';
 import AddWalletButton from '../../../component-library/components-temp/MultichainAccounts/AddWalletButton';
@@ -114,7 +115,7 @@ const ManageAccountsView = ({
       testID={testID}
     >
       <HeaderStandard
-        title="Manage accounts"
+        title={strings('multichain_accounts.manage_accounts.title')}
         onBack={onBack}
         backButtonProps={{ testID: ManageAccountsViewSelectorsIDs.BACK_BUTTON }}
         includesTopInset

--- a/app/components/Views/ManageAccounts/ManageAccountsView.tsx
+++ b/app/components/Views/ManageAccounts/ManageAccountsView.tsx
@@ -1,0 +1,195 @@
+import React, { useCallback } from 'react';
+import { ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import type { AccountGroupId, AccountWalletId } from '@metamask/account-api';
+import { Box, HeaderStandard } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+
+import type { AccountGroupObject } from '@metamask/account-tree-controller';
+import type { AccountAvatarVariant } from '../../../component-library/components-temp/MultichainAccounts/avatarAccountVariant';
+import AccountListFooter from '../../../component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter';
+import AddWalletButton from '../../../component-library/components-temp/MultichainAccounts/AddWalletButton';
+import ManageAccountRow, {
+  ManageAccountRowVariant,
+} from './components/ManageAccountRow';
+import ManageWalletSectionHeader from './components/ManageWalletSectionHeader';
+import {
+  ManageAccountsViewSelectorsIDs,
+  getManageAccountAddAccountFooterId,
+} from './ManageAccounts.testIds';
+
+/**
+ * One wallet section of the management list.
+ *
+ * The view layer decides each row's trailing-action variant from account
+ * type (entropy/HD → hide; hardware → hide + remove; imported → remove;
+ * snap → none) and injects it per group — the row only renders what it's
+ * given.
+ */
+export interface ManageAccountsSection {
+  /** Wallet display name, rendered as the section header. */
+  walletName: string;
+  /** Account groups belonging to this wallet, in display order. */
+  groups: AccountGroupObject[];
+  /**
+   * Account-wallet ID backing this section. Required for the "Add account"
+   * footer (the footer resolves the keyring from the wallets map by this ID).
+   */
+  walletId?: string;
+  /**
+   * Trailing-action variant per group ID of this section. Groups without an
+   * entry fall back to the hide toggle (Phase 1 behavior) — the wiring lane
+   * owns the account-type → variant mapping and should map every group
+   * explicitly (entropy/HD → Hide, hardware → HideAndRemove, imported →
+   * Remove, snap → None).
+   */
+  rowVariantByGroupId?: Partial<
+    Record<AccountGroupId, ManageAccountRowVariant>
+  >;
+  /** Whether the wallet's entropy is locked (renders the Locked header state). */
+  isLocked?: boolean;
+  /**
+   * Optional wallet-level remove handler. When provided, the section header
+   * renders its Remove control (hardware-section use). Omit for unlocked
+   * entropy wallets (design-TBD) and imported sections (no wallet-level
+   * removal in Figma).
+   */
+  onRemoveWallet?: () => void;
+  /**
+   * Whether to render the "Add account" footer for this section
+   * (entropy / hardware wallets only — spec §6 keeps it out of
+   * imported-accounts-only sections). Requires `walletId`.
+   */
+  showsAddAccountFooter?: boolean;
+}
+
+export interface ManageAccountsViewProps {
+  /**
+   * Wallet sections in display order. Arrives pre-computed from the
+   * integration lane (selectors own the pinned/wallet section model).
+   */
+  sections: ManageAccountsSection[];
+  /** Hidden flag per account group ID; missing key means visible. */
+  isHiddenByGroupId: Partial<Record<AccountGroupId, boolean>>;
+  /**
+   * Hide / unhide handler. `nextHidden` is the value being applied
+   * (`true` = hide, `false` = unhide).
+   */
+  onToggleHidden: (groupId: AccountGroupId, nextHidden: boolean) => void;
+  /**
+   * Optional row-level remove handler, forwarded to rows whose variant
+   * includes the remove affordance.
+   */
+  onRemoveAccount?: (groupId: AccountGroupId) => void;
+  /**
+   * Optional "Add account" handler. Its existence gates the per-section
+   * "Add account" footers (entropy / hardware sections only — imported
+   * sections never opt in, spec §6). The reused `AccountListFooter` owns the
+   * creation flow itself; this callback is invoked with the section's wallet
+   * name when the footer reports a newly created account group.
+   */
+  onAddAccount?: (walletName: string) => void;
+  /** Optional Add-wallet CTA handler. Renders the button only when provided. */
+  onAddWallet?: () => void;
+  /** User's avatar preference, forwarded to every row. */
+  avatarAccountType: AccountAvatarVariant;
+  /** Back action (wired to `navigation.goBack()` by the integration lane). */
+  onBack: () => void;
+  testID?: string;
+}
+
+/**
+ * Manage accounts screen — visuals only.
+ *
+ * Visual host: sections, hidden flags, trailing-action variants and handlers
+ * are injected via props (no Engine, no Redux, no route registration here).
+ * Every new affordance (add-account footer, add-wallet CTA, remove controls)
+ * renders only when its callback/flag is supplied, so the wiring lane can
+ * adopt them incrementally.
+ */
+const ManageAccountsView = ({
+  sections,
+  isHiddenByGroupId,
+  onToggleHidden,
+  onRemoveAccount,
+  onAddAccount,
+  onAddWallet,
+  avatarAccountType,
+  onBack,
+  testID = ManageAccountsViewSelectorsIDs.CONTAINER,
+}: ManageAccountsViewProps) => {
+  const tw = useTailwind();
+
+  const renderRows = useCallback(
+    (section: ManageAccountsSection) =>
+      section.groups.map((accountGroup) => (
+        <ManageAccountRow
+          key={accountGroup.id}
+          accountGroup={accountGroup}
+          isHidden={isHiddenByGroupId[accountGroup.id] ?? false}
+          variant={
+            section.rowVariantByGroupId?.[accountGroup.id] ??
+            ManageAccountRowVariant.Hide
+          }
+          onToggleHidden={onToggleHidden}
+          onRemove={onRemoveAccount}
+          avatarAccountType={avatarAccountType}
+        />
+      )),
+    [isHiddenByGroupId, onToggleHidden, onRemoveAccount, avatarAccountType],
+  );
+
+  return (
+    <SafeAreaView
+      edges={{ bottom: 'additive' }}
+      style={tw.style('flex-1 bg-default')}
+      testID={testID}
+    >
+      <HeaderStandard
+        title="Manage accounts"
+        onBack={onBack}
+        backButtonProps={{ testID: ManageAccountsViewSelectorsIDs.BACK_BUTTON }}
+        includesTopInset
+      />
+      <ScrollView
+        style={tw.style('flex-1')}
+        testID={ManageAccountsViewSelectorsIDs.ACCOUNT_LIST}
+        contentContainerStyle={tw.style('pb-2')}
+      >
+        {sections.map((section, sectionIndex) => (
+          <Box key={`${sectionIndex}-${section.walletName}`}>
+            <ManageWalletSectionHeader
+              walletName={section.walletName}
+              isLocked={section.isLocked}
+              onRemove={section.onRemoveWallet}
+            />
+            {renderRows(section)}
+            {section.showsAddAccountFooter && onAddAccount ? (
+              <Box
+                testID={getManageAccountAddAccountFooterId(section.walletName)}
+              >
+                <AccountListFooter
+                  walletId={section.walletId as AccountWalletId}
+                  onAccountCreated={() => onAddAccount(section.walletName)}
+                />
+              </Box>
+            ) : null}
+            {/* Section divider (spec token: border-muted). Rendered between
+                wallet blocks only, matching the Figma rhythm. */}
+            {sectionIndex < sections.length - 1 ? (
+              <Box twClassName="mx-4 my-2 h-px bg-border-muted" />
+            ) : null}
+          </Box>
+        ))}
+      </ScrollView>
+      {onAddWallet ? (
+        <AddWalletButton
+          onPress={onAddWallet}
+          testID={ManageAccountsViewSelectorsIDs.ADD_WALLET_BUTTON}
+        />
+      ) : null}
+    </SafeAreaView>
+  );
+};
+
+export default ManageAccountsView;

--- a/app/components/Views/ManageAccounts/ManageAccountsView.view.test.tsx
+++ b/app/components/Views/ManageAccounts/ManageAccountsView.view.test.tsx
@@ -1,0 +1,327 @@
+import '../../../../tests/component-view/mocks';
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import Engine from '../../../core/Engine';
+import Routes from '../../../constants/navigation/Routes';
+import { describeForPlatforms } from '../../../../tests/component-view/platform';
+import { renderComponentViewScreen } from '../../../../tests/component-view/render';
+import {
+  buildMultichainAccountsFixture,
+  type MultichainAccountsFixture,
+} from '../../../../tests/component-view/presets/multichainAccounts';
+import { deepMerge } from '../../../../tests/component-view/stateFixture';
+import ManageAccountsScreen from './ManageAccounts';
+import ManageAccountsView, {
+  type ManageAccountsSection,
+} from './ManageAccountsView';
+import { ManageAccountRowVariant } from './components/ManageAccountRow';
+import {
+  ManageAccountsViewSelectorsIDs,
+  getManageAccountRowId,
+  getManageAccountRowEyeToggleId,
+  getManageAccountRowRemoveId,
+  getManageAccountSectionHeaderId,
+  getManageAccountSectionHeaderRemoveId,
+  getManageAccountAddAccountFooterId,
+} from './ManageAccounts.testIds';
+
+const ACCOUNT_1_GROUP_ID = 'entropy:wallet1/0';
+const ACCOUNT_2_GROUP_ID = 'entropy:wallet1/1';
+const WALLET_NAME = 'Wallet 1';
+const WALLET_ID = 'entropy:wallet1';
+
+const setAccountGroupHiddenMock = jest.fn();
+
+const renderManageAccountsScreen = (fixture: MultichainAccountsFixture) =>
+  renderComponentViewScreen(
+    ManageAccountsScreen,
+    { name: Routes.MANAGE_ACCOUNTS_VIEW },
+    { state: fixture.state },
+  );
+
+const withHiddenSecondGroup = (): MultichainAccountsFixture => {
+  const fixture = buildMultichainAccountsFixture();
+  fixture.state = deepMerge(
+    fixture.state as unknown as Record<string, unknown>,
+    {
+      engine: {
+        backgroundState: {
+          AccountTreeController: {
+            accountTree: {
+              wallets: {
+                [WALLET_ID]: {
+                  groups: {
+                    [ACCOUNT_2_GROUP_ID]: {
+                      metadata: { hidden: true },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  ) as MultichainAccountsFixture['state'];
+  return fixture;
+};
+
+/**
+ * Renders the presentational view with explicit props so the callback-gated
+ * affordances (add-account footer, add-wallet CTA, header remove) can be
+ * exercised without touching the off-limits connector lane.
+ */
+interface ViewHarnessOptions {
+  fixture: MultichainAccountsFixture;
+  onToggleHidden?: (groupId: string, nextHidden: boolean) => void;
+  onRemoveAccount?: (groupId: string) => void;
+  onAddAccount?: (walletName: string) => void;
+  onAddWallet?: () => void;
+  sectionsOverrides?: Partial<ManageAccountsSection>[];
+}
+
+const makeViewHarness =
+  (options: ViewHarnessOptions): React.ComponentType =>
+  () => {
+    const {
+      fixture,
+      onToggleHidden = jest.fn(),
+      onRemoveAccount,
+      onAddAccount,
+      onAddWallet,
+      sectionsOverrides = [],
+    } = options;
+    const sections: ManageAccountsSection[] = [
+      {
+        walletName: WALLET_NAME,
+        groups: [
+          fixture.groups.account1,
+          ...(fixture.groups.account2 ? [fixture.groups.account2] : []),
+        ],
+        ...sectionsOverrides[0],
+      },
+    ];
+    return (
+      <ManageAccountsView
+        sections={sections}
+        isHiddenByGroupId={{}}
+        onToggleHidden={onToggleHidden}
+        onRemoveAccount={onRemoveAccount}
+        onAddAccount={onAddAccount}
+        onAddWallet={onAddWallet}
+        avatarAccountType="Maskicon"
+        onBack={jest.fn()}
+      />
+    );
+  };
+
+describeForPlatforms('ManageAccountsView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (
+      Engine.context.AccountTreeController as unknown as Record<string, unknown>
+    ).setAccountGroupHidden = setAccountGroupHiddenMock;
+  });
+
+  it('renders wallet sections, section headers and account rows, and hides a visible group on eye press', () => {
+    // Arrange
+    const fixture = buildMultichainAccountsFixture();
+    const { getByTestId } = renderManageAccountsScreen(fixture);
+
+    // Act
+    const header = getByTestId(getManageAccountSectionHeaderId(WALLET_NAME));
+    const row1 = getByTestId(getManageAccountRowId(ACCOUNT_1_GROUP_ID));
+    const row2 = getByTestId(getManageAccountRowId(ACCOUNT_2_GROUP_ID));
+    const eye1 = getByTestId(
+      getManageAccountRowEyeToggleId(ACCOUNT_1_GROUP_ID),
+    );
+    expect(eye1.props.accessibilityLabel).toBe('Hide account');
+    fireEvent.press(eye1);
+
+    // Assert
+    expect(header).toBeOnTheScreen();
+    expect(row1).toBeOnTheScreen();
+    expect(row2).toBeOnTheScreen();
+    expect(
+      getByTestId(ManageAccountsViewSelectorsIDs.ACCOUNT_LIST),
+    ).toBeOnTheScreen();
+    expect(setAccountGroupHiddenMock).toHaveBeenCalledTimes(1);
+    expect(setAccountGroupHiddenMock).toHaveBeenCalledWith(
+      ACCOUNT_1_GROUP_ID,
+      true,
+    );
+  });
+
+  it('renders a hidden group in the eye-slash state and unhides it on eye press', () => {
+    // Arrange
+    const fixture = withHiddenSecondGroup();
+    const { getByTestId } = renderManageAccountsScreen(fixture);
+    // The hidden row is excluded from the default accessibility tree
+    // (design intent: accessibilityElementsHidden + no-hide-descendants),
+    // so its queries include hidden elements.
+    const hiddenEye = getByTestId(
+      getManageAccountRowEyeToggleId(ACCOUNT_2_GROUP_ID),
+      { includeHiddenElements: true },
+    );
+    const hiddenRow = getByTestId(getManageAccountRowId(ACCOUNT_2_GROUP_ID), {
+      includeHiddenElements: true,
+    });
+
+    // Act
+    expect(hiddenEye.props.accessibilityLabel).toBe('Unhide account');
+    fireEvent.press(hiddenEye);
+
+    // Assert
+    expect(hiddenRow.props.accessibilityElementsHidden).toBe(true);
+    expect(setAccountGroupHiddenMock).toHaveBeenCalledTimes(1);
+    expect(setAccountGroupHiddenMock).toHaveBeenCalledWith(
+      ACCOUNT_2_GROUP_ID,
+      false,
+    );
+  });
+
+  it('keeps the back button wired to the navigation back action', () => {
+    // Arrange
+    const fixture = buildMultichainAccountsFixture();
+    const { getByTestId } = renderManageAccountsScreen(fixture);
+
+    // Act
+    const backButton = getByTestId(ManageAccountsViewSelectorsIDs.BACK_BUTTON);
+    fireEvent.press(backButton);
+
+    // Assert
+    expect(backButton).toBeOnTheScreen();
+    // goBack() on a stack with no prior route is a no-op — the wiring is
+    // validated by the screen rendering inside the navigator without error.
+    expect(
+      getByTestId(ManageAccountsViewSelectorsIDs.CONTAINER),
+    ).toBeOnTheScreen();
+  });
+
+  it('wires the connector affordances: add-account footer + add-wallet CTA, no header remove', () => {
+    // Arrange
+    const fixture = buildMultichainAccountsFixture();
+    const { queryByTestId, getByTestId } = renderManageAccountsScreen(fixture);
+
+    // Act + Assert — the connector supplies `onAddAccount` / `onAddWallet`,
+    // so the entropy section's add-account footer and the add-wallet CTA
+    // render. Wallet-level remove stays unwired (design-TBD / no controller
+    // support), so the section header Remove control is absent.
+    expect(
+      getByTestId(getManageAccountAddAccountFooterId(WALLET_NAME)),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(ManageAccountsViewSelectorsIDs.ADD_WALLET_BUTTON),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(getManageAccountSectionHeaderRemoveId(WALLET_NAME)),
+    ).toBeNull();
+  });
+
+  it('renders the add-wallet CTA and fires the injected handler on press', () => {
+    // Arrange
+    const fixture = buildMultichainAccountsFixture();
+    const onAddWallet = jest.fn();
+    const { getByTestId } = renderComponentViewScreen(
+      makeViewHarness({ fixture, onAddWallet }),
+      { name: Routes.MANAGE_ACCOUNTS_VIEW },
+      { state: fixture.state },
+    );
+
+    // Act
+    const addWalletButton = getByTestId(
+      ManageAccountsViewSelectorsIDs.ADD_WALLET_BUTTON,
+    );
+    fireEvent.press(addWalletButton);
+
+    // Assert
+    expect(addWalletButton).toBeOnTheScreen();
+    expect(onAddWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the add-account footer and section-header remove only when injected per section', () => {
+    // Arrange
+    const fixture = buildMultichainAccountsFixture();
+    const onRemoveWallet = jest.fn();
+    const onAddAccount = jest.fn();
+    const { getByTestId } = renderComponentViewScreen(
+      makeViewHarness({
+        fixture,
+        onAddAccount,
+        sectionsOverrides: [
+          {
+            walletId: WALLET_ID,
+            isLocked: true,
+            onRemoveWallet,
+            showsAddAccountFooter: true,
+          },
+        ],
+      }),
+      { name: Routes.MANAGE_ACCOUNTS_VIEW },
+      { state: fixture.state },
+    );
+
+    // Act
+    const addAccountFooter = getByTestId(
+      getManageAccountAddAccountFooterId(WALLET_NAME),
+    );
+    const removeHeaderControl = getByTestId(
+      getManageAccountSectionHeaderRemoveId(WALLET_NAME),
+    );
+    fireEvent.press(removeHeaderControl);
+
+    // Assert — the header Remove fires the section callback; the reused
+    // footer's "Add account" entry is present for this wallet section.
+    expect(addAccountFooter).toBeOnTheScreen();
+    expect(onRemoveWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders eye-only and minus-only rows per the injected trailing variants', () => {
+    // Arrange — hide-eligibility matrix at view level: entropy row gets the
+    // eye only; an imported row gets the minus only (wiring lane maps types
+    // to variants — the fixture's second group stands in for an imported one).
+    const fixture = buildMultichainAccountsFixture();
+    const onRemoveAccount = jest.fn();
+    const onToggleHidden = jest.fn();
+    const { getByTestId, queryByTestId } = renderComponentViewScreen(
+      makeViewHarness({
+        fixture,
+        onToggleHidden,
+        onRemoveAccount,
+        sectionsOverrides: [
+          {
+            rowVariantByGroupId: {
+              [ACCOUNT_1_GROUP_ID]: ManageAccountRowVariant.Hide,
+              [ACCOUNT_2_GROUP_ID]: ManageAccountRowVariant.Remove,
+            },
+          },
+        ],
+      }),
+      { name: Routes.MANAGE_ACCOUNTS_VIEW },
+      { state: fixture.state },
+    );
+
+    // Act — eye-only row: eye present and firing; no minus.
+    fireEvent.press(
+      getByTestId(getManageAccountRowEyeToggleId(ACCOUNT_1_GROUP_ID)),
+    );
+
+    // Assert
+    expect(
+      queryByTestId(getManageAccountRowRemoveId(ACCOUNT_1_GROUP_ID)),
+    ).toBeNull();
+    expect(onToggleHidden).toHaveBeenCalledWith(ACCOUNT_1_GROUP_ID, true);
+
+    // Act — minus-only row: minus present and firing; no eye.
+    fireEvent.press(
+      getByTestId(getManageAccountRowRemoveId(ACCOUNT_2_GROUP_ID)),
+    );
+
+    // Assert
+    expect(
+      queryByTestId(getManageAccountRowEyeToggleId(ACCOUNT_2_GROUP_ID)),
+    ).toBeNull();
+    expect(onRemoveAccount).toHaveBeenCalledTimes(1);
+    expect(onRemoveAccount).toHaveBeenCalledWith(ACCOUNT_2_GROUP_ID);
+  });
+});

--- a/app/components/Views/ManageAccounts/ManageAccountsView.view.test.tsx
+++ b/app/components/Views/ManageAccounts/ManageAccountsView.view.test.tsx
@@ -1,16 +1,12 @@
 import '../../../../tests/component-view/mocks';
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
-import Engine from '../../../core/Engine';
-import Routes from '../../../constants/navigation/Routes';
 import { describeForPlatforms } from '../../../../tests/component-view/platform';
 import { renderComponentViewScreen } from '../../../../tests/component-view/render';
 import {
   buildMultichainAccountsFixture,
   type MultichainAccountsFixture,
 } from '../../../../tests/component-view/presets/multichainAccounts';
-import { deepMerge } from '../../../../tests/component-view/stateFixture';
-import ManageAccountsScreen from './ManageAccounts';
 import ManageAccountsView, {
   type ManageAccountsSection,
 } from './ManageAccountsView';
@@ -29,54 +25,21 @@ const ACCOUNT_1_GROUP_ID = 'entropy:wallet1/0';
 const ACCOUNT_2_GROUP_ID = 'entropy:wallet1/1';
 const WALLET_NAME = 'Wallet 1';
 const WALLET_ID = 'entropy:wallet1';
-
-const setAccountGroupHiddenMock = jest.fn();
-
-const renderManageAccountsScreen = (fixture: MultichainAccountsFixture) =>
-  renderComponentViewScreen(
-    ManageAccountsScreen,
-    { name: Routes.MANAGE_ACCOUNTS_VIEW },
-    { state: fixture.state },
-  );
-
-const withHiddenSecondGroup = (): MultichainAccountsFixture => {
-  const fixture = buildMultichainAccountsFixture();
-  fixture.state = deepMerge(
-    fixture.state as unknown as Record<string, unknown>,
-    {
-      engine: {
-        backgroundState: {
-          AccountTreeController: {
-            accountTree: {
-              wallets: {
-                [WALLET_ID]: {
-                  groups: {
-                    [ACCOUNT_2_GROUP_ID]: {
-                      metadata: { hidden: true },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-  ) as MultichainAccountsFixture['state'];
-  return fixture;
-};
+/** Placeholder until the ManageAccounts screen / route lands in a follow-up PR. */
+const MANAGE_ACCOUNTS_VIEW_ROUTE = 'ManageAccountsView';
 
 /**
- * Renders the presentational view with explicit props so the callback-gated
- * affordances (add-account footer, add-wallet CTA, header remove) can be
- * exercised without touching the off-limits connector lane.
+ * Renders the presentational view with explicit props. Screen/connector
+ * coverage belongs in a follow-up once `ManageAccounts` ships.
  */
 interface ViewHarnessOptions {
   fixture: MultichainAccountsFixture;
+  isHiddenByGroupId?: Partial<Record<string, boolean>>;
   onToggleHidden?: (groupId: string, nextHidden: boolean) => void;
   onRemoveAccount?: (groupId: string) => void;
   onAddAccount?: (walletName: string) => void;
   onAddWallet?: () => void;
+  onBack?: () => void;
   sectionsOverrides?: Partial<ManageAccountsSection>[];
 }
 
@@ -85,10 +48,12 @@ const makeViewHarness =
   () => {
     const {
       fixture,
+      isHiddenByGroupId = {},
       onToggleHidden = jest.fn(),
       onRemoveAccount,
       onAddAccount,
       onAddWallet,
+      onBack = jest.fn(),
       sectionsOverrides = [],
     } = options;
     const sections: ManageAccountsSection[] = [
@@ -104,31 +69,37 @@ const makeViewHarness =
     return (
       <ManageAccountsView
         sections={sections}
-        isHiddenByGroupId={{}}
+        isHiddenByGroupId={isHiddenByGroupId}
         onToggleHidden={onToggleHidden}
         onRemoveAccount={onRemoveAccount}
         onAddAccount={onAddAccount}
         onAddWallet={onAddWallet}
         avatarAccountType="Maskicon"
-        onBack={jest.fn()}
+        onBack={onBack}
       />
     );
   };
 
+const renderManageAccountsView = (options: ViewHarnessOptions) =>
+  renderComponentViewScreen(
+    makeViewHarness(options),
+    { name: MANAGE_ACCOUNTS_VIEW_ROUTE },
+    { state: options.fixture.state },
+  );
+
 describeForPlatforms('ManageAccountsView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (
-      Engine.context.AccountTreeController as unknown as Record<string, unknown>
-    ).setAccountGroupHidden = setAccountGroupHiddenMock;
   });
 
   it('renders wallet sections, section headers and account rows, and hides a visible group on eye press', () => {
-    // Arrange
     const fixture = buildMultichainAccountsFixture();
-    const { getByTestId } = renderManageAccountsScreen(fixture);
+    const onToggleHidden = jest.fn();
+    const { getByTestId } = renderManageAccountsView({
+      fixture,
+      onToggleHidden,
+    });
 
-    // Act
     const header = getByTestId(getManageAccountSectionHeaderId(WALLET_NAME));
     const row1 = getByTestId(getManageAccountRowId(ACCOUNT_1_GROUP_ID));
     const row2 = getByTestId(getManageAccountRowId(ACCOUNT_2_GROUP_ID));
@@ -138,75 +109,72 @@ describeForPlatforms('ManageAccountsView', () => {
     expect(eye1.props.accessibilityLabel).toBe('Hide account');
     fireEvent.press(eye1);
 
-    // Assert
     expect(header).toBeOnTheScreen();
     expect(row1).toBeOnTheScreen();
     expect(row2).toBeOnTheScreen();
     expect(
       getByTestId(ManageAccountsViewSelectorsIDs.ACCOUNT_LIST),
     ).toBeOnTheScreen();
-    expect(setAccountGroupHiddenMock).toHaveBeenCalledTimes(1);
-    expect(setAccountGroupHiddenMock).toHaveBeenCalledWith(
-      ACCOUNT_1_GROUP_ID,
-      true,
-    );
+    expect(onToggleHidden).toHaveBeenCalledTimes(1);
+    expect(onToggleHidden).toHaveBeenCalledWith(ACCOUNT_1_GROUP_ID, true);
   });
 
   it('renders a hidden group in the eye-slash state and unhides it on eye press', () => {
-    // Arrange
-    const fixture = withHiddenSecondGroup();
-    const { getByTestId } = renderManageAccountsScreen(fixture);
-    // The hidden row is excluded from the default accessibility tree
-    // (design intent: accessibilityElementsHidden + no-hide-descendants),
-    // so its queries include hidden elements.
+    const fixture = buildMultichainAccountsFixture();
+    const onToggleHidden = jest.fn();
+    const { getByTestId, UNSAFE_getByProps } = renderManageAccountsView({
+      fixture,
+      onToggleHidden,
+      isHiddenByGroupId: { [ACCOUNT_2_GROUP_ID]: true },
+    });
+    // Cell content is excluded from the a11y tree when hidden
+    // (accessibilityElementsHidden + no-hide-descendants on the cell wrapper).
     const hiddenEye = getByTestId(
       getManageAccountRowEyeToggleId(ACCOUNT_2_GROUP_ID),
-      { includeHiddenElements: true },
     );
-    const hiddenRow = getByTestId(getManageAccountRowId(ACCOUNT_2_GROUP_ID), {
-      includeHiddenElements: true,
-    });
 
-    // Act
     expect(hiddenEye.props.accessibilityLabel).toBe('Unhide account');
+    expect(
+      UNSAFE_getByProps({ accessibilityElementsHidden: true }),
+    ).toBeTruthy();
     fireEvent.press(hiddenEye);
 
-    // Assert
-    expect(hiddenRow.props.accessibilityElementsHidden).toBe(true);
-    expect(setAccountGroupHiddenMock).toHaveBeenCalledTimes(1);
-    expect(setAccountGroupHiddenMock).toHaveBeenCalledWith(
-      ACCOUNT_2_GROUP_ID,
-      false,
-    );
+    expect(
+      getByTestId(getManageAccountRowId(ACCOUNT_2_GROUP_ID)),
+    ).toBeOnTheScreen();
+    expect(onToggleHidden).toHaveBeenCalledTimes(1);
+    expect(onToggleHidden).toHaveBeenCalledWith(ACCOUNT_2_GROUP_ID, false);
   });
 
-  it('keeps the back button wired to the navigation back action', () => {
-    // Arrange
+  it('fires the injected back handler when the back button is pressed', () => {
     const fixture = buildMultichainAccountsFixture();
-    const { getByTestId } = renderManageAccountsScreen(fixture);
+    const onBack = jest.fn();
+    const { getByTestId } = renderManageAccountsView({ fixture, onBack });
 
-    // Act
     const backButton = getByTestId(ManageAccountsViewSelectorsIDs.BACK_BUTTON);
     fireEvent.press(backButton);
 
-    // Assert
     expect(backButton).toBeOnTheScreen();
-    // goBack() on a stack with no prior route is a no-op — the wiring is
-    // validated by the screen rendering inside the navigator without error.
     expect(
       getByTestId(ManageAccountsViewSelectorsIDs.CONTAINER),
     ).toBeOnTheScreen();
+    expect(onBack).toHaveBeenCalledTimes(1);
   });
 
-  it('wires the connector affordances: add-account footer + add-wallet CTA, no header remove', () => {
-    // Arrange
+  it('renders add-account footer and add-wallet CTA when handlers are injected, without header remove', () => {
     const fixture = buildMultichainAccountsFixture();
-    const { queryByTestId, getByTestId } = renderManageAccountsScreen(fixture);
+    const { queryByTestId, getByTestId } = renderManageAccountsView({
+      fixture,
+      onAddAccount: jest.fn(),
+      onAddWallet: jest.fn(),
+      sectionsOverrides: [
+        {
+          walletId: WALLET_ID,
+          showsAddAccountFooter: true,
+        },
+      ],
+    });
 
-    // Act + Assert — the connector supplies `onAddAccount` / `onAddWallet`,
-    // so the entropy section's add-account footer and the add-wallet CTA
-    // render. Wallet-level remove stays unwired (design-TBD / no controller
-    // support), so the section header Remove control is absent.
     expect(
       getByTestId(getManageAccountAddAccountFooterId(WALLET_NAME)),
     ).toBeOnTheScreen();
@@ -219,49 +187,36 @@ describeForPlatforms('ManageAccountsView', () => {
   });
 
   it('renders the add-wallet CTA and fires the injected handler on press', () => {
-    // Arrange
     const fixture = buildMultichainAccountsFixture();
     const onAddWallet = jest.fn();
-    const { getByTestId } = renderComponentViewScreen(
-      makeViewHarness({ fixture, onAddWallet }),
-      { name: Routes.MANAGE_ACCOUNTS_VIEW },
-      { state: fixture.state },
-    );
+    const { getByTestId } = renderManageAccountsView({ fixture, onAddWallet });
 
-    // Act
     const addWalletButton = getByTestId(
       ManageAccountsViewSelectorsIDs.ADD_WALLET_BUTTON,
     );
     fireEvent.press(addWalletButton);
 
-    // Assert
     expect(addWalletButton).toBeOnTheScreen();
     expect(onAddWallet).toHaveBeenCalledTimes(1);
   });
 
   it('renders the add-account footer and section-header remove only when injected per section', () => {
-    // Arrange
     const fixture = buildMultichainAccountsFixture();
     const onRemoveWallet = jest.fn();
     const onAddAccount = jest.fn();
-    const { getByTestId } = renderComponentViewScreen(
-      makeViewHarness({
-        fixture,
-        onAddAccount,
-        sectionsOverrides: [
-          {
-            walletId: WALLET_ID,
-            isLocked: true,
-            onRemoveWallet,
-            showsAddAccountFooter: true,
-          },
-        ],
-      }),
-      { name: Routes.MANAGE_ACCOUNTS_VIEW },
-      { state: fixture.state },
-    );
+    const { getByTestId } = renderManageAccountsView({
+      fixture,
+      onAddAccount,
+      sectionsOverrides: [
+        {
+          walletId: WALLET_ID,
+          isLocked: true,
+          onRemoveWallet,
+          showsAddAccountFooter: true,
+        },
+      ],
+    });
 
-    // Act
     const addAccountFooter = getByTestId(
       getManageAccountAddAccountFooterId(WALLET_NAME),
     );
@@ -270,54 +225,41 @@ describeForPlatforms('ManageAccountsView', () => {
     );
     fireEvent.press(removeHeaderControl);
 
-    // Assert — the header Remove fires the section callback; the reused
-    // footer's "Add account" entry is present for this wallet section.
     expect(addAccountFooter).toBeOnTheScreen();
     expect(onRemoveWallet).toHaveBeenCalledTimes(1);
   });
 
   it('renders eye-only and minus-only rows per the injected trailing variants', () => {
-    // Arrange — hide-eligibility matrix at view level: entropy row gets the
-    // eye only; an imported row gets the minus only (wiring lane maps types
-    // to variants — the fixture's second group stands in for an imported one).
     const fixture = buildMultichainAccountsFixture();
     const onRemoveAccount = jest.fn();
     const onToggleHidden = jest.fn();
-    const { getByTestId, queryByTestId } = renderComponentViewScreen(
-      makeViewHarness({
-        fixture,
-        onToggleHidden,
-        onRemoveAccount,
-        sectionsOverrides: [
-          {
-            rowVariantByGroupId: {
-              [ACCOUNT_1_GROUP_ID]: ManageAccountRowVariant.Hide,
-              [ACCOUNT_2_GROUP_ID]: ManageAccountRowVariant.Remove,
-            },
+    const { getByTestId, queryByTestId } = renderManageAccountsView({
+      fixture,
+      onToggleHidden,
+      onRemoveAccount,
+      sectionsOverrides: [
+        {
+          rowVariantByGroupId: {
+            [ACCOUNT_1_GROUP_ID]: ManageAccountRowVariant.Hide,
+            [ACCOUNT_2_GROUP_ID]: ManageAccountRowVariant.Remove,
           },
-        ],
-      }),
-      { name: Routes.MANAGE_ACCOUNTS_VIEW },
-      { state: fixture.state },
-    );
+        },
+      ],
+    });
 
-    // Act — eye-only row: eye present and firing; no minus.
     fireEvent.press(
       getByTestId(getManageAccountRowEyeToggleId(ACCOUNT_1_GROUP_ID)),
     );
 
-    // Assert
     expect(
       queryByTestId(getManageAccountRowRemoveId(ACCOUNT_1_GROUP_ID)),
     ).toBeNull();
     expect(onToggleHidden).toHaveBeenCalledWith(ACCOUNT_1_GROUP_ID, true);
 
-    // Act — minus-only row: minus present and firing; no eye.
     fireEvent.press(
       getByTestId(getManageAccountRowRemoveId(ACCOUNT_2_GROUP_ID)),
     );
 
-    // Assert
     expect(
       queryByTestId(getManageAccountRowEyeToggleId(ACCOUNT_2_GROUP_ID)),
     ).toBeNull();

--- a/app/components/Views/ManageAccounts/ManageAccountsView.view.test.tsx
+++ b/app/components/Views/ManageAccounts/ManageAccountsView.view.test.tsx
@@ -17,6 +17,7 @@ import { ManageAccountRowVariant } from './components/ManageAccountRow';
 import {
   ManageAccountsViewSelectorsIDs,
   getManageAccountRowId,
+  getManageAccountRowCellId,
   getManageAccountRowEyeToggleId,
   getManageAccountRowRemoveId,
   getManageAccountSectionHeaderId,
@@ -160,13 +161,16 @@ describeForPlatforms('ManageAccountsView', () => {
   it('renders a hidden group in the eye-slash state and unhides it on eye press', () => {
     const fixture = buildMultichainAccountsFixture();
     const onToggleHidden = jest.fn();
-    const { getByTestId, UNSAFE_getByProps } = renderManageAccountsView({
+    const { getByTestId } = renderManageAccountsView({
       fixture,
       onToggleHidden,
       isHiddenByGroupId: { [ACCOUNT_2_GROUP_ID]: true },
     });
-    // Cell content is excluded from the a11y tree when hidden
-    // (accessibilityElementsHidden + no-hide-descendants on the cell wrapper).
+    const hiddenRow = getByTestId(getManageAccountRowId(ACCOUNT_2_GROUP_ID));
+    const hiddenCell = getByTestId(
+      getManageAccountRowCellId(ACCOUNT_2_GROUP_ID),
+      { includeHiddenElements: true },
+    );
     const hiddenEye = getByTestId(
       getManageAccountRowEyeToggleId(ACCOUNT_2_GROUP_ID),
     );
@@ -174,14 +178,15 @@ describeForPlatforms('ManageAccountsView', () => {
     expect(hiddenEye.props.accessibilityLabel).toBe(
       strings('multichain_accounts.account_details.unhide_account'),
     );
-    expect(
-      UNSAFE_getByProps({ accessibilityElementsHidden: true }),
-    ).toBeTruthy();
+    expect(hiddenRow).toBeOnTheScreen();
+    expect(hiddenCell).toBeOnTheScreen();
+    expect(hiddenCell.props.accessibilityElementsHidden).toBe(true);
+    expect(hiddenCell.props.importantForAccessibility).toBe(
+      'no-hide-descendants',
+    );
     fireEvent.press(hiddenEye);
 
-    expect(
-      getByTestId(getManageAccountRowId(ACCOUNT_2_GROUP_ID)),
-    ).toBeOnTheScreen();
+    expect(hiddenRow).toBeOnTheScreen();
     expect(onToggleHidden).toHaveBeenCalledTimes(1);
     expect(onToggleHidden).toHaveBeenCalledWith(ACCOUNT_2_GROUP_ID, false);
   });

--- a/app/components/Views/ManageAccounts/ManageAccountsView.view.test.tsx
+++ b/app/components/Views/ManageAccounts/ManageAccountsView.view.test.tsx
@@ -1,12 +1,15 @@
 import '../../../../tests/component-view/mocks';
 import React from 'react';
-import { fireEvent } from '@testing-library/react-native';
+import { InteractionManager } from 'react-native';
+import { fireEvent, waitFor } from '@testing-library/react-native';
 import { describeForPlatforms } from '../../../../tests/component-view/platform';
 import { renderComponentViewScreen } from '../../../../tests/component-view/render';
 import {
   buildMultichainAccountsFixture,
   type MultichainAccountsFixture,
 } from '../../../../tests/component-view/presets/multichainAccounts';
+import { strings } from '../../../../locales/i18n';
+import Engine from '../../../core/Engine';
 import ManageAccountsView, {
   type ManageAccountsSection,
 } from './ManageAccountsView';
@@ -20,6 +23,13 @@ import {
   getManageAccountSectionHeaderRemoveId,
   getManageAccountAddAccountFooterId,
 } from './ManageAccounts.testIds';
+
+interface ImmediateInteractionManager {
+  runAfterInteractions: (callback: () => void) => { cancel: () => void };
+}
+
+const immediateInteractionManager =
+  InteractionManager as unknown as ImmediateInteractionManager;
 
 const ACCOUNT_1_GROUP_ID = 'entropy:wallet1/0';
 const ACCOUNT_2_GROUP_ID = 'entropy:wallet1/1';
@@ -80,22 +90,45 @@ const makeViewHarness =
     );
   };
 
-const renderManageAccountsView = (options: ViewHarnessOptions) =>
-  renderComponentViewScreen(
+const syncEngineAccounts = (fixture: MultichainAccountsFixture) => {
+  const accountsController = Engine.context.AccountsController;
+  const selectedAccount = Object.keys(fixture.internalAccounts)[0] ?? '';
+  accountsController.state.internalAccounts = {
+    accounts: fixture.internalAccounts,
+    selectedAccount,
+  };
+};
+
+const renderManageAccountsView = (options: ViewHarnessOptions) => {
+  syncEngineAccounts(options.fixture);
+  return renderComponentViewScreen(
     makeViewHarness(options),
     { name: MANAGE_ACCOUNTS_VIEW_ROUTE },
     { state: options.fixture.state },
   );
+};
 
 describeForPlatforms('ManageAccountsView', () => {
+  let runAfterInteractionsSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    runAfterInteractionsSpy = jest
+      .spyOn(immediateInteractionManager, 'runAfterInteractions')
+      .mockImplementation((callback: () => void) => {
+        callback();
+        return { cancel: jest.fn() };
+      });
+  });
+
+  afterEach(() => {
+    runAfterInteractionsSpy.mockRestore();
   });
 
   it('renders wallet sections, section headers and account rows, and hides a visible group on eye press', () => {
     const fixture = buildMultichainAccountsFixture();
     const onToggleHidden = jest.fn();
-    const { getByTestId } = renderManageAccountsView({
+    const { getByTestId, getByText } = renderManageAccountsView({
       fixture,
       onToggleHidden,
     });
@@ -106,9 +139,14 @@ describeForPlatforms('ManageAccountsView', () => {
     const eye1 = getByTestId(
       getManageAccountRowEyeToggleId(ACCOUNT_1_GROUP_ID),
     );
-    expect(eye1.props.accessibilityLabel).toBe('Hide account');
+    expect(eye1.props.accessibilityLabel).toBe(
+      strings('multichain_accounts.account_details.hide_account'),
+    );
     fireEvent.press(eye1);
 
+    expect(
+      getByText(strings('multichain_accounts.manage_accounts.title')),
+    ).toBeOnTheScreen();
     expect(header).toBeOnTheScreen();
     expect(row1).toBeOnTheScreen();
     expect(row2).toBeOnTheScreen();
@@ -133,7 +171,9 @@ describeForPlatforms('ManageAccountsView', () => {
       getManageAccountRowEyeToggleId(ACCOUNT_2_GROUP_ID),
     );
 
-    expect(hiddenEye.props.accessibilityLabel).toBe('Unhide account');
+    expect(hiddenEye.props.accessibilityLabel).toBe(
+      strings('multichain_accounts.account_details.unhide_account'),
+    );
     expect(
       UNSAFE_getByProps({ accessibilityElementsHidden: true }),
     ).toBeTruthy();
@@ -161,12 +201,14 @@ describeForPlatforms('ManageAccountsView', () => {
     expect(onBack).toHaveBeenCalledTimes(1);
   });
 
-  it('renders add-account footer and add-wallet CTA when handlers are injected, without header remove', () => {
+  it('creates an account from the footer and fires add-wallet without showing header remove', async () => {
     const fixture = buildMultichainAccountsFixture();
-    const { queryByTestId, getByTestId } = renderManageAccountsView({
+    const onAddAccount = jest.fn();
+    const onAddWallet = jest.fn();
+    const { queryByTestId, getByTestId, getByText } = renderManageAccountsView({
       fixture,
-      onAddAccount: jest.fn(),
-      onAddWallet: jest.fn(),
+      onAddAccount,
+      onAddWallet,
       sectionsOverrides: [
         {
           walletId: WALLET_ID,
@@ -175,11 +217,25 @@ describeForPlatforms('ManageAccountsView', () => {
       ],
     });
 
+    fireEvent.press(
+      getByText(strings('multichain_accounts.wallet_details.create_account')),
+    );
+    fireEvent.press(
+      getByTestId(ManageAccountsViewSelectorsIDs.ADD_WALLET_BUTTON),
+    );
+
+    await waitFor(() => {
+      expect(
+        Engine.context.MultichainAccountService
+          .createNextMultichainAccountGroup,
+      ).toHaveBeenCalledWith({
+        entropySource: 'entropy-source-1',
+      });
+      expect(onAddAccount).toHaveBeenCalledWith(WALLET_NAME);
+    });
+    expect(onAddWallet).toHaveBeenCalledTimes(1);
     expect(
       getByTestId(getManageAccountAddAccountFooterId(WALLET_NAME)),
-    ).toBeOnTheScreen();
-    expect(
-      getByTestId(ManageAccountsViewSelectorsIDs.ADD_WALLET_BUTTON),
     ).toBeOnTheScreen();
     expect(
       queryByTestId(getManageAccountSectionHeaderRemoveId(WALLET_NAME)),
@@ -204,7 +260,7 @@ describeForPlatforms('ManageAccountsView', () => {
     const fixture = buildMultichainAccountsFixture();
     const onRemoveWallet = jest.fn();
     const onAddAccount = jest.fn();
-    const { getByTestId } = renderManageAccountsView({
+    const { getByTestId, getByText } = renderManageAccountsView({
       fixture,
       onAddAccount,
       sectionsOverrides: [
@@ -222,6 +278,15 @@ describeForPlatforms('ManageAccountsView', () => {
     );
     const removeHeaderControl = getByTestId(
       getManageAccountSectionHeaderRemoveId(WALLET_NAME),
+    );
+    expect(
+      getByText(strings('multichain_accounts.manage_accounts.locked')),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('multichain_accounts.manage_accounts.remove')),
+    ).toBeOnTheScreen();
+    expect(removeHeaderControl.props.accessibilityLabel).toBe(
+      strings('multichain_accounts.manage_accounts.remove_wallet'),
     );
     fireEvent.press(removeHeaderControl);
 

--- a/app/components/Views/ManageAccounts/components/ManageAccountRow.test.tsx
+++ b/app/components/Views/ManageAccounts/components/ManageAccountRow.test.tsx
@@ -12,6 +12,7 @@ import {
   createMockState,
   createMockWallet,
 } from '../../../../component-library/components-temp/MultichainAccounts/test-utils';
+import { strings } from '../../../../../locales/i18n';
 import ManageAccountRow, { ManageAccountRowVariant } from './ManageAccountRow';
 import {
   getManageAccountRowId,
@@ -87,7 +88,9 @@ describe('ManageAccountRow', () => {
       const eyeToggle = getByTestId(getManageAccountRowEyeToggleId(GROUP_ID));
 
       expect(eyeToggle).toBeEnabled();
-      expect(eyeToggle.props.accessibilityLabel).toBe('Hide account');
+      expect(eyeToggle.props.accessibilityLabel).toBe(
+        strings('multichain_accounts.account_details.hide_account'),
+      );
       expect(eyeToggle.props.accessibilityRole).toBe('button');
     });
 
@@ -117,7 +120,9 @@ describe('ManageAccountRow', () => {
 
       const eyeIcon = utils.getByTestId(getManageAccountRowEyeIconId(GROUP_ID));
 
-      expect(eyeToggle.props.accessibilityLabel).toBe('Unhide account');
+      expect(eyeToggle.props.accessibilityLabel).toBe(
+        strings('multichain_accounts.account_details.unhide_account'),
+      );
       expect(eyeIcon).toBeOnTheScreen();
       expect(eyeIcon.props.name).toBe(IconName.EyeSlash);
     });
@@ -212,7 +217,9 @@ describe('ManageAccountRow', () => {
         getManageAccountRowRemoveIconId(GROUP_ID),
       );
 
-      expect(removeControl.props.accessibilityLabel).toBe('Remove account');
+      expect(removeControl.props.accessibilityLabel).toBe(
+        strings('multichain_accounts.account_details.remove_account'),
+      );
       expect(removeControl.props.accessibilityRole).toBe('button');
       expect(removeControl).toBeEnabled();
       expect(removeIcon).toBeOnTheScreen();
@@ -267,7 +274,7 @@ describe('ManageAccountRow', () => {
       expect(
         utils.getByTestId(getManageAccountRowEyeToggleId(GROUP_ID)).props
           .accessibilityLabel,
-      ).toBe('Hide account');
+      ).toBe(strings('multichain_accounts.account_details.hide_account'));
       expect(
         utils.getByTestId(getManageAccountRowRemoveId(GROUP_ID)),
       ).toBeOnTheScreen();

--- a/app/components/Views/ManageAccounts/components/ManageAccountRow.tsx
+++ b/app/components/Views/ManageAccounts/components/ManageAccountRow.tsx
@@ -24,12 +24,11 @@ import {
 } from '../ManageAccounts.testIds';
 
 /**
- * Trailing action variant, decided by the view layer per row (type → variant
- * mapping is the wiring lane's job):
- * - `hide` — eye / eye-slash toggle (entropy & HD account rows only).
- * - `remove` — error-colored minus control (hardware & imported rows).
- * - `hideAndRemove` — both controls (hardware rows).
- * - `none` — no trailing action (snap rows).
+ * Trailing action variant for a row:
+ * - `hide` — eye / eye-slash toggle.
+ * - `remove` — minus control.
+ * - `hideAndRemove` — both controls.
+ * - `none` — no trailing action.
  */
 export enum ManageAccountRowVariant {
   Hide = 'hide',

--- a/app/components/Views/ManageAccounts/components/ManageAccountRow.tsx
+++ b/app/components/Views/ManageAccounts/components/ManageAccountRow.tsx
@@ -17,6 +17,7 @@ import type { AccountAvatarVariant } from '../../../../component-library/compone
 import { strings } from '../../../../../locales/i18n';
 import {
   getManageAccountRowId,
+  getManageAccountRowCellId,
   getManageAccountRowEyeToggleId,
   getManageAccountRowEyeIconId,
   getManageAccountRowRemoveId,
@@ -103,6 +104,7 @@ const ManageAccountRow = ({
         pointerEvents={isHidden ? 'none' : 'auto'}
         accessibilityElementsHidden={isHidden}
         importantForAccessibility={isHidden ? 'no-hide-descendants' : 'auto'}
+        testID={getManageAccountRowCellId(accountGroup.id)}
       >
         <AccountCell
           accountGroup={accountGroup}

--- a/app/components/Views/ManageAccounts/components/ManageWalletSectionHeader.tsx
+++ b/app/components/Views/ManageAccounts/components/ManageWalletSectionHeader.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+
+import { strings } from '../../../../../locales/i18n';
+import {
+  getManageAccountSectionHeaderId,
+  getManageAccountSectionHeaderRemoveId,
+} from '../ManageAccounts.testIds';
+
+export interface ManageWalletSectionHeaderProps {
+  /** Wallet display name rendered as the section title. */
+  walletName: string;
+  /** When true, shows a Locked label and lock icon. */
+  isLocked?: boolean;
+  /** When provided, shows a Remove control. */
+  onRemove?: () => void;
+}
+
+/** Wallet section header for the Manage Accounts screen. */
+const ManageWalletSectionHeader = ({
+  walletName,
+  isLocked = false,
+  onRemove,
+}: ManageWalletSectionHeaderProps) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    twClassName="px-4 py-2"
+    testID={getManageAccountSectionHeaderId(walletName)}
+  >
+    <Text
+      variant={TextVariant.BodyMd}
+      color={TextColor.TextAlternative}
+      fontWeight={FontWeight.Medium}
+      twClassName="flex-1"
+    >
+      {walletName}
+    </Text>
+    {isLocked ? (
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        twClassName="ml-3"
+      >
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          testID={`${getManageAccountSectionHeaderId(walletName)}-lock-label`}
+        >
+          {strings('multichain_accounts.manage_accounts.locked')}
+        </Text>
+        <Icon
+          name={IconName.Lock}
+          size={IconSize.Sm}
+          color={IconColor.IconAlternative}
+          twClassName="ml-1"
+        />
+      </Box>
+    ) : null}
+    {onRemove ? (
+      <Text
+        variant={TextVariant.BodyMd}
+        color={TextColor.ErrorDefault}
+        fontWeight={FontWeight.Medium}
+        onPress={onRemove}
+        accessibilityRole="button"
+        accessibilityLabel={strings(
+          'multichain_accounts.manage_accounts.remove_wallet',
+        )}
+        testID={getManageAccountSectionHeaderRemoveId(walletName)}
+        twClassName="ml-3"
+      >
+        {strings('multichain_accounts.manage_accounts.remove')}
+      </Text>
+    ) : null}
+  </Box>
+);
+
+export default ManageWalletSectionHeader;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9480,6 +9480,11 @@
       "search_placeholder": "Search networks",
       "no_networks_found": "No networks found",
       "no_networks_available": "No networks available"
+    },
+    "manage_accounts": {
+      "locked": "Locked",
+      "remove": "Remove",
+      "remove_wallet": "Remove wallet"
     }
   },
   "deep_link_modal": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9482,6 +9482,7 @@
       "no_networks_available": "No networks available"
     },
     "manage_accounts": {
+      "title": "Manage accounts",
       "locked": "Locked",
       "remove": "Remove",
       "remove_wallet": "Remove wallet"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Adds the presentational `ManageAccountsView` screen shell and supporting `ManageWalletSectionHeader` component as part of the Multichain Accounts Manage Accounts screen.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-2178

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

Not wired at the momeny. 


## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A (New presentational component)

### **After**

N/A (Presentational component not yet wired to a route; verified via component view tests in `ManageAccountsView.view.test.tsx`)

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only, prop-driven view with no navigation or state wiring; account actions are delegated to injected callbacks and covered by tests.
> 
> **Overview**
> Introduces a **presentational** `ManageAccountsView` for multichain **Manage accounts**: header with back, scrollable wallet sections, optional **Add wallet** CTA, and callbacks for hide/unhide, remove account, add account, and add wallet. The screen is **not routed yet**; behavior is covered by component-view tests.
> 
> Each section uses new **`ManageWalletSectionHeader`** (wallet name, optional **Locked** label, optional **Remove wallet**) and existing **`ManageAccountRow`** rows with per-group trailing variants (hide vs remove). Sections can optionally show **`AccountListFooter`** for create-account when `walletId` and handlers are provided.
> 
> Supporting tweaks: **`getManageAccountRowCellId`** on the account-cell wrapper (for hidden-row a11y tests), **`ManageAccountRow`** unit tests aligned with i18n strings, and **`multichain_accounts.manage_accounts`** copy in `en.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06ebea96209bda4f0950046fe743436c0caa50e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->