### PR TITLE
fix(perps): add padding between TWAP filters and inner tabs

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -555,6 +555,7 @@ export const PerpsProMarketViewSelectorsIDs = {
   GEO_BLOCK_TOOLTIP: 'perps-pro-positions-panel-geo-block-tooltip',
   POSITIONS_PANEL_TAB_TWAP: 'perps-pro-market-positions-panel-tab-twap',
   TWAP_LIST: 'perps-pro-market-twap-list',
+  TWAP_TAB_BODY: 'perps-pro-market-twap-tab-body',
   TWAP_VIEW_TABS: 'perps-pro-market-twap-view-tabs',
   TWAP_VIEW_TAB_ACTIVE: 'perps-pro-market-twap-view-tab-active',
   TWAP_VIEW_TAB_HISTORY: 'perps-pro-market-twap-view-tab-history',

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.test.tsx
@@ -391,6 +391,33 @@ describe('PerpsProPositionsPanel', () => {
     });
   });
 
+  it('spaces the TWAP inner tabs below the filter row', () => {
+    // Arrange
+    renderWithProvider(<PerpsProPositionsPanel symbol="SOL" />, {
+      state: buildTwapEnabledState(false),
+    });
+
+    // Act
+    fireEvent.press(
+      screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.POSITIONS_PANEL_TAB_TWAP,
+      ),
+    );
+
+    // Assert
+    expect(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.TWAP_TAB_BODY),
+    ).toHaveStyle({ paddingTop: 12 });
+    expect(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.TWAP_VIEW_TABS),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.TWAP_SIDE_FILTER_BUTTON,
+      ),
+    ).toBeOnTheScreen();
+  });
+
   it('keeps TWAP selected when Chase is hidden', () => {
     // Arrange
     renderWithProvider(<PerpsProPositionsPanel symbol="SOL" />, {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.tsx
@@ -844,22 +844,27 @@ const PerpsProPositionsPanel = ({
   };
 
   const renderTwapTab = () => (
-    <PerpsProTwapPanel
-      activeTwapOrders={activeTwapOrders}
-      historicalTwapOrders={historicalTwapOrders}
-      isInitialLoading={areTwapOrdersInitiallyLoading}
-      error={twapOrdersError}
-      onRetry={refreshTwapOrders}
-      isRefreshing={areTwapOrdersRefreshing}
-      onSelectMarket={onSelectMarket ? handleSelectTwapMarket : undefined}
-      onTerminate={handleSelectTwapToTerminate}
-      isTerminationInFlight={isTerminationInFlight}
-      filterScopeKey={twapFilterScopeKey}
-      acceptedTerminationOrderIdentityKeys={
-        acceptedTerminationOrderIdentityKeys
-      }
-      emptyMetadataByView={twapEmptyMetadataByView}
-    />
+    <Box
+      twClassName="pt-3"
+      testID={PerpsProMarketViewSelectorsIDs.TWAP_TAB_BODY}
+    >
+      <PerpsProTwapPanel
+        activeTwapOrders={activeTwapOrders}
+        historicalTwapOrders={historicalTwapOrders}
+        isInitialLoading={areTwapOrdersInitiallyLoading}
+        error={twapOrdersError}
+        onRetry={refreshTwapOrders}
+        isRefreshing={areTwapOrdersRefreshing}
+        onSelectMarket={onSelectMarket ? handleSelectTwapMarket : undefined}
+        onTerminate={handleSelectTwapToTerminate}
+        isTerminationInFlight={isTerminationInFlight}
+        filterScopeKey={twapFilterScopeKey}
+        acceptedTerminationOrderIdentityKeys={
+          acceptedTerminationOrderIdentityKeys
+        }
+        emptyMetadataByView={twapEmptyMetadataByView}
+      />
+    </Box>
   );
 
   const renderTickerOnlyCheckbox = () => (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

On the Pro TWAP tab, All sides / ticker-only sat flush against Active / History / Fill history. Chase already has `pt-3` under the same filter row. This wraps the TWAP body the same way.

<!-- recipe-evidence suggestion: edit as needed before publishing. -->
TAT-3922. Recipe-backed before/after is below.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed missing padding between TWAP filters and the Active / History / Fill history tabs

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/TAT-3922

## **Manual testing steps**

<!-- recipe-evidence summary: keep reviewer-facing checks concise; full paths stay in pr-package/evidence.md. -->
Recipe evidence: `warn` (AC proved; first-run Lite/Pro chooser is outside `start_state`)
- Full evidence package: `pr-package/evidence.md`
- Quality report: `pr-package/recipe-quality.json`
- Baseline (buggy): `pr-package/runs/artifacts-baseline-run-2/`
- After (fixed): `pr-package/runs/artifacts-recipe-run/`
- Setup miss (ModeSelection): `pr-package/runs/artifacts-baseline-run/`

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Pro TWAP tab filter spacing

  Scenario: user opens the TWAP tab
    Given I am in MetaMask Mobile Pro on a market
    And the TWAP tab is available

    When user opens the TWAP tab
    Then All sides and the ticker-only filter sit above Active / History / Fill history
    And there is a 12px gap between those two rows
```

## **Screenshots/Recordings**

<table>
<tr><td colspan="2"><strong>Recipe visual evidence</strong><br/>Screenshots are grouped for quick reviewer comparison.</td></tr>
<tr>
<td align="center" width="50%"><strong>Before: All sides / BTC only flush on Active / History / Fill history</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/TAT-3922-fix-twap-tab-padding-0016/01-before-twap-filters-flush.png" alt="Before: All sides / BTC only flush on Active / History / Fill history" width="400" /></td>
<td align="center" width="50%"><strong>After: 12px (pt-3) gap between the filter row and inner TWAP tabs</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/TAT-3922-fix-twap-tab-padding-0016/02-after-twap-filters-gap.png" alt="After: 12px (pt-3) gap between the filter row and inner TWAP tabs" width="400" /></td>
</tr>
</table>

### **Before**

All sides / BTC only flush on Active / History / Fill history. `pr-package/images/01-before-twap-filters-flush.png`

### **After**

12px (`pt-3`) gap under the filter row. `pr-package/images/02-after-twap-filters-gap.png`

### **Recipe evidence**

<!-- Generated from .github/pull-request-template.md. Hosted image URLs are injected on upload. -->

<table>
<tr><td colspan="2"><strong>Recipe visual evidence</strong><br/>iOS mmdev-4, Runway dev client, Hyperliquid testnet, BTC Pro.</td></tr>
<tr>
<td align="center" width="50%"><strong>Before: All sides / BTC only flush on Active / History / Fill history</strong><br/><!-- IMAGE_SLOT_01: drag/drop pr-package/images/01-before-twap-filters-flush.png here. --><br/><code>pr-package/images/01-before-twap-filters-flush.png</code></td>
<td align="center" width="50%"><strong>After: 12px (pt-3) gap between the filter row and inner TWAP tabs</strong><br/><!-- IMAGE_SLOT_02: drag/drop pr-package/images/02-after-twap-filters-gap.png here. --><br/><code>pr-package/images/02-after-twap-filters-gap.png</code></td>
</tr>
</table>


## **Recipe artifact package**

Task path: `/Users/deeeed/dev/metamask/metamask-mobile-4/temp/tasks/recipe-cook/20260904T160546Z-twap-tab-padding`
PR package: `/Users/deeeed/dev/metamask/metamask-mobile-4/temp/tasks/recipe-cook/20260904T160546Z-twap-tab-padding/pr-package`
- Full evidence: `pr-package/evidence.md`
- Quality report: `pr-package/recipe-quality.json`
- Image files: `pr-package/images/`
- Checklist: `pr-package/checklist.md`
- Recipe run: `pr-package/runs/artifacts-baseline-run-2/`
- Recipe run: `pr-package/runs/artifacts-baseline-run/`
- Recipe run: `pr-package/runs/artifacts-mode-selection-press/`
- Recipe run: `pr-package/runs/artifacts-mode-selection-probe/`
- Recipe run: `pr-package/runs/artifacts-recipe-run/`

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual layout-only change in the Pro TWAP tab with no trading, auth, or data-path impact.
> 
> **Overview**
> Adds **12px top padding** (`pt-3`) on the Pro positions panel **TWAP tab** so the All sides / ticker-only filter row no longer sits flush against the Active / History / Fill history inner tabs, matching spacing already used on **Chase**.
> 
> The TWAP panel content is wrapped in a `Box` with test ID `TWAP_TAB_BODY`, and a unit test asserts that padding when the TWAP tab is selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7159cf4910fd20fe5dab16e55a76b130bfe08d87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->