### PR TITLE
fix(predict): scale up live now card logo and tighten subtitle spacing

### DIFF
--- a/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
@@ -124,8 +124,6 @@ const CHART_REQUEST_DURATION_BY_RECURRENCE_MS: Record<string, number> = {
 };
 const PROGRESS_RING_SIZE = 54;
 const PROGRESS_RING_STROKE_WIDTH = 4;
-const COMPACT_PROGRESS_RING_SIZE = 40;
-const COMPACT_PROGRESS_RING_STROKE_WIDTH = 2;
 const CRYPTO_ACCENT_DEFAULT = 'rgb(245, 158, 11)';
 const CRYPTO_ACCENT_BY_SYMBOL: Record<string, string> = {
   BTC: 'rgb(247, 147, 26)',
@@ -814,19 +812,15 @@ const ProgressLogo = React.memo(
     progress,
     color,
     trackColor,
-    compact,
   }: {
     imageUrl?: string;
     progress: number;
     color: string;
     trackColor: string;
-    compact?: boolean;
   }) => {
     const tw = useTailwind();
-    const ringSize = compact ? COMPACT_PROGRESS_RING_SIZE : PROGRESS_RING_SIZE;
-    const strokeWidth = compact
-      ? COMPACT_PROGRESS_RING_STROKE_WIDTH
-      : PROGRESS_RING_STROKE_WIDTH;
+    const ringSize = PROGRESS_RING_SIZE;
+    const strokeWidth = PROGRESS_RING_STROKE_WIDTH;
     const radius = (ringSize - strokeWidth) / 2;
     const circumference = 2 * Math.PI * radius;
     const strokeDashoffset = circumference * (1 - progress);
@@ -865,11 +859,7 @@ const ProgressLogo = React.memo(
             />
           </Svg>
         </Box>
-        <Box
-          twClassName={`${
-            compact ? 'h-8 w-8' : 'h-10 w-10'
-          } overflow-hidden rounded-full bg-default`}
-        >
+        <Box twClassName="h-10 w-10 overflow-hidden rounded-full bg-default">
           {imageUrl ? (
             <Image
               source={{ uri: imageUrl }}
@@ -918,7 +908,6 @@ const LiveStatus = React.memo(
         progress={progressRemaining}
         color={accentColor}
         trackColor={trackColor}
-        compact={compact}
       />
     );
 


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

The compact crypto up/down card rendered a smaller progress ring (40pt with a 2pt stroke) and a smaller logo (32pt) than the full-size card. In the Predict home "Live now" rail this made the live BTC card read as an afterthought: the token logo was small, the counter-clockwise countdown ring was hairline-thin, and the leftover vertical slack pushed a wide gap between "Resets every 5 min" and the Up/Down CTAs.

This reuses the full-size card's ring and logo dimensions (54pt ring, 4pt stroke, 40pt logo) for the compact variant. The logo and ring grow into the slack that was already above the subtitle, which simultaneously tightens the subtitle-to-CTA gap, and the card height stays at 220pt so the rail's cards remain aligned. Since both variants are now identical, the redundant compact ring constants and the `ProgressLogo` `compact` prop are removed rather than left branching between equal values.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Enlarged the token logo and countdown ring on the live Predict card

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A. Visual polish on the Predict "Live now" crypto card from design review; no tracking issue.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict live now card logo treatment

  Background:
    Given I am logged into MetaMask Mobile
    And a live crypto up/down market is available

  Scenario: user views the live card in the Live now rail
    Given I am on the Wallet home screen

    When user opens Predictions
    Then the "BTC Up or Down 5m" card shows a 40pt token logo inside a 54pt countdown ring with a 4pt stroke
    And the countdown ring animates counter-clockwise as the round elapses
    And "Resets every 5 min" sits close above the Up/Down CTAs
    And the card is the same height as the other cards in the rail, with CTAs aligned across cards
```

Verified on the iOS simulator by measuring the rendered pixels: logo ring stroke 4.0pt (was ~1.7pt), ring diameter grown from ~25pt, subtitle-to-CTA gap reduced from 38pt, and card height unchanged at 220pt.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

"Live now" rail with the small logo, hairline countdown ring, and wide subtitle-to-CTA gap:

<img src="https://github.com/user-attachments/assets/c5d7387b-c70c-47e5-9473-167ce46e6b1b" alt="Before: small BTC logo with thin countdown ring and a wide gap above the CTAs" width="520" />

Predict home for context:

<img src="https://github.com/user-attachments/assets/7aeab49f-7b57-47e9-8292-f00d3a7f03b0" alt="Before: Predict home Live now rail" width="390" />

### **After**

Larger logo, 4pt countdown ring, and the subtitle tightened toward the CTAs at the same card height:

<img src="https://github.com/user-attachments/assets/c13a412d-477f-46e9-bf56-e70d3d076454" alt="After: larger BTC logo with a 4pt countdown ring and the subtitle close to the CTAs" width="520" />

Predict home for context:

<img src="https://github.com/user-attachments/assets/f55a9e1c-da57-440c-8b40-cc587f434bbf" alt="After: Predict home Live now rail" width="390" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

Considered and not applicable: this is a static style change with no new state, renders, or network work, and it removes a prop rather than adding one. Visual verification was done on the iOS simulator; the constants are platform-independent.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static UI sizing in a single Predict card component; no logic, data, or API changes.
> 
> **Overview**
> The compact **Live now** crypto up/down card no longer uses a smaller countdown ring and token logo. **`ProgressLogo`** always renders the full-size treatment (54pt ring, 4pt stroke, 40pt logo) instead of the previous compact 40pt / 2pt / 32pt sizing.
> 
> Compact-only constants and the **`compact`** prop on **`ProgressLogo`** are removed because both card modes now share the same dimensions. The larger logo and ring use existing vertical space in the carousel card, which pulls the “Resets every …” subtitle closer to the Up/Down CTAs without changing card height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b8d273d01757c6f08510a66b52df1ca23417a9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->