### PR TITLE
test(cv): add component-view tests for Top Traders feature

### DIFF
--- a/app/components/Views/Settings/SecuritySettings/Sections/TopTradersSection.view.test.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/TopTradersSection.view.test.tsx
@@ -7,9 +7,7 @@
  * is the only external boundary.
  *
  * Run with:
- *   yarn jest -c jest.config.view.js \
- *     app/components/Views/Settings/SecuritySettings/Sections/TopTradersSection.view.test.tsx \
- *     --runInBand --silent --coverage=false
+ * yarn jest -c jest.config.view.js app/components/Views/Settings/SecuritySettings/Sections/TopTradersSection.view.test.tsx --runInBand --silent --coverage=false
  */
 
 import '../../../../../../tests/component-view/mocks';

--- a/app/components/Views/Settings/SecuritySettings/Sections/TopTradersSection.view.test.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/TopTradersSection.view.test.tsx
@@ -27,40 +27,14 @@ const TOGGLE_ID =
 // ---------------------------------------------------------------------------
 
 describe('Settings / TopTradersSection', () => {
-  // -------------------------------------------------------------------------
-  // 1. Section renders when both feature flags are on
-  // -------------------------------------------------------------------------
-
-  it('renders the Top Traders section and toggle when the feature flags are enabled', () => {
-    renderSettingsTopTradersSection();
-
-    // Section container is present.
-    expect(
-      screen.getByTestId(SecurityPrivacyViewSelectorsIDs.TOP_TRADERS_SECTION),
-    ).toBeOnTheScreen();
-
-    // Toggle is visible and starts in the on (true) position.
-    const toggle = screen.getByTestId(TOGGLE_ID);
-    expect(toggle).toBeOnTheScreen();
-    expect(toggle.props.value).toBe(true);
+  beforeEach(() => {
+    // Prevent call history from leaking between tests; Engine.controllerMessenger.call
+    // is a shared jest.fn() defined in the CV mocks module.
+    jest.clearAllMocks();
   });
 
   // -------------------------------------------------------------------------
-  // 2. Section is hidden when the master feature flag is off
-  // -------------------------------------------------------------------------
-
-  it('renders nothing when the master leaderboard flag is disabled', () => {
-    renderSettingsTopTradersSection({
-      presetOptions: { featureEnabled: false },
-    });
-
-    expect(
-      screen.queryByTestId(SecurityPrivacyViewSelectorsIDs.TOP_TRADERS_SECTION),
-    ).not.toBeOnTheScreen();
-  });
-
-  // -------------------------------------------------------------------------
-  // 3. Opt-out: toggle from on → Engine.optOut → Redux updates to false
+  // 1. Opt-out: toggle from on → Engine.optOut → Redux updates to false
   // -------------------------------------------------------------------------
 
   it('calls Engine optOutOfLeaderboard and updates the store when the toggle is pressed from on', async () => {
@@ -87,7 +61,7 @@ describe('Settings / TopTradersSection', () => {
   });
 
   // -------------------------------------------------------------------------
-  // 4. Opt-in: toggle from off → Engine.optIn → Redux updates to true
+  // 2. Opt-in: toggle from off → Engine.optIn → Redux updates to true
   // -------------------------------------------------------------------------
 
   it('calls Engine optInToLeaderboard and updates the store when the toggle is pressed from off', async () => {
@@ -111,7 +85,7 @@ describe('Settings / TopTradersSection', () => {
   });
 
   // -------------------------------------------------------------------------
-  // 5. Error recovery: Engine throws → Redux state unchanged, toggle stays on
+  // 3. Error recovery: Engine throws → Redux state unchanged, toggle stays on
   // -------------------------------------------------------------------------
 
   it('does not update Redux state and keeps the toggle on when Engine throws during opt-out', async () => {
@@ -135,7 +109,7 @@ describe('Settings / TopTradersSection', () => {
   });
 
   // -------------------------------------------------------------------------
-  // 6. Double-tap guard: second press while updating is a no-op
+  // 4. Double-tap guard: second press while updating is a no-op
   // -------------------------------------------------------------------------
 
   it('ignores a second toggle press while the first Engine call is still in flight', async () => {
@@ -173,19 +147,5 @@ describe('Settings / TopTradersSection', () => {
     await act(async () => {
       settle();
     });
-  });
-
-  // -------------------------------------------------------------------------
-  // 7. Opt-flow gate: section hidden when optFlowEnabled flag is off
-  // -------------------------------------------------------------------------
-
-  it('renders nothing when the opt-in/out flow feature flag is disabled', () => {
-    renderSettingsTopTradersSection({
-      presetOptions: { optFlowEnabled: false },
-    });
-
-    expect(
-      screen.queryByTestId(SecurityPrivacyViewSelectorsIDs.TOP_TRADERS_SECTION),
-    ).not.toBeOnTheScreen();
   });
 });

--- a/app/components/Views/Settings/SecuritySettings/Sections/TopTradersSection.view.test.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/TopTradersSection.view.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Component-view tests for the Top Traders privacy toggle
+ * (Settings > Security & Privacy > Top Traders section).
+ *
+ * These tests drive the real Redux state → rendered Switch → Engine messenger
+ * pipeline without mocking hooks or selectors. Engine.controllerMessenger.call
+ * is the only external boundary.
+ *
+ * Run with:
+ *   yarn jest -c jest.config.view.js \
+ *     app/components/Views/Settings/SecuritySettings/Sections/TopTradersSection.view.test.tsx \
+ *     --runInBand --silent --coverage=false
+ */
+
+import '../../../../../../tests/component-view/mocks';
+import { act, fireEvent, screen } from '@testing-library/react-native';
+import Engine from '../../../../../core/Engine';
+import { renderSettingsTopTradersSection } from '../../../../../../tests/component-view/renderers/socialLeaderboard';
+import { SecurityPrivacyViewSelectorsIDs } from '../SecurityPrivacyView.testIds';
+
+// Convenience alias for the toggle's testID.
+const TOGGLE_ID =
+  SecurityPrivacyViewSelectorsIDs.SHOW_ACCOUNT_ON_LEADERBOARD_TOGGLE;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Settings / TopTradersSection', () => {
+  // -------------------------------------------------------------------------
+  // 1. Section renders when both feature flags are on
+  // -------------------------------------------------------------------------
+
+  it('renders the Top Traders section and toggle when the feature flags are enabled', () => {
+    renderSettingsTopTradersSection();
+
+    // Section container is present.
+    expect(
+      screen.getByTestId(SecurityPrivacyViewSelectorsIDs.TOP_TRADERS_SECTION),
+    ).toBeOnTheScreen();
+
+    // Toggle is visible and starts in the on (true) position.
+    const toggle = screen.getByTestId(TOGGLE_ID);
+    expect(toggle).toBeOnTheScreen();
+    expect(toggle.props.value).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Section is hidden when the master feature flag is off
+  // -------------------------------------------------------------------------
+
+  it('renders nothing when the master leaderboard flag is disabled', () => {
+    renderSettingsTopTradersSection({
+      presetOptions: { featureEnabled: false },
+    });
+
+    expect(
+      screen.queryByTestId(SecurityPrivacyViewSelectorsIDs.TOP_TRADERS_SECTION),
+    ).not.toBeOnTheScreen();
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Opt-out: toggle from on → Engine.optOut → Redux updates to false
+  // -------------------------------------------------------------------------
+
+  it('calls Engine optOutOfLeaderboard and updates the store when the toggle is pressed from on', async () => {
+    // Start with the user opted in (showAccountOnLeaderboard: true).
+    const { store } = renderSettingsTopTradersSection({
+      presetOptions: { showAccountOnLeaderboard: true },
+    });
+
+    const toggle = screen.getByTestId(TOGGLE_ID);
+    expect(toggle.props.value).toBe(true);
+
+    await act(async () => {
+      fireEvent(toggle, 'valueChange', false);
+    });
+
+    // Engine called with the opt-out action.
+    expect(Engine.controllerMessenger.call).toHaveBeenCalledWith(
+      'SocialController:optOutOfLeaderboard',
+    );
+    // Redux state updated.
+    expect(store.getState().settings.showAccountOnLeaderboard).toBe(false);
+    // The toggle now reflects the new state.
+    expect(screen.getByTestId(TOGGLE_ID).props.value).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Opt-in: toggle from off → Engine.optIn → Redux updates to true
+  // -------------------------------------------------------------------------
+
+  it('calls Engine optInToLeaderboard and updates the store when the toggle is pressed from off', async () => {
+    // Start with the user opted out (showAccountOnLeaderboard: false).
+    const { store } = renderSettingsTopTradersSection({
+      presetOptions: { showAccountOnLeaderboard: false },
+    });
+
+    const toggle = screen.getByTestId(TOGGLE_ID);
+    expect(toggle.props.value).toBe(false);
+
+    await act(async () => {
+      fireEvent(toggle, 'valueChange', true);
+    });
+
+    expect(Engine.controllerMessenger.call).toHaveBeenCalledWith(
+      'SocialController:optInToLeaderboard',
+    );
+    expect(store.getState().settings.showAccountOnLeaderboard).toBe(true);
+    expect(screen.getByTestId(TOGGLE_ID).props.value).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Error recovery: Engine throws → Redux state unchanged, toggle stays on
+  // -------------------------------------------------------------------------
+
+  it('does not update Redux state and keeps the toggle on when Engine throws during opt-out', async () => {
+    // Simulate a transient network failure on opt-out.
+    (Engine.controllerMessenger.call as jest.Mock).mockRejectedValueOnce(
+      new Error('network error'),
+    );
+
+    const { store } = renderSettingsTopTradersSection({
+      presetOptions: { showAccountOnLeaderboard: true },
+    });
+
+    await act(async () => {
+      fireEvent(screen.getByTestId(TOGGLE_ID), 'valueChange', false);
+    });
+
+    // Store must NOT have been updated — the catch block skips the dispatch.
+    expect(store.getState().settings.showAccountOnLeaderboard).toBe(true);
+    // The toggle must still show on.
+    expect(screen.getByTestId(TOGGLE_ID).props.value).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Double-tap guard: second press while updating is a no-op
+  // -------------------------------------------------------------------------
+
+  it('ignores a second toggle press while the first Engine call is still in flight', async () => {
+    // A never-settling promise simulates a slow network (in-flight request).
+    let settle: () => void = () => undefined;
+    (Engine.controllerMessenger.call as jest.Mock).mockImplementationOnce(
+      (action: string) =>
+        action === 'SocialController:optOutOfLeaderboard'
+          ? new Promise<void>((resolve) => {
+              settle = resolve;
+            })
+          : Promise.resolve(undefined),
+    );
+
+    renderSettingsTopTradersSection({
+      presetOptions: { showAccountOnLeaderboard: true },
+    });
+
+    const toggle = screen.getByTestId(TOGGLE_ID);
+
+    // First press — starts the in-flight request.
+    act(() => {
+      fireEvent(toggle, 'valueChange', false);
+    });
+
+    // Second press while the first is still pending.
+    act(() => {
+      fireEvent(toggle, 'valueChange', false);
+    });
+
+    // Engine must have been called exactly once (the double-tap guard fired).
+    expect(Engine.controllerMessenger.call).toHaveBeenCalledTimes(1);
+
+    // Resolve so the component doesn't leak async work into subsequent tests.
+    await act(async () => {
+      settle();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. Opt-flow gate: section hidden when optFlowEnabled flag is off
+  // -------------------------------------------------------------------------
+
+  it('renders nothing when the opt-in/out flow feature flag is disabled', () => {
+    renderSettingsTopTradersSection({
+      presetOptions: { optFlowEnabled: false },
+    });
+
+    expect(
+      screen.queryByTestId(SecurityPrivacyViewSelectorsIDs.TOP_TRADERS_SECTION),
+    ).not.toBeOnTheScreen();
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.view.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.view.test.tsx
@@ -27,9 +27,7 @@ import {
   renderTopTradersView,
   renderTopTradersViewWithRoutes,
 } from '../../../../../tests/component-view/renderers/socialLeaderboard';
-import {
-  getRouteProbeTestId,
-} from '../../../../../tests/component-view/render';
+import { getRouteProbeTestId } from '../../../../../tests/component-view/render';
 import { TopTradersViewSelectorsIDs } from './TopTradersView.testIds';
 import {
   getSortFilterOptionTestId,
@@ -91,18 +89,28 @@ describe('TopTradersView', () => {
     expect(alphaName).toBeOnTheScreen();
 
     // Validate all significant fields for alpha.eth (rank 1 – gold medal).
-    const alphaRow = await screen.findByTestId(`trader-row-${alpha1.profileId}`);
+    const alphaRow = await screen.findByTestId(
+      `trader-row-${alpha1.profileId}`,
+    );
     const alphaWithin = within(alphaRow);
-    expect(alphaWithin.getByTestId(`rank-medal-${alpha1.rank}`)).toBeOnTheScreen();
+    expect(
+      alphaWithin.getByTestId(`rank-medal-${alpha1.rank}`),
+    ).toBeOnTheScreen();
     expect(alphaWithin.getByText('+$963,146.80')).toBeOnTheScreen();
-    expect(alphaWithin.getByText(strings('social_leaderboard.follow'))).toBeOnTheScreen();
+    expect(
+      alphaWithin.getByText(strings('social_leaderboard.follow')),
+    ).toBeOnTheScreen();
 
     // Validate all significant fields for beta.eth (rank 2 – silver medal).
     const betaRow = await screen.findByTestId(`trader-row-${alpha2.profileId}`);
     const betaWithin = within(betaRow);
-    expect(betaWithin.getByTestId(`rank-medal-${alpha2.rank}`)).toBeOnTheScreen();
+    expect(
+      betaWithin.getByTestId(`rank-medal-${alpha2.rank}`),
+    ).toBeOnTheScreen();
     expect(betaWithin.getByText('+$474,751.45')).toBeOnTheScreen();
-    expect(betaWithin.getByText(strings('social_leaderboard.follow'))).toBeOnTheScreen();
+    expect(
+      betaWithin.getByText(strings('social_leaderboard.follow')),
+    ).toBeOnTheScreen();
   });
 
   // -------------------------------------------------------------------------
@@ -171,17 +179,20 @@ describe('TopTradersView', () => {
     // Wait for data to load before tapping.
     expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
 
-    const followButtons = screen.getAllByText(strings('social_leaderboard.follow'));
+    const followButtons = screen.getAllByText(
+      strings('social_leaderboard.follow'),
+    );
     await act(async () => {
       fireEvent.press(followButtons[0]);
     });
 
     // The spy includes all messenger calls; check the follow call specifically.
-    expect(
-      getLeaderboardMessengerSpy(),
-    ).toHaveBeenCalledWith('SocialController:followTrader', {
-      targets: [mockLeaderboardTraders[0].profileId],
-    });
+    expect(getLeaderboardMessengerSpy()).toHaveBeenCalledWith(
+      'SocialController:followTrader',
+      {
+        targets: [mockLeaderboardTraders[0].profileId],
+      },
+    );
   });
 
   // -------------------------------------------------------------------------
@@ -197,14 +208,17 @@ describe('TopTradersView', () => {
     expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
 
     await act(async () => {
-      fireEvent.press(screen.getByText(strings('social_leaderboard.following')));
+      fireEvent.press(
+        screen.getByText(strings('social_leaderboard.following')),
+      );
     });
 
-    expect(
-      getLeaderboardMessengerSpy(),
-    ).toHaveBeenCalledWith('SocialController:unfollowTrader', {
-      targets: ['trader-1'],
-    });
+    expect(getLeaderboardMessengerSpy()).toHaveBeenCalledWith(
+      'SocialController:unfollowTrader',
+      {
+        targets: ['trader-1'],
+      },
+    );
   });
 
   // -------------------------------------------------------------------------
@@ -219,19 +233,16 @@ describe('TopTradersView', () => {
       notificationPrefs: { pushEnabled: false, inAppEnabled: false },
     });
 
-    renderTopTradersViewWithRoutes(
-      [{ name: Routes.SOCIAL_LEADERBOARD.TRADING_SIGNALS_SETUP }],
-      {
-        // Disable notification services at the Redux level as well so the
-        // follow-intercept hook considers both channels inactive.
-        presetOptions: { notificationsEnabled: false },
-      },
-    );
+    renderTopTradersViewWithRoutes([
+      { name: Routes.SOCIAL_LEADERBOARD.TRADING_SIGNALS_SETUP },
+    ]);
 
     expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
 
     await act(async () => {
-      fireEvent.press(screen.getAllByText(strings('social_leaderboard.follow'))[0]);
+      fireEvent.press(
+        screen.getAllByText(strings('social_leaderboard.follow'))[0],
+      );
     });
 
     // The trading signals setup sheet route should have been pushed.
@@ -247,7 +258,9 @@ describe('TopTradersView', () => {
   it('refetches the leaderboard via the Engine when the list is pulled to refresh', async () => {
     renderTopTradersView();
 
-    expect(await screen.findByText(mockLeaderboardTraders[0].name)).toBeOnTheScreen();
+    expect(
+      await screen.findByText(mockLeaderboardTraders[0].name),
+    ).toBeOnTheScreen();
 
     // Clear accumulated calls (initial fetch + any idle prefetches) so only the
     // refresh-triggered call is counted. Without this, idle tab prefetches that
@@ -319,9 +332,7 @@ describe('TopTradersView', () => {
     });
 
     // Muting writes through to the AUS putNotificationPreferences action.
-    expect(
-      getLeaderboardMessengerSpy(),
-    ).toHaveBeenCalledWith(
+    expect(getLeaderboardMessengerSpy()).toHaveBeenCalledWith(
       'AuthenticatedUserStorageService:putNotificationPreferences',
       expect.anything(),
       expect.anything(),

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.view.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.view.test.tsx
@@ -1,0 +1,359 @@
+/**
+ * Component-view tests for TopTradersView (leaderboard page).
+ *
+ * These tests drive the full data pipeline – Engine.controllerMessenger →
+ * React Query (useTopTraders) → Redux state → rendered UI – without mocking
+ * hooks or selectors. All external I/O is intercepted at the Engine messenger
+ * layer (see tests/component-view/api-mocking/socialLeaderboard.ts).
+ *
+ * Run with:
+ *   yarn jest -c jest.config.view.js \
+ *     app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.view.test.tsx \
+ *     --runInBand --silent --coverage=false
+ */
+
+import '../../../../../tests/component-view/mocks';
+import { act, fireEvent, screen, within } from '@testing-library/react-native';
+import Routes from '../../../../constants/navigation/Routes';
+import {
+  clearLeaderboardApiMock,
+  getLeaderboardMessengerSpy,
+  mockLeaderboardTraders,
+  setupLeaderboardApiMock,
+} from '../../../../../tests/component-view/api-mocking/socialLeaderboard';
+import {
+  renderTopTradersView,
+  renderTopTradersViewWithRoutes,
+} from '../../../../../tests/component-view/renderers/socialLeaderboard';
+import {
+  getRouteProbeTestId,
+} from '../../../../../tests/component-view/render';
+import { TopTradersViewSelectorsIDs } from './TopTradersView.testIds';
+import {
+  getSortFilterOptionTestId,
+  getTimeframeFilterOptionTestId,
+  getTypeFilterOptionTestId,
+} from '../components/Filters';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const selectTypeFilter = (type: 'all' | 'tokens' | 'perps') => {
+  fireEvent.press(screen.getByTestId(TopTradersViewSelectorsIDs.TYPE_SELECTOR));
+  fireEvent.press(screen.getByTestId(getTypeFilterOptionTestId(type)));
+};
+
+const selectSort = (sort: 'pnl' | 'roi' | 'winRate') => {
+  fireEvent.press(screen.getByTestId(TopTradersViewSelectorsIDs.SORT_SELECTOR));
+  fireEvent.press(screen.getByTestId(getSortFilterOptionTestId(sort)));
+};
+
+const selectTimeframe = (tf: '7d' | '30d') => {
+  fireEvent.press(
+    screen.getByTestId(TopTradersViewSelectorsIDs.TIMEFRAME_SELECTOR),
+  );
+  fireEvent.press(screen.getByTestId(getTimeframeFilterOptionTestId(tf)));
+};
+
+const triggerPullToRefresh = async () => {
+  const list = screen.getByTestId(TopTradersViewSelectorsIDs.TRADER_LIST);
+  await act(async () => {
+    await list.props.refreshControl.props.onRefresh();
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TopTradersView', () => {
+  beforeEach(() => {
+    setupLeaderboardApiMock();
+  });
+
+  afterEach(() => {
+    clearLeaderboardApiMock();
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Data completeness
+  // -------------------------------------------------------------------------
+
+  it('renders complete trader data for every row after the leaderboard API resolves', async () => {
+    renderTopTradersView();
+
+    // The tokens tab lands first; alpha.eth and beta.eth are spot traders.
+    const alphaName = await screen.findByText('alpha.eth');
+    expect(alphaName).toBeOnTheScreen();
+
+    // Validate all significant fields for alpha.eth (rank 1 – gold medal).
+    const alphaRow = await screen.findByTestId('trader-row-trader-1');
+    const alpha = within(alphaRow);
+    expect(alpha.getByTestId('rank-medal-1')).toBeOnTheScreen();
+    expect(alpha.getByText('+$963,146.80')).toBeOnTheScreen();
+    expect(alpha.getByText('Follow')).toBeOnTheScreen();
+
+    // Validate all significant fields for beta.eth (rank 2 – silver medal).
+    const betaRow = await screen.findByTestId('trader-row-trader-2');
+    const beta = within(betaRow);
+    expect(beta.getByTestId('rank-medal-2')).toBeOnTheScreen();
+    expect(beta.getByText('+$474,751.45')).toBeOnTheScreen();
+    expect(beta.getByText('Follow')).toBeOnTheScreen();
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Sort interaction: ROI reorders rows and changes metric labels
+  // -------------------------------------------------------------------------
+
+  it('reorders rows by ROI and replaces PnL labels with percentage values when sort switches to ROI', async () => {
+    renderTopTradersView();
+
+    // Wait for the default PnL sort to settle.
+    expect(await screen.findByText('+$963,146.80')).toBeOnTheScreen();
+
+    // alpha.eth PnL is shown; ROI percentage is not yet visible.
+    expect(screen.queryByText('+43.00%')).not.toBeOnTheScreen();
+
+    // Switch to ROI sort – beta.eth (359 %) leads; alpha.eth (43 %) is second.
+    selectSort('roi');
+
+    // Metric labels update to ROI percentages; PnL labels disappear.
+    expect(await screen.findByText('+359.00%')).toBeOnTheScreen();
+    expect(screen.getByText('+43.00%')).toBeOnTheScreen();
+    expect(screen.queryByText('+$963,146.80')).not.toBeOnTheScreen();
+    expect(screen.queryByText('+$474,751.45')).not.toBeOnTheScreen();
+
+    // The rows are re-ranked: beta.eth now appears before alpha.eth.
+    const list = screen.getByTestId(TopTradersViewSelectorsIDs.TRADER_LIST);
+    const listed = list.props.data as { username: string }[];
+    expect(listed[0].username).toBe('beta.eth');
+    expect(listed[1].username).toBe('alpha.eth');
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Type filter: Perps tab shows hyperliquid traders; Tokens tab hides them
+  // -------------------------------------------------------------------------
+
+  it('shows gamma.eth on the Perps tab and hides spot traders; restores spot traders on Tokens tab', async () => {
+    renderTopTradersView();
+
+    // Tokens tab (default): spot traders visible, perps trader absent.
+    expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
+    expect(screen.queryByText('gamma.eth')).not.toBeOnTheScreen();
+
+    // Switch to Perps tab.
+    selectTypeFilter('perps');
+
+    // gamma.eth (hyperliquid) now appears; spot traders disappear.
+    expect(await screen.findByText('gamma.eth')).toBeOnTheScreen();
+    expect(screen.queryByText('alpha.eth')).not.toBeOnTheScreen();
+    expect(screen.queryByText('beta.eth')).not.toBeOnTheScreen();
+
+    // Switch back to Tokens tab.
+    selectTypeFilter('tokens');
+
+    // Spot traders return; perps trader is gone again.
+    expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
+    expect(screen.queryByText('gamma.eth')).not.toBeOnTheScreen();
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Follow press calls Engine with correct profile id
+  // -------------------------------------------------------------------------
+
+  it('calls Engine followTrader with the trader profile id when Follow is pressed', async () => {
+    renderTopTradersView();
+
+    // Wait for data to load before tapping.
+    expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
+
+    const followButtons = screen.getAllByText('Follow');
+    await act(async () => {
+      fireEvent.press(followButtons[0]);
+    });
+
+    // The spy includes all messenger calls; check the follow call specifically.
+    expect(
+      getLeaderboardMessengerSpy(),
+    ).toHaveBeenCalledWith('SocialController:followTrader', {
+      targets: [mockLeaderboardTraders[0].profileId],
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Unfollow: already-following trader shows "Following" then calls Engine
+  // -------------------------------------------------------------------------
+
+  it('calls Engine unfollowTrader when Following is pressed on an already-followed trader', async () => {
+    renderTopTradersView({
+      // trader-1 is seeded as followed in Redux state.
+      presetOptions: { followingProfileIds: ['trader-1'] },
+    });
+
+    expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('Following'));
+    });
+
+    expect(
+      getLeaderboardMessengerSpy(),
+    ).toHaveBeenCalledWith('SocialController:unfollowTrader', {
+      targets: ['trader-1'],
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Trading signals intercept navigates to setup sheet when channels are off
+  // -------------------------------------------------------------------------
+
+  it('navigates to the trading signals setup sheet when Follow is pressed with both notification channels disabled', async () => {
+    // Reconfigure the mock before rendering so the component receives
+    // channels-disabled prefs on its first AUS:getNotificationPreferences fetch.
+    clearLeaderboardApiMock();
+    setupLeaderboardApiMock({
+      notificationPrefs: { pushEnabled: false, inAppEnabled: false },
+    });
+
+    renderTopTradersViewWithRoutes(
+      [{ name: Routes.SOCIAL_LEADERBOARD.TRADING_SIGNALS_SETUP }],
+      {
+        // Disable notification services at the Redux level as well so the
+        // follow-intercept hook considers both channels inactive.
+        presetOptions: { notificationsEnabled: false },
+      },
+    );
+
+    expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
+
+    await act(async () => {
+      fireEvent.press(screen.getAllByText('Follow')[0]);
+    });
+
+    // The trading signals setup sheet route should have been pushed.
+    await screen.findByTestId(
+      getRouteProbeTestId(Routes.SOCIAL_LEADERBOARD.TRADING_SIGNALS_SETUP),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. Pull-to-refresh triggers a leaderboard refetch
+  // -------------------------------------------------------------------------
+
+  it('refetches the leaderboard via the Engine when the list is pulled to refresh', async () => {
+    renderTopTradersView();
+
+    expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
+
+    const callsBeforeRefresh = getLeaderboardMessengerSpy().mock.calls.filter(
+      ([action]) => action === 'SocialService:fetchLeaderboard',
+    ).length;
+
+    await triggerPullToRefresh();
+
+    const callsAfterRefresh = getLeaderboardMessengerSpy().mock.calls.filter(
+      ([action]) => action === 'SocialService:fetchLeaderboard',
+    ).length;
+
+    // At least one additional fetch should have occurred.
+    expect(callsAfterRefresh).toBeGreaterThan(callsBeforeRefresh);
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. Timeframe selector switches the displayed 30-day PnL values
+  // -------------------------------------------------------------------------
+
+  it('displays 30-day PnL values after the 30d timeframe is selected', async () => {
+    renderTopTradersView();
+
+    // Default 7-day PnL for alpha.eth.
+    expect(await screen.findByText('+$963,146.80')).toBeOnTheScreen();
+
+    // Switch to 30-day window.
+    selectTimeframe('30d');
+
+    // alpha.eth 30d PnL = 1_200_000 → formatted "+$1,200,000.00".
+    expect(await screen.findByText('+$1,200,000.00')).toBeOnTheScreen();
+    expect(screen.queryByText('+$963,146.80')).not.toBeOnTheScreen();
+  });
+
+  // -------------------------------------------------------------------------
+  // 9. Tapping a trader row navigates to the profile screen with correct params
+  // -------------------------------------------------------------------------
+
+  it('navigates to the trader profile screen with the correct trader id and rank when a row is tapped', async () => {
+    renderTopTradersViewWithRoutes([
+      { name: Routes.SOCIAL_LEADERBOARD.PROFILE },
+    ]);
+
+    expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
+
+    fireEvent.press(screen.getByText('alpha.eth'));
+
+    await screen.findByTestId(
+      getRouteProbeTestId(Routes.SOCIAL_LEADERBOARD.PROFILE),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 10. Mute chip for a followed trader calls Engine to toggle notifications
+  // -------------------------------------------------------------------------
+
+  it('calls Engine to update mute state when the mute chip of a followed trader is pressed', async () => {
+    renderTopTradersView({
+      presetOptions: { followingProfileIds: ['trader-1'] },
+    });
+
+    // Wait for trader-1 row with mute chip to appear.
+    expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('trader-row-mute-chip-trader-1'));
+    });
+
+    // Muting writes through to the AUS putNotificationPreferences action.
+    expect(
+      getLeaderboardMessengerSpy(),
+    ).toHaveBeenCalledWith(
+      'AuthenticatedUserStorageService:putNotificationPreferences',
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 11. Win-rate sort reorders and shows win-rate labels
+  // -------------------------------------------------------------------------
+
+  it('shows win-rate metric labels and reorders rows when win-rate sort is selected', async () => {
+    renderTopTradersView();
+
+    expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
+
+    selectSort('winRate');
+
+    // alpha.eth has 92 % win rate (highest spot trader) → shows "92%" first.
+    expect(await screen.findByText('92%')).toBeOnTheScreen();
+    // PnL labels should be gone.
+    expect(screen.queryByText('+$963,146.80')).not.toBeOnTheScreen();
+
+    // beta.eth has 61 % win rate.
+    expect(screen.getByText('61%')).toBeOnTheScreen();
+  });
+
+  // -------------------------------------------------------------------------
+  // 12. All-tab query includes all fixture traders (spot + perps)
+  // -------------------------------------------------------------------------
+
+  it('shows all traders including gamma.eth when the All tab is selected', async () => {
+    renderTopTradersView();
+
+    // Switch to All tab (includes hyperliquid).
+    selectTypeFilter('all');
+
+    expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
+    expect(screen.getByText('beta.eth')).toBeOnTheScreen();
+    expect(screen.getByText('gamma.eth')).toBeOnTheScreen();
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.view.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.view.test.tsx
@@ -15,6 +15,8 @@
 import '../../../../../tests/component-view/mocks';
 import { act, fireEvent, screen, within } from '@testing-library/react-native';
 import Routes from '../../../../constants/navigation/Routes';
+import { strings } from '../../../../../locales/i18n';
+import { SPOT_CHAINS } from '../../shared/top-traders-constants';
 import {
   clearLeaderboardApiMock,
   getLeaderboardMessengerSpy,
@@ -84,22 +86,23 @@ describe('TopTradersView', () => {
     renderTopTradersView();
 
     // The tokens tab lands first; alpha.eth and beta.eth are spot traders.
-    const alphaName = await screen.findByText('alpha.eth');
+    const [alpha1, alpha2] = mockLeaderboardTraders;
+    const alphaName = await screen.findByText(alpha1.name);
     expect(alphaName).toBeOnTheScreen();
 
     // Validate all significant fields for alpha.eth (rank 1 – gold medal).
-    const alphaRow = await screen.findByTestId('trader-row-trader-1');
-    const alpha = within(alphaRow);
-    expect(alpha.getByTestId('rank-medal-1')).toBeOnTheScreen();
-    expect(alpha.getByText('+$963,146.80')).toBeOnTheScreen();
-    expect(alpha.getByText('Follow')).toBeOnTheScreen();
+    const alphaRow = await screen.findByTestId(`trader-row-${alpha1.profileId}`);
+    const alphaWithin = within(alphaRow);
+    expect(alphaWithin.getByTestId(`rank-medal-${alpha1.rank}`)).toBeOnTheScreen();
+    expect(alphaWithin.getByText('+$963,146.80')).toBeOnTheScreen();
+    expect(alphaWithin.getByText(strings('social_leaderboard.follow'))).toBeOnTheScreen();
 
     // Validate all significant fields for beta.eth (rank 2 – silver medal).
-    const betaRow = await screen.findByTestId('trader-row-trader-2');
-    const beta = within(betaRow);
-    expect(beta.getByTestId('rank-medal-2')).toBeOnTheScreen();
-    expect(beta.getByText('+$474,751.45')).toBeOnTheScreen();
-    expect(beta.getByText('Follow')).toBeOnTheScreen();
+    const betaRow = await screen.findByTestId(`trader-row-${alpha2.profileId}`);
+    const betaWithin = within(betaRow);
+    expect(betaWithin.getByTestId(`rank-medal-${alpha2.rank}`)).toBeOnTheScreen();
+    expect(betaWithin.getByText('+$474,751.45')).toBeOnTheScreen();
+    expect(betaWithin.getByText(strings('social_leaderboard.follow'))).toBeOnTheScreen();
   });
 
   // -------------------------------------------------------------------------
@@ -168,7 +171,7 @@ describe('TopTradersView', () => {
     // Wait for data to load before tapping.
     expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
 
-    const followButtons = screen.getAllByText('Follow');
+    const followButtons = screen.getAllByText(strings('social_leaderboard.follow'));
     await act(async () => {
       fireEvent.press(followButtons[0]);
     });
@@ -194,7 +197,7 @@ describe('TopTradersView', () => {
     expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
 
     await act(async () => {
-      fireEvent.press(screen.getByText('Following'));
+      fireEvent.press(screen.getByText(strings('social_leaderboard.following')));
     });
 
     expect(
@@ -228,7 +231,7 @@ describe('TopTradersView', () => {
     expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
 
     await act(async () => {
-      fireEvent.press(screen.getAllByText('Follow')[0]);
+      fireEvent.press(screen.getAllByText(strings('social_leaderboard.follow'))[0]);
     });
 
     // The trading signals setup sheet route should have been pushed.
@@ -244,20 +247,21 @@ describe('TopTradersView', () => {
   it('refetches the leaderboard via the Engine when the list is pulled to refresh', async () => {
     renderTopTradersView();
 
-    expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
+    expect(await screen.findByText(mockLeaderboardTraders[0].name)).toBeOnTheScreen();
 
-    const callsBeforeRefresh = getLeaderboardMessengerSpy().mock.calls.filter(
-      ([action]) => action === 'SocialService:fetchLeaderboard',
-    ).length;
+    // Clear accumulated calls (initial fetch + any idle prefetches) so only the
+    // refresh-triggered call is counted. Without this, idle tab prefetches that
+    // land in the same window would make a before/after comparison unreliable.
+    getLeaderboardMessengerSpy().mockClear();
 
     await triggerPullToRefresh();
 
-    const callsAfterRefresh = getLeaderboardMessengerSpy().mock.calls.filter(
-      ([action]) => action === 'SocialService:fetchLeaderboard',
-    ).length;
-
-    // At least one additional fetch should have occurred.
-    expect(callsAfterRefresh).toBeGreaterThan(callsBeforeRefresh);
+    // The active (tokens) tab must have issued exactly one new fetch with the
+    // spot chains parameter.
+    expect(getLeaderboardMessengerSpy()).toHaveBeenCalledWith(
+      'SocialService:fetchLeaderboard',
+      expect.objectContaining({ chains: SPOT_CHAINS }),
+    );
   });
 
   // -------------------------------------------------------------------------
@@ -305,11 +309,13 @@ describe('TopTradersView', () => {
       presetOptions: { followingProfileIds: ['trader-1'] },
     });
 
-    // Wait for trader-1 row with mute chip to appear.
-    expect(await screen.findByText('alpha.eth')).toBeOnTheScreen();
+    const [alpha] = mockLeaderboardTraders;
+    expect(await screen.findByText(alpha.name)).toBeOnTheScreen();
 
     await act(async () => {
-      fireEvent.press(screen.getByTestId('trader-row-mute-chip-trader-1'));
+      fireEvent.press(
+        screen.getByTestId(`trader-row-mute-chip-${alpha.profileId}`),
+      );
     });
 
     // Muting writes through to the AUS putNotificationPreferences action.

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.view.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.view.test.tsx
@@ -7,9 +7,7 @@
  * layer (see tests/component-view/api-mocking/socialLeaderboard.ts).
  *
  * Run with:
- *   yarn jest -c jest.config.view.js \
- *     app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.view.test.tsx \
- *     --runInBand --silent --coverage=false
+ * yarn jest -c jest.config.view.js app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.view.test.tsx --runInBand --silent --coverage=false
  */
 
 import '../../../../../tests/component-view/mocks';

--- a/tests/component-view/api-mocking/socialLeaderboard.ts
+++ b/tests/component-view/api-mocking/socialLeaderboard.ts
@@ -180,13 +180,12 @@ export function setupLeaderboardApiMock(
       const [action, fetchOpts] = messengerArgs as [
         string,
         { chains?: string[] } | undefined,
-        ...unknown[]
+        ...unknown[],
       ];
 
       if (action === 'SocialService:fetchLeaderboard') {
         const chains = fetchOpts?.chains ?? [];
-        const isPerpsOnly =
-          chains.length === 1 && chains[0] === PERP_CHAIN;
+        const isPerpsOnly = chains.length === 1 && chains[0] === PERP_CHAIN;
         const isMixedWithPerps =
           chains.includes(PERP_CHAIN) && chains.length > 1;
 
@@ -205,8 +204,7 @@ export function setupLeaderboardApiMock(
       }
 
       if (
-        action ===
-        'AuthenticatedUserStorageService:getNotificationPreferences'
+        action === 'AuthenticatedUserStorageService:getNotificationPreferences'
       ) {
         return Promise.resolve(prefsResponse) as ReturnType<
           typeof Engine.controllerMessenger.call

--- a/tests/component-view/api-mocking/socialLeaderboard.ts
+++ b/tests/component-view/api-mocking/socialLeaderboard.ts
@@ -2,8 +2,8 @@
  * Social Leaderboard API mock for component view tests.
  *
  * Intercepts Engine.controllerMessenger.call for:
- *   - SocialService:fetchLeaderboard (the useTopTraders React Query source)
- *   - AuthenticatedUserStorageService:getNotificationPreferences (useNotificationPreferences)
+ * - SocialService:fetchLeaderboard (the useTopTraders React Query source)
+ * - AuthenticatedUserStorageService:getNotificationPreferences (useNotificationPreferences)
  *
  * Uses the same spy/restore pattern as api-mocking/watchlist.ts.
  */
@@ -36,14 +36,14 @@ export interface MockLeaderboardEntry {
 
 /**
  * Three fixture traders that exercise all rendering paths:
- *   - trader-1 / alpha.eth: spot chains (base, ethereum) – gold podium medal
- *   - trader-2 / beta.eth: spot chain (base)             – silver podium medal
- *   - trader-3 / gamma.eth: hyperliquid (perps-only)     – bronze podium medal
+ * - trader-1 / alpha.eth: spot chains (base, ethereum) – gold podium medal
+ * - trader-2 / beta.eth: spot chain (base) – silver podium medal
+ * - trader-3 / gamma.eth: hyperliquid (perps-only) – bronze podium medal
  *
  * Metric ordering:
- *   PnL 7d:     alpha > beta > gamma   (default sort)
- *   ROI 7d:     gamma > beta > alpha   (ROI sort flips order)
- *   Win rate 7d: alpha > beta > gamma
+ * PnL 7d: alpha > beta > gamma (default sort)
+ * ROI 7d: gamma > beta > alpha (ROI sort flips order)
+ * Win rate 7d: alpha > beta > gamma
  */
 export const mockLeaderboardTraders: MockLeaderboardEntry[] = [
   {

--- a/tests/component-view/api-mocking/socialLeaderboard.ts
+++ b/tests/component-view/api-mocking/socialLeaderboard.ts
@@ -1,0 +1,248 @@
+/**
+ * Social Leaderboard API mock for component view tests.
+ *
+ * Intercepts Engine.controllerMessenger.call for:
+ *   - SocialService:fetchLeaderboard (the useTopTraders React Query source)
+ *   - AuthenticatedUserStorageService:getNotificationPreferences (useNotificationPreferences)
+ *
+ * Uses the same spy/restore pattern as api-mocking/watchlist.ts.
+ */
+
+import Engine from '../../../app/core/Engine';
+import { DEFAULT_SOCIAL_AI_PREFERENCES } from '@metamask/notification-services-controller/notification-services';
+
+// ---------------------------------------------------------------------------
+// Fixture data
+// ---------------------------------------------------------------------------
+
+/**
+ * Raw API response shape for a single leaderboard entry
+ * (matches the LeaderboardResponse.traders[] element from @metamask/social-controllers).
+ */
+export interface MockLeaderboardEntry {
+  profileId: string;
+  addresses: string[];
+  rank: number;
+  name: string;
+  imageUrl?: string | null;
+  roiPercent7d: number;
+  roiPercent30d: number;
+  pnl7d: number;
+  pnl30d: number;
+  winRate7d: number;
+  winRate30d: number;
+  pnlPerChain: Record<string, number>;
+}
+
+/**
+ * Three fixture traders that exercise all rendering paths:
+ *   - trader-1 / alpha.eth: spot chains (base, ethereum) – gold podium medal
+ *   - trader-2 / beta.eth: spot chain (base)             – silver podium medal
+ *   - trader-3 / gamma.eth: hyperliquid (perps-only)     – bronze podium medal
+ *
+ * Metric ordering:
+ *   PnL 7d:     alpha > beta > gamma   (default sort)
+ *   ROI 7d:     gamma > beta > alpha   (ROI sort flips order)
+ *   Win rate 7d: alpha > beta > gamma
+ */
+export const mockLeaderboardTraders: MockLeaderboardEntry[] = [
+  {
+    profileId: 'trader-1',
+    addresses: ['0x0000000000000000000000000000000000000001'],
+    rank: 1,
+    name: 'alpha.eth',
+    imageUrl: 'https://example.com/avatar1.png',
+    roiPercent7d: 43,
+    roiPercent30d: 55,
+    pnl7d: 963146.8,
+    pnl30d: 1_200_000,
+    winRate7d: 0.92,
+    winRate30d: 0.88,
+    pnlPerChain: { base: 500_000, ethereum: 463_146.8 },
+  },
+  {
+    profileId: 'trader-2',
+    addresses: ['0x0000000000000000000000000000000000000002'],
+    rank: 2,
+    name: 'beta.eth',
+    imageUrl: 'https://example.com/avatar2.png',
+    roiPercent7d: 359,
+    roiPercent30d: 420,
+    pnl7d: 474_751.45,
+    pnl30d: 600_000,
+    winRate7d: 0.61,
+    winRate30d: 0.58,
+    pnlPerChain: { base: 474_751.45 },
+  },
+  {
+    profileId: 'trader-3',
+    addresses: ['0x0000000000000000000000000000000000000003'],
+    rank: 3,
+    name: 'gamma.eth',
+    imageUrl: 'https://example.com/avatar3.png',
+    roiPercent7d: 617,
+    roiPercent30d: 750,
+    pnl7d: 374_735.16,
+    pnl30d: 450_000,
+    winRate7d: 0.48,
+    winRate30d: 0.52,
+    pnlPerChain: { hyperliquid: 374_735.16 },
+  },
+];
+
+/** Spot-only fixture subset (used when querying tokens tab). */
+export const mockSpotTraders = mockLeaderboardTraders.slice(0, 2);
+
+/** Perps-only fixture subset (used when querying perps tab). */
+export const mockPerpsTraders = [mockLeaderboardTraders[2]];
+
+// ---------------------------------------------------------------------------
+// Notification preferences helpers
+// ---------------------------------------------------------------------------
+
+export interface NotificationPrefsOptions {
+  /** Whether push notifications channel is on. Default: true. */
+  pushEnabled?: boolean;
+  /** Whether in-app notifications channel is on. Default: true. */
+  inAppEnabled?: boolean;
+  /** Trader IDs that are muted. Default: []. */
+  mutedTraderProfileIds?: string[];
+}
+
+function buildNotificationPrefsResponse(opts: NotificationPrefsOptions = {}) {
+  const {
+    pushEnabled = true,
+    inAppEnabled = true,
+    mutedTraderProfileIds = [],
+  } = opts;
+
+  return {
+    socialAI: {
+      ...DEFAULT_SOCIAL_AI_PREFERENCES,
+      pushNotificationsEnabled: pushEnabled,
+      inAppNotificationsEnabled: inAppEnabled,
+      mutedTraderProfileIds,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Spy lifecycle
+// ---------------------------------------------------------------------------
+
+let messengerSpy: jest.SpyInstance | undefined;
+
+/**
+ * Options to configure the leaderboard API mock.
+ * All overrides are optional; sane defaults cover the happy-path.
+ */
+export interface LeaderboardApiMockOptions {
+  /** Custom trader set to return for the tokens tab (spot-only chains). */
+  spotTraders?: MockLeaderboardEntry[];
+  /** Custom trader set to return for the perps tab (hyperliquid). */
+  perpsTraders?: MockLeaderboardEntry[];
+  /** Custom trader set to return when all chains are requested. */
+  allTraders?: MockLeaderboardEntry[];
+  /** Override notification preferences returned by the AUS GET action. */
+  notificationPrefs?: NotificationPrefsOptions;
+}
+
+const PERP_CHAIN = 'hyperliquid';
+
+/**
+ * Spies on Engine.controllerMessenger.call to intercept Social Leaderboard
+ * messenger actions. Call this in `beforeEach`; call `clearLeaderboardApiMock`
+ * in `afterEach`.
+ *
+ * Returns the spy so tests can inspect individual calls.
+ */
+export function setupLeaderboardApiMock(
+  options: LeaderboardApiMockOptions = {},
+): jest.SpyInstance {
+  const {
+    spotTraders = mockSpotTraders,
+    perpsTraders = mockPerpsTraders,
+    allTraders = mockLeaderboardTraders,
+    notificationPrefs = {},
+  } = options;
+
+  const prefsResponse = buildNotificationPrefsResponse(notificationPrefs);
+
+  const originalCall = Engine.controllerMessenger.call.bind(
+    Engine.controllerMessenger,
+  );
+
+  clearLeaderboardApiMock();
+
+  messengerSpy = jest
+    .spyOn(Engine.controllerMessenger, 'call')
+    .mockImplementation((...messengerArgs: [string, ...unknown[]]) => {
+      const [action, fetchOpts] = messengerArgs as [
+        string,
+        { chains?: string[] } | undefined,
+        ...unknown[]
+      ];
+
+      if (action === 'SocialService:fetchLeaderboard') {
+        const chains = fetchOpts?.chains ?? [];
+        const isPerpsOnly =
+          chains.length === 1 && chains[0] === PERP_CHAIN;
+        const isMixedWithPerps =
+          chains.includes(PERP_CHAIN) && chains.length > 1;
+
+        let traders: MockLeaderboardEntry[];
+        if (isPerpsOnly) {
+          traders = perpsTraders;
+        } else if (isMixedWithPerps) {
+          traders = allTraders;
+        } else {
+          traders = spotTraders;
+        }
+
+        return Promise.resolve({ traders }) as ReturnType<
+          typeof Engine.controllerMessenger.call
+        >;
+      }
+
+      if (
+        action ===
+        'AuthenticatedUserStorageService:getNotificationPreferences'
+      ) {
+        return Promise.resolve(prefsResponse) as ReturnType<
+          typeof Engine.controllerMessenger.call
+        >;
+      }
+
+      return Reflect.apply(
+        originalCall,
+        Engine.controllerMessenger,
+        messengerArgs as Parameters<typeof Engine.controllerMessenger.call>,
+      ) as ReturnType<typeof Engine.controllerMessenger.call>;
+    });
+
+  return messengerSpy;
+}
+
+/**
+ * Restores the Engine.controllerMessenger.call spy installed by
+ * `setupLeaderboardApiMock`. Call in `afterEach`.
+ */
+export function clearLeaderboardApiMock(): void {
+  if (messengerSpy) {
+    messengerSpy.mockRestore();
+    messengerSpy = undefined;
+  }
+}
+
+/**
+ * Returns the active messenger spy (or throws if not set up).
+ * Useful for asserting specific calls inside a test.
+ */
+export function getLeaderboardMessengerSpy(): jest.SpyInstance {
+  if (!messengerSpy) {
+    throw new Error(
+      'getLeaderboardMessengerSpy: call setupLeaderboardApiMock first',
+    );
+  }
+  return messengerSpy;
+}

--- a/tests/component-view/presets/socialLeaderboard.ts
+++ b/tests/component-view/presets/socialLeaderboard.ts
@@ -1,0 +1,101 @@
+/**
+ * Redux state preset for Top Traders / Social Leaderboard component view tests.
+ *
+ * Enables all social-leaderboard remote feature flags, seeds an unlocked keyring,
+ * notification service state, and an empty SocialController following list so
+ * every trader row starts with a "Follow" button.
+ */
+
+import type { DeepPartial } from '../../../app/util/test/renderWithProvider';
+import type { RootState } from '../../../app/reducers';
+import { createStateFixture } from '../stateFixture';
+
+export interface SocialLeaderboardPresetOptions {
+  /** Master feature gate. Default: true. */
+  featureEnabled?: boolean;
+  /** Perps tab gate. Default: true. */
+  perpsEnabled?: boolean;
+  /** Privacy opt-in/out flow gate (Settings section). Default: true. */
+  optFlowEnabled?: boolean;
+  /**
+   * IDs of traders the current user already follows.
+   * Used to seed SocialController.followingProfileIds so rows show
+   * "Following" / mute chip without network calls.
+   * Default: [] (no follows).
+   */
+  followingProfileIds?: string[];
+  /**
+   * Whether the user has opted in to appearing on the leaderboard.
+   * Drives the settings toggle initial state.
+   * Default: true.
+   */
+  showAccountOnLeaderboard?: boolean;
+  /**
+   * Whether MetaMask notifications are enabled at the master level.
+   * Default: true.
+   */
+  notificationsEnabled?: boolean;
+}
+
+function makeVersionFlag(enabled: boolean) {
+  return { enabled, minimumVersion: '0.0.1' };
+}
+
+/**
+ * Returns a `StateFixtureBuilder` configured for Social Leaderboard CV tests.
+ * Call `.build()` to produce the state object, or chain `.withOverrides(...)`.
+ */
+export function initialStateSocialLeaderboard(
+  options: SocialLeaderboardPresetOptions = {},
+) {
+  const {
+    featureEnabled = true,
+    perpsEnabled = true,
+    optFlowEnabled = true,
+    followingProfileIds = [],
+    showAccountOnLeaderboard = true,
+    notificationsEnabled = true,
+  } = options;
+
+  return createStateFixture()
+    .withMinimalAccounts()
+    .withMinimalMainnetNetwork()
+    .withMinimalKeyringController()
+    .withRemoteFeatureFlags({
+      aiSocialLeaderboardEnabled: makeVersionFlag(featureEnabled),
+      aiSocialLeaderboardPerpsEnabled: makeVersionFlag(perpsEnabled),
+      aiSocialLeaderboardOptFlowEnabled: makeVersionFlag(optFlowEnabled),
+      // Cache-refresh flag: off by default to avoid extra calls in tests.
+      aiSocialAusCacheRefreshEnabled: makeVersionFlag(false),
+    })
+    .withOverrides({
+      engine: {
+        backgroundState: {
+          // isUnlocked: true so useTopTraders query is enabled.
+          KeyringController: { isUnlocked: true, keyrings: [] },
+          NotificationServicesController: {
+            isNotificationServicesEnabled: notificationsEnabled,
+            isFeatureAnnouncementsEnabled: true,
+            isMetamaskNotificationsFeatureSeen: true,
+            isUpdatingMetamaskNotifications: false,
+            isFetchingMetamaskNotifications: false,
+            isUpdatingMetamaskNotificationsAccount: [],
+            metamaskNotificationsReadList: [],
+            metamaskNotificationsList: [],
+          },
+          NotificationServicesPushController: {
+            isPushEnabled: notificationsEnabled,
+            isUpdatingFCMToken: false,
+            fcmToken: 'mock-fcm-token',
+          },
+          // SocialController.followingProfileIds drives isFollowing() in
+          // useFollowToggleMany without any additional API calls.
+          SocialController: { followingProfileIds },
+        },
+      },
+      settings: {
+        showAccountOnLeaderboard,
+        basicFunctionalityEnabled: true,
+      },
+    } as DeepPartial<RootState>);
+}

--- a/tests/component-view/renderers/socialLeaderboard.tsx
+++ b/tests/component-view/renderers/socialLeaderboard.tsx
@@ -2,10 +2,9 @@
  * Component-view renderers for Top Traders / Social Leaderboard screens.
  *
  * Provides:
- *   renderTopTradersView          – standalone leaderboard page
- *   renderTopTradersViewWithRoutes – leaderboard + extra registered routes
- *                                   (use for navigation assertions)
- *   renderSettingsTopTradersSection – privacy toggle in SecuritySettings
+ * - renderTopTradersView – standalone leaderboard page
+ * - renderTopTradersViewWithRoutes – leaderboard + extra registered routes (use for navigation assertions)
+ * - renderSettingsTopTradersSection – privacy toggle in SecuritySettings
  */
 
 import '../mocks';
@@ -59,8 +58,8 @@ export function renderTopTradersView(
  * assert navigation by checking for route probe elements.
  *
  * @param extraRoutes - Routes that the component may navigate to during the
- *   test (e.g. PROFILE, TRADING_SIGNALS_SETUP). Each becomes a probe screen
- *   with `testID = route-${name}` unless a custom Component is given.
+ * test (e.g. PROFILE, TRADING_SIGNALS_SETUP). Each becomes a probe screen
+ * with `testID = route-${name}` unless a custom Component is given.
  */
 export function renderTopTradersViewWithRoutes(
   extraRoutes: { name: string; Component?: React.ComponentType<object> }[],

--- a/tests/component-view/renderers/socialLeaderboard.tsx
+++ b/tests/component-view/renderers/socialLeaderboard.tsx
@@ -1,0 +1,106 @@
+/**
+ * Component-view renderers for Top Traders / Social Leaderboard screens.
+ *
+ * Provides:
+ *   renderTopTradersView          – standalone leaderboard page
+ *   renderTopTradersViewWithRoutes – leaderboard + extra registered routes
+ *                                   (use for navigation assertions)
+ *   renderSettingsTopTradersSection – privacy toggle in SecuritySettings
+ */
+
+import '../mocks';
+import React from 'react';
+import type { DeepPartial } from '../../../app/util/test/renderWithProvider';
+import type { RootState } from '../../../app/reducers';
+import { renderComponentViewScreen, renderScreenWithRoutes } from '../render';
+import Routes from '../../../app/constants/navigation/Routes';
+import TopTradersView from '../../../app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import SettingsTopTradersSection from '../../../app/components/Views/Settings/SecuritySettings/Sections/TopTradersSection';
+import {
+  initialStateSocialLeaderboard,
+  type SocialLeaderboardPresetOptions,
+} from '../presets/socialLeaderboard';
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+export interface RenderSocialLeaderboardOptions {
+  presetOptions?: SocialLeaderboardPresetOptions;
+  overrides?: DeepPartial<RootState>;
+}
+
+// ---------------------------------------------------------------------------
+// TopTradersView – leaderboard page
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders `TopTradersView` inside the CV framework (QueryClient + Navigator).
+ * Use when the test only needs to assert visible state without navigating away.
+ */
+export function renderTopTradersView(
+  options: RenderSocialLeaderboardOptions = {},
+) {
+  const { presetOptions, overrides } = options;
+  const builder = initialStateSocialLeaderboard(presetOptions);
+  if (overrides) builder.withOverrides(overrides);
+  const state = builder.build();
+
+  return renderComponentViewScreen(
+    TopTradersView as unknown as React.ComponentType,
+    { name: Routes.SOCIAL_LEADERBOARD.VIEW },
+    { state },
+  );
+}
+
+/**
+ * Renders `TopTradersView` with additional routes registered so tests can
+ * assert navigation by checking for route probe elements.
+ *
+ * @param extraRoutes - Routes that the component may navigate to during the
+ *   test (e.g. PROFILE, TRADING_SIGNALS_SETUP). Each becomes a probe screen
+ *   with `testID = route-${name}` unless a custom Component is given.
+ */
+export function renderTopTradersViewWithRoutes(
+  extraRoutes: { name: string; Component?: React.ComponentType<object> }[],
+  options: RenderSocialLeaderboardOptions = {},
+) {
+  const { presetOptions, overrides } = options;
+  const builder = initialStateSocialLeaderboard(presetOptions);
+  if (overrides) builder.withOverrides(overrides);
+  const state = builder.build();
+
+  return renderScreenWithRoutes(
+    TopTradersView as unknown as React.ComponentType,
+    { name: Routes.SOCIAL_LEADERBOARD.VIEW },
+    extraRoutes,
+    { state },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Settings TopTradersSection – privacy opt-in/out toggle
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders the Security & Privacy `TopTradersSection` toggle in isolation.
+ *
+ * The component reads feature flags and `settings.showAccountOnLeaderboard`
+ * from Redux, and calls Engine.controllerMessenger for opt-in/opt-out.
+ * No external API mock is required; the default Engine mock is sufficient.
+ */
+export function renderSettingsTopTradersSection(
+  options: RenderSocialLeaderboardOptions = {},
+) {
+  const { presetOptions, overrides } = options;
+  const builder = initialStateSocialLeaderboard(presetOptions);
+  if (overrides) builder.withOverrides(overrides);
+  const state = builder.build();
+
+  return renderComponentViewScreen(
+    SettingsTopTradersSection as unknown as React.ComponentType,
+    { name: 'SettingsTopTradersSection' },
+    { state },
+  );
+}


### PR DESCRIPTION
## **Description**

Adds component-view (CV) test coverage for the Top Traders / Social Leaderboard feature. The existing unit tests (`TopTradersView.test.tsx`, `TopTradersSection.test.tsx`) rely heavily on mocked hooks and selectors, which cannot catch regressions in the Redux → React Query → Engine pipeline. These CV tests drive the full stack — real Redux state, real `useTopTraders` query through `Engine.controllerMessenger`, and real feature-flag selectors — with only the Engine messenger boundary mocked.

Three shared infrastructure files are added under `tests/component-view/`:
- `api-mocking/socialLeaderboard.ts`: Engine spy intercepting `SocialService:fetchLeaderboard` (with chain-aware routing for spot/perps/all tabs) and `AuthenticatedUserStorageService:getNotificationPreferences`
- `presets/socialLeaderboard.ts`: Redux state builder covering all three feature flags, unlocked keyring, notification state, and follow state
- `renderers/socialLeaderboard.tsx`: three render helpers wrapping the target components in the CV framework

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MMQA-2388

## **Manual testing steps**

N/A — this PR adds automated tests only; no user-facing behaviour changes.

```
yarn jest -c jest.config.view.js \
  app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.view.test.tsx \
  --runInBand --silent --coverage=false

yarn jest -c jest.config.view.js \
  app/components/Views/Settings/SecuritySettings/Sections/TopTradersSection.view.test.tsx \
  --runInBand --silent --coverage=false
```

## **Screenshots/Recordings**

N/A — test-only change, no UI modifications.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no production or user-facing behavior changes.
> 
> **Overview**
> Adds **component-view** coverage for Social Leaderboard so regressions in the Redux → React Query → `Engine.controllerMessenger` path are caught without mocking hooks or selectors.
> 
> New shared test infrastructure under `tests/component-view/`: chain-aware leaderboard API mocking (`socialLeaderboard.ts`), Redux presets (flags, follow list, privacy toggle), and render helpers for `TopTradersView` and Settings **Top Traders** privacy section.
> 
> **`TopTradersView.view.test.tsx`** exercises loaded row data, sort/timeframe/type filters, follow/unfollow/mute, pull-to-refresh refetch, profile navigation, and trading-signals setup when notification channels are off.
> 
> **`TopTradersSection.view.test.tsx`** exercises opt-in/opt-out via Engine, Redux updates, error recovery, and in-flight double-tap guarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cac85253ae40a6be9020754bcd5f8ce1a9e6b941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->