### PR TITLE
perf(activity): replace O(n·m) bridge scans in ActivityList non-EVM merge

### DIFF
--- a/app/components/UI/Bridge/hooks/useBridgeHistoryItemBySrcTxHash/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeHistoryItemBySrcTxHash/index.ts
@@ -3,8 +3,11 @@ import { selectBridgeHistoryForAccount } from '../../../../../selectors/bridgeSt
 import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import { useMemo } from 'react';
 
+const normalizeEvmTransactionHash = (hash: string) =>
+  /^0x/i.test(hash) ? hash.toLowerCase() : undefined;
+
 /**
- * Looks up a bridge history item by source tx hash (case-insensitive)
+ * Looks up by exact source tx hash, with case-insensitive matching for EVM hashes.
  */
 export const findBridgeHistoryItemBySrcTxHash = (
   bridgeHistoryItemsBySrcTxHash: Record<string, BridgeHistoryItem>,
@@ -14,12 +17,10 @@ export const findBridgeHistoryItemBySrcTxHash = (
     return undefined;
   }
 
-  const normalizedHash = hash.toLowerCase();
+  const normalizedHash = normalizeEvmTransactionHash(hash);
   return (
     bridgeHistoryItemsBySrcTxHash[hash] ??
-    Object.entries(bridgeHistoryItemsBySrcTxHash).find(
-      ([key]) => key.toLowerCase() === normalizedHash,
-    )?.[1]
+    (normalizedHash ? bridgeHistoryItemsBySrcTxHash[normalizedHash] : undefined)
   );
 };
 
@@ -45,10 +46,18 @@ export const useBridgeHistoryItemBySrcTxHash = () => {
         const srcTxHash = bridgeTx.status?.srcChain?.txHash;
         if (srcTxHash) {
           bySrcTxHash[srcTxHash] = bridgeTx;
+          const normalizedSrcTxHash = normalizeEvmTransactionHash(srcTxHash);
+          if (normalizedSrcTxHash) {
+            bySrcTxHash[normalizedSrcTxHash] = bridgeTx;
+          }
         }
         const destTxHash = bridgeTx.status?.destChain?.txHash;
         if (destTxHash) {
           byDestTxHash[destTxHash] = bridgeTx;
+          const normalizedDestTxHash = normalizeEvmTransactionHash(destTxHash);
+          if (normalizedDestTxHash) {
+            byDestTxHash[normalizedDestTxHash] = bridgeTx;
+          }
         }
       });
 

--- a/app/components/UI/Bridge/hooks/useBridgeHistoryItemBySrcTxHash/useBridgeHistoryItemBySrcTxHash.test.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeHistoryItemBySrcTxHash/useBridgeHistoryItemBySrcTxHash.test.tsx
@@ -1,6 +1,9 @@
 import { initialState } from '../../_mocks_/initialState';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
-import { useBridgeHistoryItemBySrcTxHash } from '.';
+import {
+  findBridgeHistoryItemBySrcTxHash,
+  useBridgeHistoryItemBySrcTxHash,
+} from '.';
 import { cloneDeep } from 'lodash';
 
 describe('useBridgeHistoryItemBySrcTxHash', () => {
@@ -31,6 +34,30 @@ describe('useBridgeHistoryItemBySrcTxHash', () => {
       initialState.engine.backgroundState.BridgeStatusController.txHistory[
         'test-tx-id'
       ],
+    );
+  });
+
+  it('indexes EVM transaction hashes case-insensitively for constant-time lookup', () => {
+    const state = cloneDeep(initialState);
+    const bridgeHistoryItem =
+      state.engine.backgroundState.BridgeStatusController.txHistory[
+        'test-tx-id'
+      ];
+    bridgeHistoryItem.status.srcChain.txHash = '0xAbC';
+
+    const { result } = renderHookWithProvider(
+      () => useBridgeHistoryItemBySrcTxHash(),
+      { state },
+    );
+
+    expect(
+      findBridgeHistoryItemBySrcTxHash(
+        result.current.bridgeHistoryItemsBySrcTxHash,
+        '0xaBc',
+      ),
+    ).toBe(bridgeHistoryItem);
+    expect(result.current.bridgeHistoryItemsBySrcTxHash['0xabc']).toBe(
+      bridgeHistoryItem,
     );
   });
 });

--- a/app/components/Views/ActivityList/ActivityList.test.tsx
+++ b/app/components/Views/ActivityList/ActivityList.test.tsx
@@ -1945,6 +1945,29 @@ describe('ActivityList', () => {
     });
   });
 
+  it('includes bridge transactions for configured destination chains without duplicate rows', () => {
+    selectorValues.enabledNonEvm = [];
+    selectorValues.nonEvmState = {
+      transactions: [
+        { chain: 'solana:mainnet', id: 'solanaCross', from: [], to: [] },
+        { chain: 'solana:mainnet', id: 'solanaCross', from: [], to: [] },
+      ],
+    };
+    (useTransactionsQuery as jest.Mock).mockReturnValue({
+      data: { pages: [{ data: [] }] },
+      fetchNextPage: mockFetchNextPage,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      isInitialLoading: false,
+      refetch: mockRefetch,
+    });
+    (useLocalActivityItems as jest.Mock).mockReturnValue([]);
+
+    render(<ActivityList header={<></>} />);
+
+    expect(screen.getAllByTestId('row-solanaCross')).toHaveLength(1);
+  });
+
   it('routes non-EVM cross-chain bridge taps to ActivityDetails', () => {
     selectorValues.enabledNonEvm = ['solana:mainnet'];
     selectorValues.nonEvmState = {

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -360,6 +360,7 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
       const configuredEvmSet = new Set(
         (configuredEVMChainIds ?? []).map((id) => id.toLowerCase()),
       );
+      const configuredNonEvmSet = new Set(configuredNonEVMChainIds);
 
       // Filter local items to configured EVM chains only, also deduplicate against confirmed
       const confirmedHashes = new Set(
@@ -464,22 +465,23 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
       });
 
       // Non-EVM: filter to configured chains, include bridge txns whose dest chain is configured
-      const filteredNonEvmTransactions = nonEvmTransactions
-        .filter((tx) => {
-          if (configuredNonEVMChainIds.includes(tx.chain)) return true;
-          const bridge = Object.values(bridgeHistory ?? {}).find(
-            (item) => item.status?.srcChain?.txHash === tx.id,
-          );
-          return (
-            bridge?.quote?.destChainId !== undefined &&
-            configuredEVMChainIds.includes(
-              numberToHex(bridge.quote.destChainId),
-            )
-          );
-        })
-        .filter(
-          (tx, index, self) => index === self.findIndex((t) => t.id === tx.id),
-        );
+      const seenNonEvmTransactionIds = new Set<string>();
+      const filteredNonEvmTransactions = nonEvmTransactions.filter((tx) => {
+        if (seenNonEvmTransactionIds.has(tx.id)) return false;
+
+        const bridge = getBridgeHistoryItemByHash(tx.id);
+        const shouldInclude =
+          configuredNonEvmSet.has(tx.chain) ||
+          (bridge?.quote?.destChainId !== undefined &&
+            configuredEvmSet.has(
+              numberToHex(bridge.quote.destChainId).toLowerCase(),
+            ));
+
+        if (shouldInclude) {
+          seenNonEvmTransactionIds.add(tx.id);
+        }
+        return shouldInclude;
+      });
 
       const filteredNonEvmForMalicious =
         filterMultichainTransactionsExcludingMaliciousTokenActivity(
@@ -487,13 +489,16 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
           maliciousTokenKeys,
         );
 
+      const accountAddressById = new Map(
+        selectedAccountGroupInternalAccounts.map((account) => [
+          account.id,
+          account.address,
+        ]),
+      );
       const nonEvmItems = mapNonEvmTransactions(
         filteredNonEvmForMalicious,
         getBridgeHistoryItemByHash,
-        (transaction) =>
-          selectedAccountGroupInternalAccounts.find(
-            (account) => account.id === transaction.account,
-          )?.address,
+        (transaction) => accountAddressById.get(transaction.account),
       );
 
       // Drop confirmed copies whose local copy won above, so the winning local


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Activity tab rebuilds were doing linear `Object.values(bridgeHistory).find` per non-EVM tx plus `findIndex` dedupe (`O(n·m)` + `O(n²)`). The src-hash map already existed on the same component and was unused by this filter.
This swaps the filter to `getBridgeHistoryItemByHash` + a `Set` of seen ids, precomputes `accountId → address`, and indexes EVM hashes lowercase in the bridge lookup so case-insensitive matches stay `O(1)` instead of falling back to `Object.entries().find`. Behavior is unchanged: configured-chain rows, dest-chain bridge arrivals, and first-id-wins dedupe.


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/TMCU-1356

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Activity list non-EVM and bridge merge

  Scenario: user opens Activity with Solana txs and a pending cross-chain bridge
    Given a wallet with Solana configured and a Solana→Ethereum bridge whose dest chain is configured
    And the same source tx id appears twice in non-EVM history

    When user opens the Activity tab
    Then the source tx appears once
    And the in-flight cross-chain bridge row stays pending until the dest leg lands
    And same-chain Solana swaps still render as swaps
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-focused refactor of Activity list merge and bridge hash maps; behavior is intended to match prior filtering and dedupe, with added tests.
> 
> **Overview**
> **Activity tab** non-EVM filtering no longer scans all bridge history per transaction or uses `findIndex` for dedupe. It uses the existing **`getBridgeHistoryItemByHash`** helper, a **`Set`** for first-seen transaction ids, and a prebuilt **`accountId → address`** map.
> 
> **Bridge history hook** now indexes **EVM** source/destination hashes in lowercase at build time and resolves lookups via map keys instead of **`Object.entries().find`**, so case-insensitive EVM matching stays **O(1)**. Non-`0x` ids (e.g. Solana) are left case-sensitive.
> 
> Tests cover case-insensitive EVM indexing and a single row when duplicate non-EVM bridge source ids appear for configured destination chains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73c83221f1c2e19345a315b35c66124ba32cc1f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->