### PR TITLE
revert: do not arm isMaxAmount on Money Account Max withdraw (#35614)

### DIFF
--- a/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
@@ -7,26 +7,18 @@ import { transactionApprovalControllerMock } from '../../../__mocks__/controller
 import {
   useIsTransactionPayLoading,
   useTransactionPayIsMaxAmount,
-  useTransactionPayRequiredTokens,
   useTransactionPayTotals,
 } from '../../../hooks/pay/useTransactionPayData';
-import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
-import {
-  TransactionPaymentToken,
-  TransactionPayTotals,
-} from '@metamask/transaction-pay-controller';
+import { TransactionPayTotals } from '@metamask/transaction-pay-controller';
 import { TransactionType } from '@metamask/transaction-controller';
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
 
 jest.mock('../../../hooks/pay/useTransactionPayData');
-jest.mock('../../../hooks/pay/useTransactionPayToken');
 jest.mock('../../../hooks/pay/useTransactionPayWithdraw');
 
 const TOTAL_FIAT_MOCK = '$123.46';
 const RECEIVE_FIAT_MOCK = '$99.38';
-const MUSD_ADDRESS_MOCK = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
-const MUSD_CHAIN_ID_MOCK = '0x1';
 
 function render(options: { type?: TransactionType } = {}) {
   const state = merge(
@@ -56,10 +48,6 @@ describe('TotalRow', () => {
   const useTransactionPayIsMaxAmountMock = jest.mocked(
     useTransactionPayIsMaxAmount,
   );
-  const useTransactionPayRequiredTokensMock = jest.mocked(
-    useTransactionPayRequiredTokens,
-  );
-  const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
   const useTransactionPayWithdrawMock = jest.mocked(useTransactionPayWithdraw);
 
   beforeEach(() => {
@@ -69,13 +57,6 @@ describe('TotalRow', () => {
       total: { usd: '123.456' },
       targetAmount: { usd: '99.38', fiat: '99.38' },
     } as unknown as TransactionPayTotals);
-    useTransactionPayRequiredTokensMock.mockReturnValue([]);
-    useTransactionPayTokenMock.mockReturnValue({
-      payToken: {
-        address: MUSD_ADDRESS_MOCK,
-        chainId: MUSD_CHAIN_ID_MOCK,
-      } as unknown as TransactionPaymentToken,
-    } as ReturnType<typeof useTransactionPayToken>);
 
     useIsTransactionPayLoadingMock.mockReturnValue(false);
 
@@ -185,7 +166,7 @@ describe('TotalRow', () => {
       expect(getByTestId('receive-row-skeleton')).toBeDefined();
     });
 
-    it('renders the target amount even when it is zero and no required amount exists', () => {
+    it('renders the target amount even when it is zero', () => {
       useTransactionPayWithdrawMock.mockReturnValue({
         isWithdraw: true,
         canSelectWithdrawToken: true,
@@ -194,65 +175,10 @@ describe('TotalRow', () => {
         total: { usd: '123.456' },
         targetAmount: { usd: '0', fiat: '0' },
       } as unknown as TransactionPayTotals);
-      useTransactionPayRequiredTokensMock.mockReturnValue([]);
 
       const { getByText } = render();
 
       expect(getByText('$0')).toBeOnTheScreen();
-    });
-
-    it('falls back to required token amount when targetAmount is 0 for direct same-token withdraw routes', () => {
-      useTransactionPayWithdrawMock.mockReturnValue({
-        isWithdraw: true,
-        canSelectWithdrawToken: true,
-      });
-      useTransactionPayTotalsMock.mockReturnValue({
-        total: { usd: '0' },
-        targetAmount: { usd: '0', fiat: '0' },
-      } as unknown as TransactionPayTotals);
-      useTransactionPayRequiredTokensMock.mockReturnValue([
-        {
-          address: MUSD_ADDRESS_MOCK,
-          chainId: MUSD_CHAIN_ID_MOCK,
-          amountUsd: '27.51',
-          skipIfBalance: false,
-        },
-      ] as never);
-
-      const { getByText, queryByText } = render();
-
-      expect(getByText('$27.51')).toBeOnTheScreen();
-      expect(queryByText('$0')).toBeNull();
-    });
-
-    it('does not fall back to required token amount for cross-token routes when targetAmount is 0', () => {
-      useTransactionPayWithdrawMock.mockReturnValue({
-        isWithdraw: true,
-        canSelectWithdrawToken: true,
-      });
-      useTransactionPayTotalsMock.mockReturnValue({
-        total: { usd: '0' },
-        targetAmount: { usd: '0', fiat: '0' },
-      } as unknown as TransactionPayTotals);
-      useTransactionPayRequiredTokensMock.mockReturnValue([
-        {
-          address: MUSD_ADDRESS_MOCK,
-          chainId: MUSD_CHAIN_ID_MOCK,
-          amountUsd: '27.51',
-          skipIfBalance: false,
-        },
-      ] as never);
-      useTransactionPayTokenMock.mockReturnValue({
-        payToken: {
-          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-          chainId: MUSD_CHAIN_ID_MOCK,
-        } as unknown as TransactionPaymentToken,
-      } as ReturnType<typeof useTransactionPayToken>);
-
-      const { getByText, queryByText } = render();
-
-      expect(getByText('$0')).toBeOnTheScreen();
-      expect(queryByText('$27.51')).toBeNull();
     });
   });
 });

--- a/app/components/Views/confirmations/components/rows/total-row/total-row.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.tsx
@@ -6,10 +6,8 @@ import { BigNumber } from 'bignumber.js';
 import {
   useIsTransactionPayLoading,
   useTransactionPayIsMaxAmount,
-  useTransactionPayRequiredTokens,
   useTransactionPayTotals,
 } from '../../../hooks/pay/useTransactionPayData';
-import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
 import { isTransactionPayWithdraw } from '../../../utils/transaction';
 import { InfoRowSkeleton, InfoRowVariant } from '../../UI/info-row/info-row';
@@ -22,20 +20,6 @@ import {
   TextVariant,
   TextColor,
 } from '@metamask/design-system-react-native';
-
-function isSameTokenAddressAndChain(
-  left: { address?: string; chainId?: string } | undefined,
-  right: { address?: string; chainId?: string } | undefined,
-): boolean {
-  if (!left?.address || !left.chainId || !right?.address || !right.chainId) {
-    return false;
-  }
-
-  return (
-    left.address.toLowerCase() === right.address.toLowerCase() &&
-    left.chainId.toLowerCase() === right.chainId.toLowerCase()
-  );
-}
 
 /**
  * Row component that owns the bottom line of the totals section.
@@ -108,51 +92,23 @@ function TotalFeesRow() {
 /**
  * Displays "You'll receive" for withdrawal, input-based, and Max flows.
  *
- * Prefers `totals.targetAmount.usd` from executable quotes (after fees). Direct
- * same-token routes only produce a None-strategy no-op quote, which is excluded
- * from totals and leaves targetAmount at 0 — fall back to the required token
- * amount only when the destination payment token matches that required token
- * (same-chain mUSD Money Account withdraw). Cross-token routes must not show
- * the source amount as received when the quote is missing.
+ * The net received amount is the target amount computed by the Transaction Pay
+ * controller (after all provider, network, and MetaMask fees), so this row
+ * simply renders `totals.targetAmount.usd` rather than re-deriving it from the
+ * input amount.
  */
 function ReceiveRow() {
   const formatFiat = useFiatFormatter({ currency: 'usd' });
   const isLoading = useIsTransactionPayLoading();
   const totals = useTransactionPayTotals();
-  const requiredTokens = useTransactionPayRequiredTokens();
-  const { payToken } = useTransactionPayToken();
 
   const receiveUsd = useMemo(() => {
     const targetAmountUsd = totals?.targetAmount?.usd;
-    const targetBn =
-      targetAmountUsd == null ? null : new BigNumber(targetAmountUsd);
 
-    if (targetBn?.gt(0)) {
-      return formatFiat(targetBn);
-    }
+    if (targetAmountUsd == null) return '';
 
-    const primaryRequiredToken = (requiredTokens ?? []).find(
-      (token) => !token.skipIfBalance,
-    );
-    const isDirectSameTokenRoute = isSameTokenAddressAndChain(
-      primaryRequiredToken,
-      payToken,
-    );
-
-    if (
-      isDirectSameTokenRoute &&
-      primaryRequiredToken?.amountUsd &&
-      new BigNumber(primaryRequiredToken.amountUsd).gt(0)
-    ) {
-      return formatFiat(new BigNumber(primaryRequiredToken.amountUsd));
-    }
-
-    if (targetBn == null) {
-      return '';
-    }
-
-    return formatFiat(targetBn);
-  }, [formatFiat, payToken, requiredTokens, totals?.targetAmount?.usd]);
+    return formatFiat(new BigNumber(targetAmountUsd));
+  }, [totals?.targetAmount?.usd, formatFiat]);
 
   if (isLoading) {
     return <InfoRowSkeleton testId="receive-row-skeleton" />;

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -1210,10 +1210,9 @@ describe('useTransactionCustomAmount', () => {
       expect(result.current.amountFiat).toBe('500');
     });
 
-    it('does not set isMaxAmount for money account withdraw when Max is pressed', async () => {
-      // Max still fills the full withdrawable amount, but must not arm
-      // isMaxAmount — post-quote would otherwise treat destination payment
-      // token balance as the source amount instead of nested-tx mUSD.
+    it('sets isMaxAmount=true for money account withdraw when Max is pressed', async () => {
+      // The mUSD + vmUSD aggregate balance is resolved by TPC's getBalance
+      // callback, so the Max button always arms isMaxAmount here too.
       useTokenFiatRateMock.mockReturnValue(1);
       useMoneyAccountBalanceMock.mockReturnValue({
         withdrawableMusd: new BigNumber(500),
@@ -1231,31 +1230,10 @@ describe('useTransactionCustomAmount', () => {
       });
 
       expect(result.current.amountFiat).toBe('500');
-      expect(setTransactionConfigMock).not.toHaveBeenCalled();
-    });
 
-    it('uses exact fractional redeemable balance for money account withdraw Max without isMaxAmount', async () => {
-      // Fiat ROUND_DOWN to 2 decimals would leave dust (500.12 from
-      // 500.123456). Max must keep full balanceRaw precision while still
-      // leaving isMaxAmount unset.
-      useTokenFiatRateMock.mockReturnValue(1);
-      useMoneyAccountBalanceMock.mockReturnValue({
-        withdrawableMusd: new BigNumber('500.123456'),
-      } as ReturnType<typeof useMoneyAccountBalance>);
-
-      const { result } = runHook({
-        transactionMeta: {
-          type: TransactionType.moneyAccountWithdraw,
-        },
-        stateOverrides: getMoneyAccountState('500123456'),
-      });
-
-      await act(async () => {
-        result.current.updatePendingAmountPercentage(100);
-      });
-
-      expect(result.current.amountFiat).toBe('500.123456');
-      expect(setTransactionConfigMock).not.toHaveBeenCalled();
+      const config = { isMaxAmount: false };
+      setTransactionConfigMock.mock.calls[0][1](config);
+      expect(config.isMaxAmount).toBe(true);
     });
 
     it('returns 0 for money account withdraw when withdrawableMusd is undefined', async () => {

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -15,7 +15,6 @@ import { useParams } from '../../../../../util/navigation/navUtils';
 import { debounce } from 'lodash';
 import {
   MUSD_CONVERSION_DEFAULT_CHAIN_ID,
-  MUSD_DECIMALS,
   MUSD_TOKEN_ADDRESS,
 } from '../../../../UI/Earn/constants/musd';
 import Engine from '../../../../../core/Engine';
@@ -126,7 +125,7 @@ export function useTransactionCustomAmount({
   const tokenFiatRate = isMoneyAccountWithdraw
     ? musdFiatRate
     : payTokenFiatRate;
-  const { balanceRaw, balanceUsd } = useTransactionPayBalance({ currency });
+  const { balanceUsd } = useTransactionPayBalance({ currency });
   const { payToken } = useTransactionPayToken();
   const payTokenKey = `${payToken?.chainId ?? ''}:${
     payToken?.address.toLowerCase() ?? ''
@@ -354,28 +353,12 @@ export function useTransactionCustomAmount({
         return false;
       }
 
-      // Money-account withdraw Max must not arm isMaxAmount (post-quote would
-      // treat destination payment-token balance as the source). Use the exact
-      // redeemable balanceRaw instead of fiat rounded to cents so Max does not
-      // leave dust.
-      let newAmount: string;
-      if (percentage === 100 && isMoneyAccountWithdraw && balanceRaw) {
-        const exactHuman = new BigNumber(balanceRaw).shiftedBy(-MUSD_DECIMALS);
-        if (!exactHuman.isFinite() || exactHuman.lte(0)) {
-          return false;
-        }
-        const exactFiat = tokenFiatRate
-          ? exactHuman.multipliedBy(tokenFiatRate)
-          : exactHuman;
-        newAmount = exactFiat.toFixed();
-      } else {
-        newAmount = formatFiatAmount(
-          new BigNumber(percentage)
-            .dividedBy(100)
-            .multipliedBy(balanceUsd)
-            .decimalPlaces(2, BigNumber.ROUND_DOWN),
-        );
-      }
+      const newAmount = formatFiatAmount(
+        new BigNumber(percentage)
+          .dividedBy(100)
+          .multipliedBy(balanceUsd)
+          .decimalPlaces(2, BigNumber.ROUND_DOWN),
+      );
 
       // Sub-cent / dust balances ROUND_DOWN to $0. Treat that like no balance
       // so Max does not arm auto-submit and strand the page on Loading.
@@ -392,12 +375,12 @@ export function useTransactionCustomAmount({
         },
       });
 
-      // Arm isMaxAmount on a full (100%) selection so TPC can resolve the exact
-      // source balance via getBalance (perps HyperLiquid, predict Polymarket,
-      // money-account deposit mUSD + vmUSD). Money-account withdraws are the
-      // exception: Max must keep the explicit nested-tx amount, not treat the
-      // destination payment token balance as the source amount in post-quote.
-      if (percentage === 100 && !isMoneyAccountWithdraw) {
+      // Always arm isMaxAmount on a full (100%) selection. TPC resolves the
+      // correct source balance for every flow — including money-account deposit
+      // max — via the getBalance callback (perps HyperLiquid, predict
+      // Polymarket, money-account mUSD + vmUSD), so no per-transaction-type
+      // exclusion or client-side full-precision override is needed here.
+      if (percentage === 100) {
         setIsMax(true);
       } else if (isMaxAmount) {
         setIsMax(false);
@@ -406,15 +389,7 @@ export function useTransactionCustomAmount({
       setAmountFiat(newAmount);
       return true;
     },
-    [
-      balanceRaw,
-      balanceUsd,
-      isMaxAmount,
-      isMoneyAccountWithdraw,
-      setConfirmationMetric,
-      setIsMax,
-      tokenFiatRate,
-    ],
+    [balanceUsd, isMaxAmount, setIsMax, setConfirmationMetric],
   );
 
   const prevHasPrefilled = useRef(depositPrefill.hasPrefilled);


### PR DESCRIPTION
## **Description**

Reverts https://github.com/MetaMask/metamask-mobile/pull/35614.

#35614 stopped setting `isMaxAmount` on Money Account Max withdraw and added Receive-row fallback for same-token mUSD no-op quotes. Restoring `isMaxAmount` on Max so TransactionPayController can resolve the Money Account source amount via `getBalance`, and restoring the previous Receive-row behavior.

## **Changelog**

CHANGELOG entry: Reverted Money Account Max withdraw `isMaxAmount` skip from #35614

## **Related issues**

Related: https://consensyssoftware.atlassian.net/browse/CONF-1914
Reverts: https://github.com/MetaMask/metamask-mobile/pull/35614

## **Manual testing steps**

```gherkin
Feature: Money Account Max withdraw after revert

  Scenario: user Max-withdraws to a non-mUSD destination token
    Given the user has a Money Account with redeemable balance
    And the user opens Money Account Send / withdraw
    And the user selects a destination token other than mUSD on Monad (e.g. USDC on mainnet)

    When the user taps Max
    Then the amount field shows the full withdrawable balance
    And TransactionPayController sets isMaxAmount to true
    And a quote is requested from mUSD on Monad to the destination

  Scenario: user Max-withdraws to mUSD on Monad
    Given the user has a Money Account with redeemable balance
    And the user selects mUSD on Monad as the destination

    When the user taps Max
    Then the same-chain withdraw still completes as before
```

## **Screenshots/Recordings**

N/A — revert of controller-flag / quote-path logic.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## Test plan

- [ ] Unit tests for `useTransactionCustomAmount` and `total-row` (already passing locally)
- [ ] Money Account Max withdraw to a non-mUSD destination token
- [ ] Money Account Max withdraw to mUSD on Monad
- [ ] Confirm Max arms `isMaxAmount` again

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Money Account Max withdraw quoting and confirmation “You receive” display when quotes leave targetAmount at zero; wrong TPC getBalance behavior would show incorrect amounts or failed Max withdraws.
> 
> **Overview**
> Reverts the behavior from #35614 so **Money Account Max withdraw** again arms **`isMaxAmount`** and lets Transaction Pay Controller resolve the source balance via **`getBalance`** (including cross-token withdraws to non-mUSD destinations).
> 
> In **`useTransactionCustomAmount`**, the money-account-withdraw exception is removed: 100% / Max always calls **`setIsMax(true)`**, and Max amounts come from the usual **`balanceUsd`** percentage math instead of a **`balanceRaw`** full-precision path. **`ReceiveRow`** in **`total-row`** no longer falls back to required-token USD when **`targetAmount`** is zero; it only displays **`totals.targetAmount.usd`**. Unit tests are updated to match (including dropping same-token / cross-token receive fallbacks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dec2f20717c02dd750cd118461e3ab657979ded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->