### PR TITLE
feat: conditional Market Insights refresh timestamp

### DIFF
--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.test.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.test.tsx
@@ -8,6 +8,7 @@ import MarketInsightsEntryCard from './MarketInsightsEntryCard';
 import { EVENT_NAME } from '../../../../../core/Analytics/MetaMetrics.events';
 import { AnalyticsEventBuilder } from '../../../../../util/analytics/AnalyticsEventBuilder';
 import { createMockUseAnalyticsHook } from '../../../../../util/test/analyticsMock';
+import { strings } from '../../../../../../locales/i18n';
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
@@ -241,6 +242,23 @@ describe('MarketInsightsEntryCard', () => {
     );
 
     expect(getByText(/5h ago/)).toBeOnTheScreen();
+  });
+
+  it('omits the timestamp separator when timeAgo is empty', () => {
+    const { getByText, queryByText } = renderWithProvider(
+      <MarketInsightsEntryCard
+        report={mockReport as never}
+        timeAgo=""
+        onPress={jest.fn()}
+        source="token_details"
+        testID="market-insights-entry-card"
+      />,
+    );
+
+    expect(
+      getByText(strings('market_insights.card_footer_disclaimer')),
+    ).toBeOnTheScreen();
+    expect(queryByText(/•/)).toBeNull();
   });
 
   it('updates card dimensions on layout and skips redundant updates', async () => {

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
@@ -302,8 +302,7 @@ const MarketInsightsEntryCard: React.FC<MarketInsightsEntryCardProps> = ({
                 twClassName="shrink"
               >
                 {strings('market_insights.card_footer_disclaimer')}
-                {' • '}
-                {timeAgo}
+                {timeAgo ? ` • ${timeAgo}` : ''}
               </Text>
               <ButtonIcon
                 iconName={IconName.Info}

--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
@@ -6,6 +6,7 @@ import {
   QueryClientProvider,
 } from '@tanstack/react-query';
 import type { MarketInsightsReport } from '@metamask/ai-controllers';
+import { strings } from '../../../../../locales/i18n';
 import { useMarketInsights } from './useMarketInsights';
 const mockFetchMarketInsights = jest.fn();
 
@@ -95,6 +96,79 @@ describe('useMarketInsights', () => {
     expect(result.current.reportAssetId).toBe('eip155:1/erc20:0x123');
     expect(result.current.error).toBeNull();
     expect(result.current.timeAgo).toBe('5m ago');
+  });
+
+  it('returns Today when the report was generated more than 6 hours ago', async () => {
+    const report = {
+      version: '1.0',
+      asset: 'eth',
+      generatedAt: '2026-02-17T04:00:00.000Z',
+      headline: 'ETH advances',
+      summary: 'ETF headlines support demand',
+      trends: [],
+      sources: [],
+    };
+
+    mockFetchMarketInsights.mockResolvedValue(report);
+
+    const { result } = renderHook(
+      () => useMarketInsights('eip155:1/erc20:0x123', true),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.timeAgo).toBe(
+      strings('market_insights.refresh_today'),
+    );
+  });
+
+  it('returns Yesterday when the report was generated more than 24 hours ago', async () => {
+    const report = {
+      version: '1.0',
+      asset: 'eth',
+      generatedAt: '2026-02-16T06:00:00.000Z',
+      headline: 'ETH advances',
+      summary: 'ETF headlines support demand',
+      trends: [],
+      sources: [],
+    };
+
+    mockFetchMarketInsights.mockResolvedValue(report);
+
+    const { result } = renderHook(
+      () => useMarketInsights('eip155:1/erc20:0x123', true),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.timeAgo).toBe(
+      strings('market_insights.refresh_yesterday'),
+    );
+  });
+
+  it('returns empty timeAgo when the report was generated 48 hours ago or more', async () => {
+    const report = {
+      version: '1.0',
+      asset: 'eth',
+      generatedAt: '2026-02-15T10:00:00.000Z',
+      headline: 'ETH advances',
+      summary: 'ETF headlines support demand',
+      trends: [],
+      sources: [],
+    };
+
+    mockFetchMarketInsights.mockResolvedValue(report);
+
+    const { result } = renderHook(
+      () => useMarketInsights('eip155:1/erc20:0x123', true),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.timeAgo).toBe('');
   });
 
   it('returns null when controller has no insights', async () => {

--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
@@ -6,7 +6,7 @@ import {
   digestQueryStaleTime,
 } from '../../../../constants/digestQuery';
 import Engine from '../../../../core/Engine';
-import { formatRelativeTime } from '../utils/marketInsightsFormatting';
+import { formatInsightRefreshLabel } from '../utils/marketInsightsFormatting';
 
 const MARKET_INSIGHTS_QUERY_KEY = 'market-insights';
 
@@ -22,7 +22,7 @@ export interface UseMarketInsightsResult {
   isLoading: boolean;
   /** Error message if the data fetch failed */
   error: string | null;
-  /** Relative time since the report was generated (e.g., "3m ago") */
+  /** Refresh label for the report (e.g., "3m ago", "Today"), or empty when stale */
   timeAgo: string;
 }
 
@@ -76,7 +76,7 @@ export const useMarketInsights = (
       : null;
 
   const timeAgo = useMemo(
-    () => (report ? formatRelativeTime(report.generatedAt) : ''),
+    () => (report ? formatInsightRefreshLabel(report.generatedAt) : ''),
     [report],
   );
 

--- a/app/components/UI/MarketInsights/utils/marketInsightsFormatting.test.ts
+++ b/app/components/UI/MarketInsights/utils/marketInsightsFormatting.test.ts
@@ -1,8 +1,10 @@
 import {
+  formatInsightRefreshLabel,
   formatRelativeTime,
   getFaviconUrl,
   isXSourceUrl,
 } from './marketInsightsFormatting';
+import { strings } from '../../../../../locales/i18n';
 
 describe('formatRelativeTime', () => {
   const ANCHOR = new Date('2026-05-07T12:00:00.000Z');
@@ -38,6 +40,53 @@ describe('formatRelativeTime', () => {
 
   it('returns Xd ago for diffs of 1 day or more', () => {
     expect(formatRelativeTime(minutesBeforeAnchor(4 * 24 * 60))).toBe('4d ago');
+  });
+});
+
+describe('formatInsightRefreshLabel', () => {
+  const ANCHOR = new Date('2026-05-07T12:00:00.000Z');
+
+  const minutesBeforeAnchor = (n: number) =>
+    new Date(ANCHOR.getTime() - n * 60 * 1000).toISOString();
+
+  beforeEach(() => {
+    jest.useFakeTimers({ now: ANCHOR });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns empty string for an invalid date string', () => {
+    expect(formatInsightRefreshLabel('not-a-date')).toBe('');
+  });
+
+  it('returns relative time when generated at most 6 hours ago', () => {
+    expect(formatInsightRefreshLabel(minutesBeforeAnchor(6 * 60))).toBe(
+      '6h ago',
+    );
+  });
+
+  it('returns Today when generated more than 6 hours and less than 24 hours ago', () => {
+    expect(formatInsightRefreshLabel(minutesBeforeAnchor(6 * 60 + 1))).toBe(
+      strings('market_insights.refresh_today'),
+    );
+    expect(formatInsightRefreshLabel(minutesBeforeAnchor(23 * 60))).toBe(
+      strings('market_insights.refresh_today'),
+    );
+  });
+
+  it('returns Yesterday when generated at least 24 hours and less than 48 hours ago', () => {
+    expect(formatInsightRefreshLabel(minutesBeforeAnchor(24 * 60))).toBe(
+      strings('market_insights.refresh_yesterday'),
+    );
+    expect(formatInsightRefreshLabel(minutesBeforeAnchor(47 * 60))).toBe(
+      strings('market_insights.refresh_yesterday'),
+    );
+  });
+
+  it('returns empty string when generated 48 hours ago or more', () => {
+    expect(formatInsightRefreshLabel(minutesBeforeAnchor(48 * 60))).toBe('');
   });
 });
 

--- a/app/components/UI/MarketInsights/utils/marketInsightsFormatting.ts
+++ b/app/components/UI/MarketInsights/utils/marketInsightsFormatting.ts
@@ -1,4 +1,5 @@
 import type { MarketInsightsSource } from '@metamask/ai-controllers';
+import { strings } from '../../../../../locales/i18n';
 
 export interface RelativeTimeOptions {
   nowLabel?: string;
@@ -40,6 +41,30 @@ export const formatRelativeTime = (
   if (diffMins < 60) return `${diffMins}m ago`;
   if (diffHours < 24) return `${diffHours}h ago`;
   return `${diffDays}d ago`;
+};
+
+const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+const FORTY_EIGHT_HOURS_MS = 48 * 60 * 60 * 1000;
+
+export const formatInsightRefreshLabel = (generatedAt: string): string => {
+  const date = new Date(generatedAt);
+  if (isNaN(date.getTime())) {
+    return '';
+  }
+
+  const diffMs = Date.now() - date.getTime();
+
+  if (diffMs <= SIX_HOURS_MS) {
+    return formatRelativeTime(generatedAt);
+  }
+  if (diffMs < TWENTY_FOUR_HOURS_MS) {
+    return strings('market_insights.refresh_today');
+  }
+  if (diffMs < FORTY_EIGHT_HOURS_MS) {
+    return strings('market_insights.refresh_yesterday');
+  }
+  return '';
 };
 
 export const getNormalizedHandle = (author: string): string =>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2949,6 +2949,8 @@
     "a_closer_look": "A closer look",
     "whats_being_said": "What's being said",
     "card_footer_disclaimer": "AI generated",
+    "refresh_today": "Today",
+    "refresh_yesterday": "Yesterday",
     "footer_disclaimer": "AI summary for information only",
     "disclaimer_modal": {
       "title": "AI-generated content",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Implements [TSA-621](https://consensyssoftware.atlassian.net/browse/TSA-621) by changing how the Market Insights entry card shows digest freshness from `generatedAt`.

- **≤ 6 hours:** keep the existing relative label (`5m ago`, `6h ago`)
- **> 6 hours and < 24 hours:** show **Today**
- **≥ 24 hours and < 48 hours:** show **Yesterday**
- **≥ 48 hours:** hide the timestamp and the ` • ` separator so the footer stays `AI generated` without looking stale

Relative tweet/article times are unchanged (`formatRelativeTime` is still used there).

## Related issues

TSA-621

## Screenshots/Recordings

N/A — unit-tested label logic

## Pre-merge checklist

- [x] I’ve read and understood the [Code of Conduct](https://github.com/MetaMask/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I’ve read and understood the [Contributing guidelines](https://github.com/MetaMask/.github/blob/main/CONTRIBUTING.md)
- [x] I included a description of **what** this PR does and **why**
- [x] I linked the related issue(s)
- [x] I added tests to cover my changes
- [ ] I included screenshots/recordings if this PR changes the UI
- [x] I included changelog notes (or marked this as NOT USER-FACING)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0706c-4a8f-7e7b-b23c-259b7cd090d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0706c-4a8f-7e7b-b23c-259b7cd090d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TSA-621]: https://consensyssoftware.atlassian.net/browse/TSA-621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ