### PR TITLE
feat: add gas fees and balance checks on swaps limit order

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.test.tsx
@@ -11,6 +11,9 @@ import { ethToken1Address } from '../../../_mocks_/initialState';
 import { createBridgeTestState, createMockToken } from '../../../testUtils';
 import type { RootState } from '../../../../../../reducers';
 import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
+import { strings } from '../../../../../../../locales/i18n';
+import useIsInsufficientBalance from '../../../hooks/useInsufficientBalance';
+import { useHasSufficientGas } from '../../../hooks/useHasSufficientGas';
 import { BridgeLimitOrderFooterView } from './BridgeLimitOrderFooterView';
 
 const pricedDestToken = createMockToken({
@@ -33,6 +36,15 @@ jest.mock('../../../hooks/useBridgeQuoteData', () => ({
   useBridgeQuoteData: jest
     .fn()
     .mockImplementation(() => mockUseBridgeQuoteData),
+}));
+
+jest.mock('../../../hooks/useInsufficientBalance', () => ({
+  __esModule: true,
+  default: jest.fn(() => false),
+}));
+
+jest.mock('../../../hooks/useHasSufficientGas', () => ({
+  useHasSufficientGas: jest.fn(() => true),
 }));
 
 jest.mock('../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => {
@@ -98,6 +110,8 @@ function renderFooter(
 describe('BridgeLimitOrderFooterView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(useIsInsufficientBalance).mockReturnValue(false);
+    jest.mocked(useHasSufficientGas).mockReturnValue(true);
   });
 
   it('renders nothing when source amount is missing', () => {
@@ -152,5 +166,38 @@ describe('BridgeLimitOrderFooterView', () => {
     fireEvent.press(getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON));
 
     expect(onCTAPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the confirm button and shows insufficient funds when source balance is too low', () => {
+    jest.mocked(useIsInsufficientBalance).mockReturnValue(true);
+
+    const onCTAPress = jest.fn();
+    const { getByTestId } = renderFooter(buildActiveQuoteState(), {
+      onCTAPress,
+    });
+    fireEvent.press(getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON));
+
+    expect(getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON)).toHaveTextContent(
+      strings('bridge.insufficient_funds'),
+    );
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON).props
+        .accessibilityState?.disabled,
+    ).toBe(true);
+    expect(onCTAPress).not.toHaveBeenCalled();
+  });
+
+  it('disables the confirm button and shows insufficient gas when gas token balance is too low', () => {
+    jest.mocked(useHasSufficientGas).mockReturnValue(false);
+
+    const { getByTestId } = renderFooter(buildActiveQuoteState());
+
+    expect(getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON)).toHaveTextContent(
+      strings('bridge.insufficient_gas'),
+    );
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON).props
+        .accessibilityState?.disabled,
+    ).toBe(true);
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.test.tsx
@@ -177,9 +177,9 @@ describe('BridgeLimitOrderFooterView', () => {
     });
     fireEvent.press(getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON));
 
-    expect(getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON)).toHaveTextContent(
-      strings('bridge.insufficient_funds'),
-    );
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON),
+    ).toHaveTextContent(strings('bridge.insufficient_funds'));
     expect(
       getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON).props
         .accessibilityState?.disabled,
@@ -192,9 +192,9 @@ describe('BridgeLimitOrderFooterView', () => {
 
     const { getByTestId } = renderFooter(buildActiveQuoteState());
 
-    expect(getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON)).toHaveTextContent(
-      strings('bridge.insufficient_gas'),
-    );
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON),
+    ).toHaveTextContent(strings('bridge.insufficient_gas'));
     expect(
       getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON).props
         .accessibilityState?.disabled,

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderFooterView.tsx
@@ -6,8 +6,7 @@ import {
   selectSourceToken,
   selectBridgeControllerState,
 } from '../../../../../../core/redux/slices/bridge';
-import { useBridgeQuoteDataContext } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
-import { useHasMissingQuoteAndAssetsPriceData } from '../../../hooks/useHasMissingQuoteAndAssetsPriceData';
+import type { useLatestBalance } from '../../../hooks/useLatestBalance';
 import {
   Box,
   BoxAlignItems,
@@ -20,17 +19,18 @@ interface Props {
   onCTAPress: () => void;
   ctaDisabled?: boolean;
   ctaLabel: string;
+  latestSourceBalance?: ReturnType<typeof useLatestBalance>;
 }
 
 export const BridgeLimitOrderFooterView = ({
   onCTAPress,
   ctaLabel,
   ctaDisabled,
+  latestSourceBalance,
 }: Props) => {
   const { bottom: bottomInset } = useSafeAreaInsets();
   const sourceAmount = useSelector(selectSourceAmount);
   const sourceToken = useSelector(selectSourceToken);
-  const { activeQuote, isLoading, needsNewQuote } = useBridgeQuoteDataContext();
   const { quotesLastFetched } = useSelector(selectBridgeControllerState);
 
   const isValidSourceAmount =
@@ -57,6 +57,7 @@ export const BridgeLimitOrderFooterView = ({
         testID={BridgeViewSelectorsIDs.CONFIRM_BUTTON}
         disabled={ctaDisabled}
         loading={ctaDisabled}
+        latestSourceBalance={latestSourceBalance}
       />
     </Box>
   );

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.test.tsx
@@ -12,6 +12,8 @@ import { useSwapsLimitOrderPriceAdjust } from '../../../hooks/useSwapsLimitOrder
 import { useSwapsLimitOrderKeypad } from '../../../hooks/useSwapsLimitOrderKeypad';
 import { useHasMissingQuoteAndAssetsPriceData } from '../../../hooks/useHasMissingQuoteAndAssetsPriceData';
 import { useLatestBalance } from '../../../hooks/useLatestBalance';
+import useIsInsufficientBalance from '../../../hooks/useInsufficientBalance';
+import { useHasSufficientGas } from '../../../hooks/useHasSufficientGas';
 import {
   LimitOrderExecutionType,
   getSwapsLimitOrderExpirationLabel,
@@ -56,6 +58,15 @@ jest.mock('../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => {
 
 jest.mock('../../../hooks/useLatestBalance', () => ({
   useLatestBalance: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useInsufficientBalance', () => ({
+  __esModule: true,
+  default: jest.fn(() => false),
+}));
+
+jest.mock('../../../hooks/useHasSufficientGas', () => ({
+  useHasSufficientGas: jest.fn(() => true),
 }));
 
 jest.mock('../../../hooks/useLimitOrderSwapsInput', () => ({
@@ -367,6 +378,8 @@ describe('BridgeLimitOrderView', () => {
       .mocked(useSwapsLimitOrderKeypad)
       .mockImplementation(() => buildKeypadMock());
     jest.mocked(useHasMissingQuoteAndAssetsPriceData).mockReturnValue(false);
+    jest.mocked(useIsInsufficientBalance).mockReturnValue(false);
+    jest.mocked(useHasSufficientGas).mockReturnValue(true);
   });
 
   it('renders the limit order container and source token input', () => {
@@ -426,6 +439,38 @@ describe('BridgeLimitOrderView', () => {
 
     const { getByTestId } = renderLimitOrderView();
 
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON_KEYPAD).props
+        .accessibilityState?.disabled,
+    ).toBe(true);
+  });
+
+  it('disables the keypad confirm button and shows insufficient funds when source balance is too low', () => {
+    mockIsAmountFocused = true;
+    mockSourceAmount = '2';
+    jest.mocked(useIsInsufficientBalance).mockReturnValue(true);
+
+    const { getByTestId } = renderLimitOrderView();
+
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON_KEYPAD),
+    ).toHaveTextContent(strings('bridge.insufficient_funds'));
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON_KEYPAD).props
+        .accessibilityState?.disabled,
+    ).toBe(true);
+  });
+
+  it('disables the keypad confirm button and shows insufficient gas when gas token balance is too low', () => {
+    mockIsAmountFocused = true;
+    mockSourceAmount = '2';
+    jest.mocked(useHasSufficientGas).mockReturnValue(false);
+
+    const { getByTestId } = renderLimitOrderView();
+
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON_KEYPAD),
+    ).toHaveTextContent(strings('bridge.insufficient_gas'));
     expect(
       getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON_KEYPAD).props
         .accessibilityState?.disabled,

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
@@ -417,6 +417,7 @@ const BridgeLimitOrderViewContent = ({
           ctaDisabled={isMissingPrice || !isQuoteActive}
           onCTAPress={handleCreateOrderPress}
           ctaLabel={strings('bridge.limit.create_order')}
+          latestSourceBalance={latestSourceBalance}
         />
 
         <SwapsKeypad
@@ -430,6 +431,8 @@ const BridgeLimitOrderViewContent = ({
               label={strings('bridge.limit.create_order')}
               testID={BridgeViewSelectorsIDs.CONFIRM_BUTTON_KEYPAD}
               disabled={isMissingPrice || !isQuoteActive}
+              loading={isMissingPrice || !isQuoteActive}
+              latestSourceBalance={latestSourceBalance}
             />
           ) : isAmountFocused ? (
             <GaslessQuickPickOptions

--- a/app/components/UI/Bridge/components/SwapsLimitOrderConfirmButton/SwapsLimitOrderConfirmButton.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsLimitOrderConfirmButton/SwapsLimitOrderConfirmButton.test.tsx
@@ -11,7 +11,6 @@ import { useIsNetworkFeeUnavailable } from '../../hooks/useIsNetworkFeeUnavailab
 import { BridgeViewSelectorsIDs } from '../../Views/BridgeView/BridgeView.testIds';
 import { SwapsLimitOrderConfirmButton } from './index';
 
-
 const TEST_ID = BridgeViewSelectorsIDs.CONFIRM_BUTTON;
 const DEFAULT_LABEL = 'Create Order';
 
@@ -46,7 +45,9 @@ function mockSettledQuote(
 }
 
 function renderButton(
-  props: Partial<React.ComponentProps<typeof SwapsLimitOrderConfirmButton>> = {},
+  props: Partial<
+    React.ComponentProps<typeof SwapsLimitOrderConfirmButton>
+  > = {},
 ) {
   const onPress = props.onPress ?? jest.fn();
 

--- a/app/components/UI/Bridge/components/SwapsLimitOrderConfirmButton/SwapsLimitOrderConfirmButton.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsLimitOrderConfirmButton/SwapsLimitOrderConfirmButton.test.tsx
@@ -1,51 +1,95 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
-import { SwapsLimitOrderConfirmButton } from './index';
+import { strings } from '../../../../../../locales/i18n';
+import { mockUseBridgeQuoteData } from '../../_mocks_/useBridgeQuoteData.mock';
+import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import { useHasSufficientGas } from '../../hooks/useHasSufficientGas';
+import useIsInsufficientBalance from '../../hooks/useInsufficientBalance';
+import { useInsufficientNativeReserveError } from '../../hooks/useInsufficientNativeReserveError';
+import { useIsNetworkFeeUnavailable } from '../../hooks/useIsNetworkFeeUnavailable';
 import { BridgeViewSelectorsIDs } from '../../Views/BridgeView/BridgeView.testIds';
+import { SwapsLimitOrderConfirmButton } from './index';
+
 
 const TEST_ID = BridgeViewSelectorsIDs.CONFIRM_BUTTON;
+const DEFAULT_LABEL = 'Create Order';
 
-describe('SwapsLimitOrderConfirmButton', () => {
-  it('calls onPress when pressed', () => {
-    const onPress = jest.fn();
+jest.mock('../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => ({
+  useBridgeQuoteDataContext: jest.fn(),
+}));
 
-    const { getByTestId } = renderWithProvider(
+jest.mock('../../hooks/useInsufficientBalance', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../../hooks/useHasSufficientGas', () => ({
+  useHasSufficientGas: jest.fn(),
+}));
+
+jest.mock('../../hooks/useInsufficientNativeReserveError', () => ({
+  useInsufficientNativeReserveError: jest.fn(),
+}));
+
+jest.mock('../../hooks/useIsNetworkFeeUnavailable', () => ({
+  useIsNetworkFeeUnavailable: jest.fn(),
+}));
+
+function mockSettledQuote(
+  overrides: Partial<typeof mockUseBridgeQuoteData> = {},
+) {
+  jest.mocked(useBridgeQuoteDataContext).mockReturnValue({
+    ...mockUseBridgeQuoteData,
+    ...overrides,
+  } as ReturnType<typeof useBridgeQuoteDataContext>);
+}
+
+function renderButton(
+  props: Partial<React.ComponentProps<typeof SwapsLimitOrderConfirmButton>> = {},
+) {
+  const onPress = props.onPress ?? jest.fn();
+
+  return {
+    onPress,
+    ...renderWithProvider(
       <SwapsLimitOrderConfirmButton
         onPress={onPress}
-        label="Confirm limit"
+        label={DEFAULT_LABEL}
         testID={TEST_ID}
+        {...props}
       />,
-    );
+    ),
+  };
+}
+
+describe('SwapsLimitOrderConfirmButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSettledQuote();
+    jest.mocked(useIsInsufficientBalance).mockReturnValue(false);
+    jest.mocked(useInsufficientNativeReserveError).mockReturnValue(undefined);
+    jest.mocked(useIsNetworkFeeUnavailable).mockReturnValue(false);
+    jest.mocked(useHasSufficientGas).mockReturnValue(true);
+  });
+
+  it('calls onPress when pressed', () => {
+    const { onPress, getByTestId } = renderButton();
 
     fireEvent.press(getByTestId(TEST_ID));
 
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the provided label', () => {
-    const { getByTestId } = renderWithProvider(
-      <SwapsLimitOrderConfirmButton
-        onPress={jest.fn()}
-        label="Place order"
-        testID={TEST_ID}
-      />,
-    );
+  it('renders the provided label when funds and gas are sufficient', () => {
+    const { getByTestId } = renderButton({ label: 'Place order' });
 
     expect(getByTestId(TEST_ID)).toHaveTextContent('Place order');
+    expect(getByTestId(TEST_ID).props.accessibilityState?.disabled).toBeFalsy();
   });
 
-  it('does not call onPress when disabled', () => {
-    const onPress = jest.fn();
-
-    const { getByTestId } = renderWithProvider(
-      <SwapsLimitOrderConfirmButton
-        onPress={onPress}
-        label="Confirm limit"
-        testID={TEST_ID}
-        disabled
-      />,
-    );
+  it('does not call onPress when disabled by the caller', () => {
+    const { onPress, getByTestId } = renderButton({ disabled: true });
 
     fireEvent.press(getByTestId(TEST_ID));
 
@@ -53,19 +97,103 @@ describe('SwapsLimitOrderConfirmButton', () => {
   });
 
   it('does not call onPress when loading', () => {
-    const onPress = jest.fn();
-
-    const { getByTestId } = renderWithProvider(
-      <SwapsLimitOrderConfirmButton
-        onPress={onPress}
-        label="Confirm limit"
-        testID={TEST_ID}
-        loading
-      />,
-    );
+    const { onPress, getByTestId } = renderButton({ loading: true });
 
     fireEvent.press(getByTestId(TEST_ID));
 
     expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('disables the button and shows insufficient funds when source balance is too low', () => {
+    jest.mocked(useIsInsufficientBalance).mockReturnValue(true);
+
+    const { onPress, getByTestId } = renderButton();
+    fireEvent.press(getByTestId(TEST_ID));
+
+    expect(getByTestId(TEST_ID)).toHaveTextContent(
+      strings('bridge.insufficient_funds'),
+    );
+    expect(getByTestId(TEST_ID).props.accessibilityState?.disabled).toBe(true);
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('disables the button and shows insufficient funds when native reserve is too low', () => {
+    jest.mocked(useInsufficientNativeReserveError).mockReturnValue({
+      minimumNativeBalanceToBeKeptInAccount: '10',
+      maxSwappableNativeBalance: '40',
+    });
+
+    const { getByTestId } = renderButton();
+
+    expect(getByTestId(TEST_ID)).toHaveTextContent(
+      strings('bridge.insufficient_funds'),
+    );
+    expect(getByTestId(TEST_ID).props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('disables the button and shows insufficient funds when network fee is unavailable', () => {
+    jest.mocked(useIsNetworkFeeUnavailable).mockReturnValue(true);
+
+    const { getByTestId } = renderButton();
+
+    expect(getByTestId(TEST_ID)).toHaveTextContent(
+      strings('bridge.insufficient_funds'),
+    );
+    expect(getByTestId(TEST_ID).props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('disables the button and shows insufficient gas when gas token balance is too low', () => {
+    jest.mocked(useHasSufficientGas).mockReturnValue(false);
+
+    const { onPress, getByTestId } = renderButton();
+    fireEvent.press(getByTestId(TEST_ID));
+
+    expect(getByTestId(TEST_ID)).toHaveTextContent(
+      strings('bridge.insufficient_gas'),
+    );
+    expect(getByTestId(TEST_ID).props.accessibilityState?.disabled).toBe(true);
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('prefers insufficient funds over insufficient gas when both apply', () => {
+    jest.mocked(useIsInsufficientBalance).mockReturnValue(true);
+    jest.mocked(useHasSufficientGas).mockReturnValue(false);
+
+    const { getByTestId } = renderButton();
+
+    expect(getByTestId(TEST_ID)).toHaveTextContent(
+      strings('bridge.insufficient_funds'),
+    );
+  });
+
+  it('keeps the caller label while the quote is still loading', () => {
+    mockSettledQuote({ isLoading: true });
+    jest.mocked(useIsInsufficientBalance).mockReturnValue(true);
+    jest.mocked(useHasSufficientGas).mockReturnValue(false);
+
+    const { getByTestId } = renderButton();
+
+    expect(getByTestId(TEST_ID)).toHaveTextContent(DEFAULT_LABEL);
+    expect(getByTestId(TEST_ID).props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('keeps the caller label when there is no active quote yet', () => {
+    mockSettledQuote({ activeQuote: undefined });
+    jest.mocked(useIsInsufficientBalance).mockReturnValue(true);
+
+    const { getByTestId } = renderButton();
+
+    expect(getByTestId(TEST_ID)).toHaveTextContent(DEFAULT_LABEL);
+    expect(getByTestId(TEST_ID).props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('hides the loading spinner when showing an insufficient funds label', () => {
+    jest.mocked(useIsInsufficientBalance).mockReturnValue(true);
+
+    const { getByTestId } = renderButton({ loading: true });
+
+    expect(getByTestId(TEST_ID)).toHaveTextContent(
+      strings('bridge.insufficient_funds'),
+    );
   });
 });

--- a/app/components/UI/Bridge/components/SwapsLimitOrderConfirmButton/index.tsx
+++ b/app/components/UI/Bridge/components/SwapsLimitOrderConfirmButton/index.tsx
@@ -4,8 +4,22 @@ import {
   ButtonBaseSize,
   ButtonVariant,
 } from '@metamask/design-system-react-native';
+import { useSelector } from 'react-redux';
+import { strings } from '../../../../../../locales/i18n';
+import {
+  selectSourceAmount,
+  selectSourceToken,
+} from '../../../../../core/redux/slices/bridge';
+import { selectSourceWalletAddress } from '../../../../../selectors/bridge';
+import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import { useHasSufficientGas } from '../../hooks/useHasSufficientGas';
+import useIsInsufficientBalance from '../../hooks/useInsufficientBalance';
+import { useInsufficientNativeReserveError } from '../../hooks/useInsufficientNativeReserveError';
+import { useIsNetworkFeeUnavailable } from '../../hooks/useIsNetworkFeeUnavailable';
+import type { useLatestBalance } from '../../hooks/useLatestBalance';
 
 interface Props {
+  latestSourceBalance?: ReturnType<typeof useLatestBalance>;
   loading?: boolean;
   onPress: () => void;
   testID?: string;
@@ -14,21 +28,68 @@ interface Props {
 }
 
 export const SwapsLimitOrderConfirmButton = ({
+  latestSourceBalance,
   loading,
   onPress,
   testID,
   disabled,
   label,
-}: Props) => (
-  <Button
-    variant={ButtonVariant.Primary}
-    size={ButtonBaseSize.Lg}
-    isLoading={loading}
-    onPress={onPress}
-    isFullWidth
-    testID={testID}
-    isDisabled={disabled}
-  >
-    {label}
-  </Button>
-);
+}: Props) => {
+  const sourceAmount = useSelector(selectSourceAmount);
+  const sourceToken = useSelector(selectSourceToken);
+  const walletAddress = useSelector(selectSourceWalletAddress);
+  const { activeQuote, isLoading } = useBridgeQuoteDataContext();
+
+  const hasInsufficientBalance = useIsInsufficientBalance({
+    amount: sourceAmount,
+    token: sourceToken,
+    latestAtomicBalance: latestSourceBalance?.atomicBalance,
+  });
+
+  const insufficientNativeReserveError = useInsufficientNativeReserveError({
+    amount: sourceAmount,
+    token: sourceToken,
+    latestAtomicBalance: latestSourceBalance?.atomicBalance,
+    walletAddress,
+    activeQuote,
+  });
+
+  const isNetworkFeeUnavailable = useIsNetworkFeeUnavailable(activeQuote);
+  const hasSufficientGas = useHasSufficientGas({ quote: activeQuote });
+  const hasInsufficientGas = !isNetworkFeeUnavailable && !hasSufficientGas;
+
+  const hasInsufficientFunds =
+    hasInsufficientBalance ||
+    Boolean(insufficientNativeReserveError) ||
+    isNetworkFeeUnavailable;
+
+  // Gas and native-reserve checks read from the active quote, so their result is
+  // only meaningful once a quote has settled. Before that the caller's `disabled`
+  // already covers the button state.
+  const hasSettledQuote = Boolean(activeQuote) && !isLoading;
+
+  const isDisabled = Boolean(
+    disabled || hasInsufficientFunds || hasInsufficientGas,
+  );
+
+  let resolvedLabel = label;
+  if (hasSettledQuote && hasInsufficientFunds) {
+    resolvedLabel = strings('bridge.insufficient_funds');
+  } else if (hasSettledQuote && hasInsufficientGas) {
+    resolvedLabel = strings('bridge.insufficient_gas');
+  }
+
+  return (
+    <Button
+      variant={ButtonVariant.Primary}
+      size={ButtonBaseSize.Lg}
+      isLoading={Boolean(loading) && resolvedLabel === label}
+      onPress={onPress}
+      isFullWidth
+      testID={testID}
+      isDisabled={isDisabled}
+    >
+      {resolvedLabel}
+    </Button>
+  );
+};


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The swaps limit order flow did not validate whether the user has enough source token balance or native gas to place an order. Users could tap "Create order" even when they lacked sufficient funds, leading to a poor experience and potential failed transactions.

This PR centralizes balance and gas validation in `SwapsLimitOrderConfirmButton`. The button now checks source token balance, native reserve requirements, network fee availability, and gas sufficiency against the active quote. When a quote has settled and validation fails, the button is disabled and its label updates to "Insufficient funds" or "Insufficient gas" (matching the regular bridge/swaps flow). The footer and keypad confirm buttons in `BridgeLimitOrderView` pass through `latestSourceBalance` so balance checks use up-to-date values. Loading spinner is suppressed when an insufficient-funds/gas label is shown.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added insufficient funds and gas validation to the swaps limit order confirm button

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-5019

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Swaps limit order balance and gas validation

  Background:
    Given I am logged into MetaMask Mobile
    And I navigate to the Bridge/Swaps flow
    And I switch to the Limit Order tab

  Scenario: user sees insufficient funds when source token balance is too low
    Given I have a source token with a balance lower than the entered amount
    And a limit order quote has loaded

    When I view the confirm button (footer or keypad)
    Then the button should be disabled
    And the button label should read "Insufficient funds"

  Scenario: user sees insufficient gas when native gas balance is too low
    Given I have enough source token balance for the order
    But I do not have enough native token to cover gas fees
    And a limit order quote has loaded

    When I view the confirm button (footer or keypad)
    Then the button should be disabled
    And the button label should read "Insufficient gas"

  Scenario: user can create order when balance and gas are sufficient
    Given I have enough source token balance for the entered amount
    And I have enough native token to cover gas fees
    And a limit order quote has loaded

    When I view the confirm button
    Then the button should be enabled
    And the button label should read "Create order"

  Scenario: confirm button shows default label while quote is loading
    Given I have insufficient balance or gas
    But the limit order quote is still loading

    When I view the confirm button
    Then the button should be disabled
    And the button label should remain "Create order" (not show insufficient funds/gas)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing limit-order submission is blocked based on quote and balance hooks; incorrect gating could wrongly disable orders or still allow taps, but logic reuses existing bridge validation patterns.
> 
> **Overview**
> Limit order **Create order** actions now gate on the same balance and gas checks as the main bridge/swaps flow, instead of staying tappable when funds or gas are insufficient.
> 
> **`SwapsLimitOrderConfirmButton`** owns the validation: source balance (via optional `latestSourceBalance`), native reserve, network fee availability, and gas against the settled active quote. When a quote has finished loading, the button disables and the label switches to **Insufficient funds** or **Insufficient gas** (funds win if both apply); while loading or before an active quote exists, the caller label stays and only caller `disabled`/`loading` apply, with the spinner hidden when an error label is shown.
> 
> **`BridgeLimitOrderView`** passes `latestSourceBalance` into the footer and keypad confirm buttons and wires keypad `loading` to the existing quote/price disabled state. **`BridgeLimitOrderFooterView`** drops direct quote-context usage and forwards balance into the shared confirm button. Tests cover the button matrix plus footer and keypad integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ad3d8b7f2d838f17acb6d8c8935043198169b8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->