### PR TITLE
ci(e2e): reduce Android Appium smoke shards after N=3 pool

### DIFF
--- a/.github/workflows/run-appium-smoke-tests-android.yml
+++ b/.github/workflows/run-appium-smoke-tests-android.yml
@@ -111,7 +111,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2]
+        split: [1]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -119,7 +119,7 @@ jobs:
       platform: android
       test_suite_tag: SmokeAccounts
       split_number: ${{ matrix.split }}
-      total_splits: 2
+      total_splits: 1
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
@@ -140,9 +140,9 @@ jobs:
          contains(fromJson(inputs.selected_tags), 'SmokePerps'))
       }}
     strategy:
-      # Lite + Pro nearly doubled SmokePerps; 2 shards exceeded the 25m test step.
+      # N=3 emulator pool: 13 files pack onto 2 shards under an 8m Playwright budget.
       matrix:
-        split: [1, 2, 3, 4]
+        split: [1, 2]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -150,7 +150,7 @@ jobs:
       platform: android
       test_suite_tag: SmokePerps
       split_number: ${{ matrix.split }}
-      total_splits: 4
+      total_splits: 2
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
@@ -172,7 +172,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2]
+        split: [1]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -180,7 +180,7 @@ jobs:
       platform: android
       test_suite_tag: SmokePredictions
       split_number: ${{ matrix.split }}
-      total_splits: 2
+      total_splits: 1
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
@@ -202,7 +202,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2]
+        split: [1]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -210,7 +210,7 @@ jobs:
       platform: android
       test_suite_tag: SmokeSeedlessOnboarding
       split_number: ${{ matrix.split }}
-      total_splits: 2
+      total_splits: 1
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
@@ -232,7 +232,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2, 3, 4, 5, 6]
+        split: [1, 2, 3]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -240,7 +240,7 @@ jobs:
       platform: android
       test_suite_tag: SmokeSnaps
       split_number: ${{ matrix.split }}
-      total_splits: 6
+      total_splits: 3
       # Session reuse + soft reload: denser shards; drop toward 25 after one green main.
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
@@ -263,7 +263,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2]
+        split: [1]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -271,7 +271,7 @@ jobs:
       platform: android
       test_suite_tag: SmokeNetworkAbstractions
       split_number: ${{ matrix.split }}
-      total_splits: 2
+      total_splits: 1
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
       runner_provider: ${{ inputs.runner_provider }}
@@ -292,7 +292,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2]
+        split: [1]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -300,7 +300,7 @@ jobs:
       platform: android
       test_suite_tag: SmokeWalletPlatform
       split_number: ${{ matrix.split }}
-      total_splits: 2
+      total_splits: 1
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
@@ -467,7 +467,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2, 3]
+        split: [1, 2]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -475,7 +475,7 @@ jobs:
       platform: android
       test_suite_tag: SmokeConfirmations
       split_number: ${{ matrix.split }}
-      total_splits: 3
+      total_splits: 2
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
@@ -497,7 +497,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2, 3]
+        split: [1, 2]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -505,7 +505,7 @@ jobs:
       platform: android
       test_suite_tag: SmokeMultiChainAPI
       split_number: ${{ matrix.split }}
-      total_splits: 3
+      total_splits: 2
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
@@ -527,7 +527,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2]
+        split: [1]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -535,7 +535,7 @@ jobs:
       platform: android
       test_suite_tag: SmokeNetworkExpansion
       split_number: ${{ matrix.split }}
-      total_splits: 2
+      total_splits: 1
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Android Appium smoke already boots three emulators per shard (`android-device-pool-size: 3`). This PR only drops Android `total_splits` so those workers stay busy. iOS is unchanged (N=2 work is on a separate branch).

Comparison is **Android-only CI** (iOS Appium skipped) — the usual PR path:

| PR | Pool | Android shards | Entire CI |
| --- | --- | --- | --- |
| [#35491](https://github.com/MetaMask/metamask-mobile/pull/35491) golden snapshot | 1 emu | 30 | 38 min |
| [#35700](https://github.com/MetaMask/metamask-mobile/pull/35700) N=3 probe | 3 emu | 32 | 19 min |
| [#35752](https://github.com/MetaMask/metamask-mobile/pull/35752) typical Android-only | 3 emu | 32 | 19 min |
| This PR [#35786](https://github.com/MetaMask/metamask-mobile/pull/35786) | 3 emu | 19 | **22 min** |

Versus pre-parallel Android-only (#35491): **11 fewer runners** and **16 minutes** off the full CI run (38 → 22). Versus N=3 with 32 shards (#35700 / #35752): **13 fewer runners**; full CI stays in the same ~19–22 min band.

On this PR all 19 shards passed. Slowest Playwright step 7 min (Accounts); slowest Android job 10 min.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: MMQA-2208

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Android Appium smoke shard reduction

  Scenario: CI uses 19 Android shards
    Given android-device-pool-size is 3
    When Appium Smoke Tests (Android) runs with selected_tags ALL
    Then 19 Android smoke shard jobs start plus prime-android-emulator-snapshot
    And iOS shard counts are unchanged

  Scenario: timings stay near the 8 minute Playwright budget
    When those Android shards finish
    Then the slowest Playwright step is at or under 8 minutes
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — CI shard counts. Pre-parallel: run 33707145994. Current main: run 33886627297.

### **After**

N/A — this PR: https://github.com/MetaMask/metamask-mobile/actions/runs/33908610631

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow matrix tuning only; risk is longer per-shard runs or timeouts if load estimates drift, not production app behavior.
> 
> **Overview**
> **Reduces parallel shard counts** in `run-appium-smoke-tests-android.yml` so Android smoke aligns with a three-emulator device pool per job—fewer CI runners while each shard runs more specs.
> 
> Several suites move from **2 shards to 1** (Accounts, Predictions, Seedless Onboarding, Network Abstractions, Wallet Platform, Network Expansion). **SmokePerps** goes **4 → 2** (comment notes packing under an ~8m Playwright budget). **SmokeSnaps** goes **6 → 3**. **SmokeConfirmations** and **SmokeMultiChainAPI** go **3 → 2**. Each job’s `matrix.split` and `total_splits` stay in sync; timeouts and other inputs are unchanged. iOS smoke is not touched in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c83dca116db24d3197f87c0de0252423cc05059e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

