### PR TITLE
fix(e2e): skip adb reverse --remove on pooled Android emulators

### DIFF
--- a/tests/docs/android-appium-device-pool.md
+++ b/tests/docs/android-appium-device-pool.md
@@ -108,6 +108,13 @@ device fails only its assigned Playwright worker; the provider does not kill
 or restart the sibling emulator. Appium retries use `parallelIndex`, so a
 replacement worker keeps the same serial and ports.
 
+Workers share one host `adb` server. `withFixtures` therefore skips
+`adb reverse --remove` when `ANDROID_DEVICE_POOL_SIZE >= 2`. Removing
+reverses from one worker can protocol-fault the daemon and restart it
+(`daemon not running; starting now`), which takes UiAutomator2 down on
+every emulator in the job. New tests overwrite the mappings they need
+via `adb reverse tcp:<fallback> tcp:<actual>`.
+
 ## Measuring impact
 
 Do not reduce shard counts until this data exists for the suites that matter.

--- a/tests/framework/fixtures/FixtureUtils.ts
+++ b/tests/framework/fixtures/FixtureUtils.ts
@@ -26,6 +26,7 @@ import {
   isAdbTransportFault,
   withAdbHostLock,
 } from '../services/appium/adbHostLock.ts';
+import { isSharedAndroidAdbDaemon } from '../services/providers/emulator/android/androidDevicePool.ts';
 
 const execAsync = promisify(exec);
 
@@ -77,6 +78,16 @@ export async function cleanupAllAndroidPortForwarding(): Promise<void> {
 
   // Skip on BrowserStack
   if (isBrowserStack()) {
+    return;
+  }
+
+  // Shared-adb pools: --remove races sibling UiAutomator2 and can restart the
+  // daemon (`protocol fault` → `daemon not running; starting now` → device
+  // offline). setupAndroidPortForwarding overwrites the mappings we need.
+  if (isSharedAndroidAdbDaemon()) {
+    logger.debug(
+      'Skipping adb reverse --remove on shared Android adb daemon (device pool size >= 2)',
+    );
     return;
   }
 

--- a/tests/framework/services/providers/emulator/android/androidDevicePool.test.ts
+++ b/tests/framework/services/providers/emulator/android/androidDevicePool.test.ts
@@ -2,6 +2,7 @@ import {
   applyAndroidDevicePoolToWorker,
   assertAndroidDevicePoolMatchesWorkers,
   deviceForWorker,
+  isSharedAndroidAdbDaemon,
   parseAndroidDevicePool,
   resolveAndroidDevicePoolSize,
 } from './androidDevicePool.ts';
@@ -54,6 +55,38 @@ describe('androidDevicePool', () => {
       expect(resolveZero).toThrow(
         'Invalid ANDROID_DEVICE_POOL_SIZE "0". Expected a positive integer.',
       );
+    });
+  });
+
+  describe('isSharedAndroidAdbDaemon', () => {
+    it('returns false for the single-emulator default', () => {
+      const result = isSharedAndroidAdbDaemon({});
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when the pool size is one', () => {
+      const result = isSharedAndroidAdbDaemon({
+        ANDROID_DEVICE_POOL_SIZE: '1',
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true for an N=2 Android Appium pool', () => {
+      const result = isSharedAndroidAdbDaemon({
+        ANDROID_DEVICE_POOL_SIZE: '2',
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true for an N=3 Android Appium pool', () => {
+      const result = isSharedAndroidAdbDaemon({
+        ANDROID_DEVICE_POOL_SIZE: '3',
+      });
+
+      expect(result).toBe(true);
     });
   });
 

--- a/tests/framework/services/providers/emulator/android/androidDevicePool.ts
+++ b/tests/framework/services/providers/emulator/android/androidDevicePool.ts
@@ -30,6 +30,17 @@ export function resolveAndroidDevicePoolSize(
 }
 
 /**
+ * True when two or more emulators share one host `adb` server (CI N=2 / N=3).
+ * Concurrent `adb reverse --remove` from one worker races sibling UiAutomator2
+ * traffic and can restart the daemon, taking down the whole shard.
+ */
+export function isSharedAndroidAdbDaemon(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return resolveAndroidDevicePoolSize(env) >= 2;
+}
+
+/**
  * Pool mode requires one Playwright worker per emulator. Playwright reads its
  * worker count before global setup, so changing E2E_WORKERS during boot cannot
  * repair a mismatch.


### PR DESCRIPTION

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

**Reason:** The `appium-wallet-platform-android-smoke-1` shard failed on `main` ([run 34088934820](https://github.com/MetaMask/metamask-mobile/actions/runs/34088934820/job/101640185129)) with 3 failed / 5 reported specs, none of which were product assertion failures. Every error was `'POST /element' cannot be proxied to UiAutomator2 server because the instrumentation process is not running (probably crashed)` or `socket hang up`.

Android smoke runs `N=3` emulators behind **one shared host `adb` server**. At the start of every test, `withFixtures` calls `cleanupAllAndroidPortForwarding()`, which issues nine `adb reverse --remove` commands. In this run, worker 2's cleanup protocol-faulted and restarted the daemon:

```
adb: error: protocol fault (couldn't read status): Success
* daemon not running; starting now at tcp:5037
* daemon started successfully
adb: device offline
```

That daemon restart severed the UiAutomator2 transport for the sibling workers. Worker 1 died mid-click inside `TrendingView.tapTokenRow`, and the remaining specs (`evm-provider-events`, `incoming-transactions`, `spam-token-cleanup`, `import-wallet`) failed as collateral on the same dead instrumentation.

The existing `withAdbHostLock` serializes removes across workers, but it only prevents *concurrent* adb client calls — it cannot prevent a `--remove` from faulting the shared daemon while a sibling's UiAutomator2 session is actively using that transport.

**Solution:** Skip `adb reverse --remove` entirely when the emulator pool is shared (`ANDROID_DEVICE_POOL_SIZE >= 2`). The removes were only ever a stale-state precaution, and they are redundant in pool mode: `setupAndroidPortForwarding` runs `adb reverse tcp:<fallback> tcp:<actual>` for every port each test needs, which **overwrites** any stale mapping on that emulator. Dropping the removes eliminates the daemon churn without leaving stale forwards behind.

Single-emulator runs (`ANDROID_DEVICE_POOL_SIZE` unset or `1`, including local runs and fixture validation) keep the existing `--remove` cleanup path unchanged.

Test-infrastructure only — no app code is touched.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

Refs: [Appium Smoke Tests (Android) failure on run 34088934820](https://github.com/MetaMask/metamask-mobile/actions/runs/34088934820/job/101640185129)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Android Appium smoke stability on a shared adb daemon

  Background:
    Given the Android Appium smoke job boots a pool of emulators
    And all pooled emulators share one host adb server

  Scenario: pooled run does not churn the shared adb daemon
    Given ANDROID_DEVICE_POOL_SIZE is 3 and E2E_WORKERS is 3

    When the wallet-platform Android smoke shard runs
    Then no worker issues "adb reverse --remove"
    And the log shows "Skipping adb reverse --remove on shared Android adb daemon"
    And no worker reports "protocol fault" or "daemon not running; starting now"
    And no spec fails with "instrumentation process is not running"

  Scenario: each test still reaches its own host servers
    Given ANDROID_DEVICE_POOL_SIZE is 3

    When a spec starts and allocates fixture, mock, and dapp server ports
    Then setupAndroidPortForwarding overwrites the reverse mappings for those ports
    And the app on the emulator loads its fixture from the correct host port

  Scenario: single-emulator runs keep the existing cleanup
    Given ANDROID_DEVICE_POOL_SIZE is unset

    When an Android smoke spec starts
    Then "adb reverse --remove" runs for the known fallback ports as before
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — CI-only test-infrastructure change.

Failing shard for reference: https://github.com/MetaMask/metamask-mobile/actions/runs/34088934820/job/101640185129 (`shard-status: 12 executed, 3 failed, 9 passed`).

### **After**

N/A — CI-only test-infrastructure change. Verified via the Android Appium smoke jobs on this PR.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-infrastructure only; narrows adb cleanup for multi-emulator CI without changing app code or port setup behavior.
> 
> **Overview**
> Fixes flaky Android Appium smoke failures where one worker’s per-test **`adb reverse --remove`** cleanup could protocol-fault the **shared host adb daemon** and knock out UiAutomator2 on sibling emulators in the same job.
> 
> When **`ANDROID_DEVICE_POOL_SIZE >= 2`**, **`cleanupAllAndroidPortForwarding`** in **`FixtureUtils`** now returns early instead of removing fallback port reverses. **`isSharedAndroidAdbDaemon`** in **`androidDevicePool`** encodes that rule; unit tests cover pool sizes 1 vs 2/3. Single-emulator runs (unset or `1`) still run the existing remove path. **`android-appium-device-pool.md`** documents the shared-daemon behavior and that **`setupAndroidPortForwarding`** overwrites mappings each test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c615ef4f23db6371255713227f47ac851de9d21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->