### PR TITLE
test: reverted change in money home performance test

### DIFF
--- a/tests/performance/onboarding/money/money-home-empty.spec.ts
+++ b/tests/performance/onboarding/money/money-home-empty.spec.ts
@@ -35,10 +35,12 @@ perfTest.describe(`${Performance} ${PerformanceMoney}`, () => {
       await timer.measure(async () => {
         await MoneyHomeView.waitForEmptyBalanceLoaded();
         await MoneyHomeView.waitForApyLoaded();
-        await MoneyHomeView.expectOnboardingCardTitleVisible();
-        await MoneyHomeView.expectSendButtonDisabled();
-        await MoneyHomeView.expectEarningsSectionNotVisible();
       });
+      // Don't include regular assertions in measure().
+      // Each assertion carries overhead and can skew the results.
+      await MoneyHomeView.expectOnboardingCardTitleVisible();
+      await MoneyHomeView.expectSendButtonDisabled();
+      await MoneyHomeView.expectEarningsSectionNotVisible();
 
       performanceTracker.addTimers(timer);
     },


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

A prior change moved Money Home empty-state assertions inside `timer.measure()`, which mixes UI assertion overhead into the performance timing window and diverges from the funded Money Home pattern.

This PR restores the intended split:
- Keep data-load waits (`waitForEmptyBalanceLoaded`, `waitForApyLoaded`) inside `timer.measure()`
- Run regular assertions (`expectOnboardingCardTitleVisible`, `expectSendButtonDisabled`, `expectEarningsSectionNotVisible`) after the measure block

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: MMQA-revert-money-performance-test

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — performance Appium test measurement boundary only.

```gherkin
Feature: Money Home empty performance timing

  Scenario: measure only content load waits
    Given the Money Home empty-balance performance suite runs
    When the user taps Money
    Then empty balance and APY load waits run inside timer.measure()
    And onboarding card, disabled send, and hidden earnings asserts run after the measure window
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.