### PR TITLE
fix(rewards): tighten sweepstakes balance and last-checked rows

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
@@ -203,36 +203,38 @@ const MoneyAccountSweepstakesCampaignOverview: React.FC<
           <Text variant={TextVariant.DisplayLg} fontWeight={FontWeight.Bold}>
             {balanceDisplay}
           </Text>
-          <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-1">
-            <Text
-              variant={TextVariant.BodyLg}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.TextDefault}
-            >
-              {entriesDisplay}
-            </Text>
-            <Text
-              variant={TextVariant.BodyLg}
-              color={TextColor.TextAlternative}
-            >
-              · {localizedText.thisWeekLabel}
-            </Text>
+          <Box twClassName="gap-1">
+            <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-1">
+              <Text
+                variant={TextVariant.BodyLg}
+                fontWeight={FontWeight.Medium}
+                color={TextColor.TextDefault}
+              >
+                {entriesDisplay}
+              </Text>
+              <Text
+                variant={TextVariant.BodyLg}
+                color={TextColor.TextAlternative}
+              >
+                · {localizedText.thisWeekLabel}
+              </Text>
+            </Box>
+            {qualificationMessage && (
+              <Text
+                variant={TextVariant.BodySm}
+                color={
+                  isQualified
+                    ? TextColor.SuccessDefault
+                    : isPaused
+                      ? TextColor.WarningDefault
+                      : TextColor.TextAlternative
+                }
+              >
+                {qualificationMessage}
+              </Text>
+            )}
           </Box>
-          {qualificationMessage && (
-            <Text
-              variant={TextVariant.BodySm}
-              color={
-                isQualified
-                  ? TextColor.SuccessDefault
-                  : isPaused
-                    ? TextColor.WarningDefault
-                    : TextColor.TextAlternative
-              }
-            >
-              {qualificationMessage}
-            </Text>
-          )}
-          <Box twClassName="border-t border-border-muted" />
+          <Box twClassName="my-1 border-t border-border-muted" />
           <Box twClassName="gap-1">
             <Box
               alignItems={BoxAlignItems.Center}

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
@@ -233,56 +233,58 @@ const MoneyAccountSweepstakesCampaignOverview: React.FC<
             </Text>
           )}
           <Box twClassName="border-t border-border-muted" />
-          <Box
-            alignItems={BoxAlignItems.Center}
-            flexDirection={BoxFlexDirection.Row}
-            justifyContent={BoxJustifyContent.Between}
-            testID={
-              MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.MONEY_ACCOUNT_BALANCE_ROW
-            }
-          >
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.TextAlternative}
-            >
-              {localizedText.balanceTitle}
-            </Text>
-            {showMoneyAccountBalanceSkeleton ? (
-              <Skeleton style={tw.style('h-5 w-20 rounded-md')} />
-            ) : (
-              <Text
-                variant={TextVariant.BodySm}
-                fontWeight={FontWeight.Medium}
-                color={TextColor.TextDefault}
-              >
-                {moneyAccountBalanceDisplay}
-              </Text>
-            )}
-          </Box>
-          {lastCheckedAt !== null && (
+          <Box twClassName="gap-1">
             <Box
               alignItems={BoxAlignItems.Center}
               flexDirection={BoxFlexDirection.Row}
               justifyContent={BoxJustifyContent.Between}
               testID={
-                MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.LAST_CHECKED_ROW
+                MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.MONEY_ACCOUNT_BALANCE_ROW
               }
             >
               <Text
-                variant={TextVariant.BodyMd}
+                variant={TextVariant.BodySm}
                 color={TextColor.TextAlternative}
               >
-                {strings('rewards.campaign_details.last_checked_at')}
+                {localizedText.balanceTitle}
               </Text>
-              <Text
-                variant={TextVariant.BodyMd}
-                fontWeight={FontWeight.Medium}
-                color={TextColor.TextDefault}
-              >
-                {lastCheckedAt}
-              </Text>
+              {showMoneyAccountBalanceSkeleton ? (
+                <Skeleton style={tw.style('h-5 w-20 rounded-md')} />
+              ) : (
+                <Text
+                  variant={TextVariant.BodySm}
+                  fontWeight={FontWeight.Medium}
+                  color={TextColor.TextDefault}
+                >
+                  {moneyAccountBalanceDisplay}
+                </Text>
+              )}
             </Box>
-          )}
+            {lastCheckedAt !== null && (
+              <Box
+                alignItems={BoxAlignItems.Center}
+                flexDirection={BoxFlexDirection.Row}
+                justifyContent={BoxJustifyContent.Between}
+                testID={
+                  MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.LAST_CHECKED_ROW
+                }
+              >
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
+                >
+                  {strings('rewards.campaign_details.last_checked_at')}
+                </Text>
+                <Text
+                  variant={TextVariant.BodySm}
+                  fontWeight={FontWeight.Medium}
+                  color={TextColor.TextDefault}
+                >
+                  {lastCheckedAt}
+                </Text>
+              </Box>
+            )}
+          </Box>
           {children}
         </Box>
       </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

On the Money Account Sweepstakes campaign details card, the "last checked at" row used `BodyMd` while the existing Money balance row used `BodySm`, and both sat as siblings in the card's `gap-3` stack. That made the two metadata rows look like separate blocks instead of one grouped footer.

This change sets last-checked label and value to `BodySm` and wraps both rows in a `gap-1` container so they sit closer together, while the divider above and the Add funds CTA below keep the original `gap-3` spacing.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated Money Account Sweepstakes last-checked row to match the existing balance type size and sit closer to it.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: no linked issue; visual polish of the opted-in Money Account Sweepstakes stats card.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money Account Sweepstakes stats card metadata rows

  Background:
    Given I am logged into MetaMask Mobile
    And I have opted into the Money Account Sweepstakes
    And qualifying deposit stats are available

  Scenario: user sees tighter BodySm metadata rows
    Given I open Rewards and the Money Account Sweepstakes campaign details

    Then the existing Money balance row and last-checked row both use BodySm
    And those two rows sit closer together than the rest of the card stack
    And the Add funds button still sits below with the original card spacing
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="396" height="373" alt="image" src="https://github.com/user-attachments/assets/b3efe815-be8c-4e15-b360-9503bbde81d4" />

### **After**

<img width="427" height="363" alt="image" src="https://github.com/user-attachments/assets/38f52e28-cf76-4cf7-8d5e-f4dc8e70acdc" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational layout and text variant changes only; test IDs and data logic are unchanged.
> 
> **Overview**
> **Money Account Sweepstakes** opted-in stats card layout is tightened so metadata reads as one footer block instead of two separate rows in the main `gap-3` stack.
> 
> Entries, “this week,” and the qualification message are grouped in a `gap-1` container. A divider with `my-1` separates that block from a second `gap-1` group that holds the Money balance row and the optional **last checked at** row. Last-checked label and value use **`BodySm`** (was **`BodyMd`**) to match the balance row typography.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e61e7780a920569c3671970d718ce3e048b8f30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->