### PR TITLE
feat(market-insights): add fetch and TTC Sentry spans

### DIFF
--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.test.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.test.tsx
@@ -453,6 +453,25 @@ describe('MarketInsightsView', () => {
     });
   });
 
+  it('does not end full-view time to content as empty while loading', () => {
+    mockRouteParams.source = 'token_details';
+    mockUseMarketInsights.mockReturnValue({
+      report: null,
+      reportAssetId: null,
+      isLoading: true,
+      error: null,
+      timeAgo: '',
+    });
+
+    renderWithProvider(<MarketInsightsView />);
+
+    expect(mockEndTrace).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ result: 'empty' }),
+      }),
+    );
+  });
+
   it('ends full-view time to content with an error result', () => {
     mockRouteParams.source = 'perps';
     mockRouteParams.assetIdentifier = 'ETH';

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.test.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.test.tsx
@@ -10,6 +10,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
 const mockUseMarketInsights = jest.fn();
+const mockEndTrace = jest.fn();
 const mockTrendSourcesBottomSheet = jest.fn();
 const mockFeedbackBottomSheet = jest.fn();
 const mockTrackEvent = jest.fn();
@@ -67,14 +68,23 @@ jest.mock('@react-navigation/native', () => {
 });
 
 jest.mock('../../hooks/useMarketInsights', () => ({
-  useMarketInsights: (assetIdentifier: string) => {
-    const result = mockUseMarketInsights(assetIdentifier);
+  useMarketInsights: (
+    assetIdentifier: string,
+    _isEnabled: boolean,
+    telemetryContext: unknown,
+  ) => {
+    const result = mockUseMarketInsights(assetIdentifier, telemetryContext);
     return {
       ...result,
       reportAssetId:
         result?.reportAssetId ?? (result?.report ? assetIdentifier : null),
     };
   },
+}));
+
+jest.mock('../../../../../util/trace', () => ({
+  ...jest.requireActual('../../../../../util/trace'),
+  endTrace: (...args: unknown[]) => mockEndTrace(...args),
 }));
 
 jest.mock(
@@ -413,6 +423,83 @@ describe('MarketInsightsView', () => {
 
     const { queryByTestId } = renderWithProvider(<MarketInsightsView />);
     expect(queryByTestId(MarketInsightsSelectorsIDs.VIEW_CONTAINER)).toBeNull();
+  });
+
+  it('ends full-view time to content when the report is committed', () => {
+    mockRouteParams.source = 'token_details';
+    mockUseMarketInsights.mockReturnValue({
+      report: buildMockReport(),
+      reportAssetId: 'eip155:1/erc20:0x123',
+      isLoading: false,
+      error: null,
+      timeAgo: '5m ago',
+    });
+
+    renderWithProvider(<MarketInsightsView />);
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: 'Market Insights View Load',
+      id: 'token_details:full_view:eip155:1/erc20:0x123',
+      data: {
+        result: 'success',
+        success: true,
+        content_state: 'filled',
+      },
+    });
+    expect(mockUseMarketInsights).toHaveBeenCalledWith('eip155:1/erc20:0x123', {
+      source: 'token_details',
+      stage: 'full_view',
+      assetType: 'token',
+    });
+  });
+
+  it('ends full-view time to content with an error result', () => {
+    mockRouteParams.source = 'perps';
+    mockRouteParams.assetIdentifier = 'ETH';
+    mockRouteParams.isPerps = true;
+    mockUseMarketInsights.mockReturnValue({
+      report: null,
+      reportAssetId: null,
+      isLoading: false,
+      error: 'request failed',
+      timeAgo: '',
+    });
+
+    renderWithProvider(<MarketInsightsView />);
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: 'Market Insights View Load',
+      id: 'perps:full_view:ETH',
+      data: {
+        result: 'error',
+        success: false,
+        content_state: 'error',
+      },
+    });
+  });
+
+  it('ends full-view time to content as cancelled on unmount', () => {
+    mockRouteParams.source = 'token_details';
+    mockUseMarketInsights.mockReturnValue({
+      report: null,
+      reportAssetId: null,
+      isLoading: true,
+      error: null,
+      timeAgo: '',
+    });
+    const { unmount } = renderWithProvider(<MarketInsightsView />);
+
+    unmount();
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: 'Market Insights View Load',
+      id: 'token_details:full_view:eip155:1/erc20:0x123',
+      data: {
+        result: 'cancelled',
+        success: false,
+        reason: 'owner_cancelled',
+      },
+    });
   });
 
   it('configures background video to mix with other audio', () => {

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
@@ -65,6 +65,10 @@ import {
   selectMarketInsightsPerpsEnabled,
 } from '../../../../../selectors/featureFlagController/marketInsights';
 import { endTrace, TraceName } from '../../../../../util/trace';
+import {
+  getMarketInsightsTraceEndData,
+  getMarketInsightsTraceId,
+} from '../../utils/marketInsightsPerformance';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import MarketInsightsViewSkeleton from './MarketInsightsViewSkeleton';
 import MarketInsightsViewHeader from './MarketInsightsViewHeader';
@@ -210,10 +214,21 @@ const MarketInsightsView: React.FC = () => {
   const isMarketInsightsEnabled = isPerps
     ? isPerpsInsightsEnabled
     : isTokenInsightsEnabled;
+  const assetType = isPerps ? 'perps' : 'token';
+  const fullViewTraceId = getMarketInsightsTraceId(
+    assetIdentifier,
+    routeSource,
+    'full_view',
+  );
 
   const { report, reportAssetId, isLoading, error } = useMarketInsights(
     assetIdentifier,
     isMarketInsightsEnabled,
+    {
+      source: routeSource,
+      stage: 'full_view',
+      assetType,
+    },
   );
 
   const isDarkMode = useColorScheme() === 'dark';
@@ -610,8 +625,6 @@ const MarketInsightsView: React.FC = () => {
       return;
     }
 
-    endTrace({ name: TraceName.MarketInsightsViewLoad });
-
     const event = createEventBuilder(MetaMetricsEvents.MARKET_INSIGHTS_VIEWED)
       .addProperties({
         ...assetIdProperty,
@@ -631,6 +644,41 @@ const MarketInsightsView: React.FC = () => {
     createEventBuilder,
     routeSource,
   ]);
+
+  useEffect(() => {
+    if (reportAssetId !== assetIdentifier) {
+      return;
+    }
+
+    endTrace({
+      name: TraceName.MarketInsightsViewLoad,
+      id: fullViewTraceId,
+      data: getMarketInsightsTraceEndData('success'),
+    });
+  }, [assetIdentifier, fullViewTraceId, reportAssetId]);
+
+  useEffect(() => {
+    if (isLoading || report) {
+      return;
+    }
+
+    endTrace({
+      name: TraceName.MarketInsightsViewLoad,
+      id: fullViewTraceId,
+      data: getMarketInsightsTraceEndData(error ? 'error' : 'empty'),
+    });
+  }, [error, fullViewTraceId, isLoading, report]);
+
+  useEffect(
+    () => () => {
+      endTrace({
+        name: TraceName.MarketInsightsViewLoad,
+        id: fullViewTraceId,
+        data: getMarketInsightsTraceEndData('cancelled'),
+      });
+    },
+    [fullViewTraceId],
+  );
 
   if (showLoadingSkeleton && !report && !error) {
     return (

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.test.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.test.tsx
@@ -24,6 +24,7 @@ jest.mock('@react-native-masked-view/masked-view', () =>
 );
 
 const mockTrackEvent = jest.fn();
+const mockEndTrace = jest.fn();
 jest.mock('../../../../hooks/useAnalytics/useAnalytics');
 
 let capturedOnVisible: (() => void) | null = null;
@@ -38,7 +39,7 @@ jest.mock('../../hooks/useViewportTracking', () => ({
 }));
 
 jest.mock('../../../../../util/trace', () => ({
-  endTrace: jest.fn(),
+  endTrace: (...args: unknown[]) => mockEndTrace(...args),
   TraceName: { MarketInsightsEntryCardLoad: 'MarketInsightsEntryCardLoad' },
 }));
 
@@ -140,6 +141,29 @@ describe('MarketInsightsEntryCard', () => {
 
     fireEvent.press(getByTestId('market-insights-entry-card'));
     expect(mockPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('ends the parent entry-card trace after the card commits', () => {
+    renderWithProvider(
+      <MarketInsightsEntryCard
+        report={mockReport as never}
+        timeAgo="3m ago"
+        onPress={jest.fn()}
+        traceId="perps:entry_card:ETH"
+        source="perps"
+        testID="market-insights-entry-card"
+      />,
+    );
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: 'MarketInsightsEntryCardLoad',
+      id: 'perps:entry_card:ETH',
+      data: {
+        result: 'success',
+        success: true,
+        content_state: 'filled',
+      },
+    });
   });
 
   it('renders summary text when there are no trend descriptions', () => {

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
@@ -26,6 +26,7 @@ import {
 import { endTrace, TraceName } from '../../../../../util/trace';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { useViewportTracking } from '../../hooks/useViewportTracking';
+import { getMarketInsightsTraceEndData } from '../../utils/marketInsightsPerformance';
 import { AnimatedGradientBorder } from './AnimatedGradientBorder';
 import { VISIBILITY_THRESHOLD } from './AnimatedGradientBorder.constants';
 import type { MarketInsightsEntryCardProps } from './MarketInsightsEntryCard.types';
@@ -165,6 +166,7 @@ const MarketInsightsEntryCard: React.FC<MarketInsightsEntryCardProps> = ({
   onPress,
   onDisclaimerPress,
   caip19Id,
+  traceId,
   source,
   testID,
 }) => {
@@ -222,16 +224,19 @@ const MarketInsightsEntryCard: React.FC<MarketInsightsEntryCardProps> = ({
   const { ref: cardRef, onLayout: onVisibilityLayout } = useViewportTracking(
     handleVisible,
     VISIBILITY_THRESHOLD,
+    { source, stage: 'entry_card' },
   );
 
   useEffect(() => {
-    if (caip19Id) {
+    const entryTraceId = traceId ?? caip19Id;
+    if (entryTraceId) {
       endTrace({
         name: TraceName.MarketInsightsEntryCardLoad,
-        id: caip19Id,
+        id: entryTraceId,
+        data: getMarketInsightsTraceEndData('success'),
       });
     }
-  }, [caip19Id]);
+  }, [caip19Id, traceId]);
 
   const handleLayout = useCallback(
     (event: { nativeEvent: { layout: { width: number; height: number } } }) => {

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.types.ts
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.types.ts
@@ -10,11 +10,12 @@ export interface MarketInsightsEntryCardProps {
   onPress: () => void;
   /** Callback when the disclaimer info icon is pressed */
   onDisclaimerPress?: () => void;
-  /** The CAIP-19 asset ID, used to match the trace started by the parent.
-   * Optional, only provide this when a corresponding startTrace was initiated
-   * by the parent component (AssetOverviewContent in the token details flow).
+  /** CAIP-19 asset ID used by token-details analytics. It remains a fallback
+   * trace identifier for callers that have not supplied `traceId`.
    */
   caip19Id?: CaipAssetType;
+  /** Identifier for the entry-card time-to-content trace owned by the parent. */
+  traceId?: string;
   /** Surface from which the Market Insights feature was accessed */
   source: 'token_details' | 'perps' | 'unknown';
   /** Optional test ID */

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCardOriginal.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCardOriginal.tsx
@@ -18,6 +18,7 @@ import {
 import { strings } from '../../../../../../locales/i18n';
 import type { MarketInsightsEntryCardProps } from './MarketInsightsEntryCard.types';
 import { endTrace, TraceName } from '../../../../../util/trace';
+import { getMarketInsightsTraceEndData } from '../../utils/marketInsightsPerformance';
 
 const SparkleIcon: React.FC = () => (
   <Icon name={IconName.Ai} size={IconSize.Lg} color={IconColor.IconDefault} />
@@ -29,17 +30,19 @@ const SparkleIcon: React.FC = () => (
  */
 const MarketInsightsEntryCardOriginal: React.FC<
   MarketInsightsEntryCardProps
-> = ({ report, timeAgo, onPress, caip19Id, testID }) => {
+> = ({ report, timeAgo, onPress, caip19Id, traceId, testID }) => {
   const tw = useTailwind();
 
   useEffect(() => {
-    if (caip19Id) {
+    const entryTraceId = traceId ?? caip19Id;
+    if (entryTraceId) {
       endTrace({
         name: TraceName.MarketInsightsEntryCardLoad,
-        id: caip19Id,
+        id: entryTraceId,
+        data: getMarketInsightsTraceEndData('success'),
       });
     }
-  }, [caip19Id]);
+  }, [caip19Id, traceId]);
 
   return (
     <Pressable

--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
@@ -587,6 +587,86 @@ describe('useMarketInsights', () => {
     expect(result.current.isLoading).toBe(false);
   });
 
+  it('stays loading on remount while a cached error refetches', async () => {
+    mockFetchMarketInsights.mockRejectedValueOnce(new Error('fetch failed'));
+
+    const first = renderHook(() => useMarketInsights('ETH', true), {
+      wrapper,
+    });
+    await waitFor(() =>
+      expect(first.result.current.error).toBe('fetch failed'),
+    );
+    expect(first.result.current.isLoading).toBe(false);
+    first.unmount();
+
+    let resolveRequest: (report: MarketInsightsReport) => void = () =>
+      undefined;
+    const request = new Promise<MarketInsightsReport>((resolve) => {
+      resolveRequest = resolve;
+    });
+    mockFetchMarketInsights.mockReturnValueOnce(request);
+
+    const second = renderHook(() => useMarketInsights('ETH', true), {
+      wrapper,
+    });
+
+    expect(second.result.current.report).toBeNull();
+    expect(second.result.current.isLoading).toBe(true);
+
+    const report = {
+      digestId: 'remount-error-digest',
+      version: '1.0',
+      asset: 'eth',
+      generatedAt: '2026-02-17T11:55:00.000Z',
+      headline: 'ETH advances',
+      summary: 'ETF headlines support demand',
+      trends: [],
+      sources: [],
+    } as MarketInsightsReport;
+    await act(async () => {
+      resolveRequest(report);
+      await request;
+    });
+    await waitFor(() => expect(second.result.current.report).toEqual(report));
+
+    expect(second.result.current.isLoading).toBe(false);
+    expect(second.result.current.error).toBeNull();
+  });
+
+  it('does not mark a settled error as loading during a background refetch', async () => {
+    mockFetchMarketInsights.mockRejectedValueOnce(new Error('fetch failed'));
+
+    const { result } = renderHook(() => useMarketInsights('ETH', true), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.error).toBe('fetch failed'));
+    expect(result.current.isLoading).toBe(false);
+
+    let resolveRequest: (report: MarketInsightsReport | null) => void = () =>
+      undefined;
+    const request = new Promise<MarketInsightsReport | null>((resolve) => {
+      resolveRequest = resolve;
+    });
+    mockFetchMarketInsights.mockReturnValueOnce(request);
+
+    let refetchPromise: Promise<unknown> = Promise.resolve();
+    await act(async () => {
+      refetchPromise = queryClient.refetchQueries({
+        queryKey: ['market-insights', 'ETH'],
+      });
+    });
+
+    expect(result.current.isLoading).toBe(false);
+
+    await act(async () => {
+      resolveRequest(null);
+      await refetchPromise;
+    });
+
+    expect(result.current.report).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
   it('refetches after a null miss on remount', async () => {
     const report = {
       version: '1.0',

--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
@@ -552,6 +552,41 @@ describe('useMarketInsights', () => {
     expect(second.result.current.isLoading).toBe(false);
   });
 
+  it('does not mark a settled null miss as loading during a background refetch', async () => {
+    mockFetchMarketInsights.mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() => useMarketInsights('ETH', true), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.report).toBeNull();
+
+    let resolveRequest: (report: MarketInsightsReport | null) => void = () =>
+      undefined;
+    const request = new Promise<MarketInsightsReport | null>((resolve) => {
+      resolveRequest = resolve;
+    });
+    mockFetchMarketInsights.mockReturnValueOnce(request);
+
+    let refetchPromise: Promise<unknown> = Promise.resolve();
+    await act(async () => {
+      refetchPromise = queryClient.refetchQueries({
+        queryKey: ['market-insights', 'ETH'],
+      });
+    });
+
+    expect(result.current.report).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+
+    await act(async () => {
+      resolveRequest(null);
+      await refetchPromise;
+    });
+
+    expect(result.current.report).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
   it('refetches after a null miss on remount', async () => {
     const report = {
       version: '1.0',

--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
@@ -7,7 +7,20 @@ import {
 } from '@tanstack/react-query';
 import type { MarketInsightsReport } from '@metamask/ai-controllers';
 import { useMarketInsights } from './useMarketInsights';
+
 const mockFetchMarketInsights = jest.fn();
+const mockSetAttribute = jest.fn();
+const mockTrace = jest.fn((...args: unknown[]) => {
+  const callback = args[1] as (context: {
+    setAttribute: typeof mockSetAttribute;
+  }) => unknown;
+  return callback({ setAttribute: mockSetAttribute });
+});
+
+jest.mock('../../../../util/trace', () => ({
+  ...jest.requireActual('../../../../util/trace'),
+  trace: (...args: unknown[]) => mockTrace(...args),
+}));
 
 jest.mock('../../../../core/Engine', () => ({
   __esModule: true,
@@ -82,7 +95,12 @@ describe('useMarketInsights', () => {
     mockFetchMarketInsights.mockResolvedValue(report);
 
     const { result } = renderHook(
-      () => useMarketInsights('eip155:1/erc20:0x123', true),
+      () =>
+        useMarketInsights('eip155:1/erc20:0x123', true, {
+          source: 'token_details',
+          stage: 'entry_card',
+          assetType: 'token',
+        }),
       { wrapper },
     );
 
@@ -95,6 +113,55 @@ describe('useMarketInsights', () => {
     expect(result.current.reportAssetId).toBe('eip155:1/erc20:0x123');
     expect(result.current.error).toBeNull();
     expect(result.current.timeAgo).toBe('5m ago');
+    expect(result.current.cacheState).toBe('cold');
+    expect(mockTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Market Insights Fetch',
+        op: 'market_insights.fetch',
+        tags: {
+          feature: 'market_insights',
+          source: 'token_details',
+          stage: 'entry_card',
+          asset_type: 'token',
+          cache_state: 'cold',
+        },
+      }),
+      expect.any(Function),
+    );
+    expect(mockSetAttribute).toHaveBeenCalledWith('result', 'success');
+    expect(mockSetAttribute).toHaveBeenCalledWith('success', true);
+  });
+
+  it('returns warm cache state without starting a fetch trace', async () => {
+    const report = {
+      version: '1.0',
+      asset: 'eth',
+      generatedAt: '2026-02-17T11:55:00.000Z',
+      headline: 'ETH advances',
+      summary: 'ETF headlines support demand',
+      trends: [],
+      sources: [],
+    };
+    queryClient.setQueryData(
+      ['market-insights', 'eip155:1/erc20:0x123'],
+      report,
+    );
+
+    const { result } = renderHook(
+      () =>
+        useMarketInsights('eip155:1/erc20:0x123', true, {
+          source: 'token_details',
+          stage: 'full_view',
+          assetType: 'token',
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.report).toEqual(report));
+
+    expect(result.current.cacheState).toBe('warm');
+    expect(mockFetchMarketInsights).not.toHaveBeenCalled();
+    expect(mockTrace).not.toHaveBeenCalled();
   });
 
   it('returns null when controller has no insights', async () => {
@@ -111,6 +178,8 @@ describe('useMarketInsights', () => {
     expect(result.current.reportAssetId).toBeNull();
     expect(result.current.error).toBeNull();
     expect(result.current.timeAgo).toBe('');
+    expect(mockSetAttribute).toHaveBeenCalledWith('result', 'empty');
+    expect(mockSetAttribute).toHaveBeenCalledWith('success', true);
   });
 
   it('returns an error when fetch fails', async () => {
@@ -127,6 +196,45 @@ describe('useMarketInsights', () => {
     expect(result.current.reportAssetId).toBeNull();
     expect(result.current.error).toBe('fetch failed');
     expect(result.current.timeAgo).toBe('');
+    expect(mockSetAttribute).toHaveBeenCalledWith('result', 'error');
+    expect(mockSetAttribute).toHaveBeenCalledWith('success', false);
+  });
+
+  it('marks the fetch as cancelled when its last observer unmounts', async () => {
+    let resolveRequest: (report: MarketInsightsReport) => void = () =>
+      undefined;
+    const request = new Promise<MarketInsightsReport>((resolve) => {
+      resolveRequest = resolve;
+    });
+    mockFetchMarketInsights.mockReturnValue(request);
+    const { unmount } = renderHook(
+      () =>
+        useMarketInsights('eip155:1/erc20:0x123', true, {
+          source: 'token_details',
+          stage: 'entry_card',
+          assetType: 'token',
+        }),
+      { wrapper },
+    );
+    await waitFor(() => expect(mockFetchMarketInsights).toHaveBeenCalled());
+
+    unmount();
+
+    expect(mockSetAttribute).toHaveBeenCalledWith('result', 'cancelled');
+    expect(mockSetAttribute).toHaveBeenCalledWith('success', false);
+
+    await act(async () => {
+      resolveRequest({
+        digestId: 'a8154c57-c665-449c-8bb5-fcaae96ef922',
+        asset: 'eth',
+        generatedAt: '2026-02-17T11:55:00.000Z',
+        headline: 'ETH advances',
+        summary: 'ETF headlines support demand',
+        trends: [],
+        sources: [],
+      } as MarketInsightsReport);
+      await request;
+    });
   });
 
   it('fetches using a perps market symbol as assetIdentifier', async () => {
@@ -142,9 +250,17 @@ describe('useMarketInsights', () => {
 
     mockFetchMarketInsights.mockResolvedValue(report);
 
-    const { result } = renderHook(() => useMarketInsights('ETH', true), {
-      wrapper,
-    });
+    const { result } = renderHook(
+      () =>
+        useMarketInsights('ETH', true, {
+          source: 'perps',
+          stage: 'entry_card',
+          assetType: 'perps',
+        }),
+      {
+        wrapper,
+      },
+    );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
@@ -152,6 +268,16 @@ describe('useMarketInsights', () => {
     expect(result.current.report).toEqual(report);
     expect(result.current.reportAssetId).toBe('ETH');
     expect(result.current.error).toBeNull();
+    expect(mockTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          source: 'perps',
+          stage: 'entry_card',
+          asset_type: 'perps',
+        }),
+      }),
+      expect.any(Function),
+    );
   });
 
   it('clears report and reportAssetId when assetIdentifier changes', async () => {

--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
@@ -534,6 +534,7 @@ describe('useMarketInsights', () => {
     expect(second.result.current.error).toBeNull();
 
     const report = {
+      digestId: 'remount-null-miss-digest',
       version: '1.0',
       asset: 'eth',
       generatedAt: '2026-02-17T11:55:00.000Z',

--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
@@ -508,6 +508,49 @@ describe('useMarketInsights', () => {
     expect(mockFetchMarketInsights).toHaveBeenCalledTimes(1);
   });
 
+  it('stays loading on remount while a cached null miss refetches', async () => {
+    mockFetchMarketInsights.mockResolvedValueOnce(null);
+
+    const first = renderHook(() => useMarketInsights('ETH', true), {
+      wrapper,
+    });
+    await waitFor(() => expect(first.result.current.isLoading).toBe(false));
+    expect(first.result.current.report).toBeNull();
+    first.unmount();
+
+    let resolveRequest: (report: MarketInsightsReport) => void = () =>
+      undefined;
+    const request = new Promise<MarketInsightsReport>((resolve) => {
+      resolveRequest = resolve;
+    });
+    mockFetchMarketInsights.mockReturnValueOnce(request);
+
+    const second = renderHook(() => useMarketInsights('ETH', true), {
+      wrapper,
+    });
+
+    expect(second.result.current.report).toBeNull();
+    expect(second.result.current.isLoading).toBe(true);
+    expect(second.result.current.error).toBeNull();
+
+    const report = {
+      version: '1.0',
+      asset: 'eth',
+      generatedAt: '2026-02-17T11:55:00.000Z',
+      headline: 'ETH advances',
+      summary: 'ETF headlines support demand',
+      trends: [],
+      sources: [],
+    } as MarketInsightsReport;
+    await act(async () => {
+      resolveRequest(report);
+      await request;
+    });
+    await waitFor(() => expect(second.result.current.report).toEqual(report));
+
+    expect(second.result.current.isLoading).toBe(false);
+  });
+
   it('refetches after a null miss on remount', async () => {
     const report = {
       version: '1.0',

--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
@@ -24,8 +24,9 @@ export interface UseMarketInsightsResult {
   report: MarketInsightsReport | null;
   /** The assetIdentifier the current report was fetched for, or null while loading/cleared */
   reportAssetId: string | null;
-  /** Whether this generation still lacks a settled report, including a
-   * cached `null` miss that is immediately stale and refetching. */
+  /** Whether this observer still lacks a settled report. A remount of a
+   * cached `null` miss stays loading until that observer fetches; a later
+   * focus refetch of an already-settled miss does not. */
   isLoading: boolean;
   /** Error message if the data fetch failed */
   error: string | null;
@@ -155,12 +156,14 @@ export const useMarketInsights = (
       : null;
   // `query.isLoading` is false when React Query already has cached data,
   // including a `null` miss. Those misses use staleTime 0, so remount
-  // refetches immediately. Keep TTC and UI in the loading state until this
-  // observer settles; otherwise empty/error spans close at ~0ms.
+  // refetches immediately. Keep this observer loading until that first
+  // fetch settles so TTC does not close as empty at ~0ms. Do not treat a
+  // later `isFetching` (app resume / focus) as loading or the entry card
+  // skeleton returns after a settled miss.
   const isLoading =
     isQueryEnabled &&
     !report &&
-    (query.isFetching || (query.data === null && !query.isFetchedAfterMount));
+    (query.isLoading || (query.data === null && !query.isFetchedAfterMount));
 
   const timeAgo = useMemo(
     () => (report ? formatRelativeTime(report.generatedAt) : ''),

--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
@@ -25,8 +25,8 @@ export interface UseMarketInsightsResult {
   /** The assetIdentifier the current report was fetched for, or null while loading/cleared */
   reportAssetId: string | null;
   /** Whether this observer still lacks a settled report. A remount of a
-   * cached `null` miss stays loading until that observer fetches; a later
-   * focus refetch of an already-settled miss does not. */
+   * cached `null` miss or error stays loading until that observer fetches;
+   * a later focus refetch of an already-settled result does not. */
   isLoading: boolean;
   /** Error message if the data fetch failed */
   error: string | null;
@@ -154,16 +154,12 @@ export const useMarketInsights = (
         ? query.error.message
         : 'Failed to fetch insights'
       : null;
-  // `query.isLoading` is false when React Query already has cached data,
-  // including a `null` miss. Those misses use staleTime 0, so remount
-  // refetches immediately. Keep this observer loading until that first
-  // fetch settles so TTC does not close as empty at ~0ms. Do not treat a
-  // later `isFetching` (app resume / focus) as loading or the entry card
-  // skeleton returns after a settled miss.
-  const isLoading =
-    isQueryEnabled &&
-    !report &&
-    (query.isLoading || (query.data === null && !query.isFetchedAfterMount));
+  // A remount of a cached `null` miss or error has no report and has not
+  // fetched on this observer (`isFetchedAfterMount` is false). Keep loading
+  // until that first fetch settles so TTC does not close at ~0ms. After
+  // this observer has fetched, a later focus refetch must not flip loading
+  // or the entry-card skeleton returns.
+  const isLoading = isQueryEnabled && !report && !query.isFetchedAfterMount;
 
   const timeAgo = useMemo(
     () => (report ? formatRelativeTime(report.generatedAt) : ''),

--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
@@ -24,7 +24,8 @@ export interface UseMarketInsightsResult {
   report: MarketInsightsReport | null;
   /** The assetIdentifier the current report was fetched for, or null while loading/cleared */
   reportAssetId: string | null;
-  /** Whether the data is currently loading */
+  /** Whether this generation still lacks a settled report, including a
+   * cached `null` miss that is immediately stale and refetching. */
   isLoading: boolean;
   /** Error message if the data fetch failed */
   error: string | null;
@@ -152,6 +153,14 @@ export const useMarketInsights = (
         ? query.error.message
         : 'Failed to fetch insights'
       : null;
+  // `query.isLoading` is false when React Query already has cached data,
+  // including a `null` miss. Those misses use staleTime 0, so remount
+  // refetches immediately. Keep TTC and UI in the loading state until this
+  // observer settles; otherwise empty/error spans close at ~0ms.
+  const isLoading =
+    isQueryEnabled &&
+    !report &&
+    (query.isFetching || (query.data === null && !query.isFetchedAfterMount));
 
   const timeAgo = useMemo(
     () => (report ? formatRelativeTime(report.generatedAt) : ''),
@@ -161,7 +170,7 @@ export const useMarketInsights = (
   return {
     report,
     reportAssetId,
-    isLoading: isQueryEnabled && query.isLoading,
+    isLoading,
     error,
     timeAgo,
     cacheState,

--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { MarketInsightsReport } from '@metamask/ai-controllers';
 import {
@@ -7,6 +7,12 @@ import {
 } from '../../../../constants/digestQuery';
 import Engine from '../../../../core/Engine';
 import { formatRelativeTime } from '../utils/marketInsightsFormatting';
+import { trace, TraceName, TraceOperation } from '../../../../util/trace';
+import {
+  getMarketInsightsTraceTags,
+  type MarketInsightsCacheState,
+  type MarketInsightsTelemetryContext,
+} from '../utils/marketInsightsPerformance';
 
 const MARKET_INSIGHTS_QUERY_KEY = 'market-insights';
 
@@ -24,6 +30,8 @@ export interface UseMarketInsightsResult {
   error: string | null;
   /** Relative time since the report was generated (e.g., "3m ago") */
   timeAgo: string;
+  /** Whether a report was already cached when this query generation began. */
+  cacheState: MarketInsightsCacheState;
 }
 
 /**
@@ -40,15 +48,81 @@ export interface UseMarketInsightsResult {
 export const useMarketInsights = (
   assetIdentifier: string | undefined | null,
   isEnabled = false,
+  telemetryContext?: MarketInsightsTelemetryContext,
 ): UseMarketInsightsResult => {
   const queryAssetIdentifier = assetIdentifier ?? '';
   const isQueryEnabled = isEnabled && queryAssetIdentifier.length > 0;
   const queryClient = useQueryClient();
+  const cacheStateRef = useRef<{
+    assetIdentifier: string;
+    state: MarketInsightsCacheState;
+  } | null>(null);
+
+  if (cacheStateRef.current?.assetIdentifier !== queryAssetIdentifier) {
+    const cachedReport = queryClient.getQueryData<MarketInsightsReport | null>([
+      MARKET_INSIGHTS_QUERY_KEY,
+      queryAssetIdentifier,
+    ]);
+    cacheStateRef.current = {
+      assetIdentifier: queryAssetIdentifier,
+      state: cachedReport ? 'warm' : 'cold',
+    };
+  }
+
+  const cacheState = cacheStateRef.current.state;
+  const resolvedTelemetryContext: MarketInsightsTelemetryContext =
+    telemetryContext ?? {
+      source: 'unknown',
+      stage: 'entry_card',
+      assetType: queryAssetIdentifier.includes('/') ? 'token' : 'perps',
+    };
+
   const query = useQuery<MarketInsightsReport | null, unknown>({
     queryKey: [MARKET_INSIGHTS_QUERY_KEY, queryAssetIdentifier],
-    queryFn: () =>
-      Engine.context.AiDigestController.fetchMarketInsights(
-        queryAssetIdentifier,
+    queryFn: ({ signal }) =>
+      trace(
+        {
+          name: TraceName.MarketInsightsFetch,
+          op: TraceOperation.MarketInsightsFetch,
+          tags: getMarketInsightsTraceTags(
+            resolvedTelemetryContext,
+            cacheState,
+          ),
+        },
+        async (span) => {
+          let wasCancelled = signal.aborted;
+          const markCancelled = () => {
+            wasCancelled = true;
+            span?.setAttribute('result', 'cancelled');
+            span?.setAttribute('success', false);
+          };
+
+          if (wasCancelled) {
+            markCancelled();
+          } else {
+            signal.addEventListener('abort', markCancelled, { once: true });
+          }
+
+          try {
+            const result =
+              await Engine.context.AiDigestController.fetchMarketInsights(
+                queryAssetIdentifier,
+              );
+            if (!wasCancelled) {
+              span?.setAttribute('result', result ? 'success' : 'empty');
+              span?.setAttribute('success', true);
+            }
+            return result;
+          } catch (error) {
+            if (!wasCancelled) {
+              span?.setAttribute('result', 'error');
+              span?.setAttribute('success', false);
+            }
+            throw error;
+          } finally {
+            signal.removeEventListener('abort', markCancelled);
+          }
+        },
       ),
     enabled: isQueryEnabled,
     retry: false,
@@ -63,6 +137,10 @@ export const useMarketInsights = (
         queryKey: [MARKET_INSIGHTS_QUERY_KEY, queryAssetIdentifier],
         exact: true,
       });
+      cacheStateRef.current = {
+        assetIdentifier: queryAssetIdentifier,
+        state: 'cold',
+      };
     }
   }, [isQueryEnabled, queryAssetIdentifier, queryClient]);
 
@@ -86,5 +164,6 @@ export const useMarketInsights = (
     isLoading: isQueryEnabled && query.isLoading,
     error,
     timeAgo,
+    cacheState,
   };
 };

--- a/app/components/UI/MarketInsights/hooks/useMarketInsightsEntryTrace.test.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsightsEntryTrace.test.ts
@@ -48,6 +48,12 @@ describe('useMarketInsightsEntryTrace', () => {
     });
   });
 
+  it('does not end entry-card time to content while the query is loading', () => {
+    renderHook(() => useMarketInsightsEntryTrace(defaultParams));
+
+    expect(mockEndTrace).not.toHaveBeenCalled();
+  });
+
   it('ends entry-card time to content with an empty result', () => {
     renderHook(() =>
       useMarketInsightsEntryTrace({

--- a/app/components/UI/MarketInsights/hooks/useMarketInsightsEntryTrace.test.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsightsEntryTrace.test.ts
@@ -1,0 +1,121 @@
+import { renderHook } from '@testing-library/react-native';
+import { useMarketInsightsEntryTrace } from './useMarketInsightsEntryTrace';
+
+const mockTrace = jest.fn();
+const mockEndTrace = jest.fn();
+
+jest.mock('../../../../util/trace', () => ({
+  ...jest.requireActual('../../../../util/trace'),
+  trace: (...args: unknown[]) => mockTrace(...args),
+  endTrace: (...args: unknown[]) => mockEndTrace(...args),
+}));
+
+const defaultParams = {
+  assetIdentifier: 'eip155:1/erc20:0x123',
+  assetType: 'token' as const,
+  cacheState: 'cold' as const,
+  enabled: true,
+  error: null,
+  isLoading: true,
+  report: null,
+  source: 'token_details' as const,
+};
+
+describe('useMarketInsightsEntryTrace', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('starts entry-card time to content with bounded attributes', () => {
+    const { result } = renderHook(() =>
+      useMarketInsightsEntryTrace(defaultParams),
+    );
+
+    expect(result.current).toBe(
+      'token_details:entry_card:eip155:1/erc20:0x123',
+    );
+    expect(mockTrace).toHaveBeenCalledWith({
+      name: 'Market Insights Entry Card Load',
+      op: 'market_insights.load',
+      id: 'token_details:entry_card:eip155:1/erc20:0x123',
+      tags: {
+        feature: 'market_insights',
+        source: 'token_details',
+        stage: 'entry_card',
+        asset_type: 'token',
+        cache_state: 'cold',
+      },
+    });
+  });
+
+  it('ends entry-card time to content with an empty result', () => {
+    renderHook(() =>
+      useMarketInsightsEntryTrace({
+        ...defaultParams,
+        isLoading: false,
+      }),
+    );
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: 'Market Insights Entry Card Load',
+      id: 'token_details:entry_card:eip155:1/erc20:0x123',
+      data: {
+        result: 'empty',
+        success: true,
+        content_state: 'empty',
+      },
+    });
+  });
+
+  it('ends entry-card time to content with an error result', () => {
+    renderHook(() =>
+      useMarketInsightsEntryTrace({
+        ...defaultParams,
+        error: 'request failed',
+        isLoading: false,
+      }),
+    );
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: 'Market Insights Entry Card Load',
+      id: 'token_details:entry_card:eip155:1/erc20:0x123',
+      data: {
+        result: 'error',
+        success: false,
+        content_state: 'error',
+      },
+    });
+  });
+
+  it('ends entry-card time to content as cancelled on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useMarketInsightsEntryTrace(defaultParams),
+    );
+
+    unmount();
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: 'Market Insights Entry Card Load',
+      id: 'token_details:entry_card:eip155:1/erc20:0x123',
+      data: {
+        result: 'cancelled',
+        success: false,
+        reason: 'owner_cancelled',
+      },
+    });
+  });
+
+  it('does not start a trace when instrumentation is disabled', () => {
+    const { result } = renderHook(() =>
+      useMarketInsightsEntryTrace({
+        ...defaultParams,
+        enabled: false,
+      }),
+    );
+
+    expect(result.current).toBe(
+      'token_details:entry_card:eip155:1/erc20:0x123',
+    );
+    expect(mockTrace).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/MarketInsights/hooks/useMarketInsightsEntryTrace.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsightsEntryTrace.ts
@@ -1,0 +1,92 @@
+import { useEffect, useMemo } from 'react';
+import type { MarketInsightsReport } from '@metamask/ai-controllers';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../util/trace';
+import {
+  getMarketInsightsTraceEndData,
+  getMarketInsightsTraceId,
+  getMarketInsightsTraceTags,
+  type MarketInsightsAssetType,
+  type MarketInsightsCacheState,
+  type MarketInsightsSource,
+} from '../utils/marketInsightsPerformance';
+
+interface UseMarketInsightsEntryTraceParams {
+  assetIdentifier: string | null | undefined;
+  assetType: MarketInsightsAssetType;
+  cacheState: MarketInsightsCacheState;
+  enabled: boolean;
+  error: string | null;
+  isLoading: boolean;
+  report: MarketInsightsReport | null;
+  source: MarketInsightsSource;
+}
+
+/**
+ * Owns the entry-card time-to-content trace for one asset generation.
+ * The card ends successful traces after its first committed render; this hook
+ * closes valid empty, error, and abandoned generations.
+ */
+export const useMarketInsightsEntryTrace = ({
+  assetIdentifier,
+  assetType,
+  cacheState,
+  enabled,
+  error,
+  isLoading,
+  report,
+  source,
+}: UseMarketInsightsEntryTraceParams): string | undefined => {
+  const traceId = assetIdentifier
+    ? getMarketInsightsTraceId(assetIdentifier, source, 'entry_card')
+    : undefined;
+
+  useMemo(() => {
+    if (!enabled || !traceId) {
+      return;
+    }
+
+    trace({
+      name: TraceName.MarketInsightsEntryCardLoad,
+      op: TraceOperation.MarketInsightsLoad,
+      id: traceId,
+      tags: getMarketInsightsTraceTags(
+        { source, stage: 'entry_card', assetType },
+        cacheState,
+      ),
+    });
+  }, [assetType, cacheState, enabled, source, traceId]);
+
+  useEffect(() => {
+    if (!enabled || !traceId || isLoading || report) {
+      return;
+    }
+
+    endTrace({
+      name: TraceName.MarketInsightsEntryCardLoad,
+      id: traceId,
+      data: getMarketInsightsTraceEndData(error ? 'error' : 'empty'),
+    });
+  }, [enabled, error, isLoading, report, traceId]);
+
+  useEffect(
+    () => () => {
+      if (!enabled || !traceId) {
+        return;
+      }
+
+      endTrace({
+        name: TraceName.MarketInsightsEntryCardLoad,
+        id: traceId,
+        data: getMarketInsightsTraceEndData('cancelled'),
+      });
+    },
+    [enabled, traceId],
+  );
+
+  return traceId;
+};

--- a/app/components/UI/MarketInsights/hooks/useViewportTracking.test.ts
+++ b/app/components/UI/MarketInsights/hooks/useViewportTracking.test.ts
@@ -224,7 +224,12 @@ describe('useViewportTracking', () => {
 
   it('starts a trace on first layout and ends it on visibility', () => {
     const onVisible = jest.fn();
-    const { result } = renderHook(() => useViewportTracking(onVisible));
+    const { result } = renderHook(() =>
+      useViewportTracking(onVisible, 0.5, {
+        source: 'perps',
+        stage: 'entry_card',
+      }),
+    );
 
     const mockMeasureInWindow = jest.fn(
       (cb: (x: number, y: number, w: number, h: number) => void) => {
@@ -244,6 +249,11 @@ describe('useViewportTracking', () => {
       expect.objectContaining({
         name: 'Market Insights Viewport Tracking',
         op: 'market_insights.viewport_tracking',
+        tags: {
+          feature: 'market_insights',
+          source: 'perps',
+          stage: 'entry_card',
+        },
       }),
     );
 
@@ -254,6 +264,10 @@ describe('useViewportTracking', () => {
         data: expect.objectContaining({
           measure_calls: 1,
           resolved_by: 'visibility_threshold',
+          result: 'success',
+          success: true,
+          source: 'perps',
+          stage: 'entry_card',
         }),
       }),
     );
@@ -328,6 +342,9 @@ describe('useViewportTracking', () => {
         name: 'Market Insights Viewport Tracking',
         data: expect.objectContaining({
           resolved_by: 'unmount',
+          result: 'cancelled',
+          success: false,
+          reason: 'owner_cancelled',
         }),
       }),
     );

--- a/app/components/UI/MarketInsights/hooks/useViewportTracking.ts
+++ b/app/components/UI/MarketInsights/hooks/useViewportTracking.ts
@@ -6,6 +6,10 @@ import {
   TraceName,
   TraceOperation,
 } from '../../../../util/trace';
+import type {
+  MarketInsightsSource,
+  MarketInsightsStage,
+} from '../utils/marketInsightsPerformance';
 
 const POLL_INTERVAL_MS = 250;
 const DEFAULT_AREA_THRESHOLD = 0.5;
@@ -26,6 +30,10 @@ const DEFAULT_AREA_THRESHOLD = 0.5;
 export const useViewportTracking = (
   onVisible: () => void,
   areaThreshold = DEFAULT_AREA_THRESHOLD,
+  context: {
+    source: MarketInsightsSource;
+    stage: MarketInsightsStage;
+  } = { source: 'unknown', stage: 'entry_card' },
 ) => {
   const ref = useRef<View>(null);
   const hasFired = useRef(false);
@@ -68,13 +76,17 @@ export const useViewportTracking = (
           data: {
             measure_calls: measureCountRef.current,
             resolved_by: 'visibility_threshold',
+            result: 'success',
+            success: true,
+            source: context.source,
+            stage: context.stage,
           },
         });
 
         onVisibleRef.current();
       }
     });
-  }, [areaThreshold]);
+  }, [areaThreshold, context.source, context.stage]);
 
   const onLayout = useCallback(() => {
     if (!traceStartedRef.current) {
@@ -82,6 +94,11 @@ export const useViewportTracking = (
       trace({
         name: TraceName.MarketInsightsViewportTracking,
         op: TraceOperation.MarketInsightsViewportTracking,
+        tags: {
+          feature: 'market_insights',
+          source: context.source,
+          stage: context.stage,
+        },
       });
     }
 
@@ -90,7 +107,7 @@ export const useViewportTracking = (
     if (!hasFired.current && !intervalRef.current) {
       intervalRef.current = setInterval(checkVisibility, POLL_INTERVAL_MS);
     }
-  }, [checkVisibility]);
+  }, [checkVisibility, context.source, context.stage]);
 
   useEffect(
     () => () => {
@@ -105,11 +122,16 @@ export const useViewportTracking = (
           data: {
             measure_calls: measureCountRef.current,
             resolved_by: 'unmount',
+            result: 'cancelled',
+            success: false,
+            reason: 'owner_cancelled',
+            source: context.source,
+            stage: context.stage,
           },
         });
       }
     },
-    [],
+    [context.source, context.stage],
   );
 
   return { ref, onLayout };

--- a/app/components/UI/MarketInsights/index.ts
+++ b/app/components/UI/MarketInsights/index.ts
@@ -5,4 +5,16 @@ export { default as MarketInsightsEntryCardSkeleton } from './components/MarketI
 export { default as MarketInsightsDisclaimerBottomSheet } from './components/MarketInsightsEntryCard/MarketInsightsDisclaimerBottomSheet';
 export { selectMarketInsightsEnabled } from '../../../selectors/featureFlagController/marketInsights';
 export { useMarketInsights } from './hooks/useMarketInsights';
+export { useMarketInsightsEntryTrace } from './hooks/useMarketInsightsEntryTrace';
+export {
+  getMarketInsightsTraceId,
+  getMarketInsightsTraceTags,
+} from './utils/marketInsightsPerformance';
+export type {
+  MarketInsightsAssetType,
+  MarketInsightsCacheState,
+  MarketInsightsSource,
+  MarketInsightsStage,
+  MarketInsightsTelemetryContext,
+} from './utils/marketInsightsPerformance';
 export type { MarketInsightsReport } from '@metamask/ai-controllers';

--- a/app/components/UI/MarketInsights/utils/marketInsightsPerformance.ts
+++ b/app/components/UI/MarketInsights/utils/marketInsightsPerformance.ts
@@ -1,0 +1,48 @@
+import type { TraceValue } from '../../../../util/trace';
+
+export type MarketInsightsSource = 'token_details' | 'perps' | 'unknown';
+export type MarketInsightsStage = 'entry_card' | 'full_view';
+export type MarketInsightsAssetType = 'token' | 'perps';
+export type MarketInsightsCacheState = 'warm' | 'cold';
+export type MarketInsightsResult = 'success' | 'empty' | 'error' | 'cancelled';
+
+export interface MarketInsightsTelemetryContext {
+  source: MarketInsightsSource;
+  stage: MarketInsightsStage;
+  assetType: MarketInsightsAssetType;
+}
+
+export const getMarketInsightsTraceId = (
+  assetIdentifier: string,
+  source: MarketInsightsSource,
+  stage: MarketInsightsStage,
+) => `${source}:${stage}:${assetIdentifier}`;
+
+export const getMarketInsightsTraceTags = (
+  context: MarketInsightsTelemetryContext,
+  cacheState: MarketInsightsCacheState,
+): Record<string, TraceValue> => ({
+  feature: 'market_insights',
+  source: context.source,
+  stage: context.stage,
+  asset_type: context.assetType,
+  cache_state: cacheState,
+});
+
+export const getMarketInsightsTraceEndData = (
+  result: MarketInsightsResult,
+): Record<string, TraceValue> => ({
+  result,
+  success: result === 'success' || result === 'empty',
+  ...(result !== 'cancelled'
+    ? {
+        content_state:
+          result === 'success'
+            ? 'filled'
+            : result === 'empty'
+              ? 'empty'
+              : 'error',
+      }
+    : {}),
+  ...(result === 'cancelled' ? { reason: 'owner_cancelled' } : {}),
+});

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -535,12 +535,29 @@ const mockUseMarketInsights = jest.fn(
     isLoading: false,
     error: null,
     timeAgo: '',
+    cacheState: 'cold',
   }),
 );
 
 jest.mock('../../../MarketInsights', () => ({
   useMarketInsights: (assetId: string | null | undefined, isEnabled: boolean) =>
     mockUseMarketInsights(assetId, isEnabled),
+  useMarketInsightsEntryTrace: () => 'perps:entry_card:BTC',
+  getMarketInsightsTraceId: (
+    assetIdentifier: string,
+    source: string,
+    stage: string,
+  ) => `${source}:${stage}:${assetIdentifier}`,
+  getMarketInsightsTraceTags: (
+    context: { source: string; stage: string; assetType: string },
+    cacheState: string,
+  ) => ({
+    feature: 'market_insights',
+    source: context.source,
+    stage: context.stage,
+    asset_type: context.assetType,
+    cache_state: cacheState,
+  }),
   MarketInsightsDisclaimerBottomSheet: ({
     onClose,
   }: {
@@ -5454,6 +5471,7 @@ describe('PerpsMarketDetailsView', () => {
         isLoading: false,
         error: null,
         timeAgo: '5m ago',
+        cacheState: 'cold',
       });
     });
 
@@ -5530,6 +5548,7 @@ describe('PerpsMarketDetailsView', () => {
         isLoading: false,
         error: null,
         timeAgo: '',
+        cacheState: 'cold',
       });
 
       renderWithProvider(
@@ -5559,6 +5578,7 @@ describe('PerpsMarketDetailsView', () => {
         isLoading: true,
         error: null,
         timeAgo: '',
+        cacheState: 'cold',
       });
 
       const { getByTestId, queryByTestId } = renderWithProvider(
@@ -5593,6 +5613,7 @@ describe('PerpsMarketDetailsView', () => {
         isLoading: false,
         error: null,
         timeAgo: '',
+        cacheState: 'cold',
       });
 
       const { queryByTestId } = renderWithProvider(

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -177,7 +177,10 @@ import {
   MarketInsightsEntryCard,
   MarketInsightsEntryCardSkeleton,
   MarketInsightsDisclaimerBottomSheet,
+  getMarketInsightsTraceId,
+  getMarketInsightsTraceTags,
   useMarketInsights,
+  useMarketInsightsEntryTrace,
 } from '../../../MarketInsights';
 import { MarketInsightsSelectorsIDs } from '../../../MarketInsights/MarketInsights.testIds';
 import { selectMarketInsightsPerpsEnabled } from '../../../../../selectors/featureFlagController/marketInsights';
@@ -415,7 +418,22 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
     timeAgo: perpsInsightsTimeAgo,
     isLoading: isPerpsInsightsLoading,
     error: perpsInsightsError,
-  } = useMarketInsights(market?.symbol, isPerpsInsightsEnabled);
+    cacheState: perpsInsightsCacheState,
+  } = useMarketInsights(market?.symbol, isPerpsInsightsEnabled, {
+    source: 'perps',
+    stage: 'entry_card',
+    assetType: 'perps',
+  });
+  const perpsInsightsEntryTraceId = useMarketInsightsEntryTrace({
+    assetIdentifier: market?.symbol,
+    assetType: 'perps',
+    cacheState: perpsInsightsCacheState,
+    enabled: isPerpsInsightsEnabled,
+    error: perpsInsightsError,
+    isLoading: isPerpsInsightsLoading,
+    report: perpsInsightsReport,
+    source: 'perps',
+  });
   const previousInsightsSymbolRef = useRef(market?.symbol);
   const isInsightsStateForCurrentSymbol =
     previousInsightsSymbolRef.current === market?.symbol;
@@ -1522,9 +1540,19 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
         digest_id: perpsInsightsReport.digestId,
       }),
     });
+    const traceId = getMarketInsightsTraceId(
+      market.symbol,
+      'perps',
+      'full_view',
+    );
     trace({
       name: TraceName.MarketInsightsViewLoad,
       op: TraceOperation.MarketInsightsLoad,
+      id: traceId,
+      tags: getMarketInsightsTraceTags(
+        { source: 'perps', stage: 'full_view', assetType: 'perps' },
+        'warm',
+      ),
     });
     navigation.navigate(Routes.MARKET_INSIGHTS.VIEW, {
       assetSymbol: market.symbol,
@@ -2004,6 +2032,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
                 timeAgo={perpsInsightsTimeAgo}
                 onPress={handleMarketInsightsPress}
                 onDisclaimerPress={() => setIsInsightsDisclaimerVisible(true)}
+                traceId={perpsInsightsEntryTraceId}
                 source="perps"
                 testID={MarketInsightsSelectorsIDs.ENTRY_CARD}
               />

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.test.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.test.tsx
@@ -52,6 +52,23 @@ jest.mock('../../MarketInsights', () => ({
     testID?: string;
   }) => <MockPressable onPress={onPress} testID={testID} />,
   useMarketInsights: (...args: unknown[]) => mockUseMarketInsights(...args),
+  useMarketInsightsEntryTrace: () =>
+    'token_details:entry_card:eip155:1/erc20:0x123',
+  getMarketInsightsTraceId: (
+    assetIdentifier: string,
+    source: string,
+    stage: string,
+  ) => `${source}:${stage}:${assetIdentifier}`,
+  getMarketInsightsTraceTags: (
+    context: { source: string; stage: string; assetType: string },
+    cacheState: string,
+  ) => ({
+    feature: 'market_insights',
+    source: context.source,
+    stage: context.stage,
+    asset_type: context.assetType,
+    cache_state: cacheState,
+  }),
   selectMarketInsightsEnabled: () => mockSelectMarketInsightsEnabled(),
 }));
 
@@ -237,6 +254,7 @@ const defaultMarketInsightsResult = {
   isLoading: false,
   error: null,
   timeAgo: '5m ago',
+  cacheState: 'cold',
 };
 
 describe('AssetOverviewContent', () => {

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
@@ -54,6 +54,9 @@ import {
   MarketInsightsEntryCard,
   MarketInsightsEntryCardSkeleton,
   useMarketInsights,
+  useMarketInsightsEntryTrace,
+  getMarketInsightsTraceId,
+  getMarketInsightsTraceTags,
   selectMarketInsightsEnabled,
 } from '../../MarketInsights';
 import { isCaipAssetType } from '@metamask/utils';
@@ -90,12 +93,7 @@ import { useRWAToken } from '../../Bridge/hooks/useRWAToken';
 import { BridgeToken } from '../../Bridge/types';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import ModalSafeAreaProvider from '../../../../component-library/components-temp/ModalSafeAreaProvider';
-import {
-  endTrace,
-  trace,
-  TraceName,
-  TraceOperation,
-} from '../../../../util/trace';
+import { trace, TraceName, TraceOperation } from '../../../../util/trace';
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
@@ -392,7 +390,23 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
     report: marketInsightsReport,
     timeAgo: marketInsightsTimeAgo,
     isLoading: isMarketInsightsLoading,
-  } = useMarketInsights(marketInsightsCaip19Id, isMarketInsightsEnabled);
+    error: marketInsightsError,
+    cacheState: marketInsightsCacheState,
+  } = useMarketInsights(marketInsightsCaip19Id, isMarketInsightsEnabled, {
+    source: 'token_details',
+    stage: 'entry_card',
+    assetType: 'token',
+  });
+  const marketInsightsEntryTraceId = useMarketInsightsEntryTrace({
+    assetIdentifier: marketInsightsCaip19Id,
+    assetType: 'token',
+    cacheState: marketInsightsCacheState,
+    enabled: isMarketInsightsEnabled,
+    error: marketInsightsError,
+    isLoading: isMarketInsightsLoading,
+    report: marketInsightsReport,
+    source: 'token_details',
+  });
 
   useEffect(() => {
     const severity = securityData?.resultType;
@@ -402,13 +416,6 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
     }
     if (isMarketInsightsLoading) {
       return;
-    }
-    if (!marketInsightsReport && marketInsightsCaip19Id) {
-      // No report available — cancel the orphaned trace that was started during render
-      endTrace({
-        name: TraceName.MarketInsightsEntryCardLoad,
-        id: marketInsightsCaip19Id,
-      });
     }
     onMarketInsightsDisplayResolved?.({
       isDisplayed: Boolean(marketInsightsReport),
@@ -423,27 +430,29 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
     securityData?.resultType,
   ]);
 
-  // Runs during render (not useEffect) so the trace is registered before any
-  // child's endTrace(); useMemo's deps guard against restarting it per render.
-  useMemo(() => {
-    if (isMarketInsightsEnabled && marketInsightsCaip19Id) {
-      trace({
-        name: TraceName.MarketInsightsEntryCardLoad,
-        op: TraceOperation.MarketInsightsLoad,
-        id: marketInsightsCaip19Id,
-      });
-    }
-  }, [isMarketInsightsEnabled, marketInsightsCaip19Id]);
-
   const goToBrowserUrl = (url: string) => {
     navigateWithDetails(navigation, createWebviewNavDetails({ url }));
   };
 
   const handleMarketInsightsPress = useCallback(() => {
     if (marketInsightsCaip19Id) {
+      const traceId = getMarketInsightsTraceId(
+        marketInsightsCaip19Id,
+        'token_details',
+        'full_view',
+      );
       trace({
         name: TraceName.MarketInsightsViewLoad,
         op: TraceOperation.MarketInsightsLoad,
+        id: traceId,
+        tags: getMarketInsightsTraceTags(
+          {
+            source: 'token_details',
+            stage: 'full_view',
+            assetType: 'token',
+          },
+          'warm',
+        ),
       });
       const event = createEventBuilder(MetaMetricsEvents.MARKET_INSIGHTS_OPENED)
         .addProperties({
@@ -634,6 +643,7 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
                   onPress={handleMarketInsightsPress}
                   onDisclaimerPress={onMarketInsightsDisclaimerPress}
                   caip19Id={marketInsightsCaip19Id ?? undefined}
+                  traceId={marketInsightsEntryTraceId}
                   source="token_details"
                   testID="market-insights-entry-card"
                 />

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -282,6 +282,7 @@ export enum TraceName {
   MusdConversionQuote = 'mUSD Conversion Quote',
   MusdConversionConfirm = 'mUSD Conversion Confirm',
   // Market Insights
+  MarketInsightsFetch = 'Market Insights Fetch',
   MarketInsightsEntryCardLoad = 'Market Insights Entry Card Load',
   MarketInsightsViewLoad = 'Market Insights View Load',
   MarketInsightsViewportTracking = 'Market Insights Viewport Tracking',
@@ -369,6 +370,7 @@ export enum TraceOperation {
   MusdConversionOperation = 'musd.conversion.operation',
   MusdConversionDataFetch = 'musd.conversion.data_fetch',
   // Market Insights
+  MarketInsightsFetch = 'market_insights.fetch',
   MarketInsightsLoad = 'market_insights.load',
   MarketInsightsViewportTracking = 'market_insights.viewport_tracking',
   // Homepage Section Performance

--- a/docs/ai/market-insights-sentry-reference.md
+++ b/docs/ai/market-insights-sentry-reference.md
@@ -21,10 +21,12 @@ percentiles. The populations differ because cache hits do not emit fetch spans.
 | `Market Insights Viewport Tracking` | `market_insights.viewport_tracking` | Entry card lays out                                           | At least 50% of the card is visible |
 
 Entry-card and full-view spans also terminate for valid empty responses, errors,
-and owner cancellation. Empty and error closes wait until the query generation
+and owner cancellation. Empty and error closes wait until the current observer
 settles: a cached `null` miss is immediately stale and refetches on remount, so
-that remount must not close as `empty` before the refetch completes. Latency
-widgets must use `result:success`; reliability widgets count every result.
+that remount must not close as `empty` before the refetch completes. A later
+focus refetch of an already-settled miss must not flip loading or reopen the
+entry-card skeleton. Latency widgets must use `result:success`; reliability
+widgets count every result.
 
 ## Attributes
 

--- a/docs/ai/market-insights-sentry-reference.md
+++ b/docs/ai/market-insights-sentry-reference.md
@@ -1,0 +1,153 @@
+# Market Insights Sentry Performance
+
+Sentry duration telemetry for the Market Insights entry cards and full report
+view. Product analytics events are separate and must not be used as duration
+boundaries.
+
+## Measurement model
+
+Fetch duration and time to content are separate spans. A cold time-to-content
+span normally overlaps a fetch span. A warm time-to-content span can complete
+without a fetch because React Query already has a report.
+
+Do not subtract aggregate fetch percentiles from aggregate time-to-content
+percentiles. The populations differ because cache hits do not emit fetch spans.
+
+| Span description                    | Operation                           | Start                                                         | Successful end                      |
+| ----------------------------------- | ----------------------------------- | ------------------------------------------------------------- | ----------------------------------- |
+| `Market Insights Fetch`             | `market_insights.fetch`             | Immediately before `AiDigestController.fetchMarketInsights()` | Controller promise resolves         |
+| `Market Insights Entry Card Load`   | `market_insights.load`              | Token or Perps entry-card generation begins                   | Report card commits                 |
+| `Market Insights View Load`         | `market_insights.load`              | User presses an entry card                                    | Matching full report commits        |
+| `Market Insights Viewport Tracking` | `market_insights.viewport_tracking` | Entry card lays out                                           | At least 50% of the card is visible |
+
+Entry-card and full-view spans also terminate for valid empty responses, errors,
+and owner cancellation. Latency widgets must use `result:success`; reliability
+widgets count every result.
+
+## Attributes
+
+All attributes are bounded and safe for dashboard grouping.
+
+| Attribute       | Values                                   | Notes                                                      |
+| --------------- | ---------------------------------------- | ---------------------------------------------------------- |
+| `feature`       | `market_insights`                        | Common dashboard filter                                    |
+| `source`        | `token_details`, `perps`, `unknown`      | `unknown` is reserved for entry routes without attribution |
+| `stage`         | `entry_card`, `full_view`                | Journey phase                                              |
+| `asset_type`    | `token`, `perps`                         | Present on fetch and time-to-content spans                 |
+| `cache_state`   | `cold`, `warm`                           | Cache state when the query generation began                |
+| `result`        | `success`, `empty`, `error`, `cancelled` | Terminal outcome                                           |
+| `success`       | `true`, `false`                          | `empty` is a valid successful resolution                   |
+| `content_state` | `filled`, `empty`, `error`               | Omitted for cancellation                                   |
+| `reason`        | `owner_cancelled`                        | Present for cancellation                                   |
+| `measure_calls` | positive integer                         | Viewport polling diagnostic                                |
+| `resolved_by`   | `visibility_threshold`, `unmount`        | Viewport terminal boundary                                 |
+
+Asset identifiers and digest IDs are intentionally not tags because they are
+high-cardinality values.
+
+## Dashboard queries
+
+Use the spans dataset. Keep the dashboard environment filter unset by default so
+all environments are included. Add dashboard filters for `environment`,
+`platform`, `release`, `source`, `stage`, and `cache_state`.
+
+### Latency
+
+Use `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`, and
+`count()`:
+
+```text
+span.description:"Market Insights Fetch" success:true
+```
+
+```text
+span.description:"Market Insights Entry Card Load" result:success
+```
+
+```text
+span.description:"Market Insights View Load" result:success
+```
+
+Split time-series widgets by `source`. The entry-card widget compares Token
+Details and Perps. The full-view widget compares the same sources from the user
+press boundary.
+
+### Reliability and cache behavior
+
+```text
+span.op:[market_insights.fetch,market_insights.load] result:[empty,error,cancelled]
+```
+
+Group by `span.description`, `result`, and `source`.
+
+Compare TTC counts grouped by `cache_state` with fetch counts. A warm TTC with no
+matching fetch is expected and represents a cache hit, not missing telemetry.
+
+### Viewport diagnostics
+
+```text
+span.description:"Market Insights Viewport Tracking"
+```
+
+Chart `p50(span.duration)`, `p95(span.duration)`, and `avg(measure_calls)`.
+Group cancellation rows by `resolved_by` and `source`.
+
+## Recommended dashboard layout
+
+1. **Journey health:** event volume, p50/p75/p95 fetch, entry-card TTC,
+   full-view TTC, and error/cancellation counts.
+2. **Duration trends:** one time series per authoritative span, split by source.
+3. **Cache and outcomes:** TTC grouped by cache state; outcomes grouped by
+   result and source.
+4. **Diagnostics:** viewport duration and measure calls, followed by a table of
+   slow or unsuccessful spans.
+
+Dashboard latency values are release-pending until an identifiable mobile
+release emits the new attributes. Missing pre-adoption data is not a zero.
+
+## Dashboard build sheet
+
+Create the dashboard in organization `metamask`, project `metamask-mobile` with
+the title **Mobile — Social & AI — Market Insights**. Use the spans dataset for
+every widget, a default period of 14 days, and no default environment
+restriction.
+
+| Widget                     | Visualization | Query                                                                                                                                             | Fields / grouping                                                                                                                    |
+| -------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Journey latency            | Table         | `feature:market_insights result:success span.description:["Market Insights Fetch","Market Insights Entry Card Load","Market Insights View Load"]` | Group by `span.description`, `source`; show `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`, `count()`              |
+| Fetch duration             | Time series   | `span.description:"Market Insights Fetch" success:true`                                                                                           | `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`; group by `source`                                                  |
+| Entry-card TTC             | Time series   | `span.description:"Market Insights Entry Card Load" result:success`                                                                               | `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`; group by `source`                                                  |
+| Full-view TTC              | Time series   | `span.description:"Market Insights View Load" result:success`                                                                                     | `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`; group by `source`                                                  |
+| Journey outcomes           | Table         | `feature:market_insights span.op:[market_insights.fetch,market_insights.load]`                                                                    | Group by `span.description`, `result`, `source`; show `count()`                                                                      |
+| Cache behavior             | Table         | `span.op:market_insights.load`                                                                                                                    | Group by `span.description`, `cache_state`, `source`; show `count()`, `p75(span.duration)`, `p95(span.duration)`                     |
+| Viewport diagnostics       | Table         | `span.description:"Market Insights Viewport Tracking"`                                                                                            | Group by `source`, `resolved_by`; show `count()`, `p50(span.duration)`, `p95(span.duration)`, `avg(measure_calls)`                   |
+| Slow or unsuccessful spans | Table         | `feature:market_insights (success:false OR span.duration:>2000)`                                                                                  | Show `timestamp`, `span.description`, `span.duration`, `source`, `stage`, `cache_state`, `result`, `release`, `environment`, `trace` |
+
+Add dashboard filters for:
+
+```text
+environment
+platform
+release
+source
+stage
+cache_state
+```
+
+The dashboard API available to the coding agent currently supports finding and
+reading dashboards but not creating or updating them. Use this build sheet for
+one-time UI creation. Before the new release is available, the existing spans
+can be inspected through the
+[validated 30-day baseline query](https://metamask.sentry.io/explore/traces/?query=span.description%3A%5B%22Market+Insights+Entry+Card+Load%22%2C%22Market+Insights+View+Load%22%2C%22Market+Insights+Viewport+Tracking%22%5D&project=2299799&aggregateField=%7B%22groupBy%22%3A%22span.description%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p50%28span.duration%29%22%2C%22p75%28span.duration%29%22%2C%22p95%28span.duration%29%22%2C%22count%28%29%22%5D%7D&mode=aggregate&sort=-count%28%29&statsPeriod=30d&table=span).
+
+Current baseline values (30 days, captured 2026-09-07):
+
+| Span              |      Count |    p50 |      p75 |        p95 |
+| ----------------- | ---------: | -----: | -------: | ---------: |
+| Entry Card Load   |  5,913,072 | 626 ms | 1,199 ms |   4,272 ms |
+| View Load         |     67,633 | 121 ms |   311 ms |   1,109 ms |
+| Viewport Tracking | 18,655,813 |  45 ms |   231 ms | 300,720 ms |
+
+The legacy viewport p95 includes unresolved/unmount lifetimes. After adoption,
+the viewport latency widget must filter `result:success`; cancellation volume
+belongs in the outcomes widget.

--- a/docs/ai/market-insights-sentry-reference.md
+++ b/docs/ai/market-insights-sentry-reference.md
@@ -22,9 +22,9 @@ percentiles. The populations differ because cache hits do not emit fetch spans.
 
 Entry-card and full-view spans also terminate for valid empty responses, errors,
 and owner cancellation. Empty and error closes wait until the current observer
-settles: a cached `null` miss is immediately stale and refetches on remount, so
-that remount must not close as `empty` before the refetch completes. A later
-focus refetch of an already-settled miss must not flip loading or reopen the
+settles: a cached `null` miss or error is immediately stale and refetches on
+remount, so that remount must not close before the refetch completes. A later
+focus refetch of an already-settled result must not flip loading or reopen the
 entry-card skeleton. Latency widgets must use `result:success`; reliability
 widgets count every result.
 

--- a/docs/ai/market-insights-sentry-reference.md
+++ b/docs/ai/market-insights-sentry-reference.md
@@ -21,8 +21,10 @@ percentiles. The populations differ because cache hits do not emit fetch spans.
 | `Market Insights Viewport Tracking` | `market_insights.viewport_tracking` | Entry card lays out                                           | At least 50% of the card is visible |
 
 Entry-card and full-view spans also terminate for valid empty responses, errors,
-and owner cancellation. Latency widgets must use `result:success`; reliability
-widgets count every result.
+and owner cancellation. Empty and error closes wait until the query generation
+settles: a cached `null` miss is immediately stale and refetches on remount, so
+that remount must not close as `empty` before the refetch completes. Latency
+widgets must use `result:success`; reliability widgets count every result.
 
 ## Attributes
 
@@ -134,10 +136,10 @@ stage
 cache_state
 ```
 
-The dashboard API available to the coding agent currently supports finding and
-reading dashboards but not creating or updating them. Use this build sheet for
-one-time UI creation. Before the new release is available, the existing spans
-can be inspected through the
+The dashboard described above is live at
+[Mobile — Social & AI — Market Insights](https://metamask.sentry.io/dashboard/9977958/).
+Keep this build sheet in sync when widgets change. Before the new release is
+available, the existing spans can be inspected through the
 [validated 30-day baseline query](https://metamask.sentry.io/explore/traces/?query=span.description%3A%5B%22Market+Insights+Entry+Card+Load%22%2C%22Market+Insights+View+Load%22%2C%22Market+Insights+Viewport+Tracking%22%5D&project=2299799&aggregateField=%7B%22groupBy%22%3A%22span.description%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p50%28span.duration%29%22%2C%22p75%28span.duration%29%22%2C%22p95%28span.duration%29%22%2C%22count%28%29%22%5D%7D&mode=aggregate&sort=-count%28%29&statsPeriod=30d&table=span).
 
 Current baseline values (30 days, captured 2026-09-07):


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Market Insights already had load traces, but fetch duration and user-perceived time-to-content were not comparable across Token Details, Perps, and the full report view. Dashboard latency also mixed cache hits, empty results, errors, and abandoned loads.

This PR adds a dedicated `Market Insights Fetch` span around `AiDigestController.fetchMarketInsights()`, keeps entry-card and full-view TTC as separate spans, and tags both with bounded `source`, `stage`, `asset_type`, `cache_state`, and `result` attributes. Empty, error, and cancelled generations now end explicitly instead of timing out. Sentry dashboard widget queries and the 30-day baseline are documented in `docs/ai/market-insights-sentry-reference.md`; dashboard writes are not available through the current Sentry API.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Market Insights loading surfaces

  Background:
    Given I am logged into MetaMask Mobile
    And Market Insights is enabled

  Scenario: token details still shows the entry card
    Given I open token details for an asset with a Market Insights report

    When the overview finishes loading
    Then the Market Insights entry card is visible
    And tapping the card opens the full Market Insights view

  Scenario: perps market details still shows the entry card
    Given I open a Perps market details screen with a Market Insights report

    When the market details finish loading
    Then the Market Insights entry card is visible
    And tapping the card opens the full Market Insights view
```

Sentry fetch/TTC attributes are release-pending and cannot be verified in production until this build ships.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)