### PR TITLE
ci: replace Homebrew ffmpeg with a timed static install

### DIFF
--- a/.github/scripts/qa-automation/appium-runner-prep/ensure-ffmpeg-ci.sh
+++ b/.github/scripts/qa-automation/appium-runner-prep/ensure-ffmpeg-ci.sh
@@ -1,84 +1,92 @@
 #!/usr/bin/env bash
-# Install ffmpeg for Appium XCUITest screen recording in CI.
-# Uses a cached Homebrew bottle dir + Cellar snapshot under ~/.cache/mms-ffmpeg
-# so subsequent runs skip downloading and compiling ffmpeg dependencies.
+# Install a pinned static ffmpeg for Appium XCUITest screen recording.
+# Avoids Homebrew: brew install / brew update can hang indefinitely on CI.
+# Failure is non-fatal — iOS recording is already best-effort in the test runner.
 set -euo pipefail
 
 CACHE_ROOT="${HOME}/.cache/mms-ffmpeg"
-BREW_CACHE_DIR="${CACHE_ROOT}/brew"
-CELLAR_CACHE_DIR="${CACHE_ROOT}/cellar"
+BIN_DIR="${CACHE_ROOT}/bin"
+BIN_PATH="${BIN_DIR}/ffmpeg"
+FFMPEG_VERSION='b6.1.1'
+DOWNLOAD_TIMEOUT_SEC="${FFMPEG_DOWNLOAD_TIMEOUT_SEC:-45}"
 
-export HOMEBREW_NO_AUTO_UPDATE=1
-export HOMEBREW_NO_INSTALL_CLEANUP=1
-export HOMEBREW_CACHE="${BREW_CACHE_DIR}"
+skip_without_ffmpeg() {
+  echo "::warning::ffmpeg unavailable — XCUITest failure videos will be skipped. $1"
+  exit 0
+}
 
-mkdir -p "${BREW_CACHE_DIR}" "${CELLAR_CACHE_DIR}"
-
-if ! command -v brew >/dev/null 2>&1; then
-  echo "Homebrew is required to install ffmpeg" >&2
-  exit 1
-fi
-
-restore_cached_cellars() {
-  local formula cellar_path
-  shopt -s nullglob
-  for cellar_path in "${CELLAR_CACHE_DIR}"/*; do
-    formula="$(basename "${cellar_path}")"
-    [[ "${formula}" == "ffmpeg" ]] && continue
-    mkdir -p "$(brew --cellar "${formula}")"
-    rsync -a "${cellar_path}/" "$(brew --cellar "${formula}")/"
-    brew link "${formula}" >/dev/null 2>&1 || true
-  done
-  if [[ -d "${CELLAR_CACHE_DIR}/ffmpeg" ]]; then
-    mkdir -p "$(brew --cellar ffmpeg)"
-    rsync -a "${CELLAR_CACHE_DIR}/ffmpeg/" "$(brew --cellar ffmpeg)/"
-    brew link ffmpeg >/dev/null 2>&1 || true
+export_bin_dir() {
+  if [[ -n "${GITHUB_PATH:-}" ]]; then
+    echo "${BIN_DIR}" >> "${GITHUB_PATH}"
   fi
-  shopt -u nullglob
+  export PATH="${BIN_DIR}:${PATH}"
 }
 
-cache_installed_cellars() {
-  local formula
-  for formula in ffmpeg $(brew deps --formula ffmpeg); do
-    if [[ ! -d "$(brew --cellar "${formula}")" ]]; then
-      continue
-    fi
-    mkdir -p "${CELLAR_CACHE_DIR}/${formula}"
-    rsync -a "$(brew --cellar "${formula}")/" "${CELLAR_CACHE_DIR}/${formula}/"
-  done
+ffmpeg_ok() {
+  command -v ffmpeg >/dev/null 2>&1 && ffmpeg -version >/dev/null 2>&1
 }
 
-if command -v ffmpeg >/dev/null 2>&1; then
+if ffmpeg_ok; then
   echo "ffmpeg already on PATH: $(command -v ffmpeg)"
   ffmpeg -version | head -1
   exit 0
 fi
 
-restore_cached_cellars
+mkdir -p "${BIN_DIR}"
 
-if command -v ffmpeg >/dev/null 2>&1; then
-  echo "ffmpeg restored from Cellar cache: $(command -v ffmpeg)"
-  ffmpeg -version | head -1
+if [[ -x "${BIN_PATH}" ]] && "${BIN_PATH}" -version >/dev/null 2>&1; then
+  echo "ffmpeg restored from cache: ${BIN_PATH}"
+  "${BIN_PATH}" -version | head -1
+  export_bin_dir
   exit 0
 fi
 
-echo "Installing ffmpeg via Homebrew (bottles cached under ${BREW_CACHE_DIR})..."
-if ! brew install ffmpeg; then
-  # A Homebrew older than the bottles it downloads cannot read their metadata and
-  # crashes (Utils::Bottles.load_tab NoMethodError) — brew's own error text says to
-  # run `brew update` and retry. Only reached when the plain install fails, so
-  # runners with a current brew never pay the update cost.
-  echo "brew install failed — updating Homebrew once and retrying..." >&2
-  brew update --quiet
-  brew install ffmpeg
+arch="$(uname -m)"
+case "${arch}" in
+  arm64)
+    asset='ffmpeg-darwin-arm64.gz'
+    sha256='8923876afa8db5585022d7860ec7e589af192f441c56793971276d450ed3bbfa'
+    ;;
+  x86_64)
+    asset='ffmpeg-darwin-x64.gz'
+    sha256='929b375c1182d956c51f7ac25e0b2b0411fb01f6f407aa15c9758efeb4242106'
+    ;;
+  *)
+    skip_without_ffmpeg "unsupported arch ${arch}"
+    ;;
+esac
+
+url="https://github.com/eugeneware/ffmpeg-static/releases/download/${FFMPEG_VERSION}/${asset}"
+archive="${CACHE_ROOT}/${asset}"
+
+echo "Downloading static ffmpeg ${FFMPEG_VERSION} (${asset})..."
+if ! curl --fail --location --silent --show-error \
+  --max-time "${DOWNLOAD_TIMEOUT_SEC}" \
+  --retry 2 \
+  --retry-delay 2 \
+  --output "${archive}" \
+  "${url}"; then
+  skip_without_ffmpeg "download failed or timed out after ${DOWNLOAD_TIMEOUT_SEC}s"
 fi
 
-if ! command -v ffmpeg >/dev/null 2>&1; then
-  echo "ffmpeg install finished but binary is not on PATH" >&2
-  exit 1
+actual="$(shasum -a 256 "${archive}" | awk '{print $1}')"
+if [[ "${actual}" != "${sha256}" ]]; then
+  rm -f "${archive}"
+  skip_without_ffmpeg "checksum mismatch (got ${actual})"
 fi
 
-cache_installed_cellars
+if ! gzip -dc "${archive}" > "${BIN_PATH}"; then
+  rm -f "${archive}" "${BIN_PATH}"
+  skip_without_ffmpeg "failed to decompress ffmpeg"
+fi
+chmod +x "${BIN_PATH}"
+rm -f "${archive}"
 
-echo "ffmpeg installed: $(command -v ffmpeg)"
-ffmpeg -version | head -1
+if ! "${BIN_PATH}" -version >/dev/null 2>&1; then
+  rm -f "${BIN_PATH}"
+  skip_without_ffmpeg "downloaded binary failed ffmpeg -version"
+fi
+
+echo "ffmpeg installed: ${BIN_PATH}"
+"${BIN_PATH}" -version | head -1
+export_bin_dir

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -228,6 +228,7 @@ jobs:
         with:
           path: |
             ~/.cache/yarn
+            ~/.cache/mms-ffmpeg
             .metamask
             .yarn/cache
 
@@ -292,17 +293,17 @@ jobs:
           install-applesimutils: 'false'
           runner_provider: ${{ inputs.runner_provider }}
 
-      - name: Cache ffmpeg (Homebrew)
+      - name: Cache static ffmpeg
         if: ${{ inputs.platform == 'ios' && steps.select-specs.outputs.spec_count != '0' }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/mms-ffmpeg
-          key: brew-ffmpeg-${{ runner.os }}-v1
-          restore-keys: |
-            brew-ffmpeg-${{ runner.os }}-
+          key: static-ffmpeg-b6.1.1-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install ffmpeg for XCUITest screen recording
         if: ${{ inputs.platform == 'ios' && steps.select-specs.outputs.spec_count != '0' }}
+        timeout-minutes: 2
+        continue-on-error: true
         run: bash .github/scripts/qa-automation/appium-runner-prep/ensure-ffmpeg-ci.sh
         shell: bash
 

--- a/.github/workflows/run-e2e-api-specs.yml
+++ b/.github/workflows/run-e2e-api-specs.yml
@@ -83,15 +83,15 @@ jobs:
           install-applesimutils: 'false'
           runner_provider: ${{ inputs.runner_provider || 'current' }}
 
-      - name: Cache ffmpeg (Homebrew)
+      - name: Cache static ffmpeg
         uses: actions/cache@v4
         with:
           path: ~/.cache/mms-ffmpeg
-          key: brew-ffmpeg-${{ runner.os }}-v1
-          restore-keys: |
-            brew-ffmpeg-${{ runner.os }}-
+          key: static-ffmpeg-b6.1.1-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install ffmpeg for XCUITest screen recording
+        timeout-minutes: 2
+        continue-on-error: true
         run: bash .github/scripts/qa-automation/appium-runner-prep/ensure-ffmpeg-ci.sh
         shell: bash
 

--- a/tests/framework/fixtures/playwright/driver.fixture.ts
+++ b/tests/framework/fixtures/playwright/driver.fixture.ts
@@ -162,7 +162,7 @@ export const driverFixture = {
       }
 
       if (recordVideoOnFailure) {
-        recordingBackend = await startFailureRecording(drv, platform);
+        recordingBackend = await startFailureRecording(drv, testInfo, platform);
       }
 
       await use(drv);

--- a/tests/framework/services/appium/ScreenRecording.test.ts
+++ b/tests/framework/services/appium/ScreenRecording.test.ts
@@ -172,6 +172,22 @@ describe('ScreenRecording', () => {
         rmSync(dir, { recursive: true, force: true });
       }
     });
+
+    it('returns false when the PATH entry is chmod +x but not actually runnable', () => {
+      // Simulates a wrong-architecture binary or a truncated download: the
+      // executable bit is set, but invoking it fails.
+      const dir = mkdtempSync(join(tmpdir(), 'mms-ffmpeg-'));
+      const binaryPath = join(dir, 'ffmpeg');
+      writeFileSync(binaryPath, '#!/bin/sh\nexit 1\n');
+      chmodSync(binaryPath, 0o755);
+      process.env[pathKey] = dir;
+
+      try {
+        expect(isFfmpegAvailable()).toBe(false);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('isAndroidPlatform', () => {

--- a/tests/framework/services/appium/ScreenRecording.test.ts
+++ b/tests/framework/services/appium/ScreenRecording.test.ts
@@ -1,7 +1,12 @@
+/* eslint-disable import-x/no-nodejs-modules */
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   buildRecordingFileBaseName,
   extractRecordingPayload,
   isAndroidPlatform,
+  isFfmpegAvailable,
   isLocalEmulatorProvider,
   isVideoRecordingOnFailureEnabled,
   sanitizeRecordingFileName,
@@ -123,6 +128,49 @@ describe('ScreenRecording', () => {
     it('returns true when APPIUM_RECORD_VIDEO_ALWAYS is true', () => {
       process.env[recordVideoAlwaysKey] = 'true';
       expect(shouldPersistRecordingAlways()).toBe(true);
+    });
+  });
+
+  describe('isFfmpegAvailable', () => {
+    const pathKey = 'PATH';
+    let previousPath: string | undefined;
+
+    beforeEach(() => {
+      previousPath = process.env[pathKey];
+    });
+
+    afterEach(() => {
+      if (previousPath === undefined) {
+        delete process.env[pathKey];
+      } else {
+        process.env[pathKey] = previousPath;
+      }
+    });
+
+    it('returns false when PATH has no ffmpeg binary', () => {
+      process.env[pathKey] = '/tmp/mms-no-ffmpeg-on-path';
+
+      expect(isFfmpegAvailable()).toBe(false);
+    });
+
+    it('returns false when PATH is empty', () => {
+      process.env[pathKey] = '';
+
+      expect(isFfmpegAvailable()).toBe(false);
+    });
+
+    it('returns true when PATH contains an executable ffmpeg', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'mms-ffmpeg-'));
+      const binaryPath = join(dir, 'ffmpeg');
+      writeFileSync(binaryPath, '#!/bin/sh\n');
+      chmodSync(binaryPath, 0o755);
+      process.env[pathKey] = dir;
+
+      try {
+        expect(isFfmpegAvailable()).toBe(true);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/tests/framework/services/appium/ScreenRecording.ts
+++ b/tests/framework/services/appium/ScreenRecording.ts
@@ -290,7 +290,10 @@ async function startIosRecording(
   if (!isFfmpegAvailable()) {
     const message = 'ffmpeg is not on PATH — skipping iOS screen recording';
     logRecordingIssue(message);
-    testInfo.annotations.push({ type: 'ffmpegUnavailable', description: message });
+    testInfo.annotations.push({
+      type: 'ffmpegUnavailable',
+      description: message,
+    });
     return undefined;
   }
 

--- a/tests/framework/services/appium/ScreenRecording.ts
+++ b/tests/framework/services/appium/ScreenRecording.ts
@@ -1,4 +1,5 @@
 /* eslint-disable import-x/no-nodejs-modules */
+import { execFileSync } from 'node:child_process';
 import { accessSync, constants, mkdirSync, writeFileSync } from 'node:fs';
 import { delimiter, join } from 'node:path';
 import type { TestInfo } from '@playwright/test';
@@ -159,8 +160,10 @@ function formatRecordingError(error: unknown): string {
 }
 
 /**
- * Returns whether an `ffmpeg` binary is executable on `PATH`.
- * XCUITest screen recording needs ffmpeg; skip recording when it is missing.
+ * Returns whether an `ffmpeg` binary on `PATH` actually runs.
+ * XCUITest screen recording needs ffmpeg; skip recording when it is missing
+ * or not runnable (e.g. wrong-architecture binary, truncated download —
+ * a permission-bit check alone would miss both).
  */
 export function isFfmpegAvailable(): boolean {
   const pathEnv = process.env.PATH;
@@ -172,8 +175,19 @@ export function isFfmpegAvailable(): boolean {
     if (!dir) {
       continue;
     }
+    const candidate = join(dir, 'ffmpeg');
     try {
-      accessSync(join(dir, 'ffmpeg'), constants.X_OK);
+      accessSync(candidate, constants.X_OK);
+    } catch {
+      continue;
+    }
+    // The X_OK check above only confirms the permission bit — a
+    // wrong-architecture binary or a truncated download can still be
+    // "executable" yet fail to actually run. Confirm it runs before
+    // trusting it. Passing an absolute path (not a bare command) avoids
+    // relying on the child process's own PATH search.
+    try {
+      execFileSync(candidate, ['-version'], { stdio: 'ignore', timeout: 5000 });
       return true;
     } catch {
       continue;
@@ -271,9 +285,12 @@ async function stopAndroidRecording(
 
 async function startIosRecording(
   browser: WebdriverIO.Browser,
+  testInfo: TestInfo,
 ): Promise<ScreenRecordingBackend | undefined> {
   if (!isFfmpegAvailable()) {
-    logRecordingIssue('ffmpeg is not on PATH — skipping iOS screen recording');
+    const message = 'ffmpeg is not on PATH — skipping iOS screen recording';
+    logRecordingIssue(message);
+    testInfo.annotations.push({ type: 'ffmpegUnavailable', description: message });
     return undefined;
   }
 
@@ -320,6 +337,7 @@ async function stopIosRecording(
  */
 export async function startFailureRecording(
   browser: WebdriverIO.Browser,
+  testInfo: TestInfo,
   platform?: Platform,
 ): Promise<ScreenRecordingBackend | undefined> {
   try {
@@ -327,7 +345,7 @@ export async function startFailureRecording(
       return await startAndroidScreenRecord(browser);
     }
 
-    return await startIosRecording(browser);
+    return await startIosRecording(browser, testInfo);
   } catch (error) {
     logRecordingIssue(
       `Could not start screen recording: ${formatRecordingError(error)}`,

--- a/tests/framework/services/appium/ScreenRecording.ts
+++ b/tests/framework/services/appium/ScreenRecording.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import-x/no-nodejs-modules */
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { accessSync, constants, mkdirSync, writeFileSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
 import type { TestInfo } from '@playwright/test';
 import { Platform, type ProviderName } from '../../types.ts';
 import { createLogger } from '../../logger.ts';
@@ -158,6 +158,31 @@ function formatRecordingError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+/**
+ * Returns whether an `ffmpeg` binary is executable on `PATH`.
+ * XCUITest screen recording needs ffmpeg; skip recording when it is missing.
+ */
+export function isFfmpegAvailable(): boolean {
+  const pathEnv = process.env.PATH;
+  if (!pathEnv) {
+    return false;
+  }
+
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) {
+      continue;
+    }
+    try {
+      accessSync(join(dir, 'ffmpeg'), constants.X_OK);
+      return true;
+    } catch {
+      continue;
+    }
+  }
+
+  return false;
+}
+
 function logRecordingIssue(message: string): void {
   logger.warn(message);
   // Visible in CI step logs without logger level tuning.
@@ -247,6 +272,11 @@ async function stopAndroidRecording(
 async function startIosRecording(
   browser: WebdriverIO.Browser,
 ): Promise<ScreenRecordingBackend | undefined> {
+  if (!isFfmpegAvailable()) {
+    logRecordingIssue('ffmpeg is not on PATH — skipping iOS screen recording');
+    return undefined;
+  }
+
   const appiumDriver = browser as AppiumScreenRecorder;
   if (typeof appiumDriver.startRecordingScreen !== 'function') {
     logRecordingIssue(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

iOS Appium shards can hang for hours on `brew install ffmpeg` (see [ci run 34090475981](https://github.com/MetaMask/metamask-mobile/actions/runs/34090475981/job/101644215882)). Namespace macOS profiles cannot bake ffmpeg into a custom image.

This PR stops using Homebrew for that step. CI downloads a pinned static `ffmpeg` (`eugeneware/ffmpeg-static` `b6.1.1`) with a checksum and a 45s curl timeout, caches the binary, and continues the shard if install fails. The install step also has a 2-minute timeout and `continue-on-error`. iOS recording is skipped when `ffmpeg` is not on `PATH`, so a skipped install cannot call XCUITest `startRecordingScreen`. Missing ffmpeg only drops failure videos; tests still run.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — CI-only. Unit tests cover `isFfmpegAvailable`. Confirm on an iOS Appium smoke shard that the ffmpeg step finishes within ~2 minutes and that a skipped install still reaches Playwright.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI ffmpeg provisioning and optional iOS failure screen recordings; core app and test assertions are unaffected.
> 
> **Overview**
> Replaces **Homebrew-based `ffmpeg` setup** in iOS Appium CI with a **pinned static binary** (`eugeneware/ffmpeg-static` `b6.1.1`), verified by SHA-256 and downloaded with a bounded curl timeout. Install failures emit a workflow warning and **exit successfully** so shards no longer hang on `brew install` / `brew update`.
> 
> Workflows now **cache** `~/.cache/mms-ffmpeg` (including Namespace iOS cache), use an arch-specific cache key, and run the install step with a **2-minute timeout** and **`continue-on-error`**.
> 
> The test runner adds **`isFfmpegAvailable()`** (executable on `PATH` that passes `ffmpeg -version`) and **skips iOS `startRecordingScreen`** when ffmpeg is missing, recording a Playwright **`ffmpegUnavailable`** annotation—so tests still run without failure videos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ffa49d5a321815c16261226060c3834871115e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->