### PR TITLE
fix(e2e): treat missing iOS app data container as already cleared

### DIFF
--- a/tests/framework/services/device-commands/DeviceCommandHandler.test.ts
+++ b/tests/framework/services/device-commands/DeviceCommandHandler.test.ts
@@ -321,6 +321,42 @@ describe('DeviceCommandHandler', () => {
     });
   });
 
+  it('treats a missing iOS app data container directory as already cleared', async () => {
+    const appDataPath =
+      '/Users/runner/Library/Developer/CoreSimulator/Devices/FD56728B-6F33-432A-B3DD-E90EA0C1E1D9/data/Containers/Data/Application/01235757-20FE-41D6-BCAB-FD0077C40AB3';
+    mockExecFileResponses([{ stdout: '' }, { stdout: `${appDataPath}\n` }]);
+    const missingContainer = Object.assign(
+      new Error(`ENOENT: no such file or directory, scandir '${appDataPath}'`),
+      { code: 'ENOENT' },
+    );
+    readdirMock.mockRejectedValue(missingContainer);
+
+    await expect(
+      new DeviceCommandHandler({
+        currentDeviceDetails: iosDevice(),
+      }).clearAppData(),
+    ).resolves.toBeUndefined();
+
+    expect(readdirMock).toHaveBeenCalledWith(appDataPath);
+    expect(rmMock).not.toHaveBeenCalled();
+  });
+
+  it('rethrows non-ENOENT failures while reading the iOS app data container', async () => {
+    const appDataPath = '/Users/me/Containers/Data/Application/abc';
+    mockExecFileResponses([{ stdout: '' }, { stdout: `${appDataPath}\n` }]);
+    readdirMock.mockRejectedValue(
+      Object.assign(new Error('EACCES'), { code: 'EACCES' }),
+    );
+
+    await expect(
+      new DeviceCommandHandler({
+        currentDeviceDetails: iosDevice(),
+      }).clearAppData(),
+    ).rejects.toThrow('EACCES');
+
+    expect(rmMock).not.toHaveBeenCalled();
+  });
+
   it('rejects empty iOS app data container paths', async () => {
     mockExecFileResponses([{ stdout: '' }, { stdout: '\n' }]);
 

--- a/tests/framework/services/device-commands/IOSDeviceCommandHandler.ts
+++ b/tests/framework/services/device-commands/IOSDeviceCommandHandler.ts
@@ -139,7 +139,19 @@ export class IOSDeviceCommandHandler implements PlatformDeviceCommandHandler {
     const appDataPath = stdout.trim();
     this.validateAppDataPath(appDataPath, resolvedAppId);
 
-    const entries = await fs.readdir(appDataPath);
+    let entries: string[];
+    try {
+      entries = await fs.readdir(appDataPath);
+    } catch (error) {
+      if (this.isEnoent(error)) {
+        this.options.logger?.debug(
+          `iOS app data container already missing at ${appDataPath}; treating as cleared`,
+        );
+        return;
+      }
+      throw error;
+    }
+
     await Promise.all(
       entries.map((entry) =>
         fs.rm(path.join(appDataPath, entry), {
@@ -262,5 +274,14 @@ export class IOSDeviceCommandHandler implements PlatformDeviceCommandHandler {
    */
   private formatError(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
+  }
+
+  private isEnoent(error: unknown): boolean {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as NodeJS.ErrnoException).code === 'ENOENT'
+    );
   }
 }


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

**Reason:** After an iOS Appium smoke test fails, Playwright retry runs `withFixtures` → `softReloadApp` → `clearAppData`. `simctl get_app_container … data` can still return the previous container UUID after terminate, while the directory is already gone. `readdir` then throws `ENOENT` (for example `…/Application/01235757-…`). The existing one-shot retry hits the same stale path, so the retry never relaunches the app.

**Solution:** If `readdir` fails with `ENOENT`, treat the container as already cleared and return. Other filesystem errors still fail. Soft reload can continue to `launchApp`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: iOS Appium fixture retry after a first failure

  Scenario: Playwright retry relaunches when the previous data container is gone
    Given an iOS Appium smoke test failed on the first attempt
    And simctl still reports a data container path whose directory no longer exists
    When withFixtures restarts the device for retry #1
    Then clearAppData does not fail on ENOENT
    And the retry proceeds to launch the app
```

## **Screenshots/Recordings**

### **Before**

N/A — CI test-infra change.

### **After**

N/A — CI test-infra change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-infra only; narrows error handling in iOS simulator app-data clearing with no production or auth impact.
> 
> **Overview**
> Fixes iOS Appium fixture retries where **`clearAppData`** could fail after a first test failure: **`simctl get_app_container … data`** may still return a path even though the on-disk data container was already removed, so **`readdir`** threw **`ENOENT`** and blocked **`softReloadApp`** from relaunching.
> 
> **`IOSDeviceCommandHandler.clearAppData`** now catches **`readdir`** failures: **`ENOENT`** is treated as “already cleared” (debug log, early return, no **`rm`**); other filesystem errors still propagate. Tests cover the happy missing-container case and a non-**`ENOENT`** (**`EACCES`**) failure path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b7bd4bdd99fce6ae6782b5e2c73251209df222b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->