### PR TITLE
fix(ci): pin JS bundle baseline from the PR merge-ref parent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,14 +516,10 @@ jobs:
         run: |
           set -euo pipefail
           BASE_REF='${{ github.event.pull_request.base.ref }}'
-          git fetch origin "${BASE_REF}" --depth=1
-          if ! MERGE_BASE_SHA="$(git merge-base "origin/${BASE_REF}" HEAD)"; then
-            echo "::warning::Could not resolve merge-base between HEAD and origin/${BASE_REF}; bundle size delta check will be skipped."
-            echo "MERGE_BASE_SHA=" >> "$GITHUB_ENV"
-          else
-            echo "Merge-base pinned (origin/${BASE_REF}, HEAD): ${MERGE_BASE_SHA}"
-            echo "MERGE_BASE_SHA=${MERGE_BASE_SHA}" >> "$GITHUB_ENV"
-          fi
+          # PR checkout is the merge ref (fetch-depth: 2); first parent is the base tip.
+          MERGE_BASE_SHA="$(git rev-parse HEAD^1)"
+          echo "Merge-base pinned (${BASE_REF}, HEAD): ${MERGE_BASE_SHA}"
+          echo "MERGE_BASE_SHA=${MERGE_BASE_SHA}" >> "$GITHUB_ENV"
           echo "BUNDLE_SIZE_BASE_REF=${BASE_REF}" >> "$GITHUB_ENV"
       - name: Configure Namespace cache
         if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The JS bundle size job pinned its PR baseline by fetching live `origin/main` at depth 1 and running `git merge-base`. On a delayed or retried PR run, `main` has often moved past the merge-ref parent, so that shallow tip shares no history with HEAD and the delta check is skipped.

PR checkout is already `refs/pull/N/merge` with `fetch-depth: 2`. This change pins `HEAD^1` (the base tip GitHub merged against) instead of asking the network for current `main`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: JS bundle size check skipped merge-base on delayed run https://github.com/MetaMask/metamask-mobile/actions/runs/32722674334/job/97650886392

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — CI-only workflow change; no in-app behavior. Verify on this PR that **JS bundle size check** prints `Merge-base pinned` and runs the delta check, including after a job rerun.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no UI change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
