### PR TITLE
fix(predict): match market details About rows to Token Details typography

### DIFF
--- a/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsAbout/PredictMarketDetailsAbout.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsAbout/PredictMarketDetailsAbout.tsx
@@ -6,15 +6,15 @@ import {
   BoxFlexDirection,
   BoxAlignItems,
   BoxJustifyContent,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import Icon, {
-  IconName,
-  IconSize,
-} from '../../../../../../../component-library/components/Icons/Icon';
-import { useTheme } from '../../../../../../../util/theme';
 import { formatVolume } from '../../../../utils/format';
 import type { PredictMarket } from '../../../../types';
 
@@ -23,136 +23,97 @@ export interface PredictMarketDetailsAboutProps {
   onPolymarketResolution: () => void;
 }
 
-const PredictMarketDetailsAbout = memo(
-  ({ market, onPolymarketResolution }: PredictMarketDetailsAboutProps) => {
-    const { colors } = useTheme();
+interface AboutRowProps {
+  icon: IconName;
+  label: string;
+  value?: string;
+  children?: React.ReactNode;
+}
 
-    return (
-      <Box twClassName="gap-6">
-        <Box twClassName="gap-4">
+// Label/value treatment matches the "Market details" rows on Token Details:
+// a medium-weight alternative label against a regular default-color value.
+const AboutRow = ({ icon, label, value, children }: AboutRowProps) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    justifyContent={BoxJustifyContent.Between}
+    twClassName="gap-3"
+  >
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      twClassName="gap-3"
+    >
+      <Icon name={icon} size={IconSize.Md} color={IconColor.IconAlternative} />
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
+        color={TextColor.TextAlternative}
+      >
+        {label}
+      </Text>
+    </Box>
+    {children ?? (
+      <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
+        {value}
+      </Text>
+    )}
+  </Box>
+);
+
+const PredictMarketDetailsAbout = memo(
+  ({ market, onPolymarketResolution }: PredictMarketDetailsAboutProps) => (
+    <Box twClassName="gap-6">
+      <Box twClassName="gap-2">
+        <AboutRow
+          icon={IconName.Chart}
+          label={strings('predict.market_details.volume')}
+          value={`$${formatVolume(market?.outcomes[0].volume || 0)}`}
+        />
+        <AboutRow
+          icon={IconName.Clock}
+          label={strings('predict.market_details.end_date')}
+          value={
+            market?.endDate
+              ? new Date(market?.endDate).toLocaleDateString()
+              : 'N/A'
+          }
+        />
+        <AboutRow
+          icon={IconName.Bank}
+          label={strings('predict.market_details.resolution_details')}
+        >
           <Box
             flexDirection={BoxFlexDirection.Row}
             alignItems={BoxAlignItems.Center}
-            justifyContent={BoxJustifyContent.Between}
-            twClassName="gap-3"
+            twClassName="gap-1"
           >
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              twClassName="gap-3"
-            >
-              <Icon
-                name={IconName.Chart}
-                size={IconSize.Md}
-                color={colors.text.muted}
-              />
+            <Pressable onPress={onPolymarketResolution}>
               <Text
                 variant={TextVariant.BodyMd}
-                twClassName="font-medium"
-                color={TextColor.TextDefault}
+                color={TextColor.PrimaryDefault}
               >
-                {strings('predict.market_details.volume')}
+                Polymarket
               </Text>
-            </Box>
-            <Text
-              variant={TextVariant.BodyMd}
-              twClassName="font-medium"
-              color={TextColor.TextDefault}
-            >
-              ${formatVolume(market?.outcomes[0].volume || 0)}
-            </Text>
+            </Pressable>
+            <Icon
+              name={IconName.Export}
+              size={IconSize.Sm}
+              color={IconColor.PrimaryDefault}
+            />
           </Box>
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            justifyContent={BoxJustifyContent.Between}
-            twClassName="gap-3"
-          >
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              twClassName="gap-3"
-            >
-              <Icon
-                name={IconName.Clock}
-                size={IconSize.Md}
-                color={colors.text.muted}
-              />
-              <Text
-                variant={TextVariant.BodyMd}
-                twClassName="font-medium"
-                color={TextColor.TextDefault}
-              >
-                {strings('predict.market_details.end_date')}
-              </Text>
-            </Box>
-            <Text
-              variant={TextVariant.BodyMd}
-              twClassName="font-medium"
-              color={TextColor.TextDefault}
-            >
-              {market?.endDate
-                ? new Date(market?.endDate).toLocaleDateString()
-                : 'N/A'}
-            </Text>
-          </Box>
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            justifyContent={BoxJustifyContent.Between}
-            twClassName="gap-3"
-          >
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              twClassName="gap-3"
-            >
-              <Icon
-                name={IconName.Bank}
-                size={IconSize.Md}
-                color={colors.text.muted}
-              />
-              <Text
-                variant={TextVariant.BodyMd}
-                twClassName="font-medium"
-                color={TextColor.TextDefault}
-              >
-                {strings('predict.market_details.resolution_details')}
-              </Text>
-            </Box>
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              twClassName="gap-1"
-            >
-              <Pressable onPress={onPolymarketResolution}>
-                <Text
-                  variant={TextVariant.BodyMd}
-                  twClassName="font-medium"
-                  color={TextColor.PrimaryDefault}
-                >
-                  Polymarket
-                </Text>
-              </Pressable>
-              <Icon
-                name={IconName.Export}
-                size={IconSize.Sm}
-                color={colors.primary.default}
-              />
-            </Box>
-          </Box>
-        </Box>
-        <Box twClassName="w-full border-t border-muted" />
-        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-          {market?.description}
-        </Text>
-        <Box twClassName="w-full border-t border-muted" />
-        <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
-          {strings('predict.market_details.disclaimer')}
-        </Text>
+        </AboutRow>
       </Box>
-    );
-  },
+      <Box twClassName="w-full border-t border-muted" />
+      <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+        {market?.description}
+      </Text>
+      <Box twClassName="w-full border-t border-muted" />
+      <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
+        {strings('predict.market_details.disclaimer')}
+      </Text>
+    </Box>
+  ),
 );
 
 PredictMarketDetailsAbout.displayName = 'PredictMarketDetailsAbout';

--- a/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsPositions/PredictMarketDetailsPositions.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsPositions/PredictMarketDetailsPositions.tsx
@@ -2,6 +2,7 @@ import React, { memo } from 'react';
 import { strings } from '../../../../../../../../locales/i18n';
 import {
   Box,
+  FontWeight,
   Text,
   TextColor,
   TextVariant,
@@ -55,7 +56,7 @@ const PredictMarketDetailsPositions = memo(
       <Box twClassName="space-y-4">
         <Text
           variant={TextVariant.BodyMd}
-          twClassName="font-medium"
+          fontWeight={FontWeight.Medium}
           color={TextColor.TextAlternative}
         >
           {strings('predict.market_details.no_positions_found')}

--- a/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsStatus/PredictMarketDetailsStatus.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsStatus/PredictMarketDetailsStatus.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   BoxFlexDirection,
   BoxAlignItems,
+  FontWeight,
   Text,
   TextColor,
   TextVariant,
@@ -48,7 +49,7 @@ const PredictMarketDetailsStatus = memo(
                 />
                 <Text
                   variant={TextVariant.BodyMd}
-                  twClassName="font-medium"
+                  fontWeight={FontWeight.Medium}
                   color={TextColor.TextAlternative}
                 >
                   {strings('predict.market_details.market_resulted_to', {
@@ -65,7 +66,7 @@ const PredictMarketDetailsStatus = memo(
                 />
                 <Text
                   variant={TextVariant.BodyMd}
-                  twClassName="font-medium"
+                  fontWeight={FontWeight.Medium}
                   color={TextColor.TextAlternative}
                 >
                   {strings('predict.market_details.market_ended_on', {
@@ -90,7 +91,7 @@ const PredictMarketDetailsStatus = memo(
               />
               <Text
                 variant={TextVariant.BodyMd}
-                twClassName="font-medium"
+                fontWeight={FontWeight.Medium}
                 color={TextColor.TextDefault}
               >
                 {strings('predict.market_details.waiting_for_final_resolution')}


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

The About tab on a market's details screen rendered its label/value rows with both sides in medium-weight `text-default`, so each label competed with its own value and the section did not match the equivalent "Market details" rows on Token Details.

This adopts the Token Details treatment for those rows: medium-weight `text-alternative` labels against regular `text-default` values, 8pt row spacing (Token Details uses 4pt padding above and below each row), and `icon-alternative` row icons. The icons themselves are unchanged.

The labels also set their weight through `twClassName="font-medium"`, which layers a numeric weight of 500 on top of the font family the design-system `Text` has already resolved — `Geist-Regular`, since that is `BodyMd`'s default weight. iOS then synthesizes a heavier face, which renders noticeably bolder than the genuine `Geist-Medium` that Token Details gets from `BodyMDMedium`. Passing the `fontWeight` prop instead makes the design system select the correct font file, so both screens now use the identical face. The same `BodyMd` + `font-medium` combination appeared on four other labels on this screen (the three market status lines and the empty-positions state), and those are corrected the same way.

Finally, the three duplicated row blocks collapse into a single `AboutRow` that mirrors `TokenDetailsListItem`'s `label`/`value`/`children` contract, so the styling is defined once. That also let the deprecated `component-library` `Icon` import give way to the design-system one, which is what makes `IconColor.IconAlternative` available as a token instead of a raw theme string, and removed the need for `useTheme` in the file.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Updated the Predict market details About rows to match the Token Details styling

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A. Visual alignment with the Token Details "Market details" design from design review; no tracking issue.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict market details About rows

  Background:
    Given I am logged into MetaMask Mobile
    And an open prediction market is available

  Scenario: user reads the About section of a market
    Given I am on the Wallet home screen

    When user opens Predictions
    And user opens a single market
    And user selects the "About" tab
    Then "Volume", "End date" and "Resolution details" labels are medium-weight text-alternative
    And their values are regular-weight text-default
    And the row icons are icon-alternative
    And the rows match the "Market details" rows on a token's details screen

  Scenario: user compares against Token Details
    Given I am on the Wallet home screen

    When user opens any token's details screen
    And user scrolls to "Market details"
    Then the label and value typography is the same as the Predict About rows
```

Verified on the iOS simulator against the Token Details "Market details" section. Note the four additional labels only appear in specific market states: the status lines require a closed or resolved market, and the empty state requires a market with no positions.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

Labels in medium-weight `text-default` competing with their values, at 16pt row spacing:

<img src="https://github.com/user-attachments/assets/649d038f-aa6b-409f-b8c9-4447dd0b86de" alt="Before: About rows with dark bold labels and wide row spacing" width="520" />

About tab in context:

<img src="https://github.com/user-attachments/assets/b868a259-780a-46b0-a9ee-cef017543280" alt="Before: About tab of a market details screen" width="520" />

### **After**

Labels in medium-weight `text-alternative` with regular `text-default` values, at 8pt row spacing, matching Token Details:

<img src="https://github.com/user-attachments/assets/dffe0818-e029-4115-bc55-f6cbdf8d8386" alt="After: About rows with alternative labels and regular values" width="520" />

About tab in context:

<img src="https://github.com/user-attachments/assets/2aab9708-61aa-47bb-aba4-5b1489b95cc5" alt="After: About tab matching Token Details typography" width="520" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

Considered and not applicable: this is a static style change that adds no state, effects, or network work, and it removes JSX rather than adding any. Visual verification was done on the iOS simulator; the typography tokens are platform-independent.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only typography and layout in Predict market details; no auth, data, or business-logic changes.
> 
> **Overview**
> Aligns **Predict market details** About tab label/value rows with **Token Details** “Market details” styling so labels read as secondary and values stay primary.
> 
> In `PredictMarketDetailsAbout`, duplicated row markup is replaced with a shared **`AboutRow`** (label/value/`children` like `TokenDetailsListItem`). Row labels use **`TextAlternative`** + **`FontWeight.Medium`**; values stay regular **`TextDefault`**. Row icons move to the design-system **`Icon`** with **`IconColor.IconAlternative`**, and row spacing tightens from **`gap-4`** to **`gap-2`**. The Polymarket resolution link keeps primary styling but no longer uses synthetic bold via Tailwind.
> 
> The same **`fontWeight={FontWeight.Medium}`** fix replaces **`twClassName="font-medium"`** on status copy in **`PredictMarketDetailsStatus`** and the empty-positions message in **`PredictMarketDetailsPositions`**, so those labels use the real Geist Medium face instead of iOS-synthesized bold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 192dc4422445c596188435999e209e26c2e8a1dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->