### PR TITLE
perf(predict): skip chart history for homepage BTC live price

### DIFF
--- a/app/components/UI/Predict/hooks/useCurrentCryptoUpDownMarketData.test.ts
+++ b/app/components/UI/Predict/hooks/useCurrentCryptoUpDownMarketData.test.ts
@@ -3,6 +3,7 @@ import { useCurrentCryptoUpDownMarketData } from './useCurrentCryptoUpDownMarket
 import { useCurrentPredictMarketFromSeries } from './useCurrentPredictMarketFromSeries';
 import { useCryptoTargetPrice } from './useCryptoTargetPrice';
 import { useCryptoUpDownChartData } from './useCryptoUpDownChartData';
+import { useLiveCryptoPrice } from './useLiveCryptoPrice';
 import { Recurrence, type PredictMarket, type PredictSeries } from '../types';
 
 jest.mock('./useCurrentPredictMarketFromSeries', () => ({
@@ -17,10 +18,15 @@ jest.mock('./useCryptoUpDownChartData', () => ({
   useCryptoUpDownChartData: jest.fn(),
 }));
 
+jest.mock('./useLiveCryptoPrice', () => ({
+  useLiveCryptoPrice: jest.fn(),
+}));
+
 const mockUseCurrentPredictMarketFromSeries =
   useCurrentPredictMarketFromSeries as jest.Mock;
 const mockUseCryptoTargetPrice = useCryptoTargetPrice as jest.Mock;
 const mockUseCryptoUpDownChartData = useCryptoUpDownChartData as jest.Mock;
+const mockUseLiveCryptoPrice = useLiveCryptoPrice as jest.Mock;
 
 const SERIES: PredictSeries = {
   id: 'btc-series',
@@ -70,6 +76,7 @@ describe('useCurrentCryptoUpDownMarketData', () => {
       isLive: true,
       window: 300,
     });
+    mockUseLiveCryptoPrice.mockReturnValue({ value: undefined });
   });
 
   afterEach(() => {
@@ -219,5 +226,72 @@ describe('useCurrentCryptoUpDownMarketData', () => {
       undefined,
       { enabled: false },
     );
+  });
+
+  describe('withChartData: false', () => {
+    it('sources currentPrice from useLiveCryptoPrice instead of the chart data', () => {
+      mockUseLiveCryptoPrice.mockReturnValue({ value: 93042 });
+
+      const { result } = renderHook(() =>
+        useCurrentCryptoUpDownMarketData({
+          series: SERIES,
+          withChartData: false,
+        }),
+      );
+
+      expect(mockUseLiveCryptoPrice).toHaveBeenCalledWith({
+        symbol: 'BTC',
+        enabled: true,
+        twapWindowSeconds: undefined,
+        updateIntervalMs: undefined,
+      });
+      expect(result.current.currentPrice).toBe(93042);
+    });
+
+    it('disables the chart data hook so it never builds a point-history array', () => {
+      renderHook(() =>
+        useCurrentCryptoUpDownMarketData({
+          series: SERIES,
+          withChartData: false,
+        }),
+      );
+
+      expect(mockUseCryptoUpDownChartData).toHaveBeenCalledWith(MARKET, 93000, {
+        enabled: false,
+      });
+    });
+
+    it('does not factor chart loading state into isLoading', () => {
+      mockUseCryptoUpDownChartData.mockReturnValue({
+        data: [],
+        value: 0,
+        loading: true,
+        isLive: true,
+        window: 300,
+      });
+
+      const { result } = renderHook(() =>
+        useCurrentCryptoUpDownMarketData({
+          series: SERIES,
+          withChartData: false,
+        }),
+      );
+
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('forwards a custom price update interval to useLiveCryptoPrice', () => {
+      renderHook(() =>
+        useCurrentCryptoUpDownMarketData({
+          series: SERIES,
+          withChartData: false,
+          priceUpdateIntervalMs: 2000,
+        }),
+      );
+
+      expect(mockUseLiveCryptoPrice).toHaveBeenCalledWith(
+        expect.objectContaining({ updateIntervalMs: 2000 }),
+      );
+    });
   });
 });

--- a/app/components/UI/Predict/hooks/useCurrentCryptoUpDownMarketData.ts
+++ b/app/components/UI/Predict/hooks/useCurrentCryptoUpDownMarketData.ts
@@ -16,6 +16,7 @@ import {
 } from '../utils/series';
 import { useCryptoTargetPrice } from './useCryptoTargetPrice';
 import { useCryptoUpDownChartData } from './useCryptoUpDownChartData';
+import { useLiveCryptoPrice } from './useLiveCryptoPrice';
 import {
   useCurrentPredictMarketFromSeries,
   type UseCurrentPredictMarketFromSeriesParams,
@@ -45,11 +46,24 @@ const FALLBACK_MARKET: PredictMarketWithSeries = {
   series: FALLBACK_SERIES,
 };
 
-export type UseCurrentCryptoUpDownMarketDataParams =
-  UseCurrentPredictMarketFromSeriesParams;
+export interface UseCurrentCryptoUpDownMarketDataParams
+  extends UseCurrentPredictMarketFromSeriesParams {
+  /**
+   * Set to `false` for UI that only displays the current price as a scalar
+   * (e.g. the homepage BTC row) and never renders a chart. Skips
+   * `useCryptoUpDownChartData`'s point-history array (merge/trim/reduce on
+   * every live tick) in favor of a plain throttled price ticker. Defaults to
+   * `true` for callers that render a chart.
+   */
+  withChartData?: boolean;
+  /** Live price refresh cadence when `withChartData` is `false`. */
+  priceUpdateIntervalMs?: number;
+}
 
 export const useCurrentCryptoUpDownMarketData = ({
   enabled = true,
+  withChartData = true,
+  priceUpdateIntervalMs,
   ...seriesParams
 }: UseCurrentCryptoUpDownMarketDataParams) => {
   const currentMarketQuery = useCurrentPredictMarketFromSeries({
@@ -100,9 +114,15 @@ export const useCurrentCryptoUpDownMarketData = ({
     ? resolveCryptoTargetPrice(market, targetPrice)
     : undefined;
   const chartData = useCryptoUpDownChartData(market, priceToBeat, {
-    enabled: shouldFetchMarketData,
+    enabled: shouldFetchMarketData && withChartData,
   });
-  const currentPrice = useMemo(() => {
+  const { value: liveTickerPrice } = useLiveCryptoPrice({
+    symbol,
+    enabled: shouldFetchMarketData && !withChartData,
+    twapWindowSeconds: market.twapWindowSeconds,
+    updateIntervalMs: priceUpdateIntervalMs,
+  });
+  const chartDerivedPrice = useMemo(() => {
     if (
       market.twapWindowSeconds &&
       (chartData.connectionError ||
@@ -122,6 +142,7 @@ export const useCurrentCryptoUpDownMarketData = ({
     chartData.value,
     market.twapWindowSeconds,
   ]);
+  const currentPrice = withChartData ? chartDerivedPrice : liveTickerPrice;
   const durationMs = getSeriesDurationMs(market.series.recurrence);
   const timeRemainingMs = getSeriesMarketTimeRemainingMs(market.endDate, nowMs);
 
@@ -143,7 +164,9 @@ export const useCurrentCryptoUpDownMarketData = ({
     chartData,
     isLoading:
       currentMarketQuery.isLoading ||
-      (shouldFetchMarketData && (chartData.loading || isTargetPriceFetching)),
+      (shouldFetchMarketData &&
+        withChartData &&
+        (chartData.loading || isTargetPriceFetching)),
     isFetching: currentMarketQuery.isFetching || isTargetPriceFetching,
   };
 };

--- a/app/components/UI/Predict/hooks/useLiveCryptoPrice.test.ts
+++ b/app/components/UI/Predict/hooks/useLiveCryptoPrice.test.ts
@@ -1,0 +1,146 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useLiveCryptoPrice } from './useLiveCryptoPrice';
+import Engine from '../../../../core/Engine';
+import { CryptoPriceUpdate } from '../types';
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    PredictController: {
+      subscribeToCryptoPrices: jest.fn(),
+      getConnectionStatus: jest.fn(),
+    },
+  },
+}));
+
+describe('useLiveCryptoPrice', () => {
+  const mockSubscribeToCryptoPrices = Engine.context.PredictController
+    .subscribeToCryptoPrices as jest.Mock;
+  const mockGetConnectionStatus = Engine.context.PredictController
+    .getConnectionStatus as jest.Mock;
+  const mockUnsubscribe = jest.fn();
+  let capturedCallback: (update: CryptoPriceUpdate) => void = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    mockSubscribeToCryptoPrices.mockImplementation((_symbols, callback) => {
+      capturedCallback = callback;
+      return mockUnsubscribe;
+    });
+    mockGetConnectionStatus.mockReturnValue({
+      rtdsConnected: true,
+      sportsConnected: false,
+      marketConnected: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const sendUpdate = (price: number, timestamp = Date.now()) => {
+    act(() => {
+      capturedCallback({ symbol: 'btc/usd', price, timestamp });
+    });
+  };
+
+  it('subscribes to the lowercased ws symbol when enabled', () => {
+    renderHook(() => useLiveCryptoPrice({ symbol: 'BTC', enabled: true }));
+
+    expect(mockSubscribeToCryptoPrices).toHaveBeenCalledWith(
+      ['btc/usd'],
+      expect.any(Function),
+      { twapWindowSeconds: undefined },
+    );
+  });
+
+  it('does not subscribe when disabled', () => {
+    renderHook(() => useLiveCryptoPrice({ symbol: 'BTC', enabled: false }));
+
+    expect(mockSubscribeToCryptoPrices).not.toHaveBeenCalled();
+  });
+
+  it('does not subscribe when symbol is undefined', () => {
+    renderHook(() => useLiveCryptoPrice({ symbol: undefined }));
+
+    expect(mockSubscribeToCryptoPrices).not.toHaveBeenCalled();
+  });
+
+  it('commits the first update immediately', () => {
+    const { result } = renderHook(() => useLiveCryptoPrice({ symbol: 'BTC' }));
+
+    expect(result.current.value).toBeUndefined();
+
+    sendUpdate(93000);
+
+    expect(result.current.value).toBe(93000);
+  });
+
+  it('coalesces rapid ticks to at most one commit per updateIntervalMs', () => {
+    const { result } = renderHook(() =>
+      useLiveCryptoPrice({ symbol: 'BTC', updateIntervalMs: 1000 }),
+    );
+
+    sendUpdate(93000);
+    expect(result.current.value).toBe(93000);
+
+    // Several ticks arrive within the same 1s window — none should commit
+    // synchronously since the first tick just committed.
+    sendUpdate(93010);
+    sendUpdate(93020);
+    sendUpdate(93030);
+    expect(result.current.value).toBe(93000);
+
+    // The trailing update fires once the interval elapses, applying the
+    // latest pending price rather than every intermediate one.
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.value).toBe(93030);
+  });
+
+  it('commits immediately again once updateIntervalMs has elapsed', () => {
+    const { result } = renderHook(() =>
+      useLiveCryptoPrice({ symbol: 'BTC', updateIntervalMs: 1000 }),
+    );
+
+    sendUpdate(93000);
+    expect(result.current.value).toBe(93000);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    sendUpdate(93100);
+    expect(result.current.value).toBe(93100);
+  });
+
+  it('does not build or expose any point-history array', () => {
+    const { result } = renderHook(() => useLiveCryptoPrice({ symbol: 'BTC' }));
+
+    sendUpdate(93000);
+
+    expect(result.current).toEqual({ value: 93000 });
+  });
+
+  it('unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => useLiveCryptoPrice({ symbol: 'BTC' }));
+
+    unmount();
+
+    expect(mockUnsubscribe).toHaveBeenCalled();
+  });
+
+  it('passes the twap window through to the subscription', () => {
+    renderHook(() =>
+      useLiveCryptoPrice({ symbol: 'BTC', twapWindowSeconds: 30 }),
+    );
+
+    expect(mockSubscribeToCryptoPrices).toHaveBeenCalledWith(
+      ['btc/usd'],
+      expect.any(Function),
+      { twapWindowSeconds: 30 },
+    );
+  });
+});

--- a/app/components/UI/Predict/hooks/useLiveCryptoPrice.ts
+++ b/app/components/UI/Predict/hooks/useLiveCryptoPrice.ts
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useLiveCryptoPrices } from './useLiveCryptoPrices';
+import type { CryptoPriceUpdate, CryptoTwapWindowSeconds } from '../types';
+
+const DEFAULT_UPDATE_INTERVAL_MS = 1000;
+
+export interface UseLiveCryptoPriceParams {
+  symbol: string | undefined;
+  enabled?: boolean;
+  twapWindowSeconds?: CryptoTwapWindowSeconds;
+  /**
+   * Minimum time between committed price updates. Defaults to once per
+   * second — plenty for a summary label that isn't rendering a chart.
+   */
+  updateIntervalMs?: number;
+}
+
+export interface UseLiveCryptoPriceResult {
+  value: number | undefined;
+}
+
+/**
+ * Minimal live-price ticker: subscribes to the crypto price websocket feed
+ * for `symbol` and exposes only the latest price, committed at most once
+ * every `updateIntervalMs`.
+ *
+ * Unlike `useCryptoUpDownChartData`, this does **not** build or maintain a
+ * point-history array (no per-tick merge/trim/reduce), so it's much cheaper
+ * for summary UI — e.g. the homepage BTC row — that only ever displays the
+ * latest scalar price and never renders a chart.
+ */
+export const useLiveCryptoPrice = ({
+  symbol,
+  enabled = true,
+  twapWindowSeconds,
+  updateIntervalMs = DEFAULT_UPDATE_INTERVAL_MS,
+}: UseLiveCryptoPriceParams): UseLiveCryptoPriceResult => {
+  const [value, setValue] = useState<number | undefined>(undefined);
+  const lastCommitAtRef = useRef<number | undefined>(undefined);
+  const pendingPriceRef = useRef<number | undefined>(undefined);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const commit = useCallback((price: number) => {
+    lastCommitAtRef.current = Date.now();
+    pendingPriceRef.current = undefined;
+    setValue(price);
+  }, []);
+
+  const handleUpdate = useCallback(
+    (update: CryptoPriceUpdate) => {
+      pendingPriceRef.current = update.price;
+      const elapsedSinceCommit = lastCommitAtRef.current
+        ? Date.now() - lastCommitAtRef.current
+        : updateIntervalMs;
+
+      if (elapsedSinceCommit >= updateIntervalMs) {
+        if (timerRef.current) {
+          clearTimeout(timerRef.current);
+          timerRef.current = undefined;
+        }
+        commit(update.price);
+        return;
+      }
+
+      // A commit is already scheduled for the remainder of this interval;
+      // the pending price above will be picked up when it fires.
+      if (timerRef.current) return;
+
+      timerRef.current = setTimeout(() => {
+        timerRef.current = undefined;
+        if (typeof pendingPriceRef.current === 'number') {
+          commit(pendingPriceRef.current);
+        }
+      }, updateIntervalMs - elapsedSinceCommit);
+    },
+    [commit, updateIntervalMs],
+  );
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    // Reset pending/commit bookkeeping on symbol changes so a stale timer
+    // from the previous subscription can't commit a price for the new one.
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = undefined;
+    }
+    pendingPriceRef.current = undefined;
+    lastCommitAtRef.current = undefined;
+  }, [symbol, twapWindowSeconds]);
+
+  const wsSymbol = enabled && symbol ? `${symbol.toLowerCase()}/usd` : '';
+  const liveSubscriptionArgs: [
+    string,
+    typeof handleUpdate,
+    twapWindowSeconds?: typeof twapWindowSeconds,
+  ] =
+    twapWindowSeconds !== undefined
+      ? [wsSymbol, handleUpdate, twapWindowSeconds]
+      : [wsSymbol, handleUpdate];
+  useLiveCryptoPrices(...liveSubscriptionArgs);
+
+  return { value };
+};

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictDiscovery/BtcLiveRow.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictDiscovery/BtcLiveRow.tsx
@@ -102,6 +102,7 @@ const BtcLiveValues = forwardRef<BtcLiveValuesHandle>((_props, ref) => {
     useCurrentCryptoUpDownMarketData({
       series: HOMEPAGE_PREDICT_SERIES_SLOT.series,
       enabled: isPredictEnabled && isFocused,
+      withChartData: false,
     });
 
   useImperativeHandle(ref, () => ({ marketId, market }), [market, marketId]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The homepage BTC live row only shows the current price, price to beat, and a countdown. It was still going through `useCryptoUpDownChartData`, which keeps a live point-history array (merge/trim/reduce) even though this UI never renders a chart.

This PR adds a small `useLiveCryptoPrice` hook that just tracks the latest scalar price (throttled to about once a second), and a `withChartData` flag on the existing market-data hook. The homepage row now sets `withChartData: false`. Chart screens keep the old path.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3950

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Homepage BTC live row

  Scenario: user sees live BTC price on the wallet homepage
    Given I am logged into MetaMask Mobile
    And Predict is enabled
    And I am on the Wallet homepage

    When I look at the Predictions discovery BTC row
    Then I should see a current BTC price
    And I should see a price to beat
    And the live countdown pill should tick down once per second
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-focused refactor behind a default-preserving flag; homepage display logic changes price source but not auth or data persistence.
> 
> **Overview**
> The homepage BTC predictions row only needs a scalar live price, but it was still running `useCryptoUpDownChartData`, which maintains and updates a full point history on every websocket tick.
> 
> This PR adds **`useLiveCryptoPrice`**, a lightweight hook that subscribes to the same feed (via `useLiveCryptoPrices`) and exposes only the latest price, throttled to about once per second. **`useCurrentCryptoUpDownMarketData`** gains optional **`withChartData`** (default `true`) and **`priceUpdateIntervalMs`**. When `withChartData` is `false`, chart fetching is disabled, `currentPrice` comes from the live ticker, and chart loading no longer affects `isLoading`. **`BtcLiveRow`** passes `withChartData: false`. Chart screens keep the existing chart-derived price path. Unit tests cover the new hook and the `withChartData: false` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cb3fda1a614b02d3a41f4db8cab8bf3885b8aad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->