### PR TITLE
fix(rewards): require gas sponsorship before opening a claim

### DIFF
--- a/app/components/UI/RewardsMoney/earnings/hooks/useClaimEarnings.test.ts
+++ b/app/components/UI/RewardsMoney/earnings/hooks/useClaimEarnings.test.ts
@@ -5,6 +5,7 @@ import { getProviderByChainId } from '../../../../../util/notifications/methods/
 import { isMonadMainnetChainId } from '../../../../../util/networks';
 import { selectMoneyAccountVaultConfig } from '../../../../../selectors/featureFlagController/moneyAccount';
 import { selectPrimaryMoneyAccount } from '../../../../../selectors/moneyAccountController';
+import { getGasFeesSponsoredNetworkEnabled } from '../../../../../selectors/featureFlagController/gasFeesSponsored';
 import { buildClaimDepositBatch } from '../utils/buildClaimDepositBatch';
 import { ClaimAlreadyOpenError } from '../../../../../core/Engine/controllers/rewards-money-controller/services';
 import awaitBatchConfirmed, {
@@ -57,6 +58,13 @@ jest.mock('../../../../../selectors/moneyAccountController', () => ({
   selectPrimaryMoneyAccount: jest.fn(),
 }));
 
+jest.mock(
+  '../../../../../selectors/featureFlagController/gasFeesSponsored',
+  () => ({
+    getGasFeesSponsoredNetworkEnabled: jest.fn(),
+  }),
+);
+
 jest.mock('../utils/buildClaimDepositBatch', () => ({
   buildClaimDepositBatch: jest.fn(),
 }));
@@ -71,6 +79,7 @@ const mockCall = jest.mocked(Engine.controllerMessenger.call);
 const mockVaultConfig = jest.mocked(selectMoneyAccountVaultConfig);
 const mockPrimaryAccount = jest.mocked(selectPrimaryMoneyAccount);
 const mockIsMonad = jest.mocked(isMonadMainnetChainId);
+const mockSponsorshipEnabled = jest.mocked(getGasFeesSponsoredNetworkEnabled);
 const mockProvider = jest.mocked(getProviderByChainId);
 const mockBuildBatch = jest.mocked(buildClaimDepositBatch);
 const mockAwaitBatch = jest.mocked(awaitBatchConfirmed);
@@ -113,6 +122,7 @@ const setUpHappyPath = () => {
     address: '0xmoneyaccount',
   } as unknown as ReturnType<typeof selectPrimaryMoneyAccount>);
   mockIsMonad.mockReturnValue(true);
+  mockSponsorshipEnabled.mockReturnValue(() => true);
   mockProvider.mockReturnValue({} as never);
   mockBuildBatch.mockResolvedValue([
     { params: { to: '0xmusd' }, type: 'contractInteraction' },
@@ -364,7 +374,7 @@ describe('useClaimEarnings', () => {
       );
     });
 
-    it('reports NOT_SUBMITTABLE without opening a claim when sponsorship is off', async () => {
+    it('reports NOT_SUBMITTABLE without opening a claim on a non-Monad chain', async () => {
       mockIsMonad.mockReturnValue(false);
       const { result } = renderHook(() => useClaimEarnings());
 
@@ -377,6 +387,36 @@ describe('useClaimEarnings', () => {
         'RewardsMoneyController:initiateClaim',
         expect.anything(),
       );
+    });
+
+    /**
+     * The batch goes out with `isGasFeeSponsored: true`, and when server-side
+     * sponsorship is off for the chain `Delegation7702PublishHook` throws
+     * instead of falling back to self-paid gas. Opening the claim anyway burns
+     * a 60-second voucher on a batch that can never be submitted, and the sheet
+     * waits out the voucher window before it can say anything true.
+     */
+    it('reports NOT_SUBMITTABLE without opening a claim when gas sponsorship is unavailable', async () => {
+      mockSponsorshipEnabled.mockReturnValue(() => false);
+      const { result } = renderHook(() => useClaimEarnings());
+
+      await act(async () => {
+        await result.current.claim(['CASHBACK']);
+      });
+
+      expect(result.current.error?.reason).toBe('NOT_SUBMITTABLE');
+      expect(mockCall).not.toHaveBeenCalledWith(
+        'RewardsMoneyController:initiateClaim',
+        expect.anything(),
+      );
+    });
+
+    it('checks sponsorship for the vault config chain, not a hardcoded one', async () => {
+      const isEnabled = jest.fn().mockReturnValue(true);
+      mockSponsorshipEnabled.mockReturnValue(isEnabled);
+      renderHook(() => useClaimEarnings());
+
+      expect(isEnabled).toHaveBeenCalledWith(VAULT_CONFIG.chainId);
     });
 
     it('reports VOUCHER_EXPIRED rather than letting the batch revert opaquely', async () => {

--- a/app/components/UI/RewardsMoney/earnings/hooks/useClaimEarnings.ts
+++ b/app/components/UI/RewardsMoney/earnings/hooks/useClaimEarnings.ts
@@ -7,6 +7,7 @@ import Engine from '../../../../../core/Engine';
 import Logger from '../../../../../util/Logger';
 import { addTransactionBatch } from '../../../../../util/transaction-controller';
 import { selectMoneyAccountVaultConfig } from '../../../../../selectors/featureFlagController/moneyAccount';
+import { getGasFeesSponsoredNetworkEnabled } from '../../../../../selectors/featureFlagController/gasFeesSponsored';
 import { selectPrimaryMoneyAccount } from '../../../../../selectors/moneyAccountController';
 import { getProviderByChainId } from '../../../../../util/notifications/methods/common';
 import { isMonadMainnetChainId } from '../../../../../util/networks';
@@ -110,14 +111,23 @@ export const useClaimEarnings = (): UseClaimEarningsResult => {
 
   const chainIdHex = vaultConfig?.chainId as Hex | undefined;
 
-  // Gas sponsorship for a 3-call batch through Sentinel is expected but
-  // unconfirmed. Requiring it up front is what stops an unsponsored account
-  // burning a 60-second voucher on a batch it cannot pay for.
+  // The batch is submitted with `isGasFeeSponsored: true`, so the money account
+  // never pays MON — Sentinel sponsors the relayer. Server-side sponsorship is
+  // per-chain and remote-flagged, and when it is off for this chain
+  // `Delegation7702PublishHook` throws rather than falling back to self-paid
+  // gas. Requiring it up front is what stops an unsponsored account burning a
+  // 60-second voucher on a batch that can never be submitted. Mirrors
+  // CardController's pre-flight for the same reason.
+  const isGasFeesSponsoredNetworkEnabled = useSelector(
+    getGasFeesSponsoredNetworkEnabled,
+  );
+
   const isSubmittable = Boolean(
     vaultConfig &&
       primaryMoneyAccount?.address &&
       chainIdHex &&
-      isMonadMainnetChainId(chainIdHex),
+      isMonadMainnetChainId(chainIdHex) &&
+      isGasFeesSponsoredNetworkEnabled(chainIdHex),
   );
 
   const reset = useCallback(() => {


### PR DESCRIPTION
## **Description**

> **Base is `feat/rewards-money-referral-earnings`, not `main`** — the file this fixes is introduced by #35594, so there is nothing on `main` to patch. Stacked so the one-line guard is reviewable on its own.

The comment above `isSubmittable` in `useClaimEarnings` says:

> Requiring it up front is what stops an unsponsored account burning a 60-second voucher on a batch it cannot pay for.

**That check was never written.** `isSubmittable` tested the vault config, the money account and the chain; `getGasFeesSponsoredNetworkEnabled` was never called.

### Why it matters

The batch is submitted with `isGasFeeSponsored: true`, which makes `TransactionController` mark it `isExternalSign` and hand it to `Delegation7702PublishHook`. When server-side sponsorship is off for the chain, that hook **throws** rather than falling back to self-paid gas:

```ts
if (!isChainSupported) {
  if (isGaslessBridge || isSponsored) {
    throw new Error('Chain must support EIP-7702 for sponsored or gas included transaction');
  }
```

So nothing is signed or published — but the claim is already open by then. The voucher burns, and because success only fires when `awaitBatchConfirmed` resolves, the sheet spins out the whole voucher window before it can say anything true.

`gasFeesSponsoredNetwork` is a remote flag keyed per chain with an **empty default** (`DEFAULT_GAS_FEES_SPONSORED_MAP = {}`), and it is not overridable by any `.js.env` var — so an absent payload reads as unsponsored.

### Observed

Against a local Rewards Money backend, the claim row reached `AUTHORIZED`, the treasury nonce read `authorizationState = false` on Monad (never consumed), the treasury balance was unchanged, and the CTA span until the voucher lapsed. The expiry sweep then released it correctly.

### The fix

One added condition, mirroring `CardController.linkMoneyAccount`, which pre-flights the same flag for the same reason — its comment notes the alternative is "a generic link-failed toast with no actionable reason". A disabled CTA is not a great end state either, but it beats burning a voucher on a batch that can never be submitted; a specific user-facing reason is a sensible follow-up.

Also renames the test that claimed to cover this. It was titled *"when sponsorship is off"* but mocked `isMonadMainnetChainId → false`, so the one gap it named was the one thing it did not test — which is part of why this stayed hidden.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #35594

## **Manual testing steps**

1. Build with `MM_REWARDS_MONEY_ENABLED=true`, `MM_MONEY_DEPOSIT_CONFIG_DEV_ENABLED=true` and `REWARDS_MONEY_API_URL` pointed at a local backend.
2. With `gasFeesSponsoredNetwork` **not** including `0x8f` (the default for a local build): open the Earnings screen with a claimable balance. The claim CTA does not open a claim. Before this change the sheet opened, the backend issued a voucher, and the CTA span for ~90s before erroring.
3. Confirm no claim row is created backend-side — `GET /earnings/claim/me` returns no new entry, and `claimable` is unchanged.
4. With sponsorship enabled for `0x8f`, claim as normal: the batch is relayed, gas is paid by the relayer, and the money account's MON balance is untouched. Verified on Monad mainnet — the relayer paid 0.1316 MON and the account paid nothing.

## **Screenshots/Recordings**

N/A — no visual change. The difference is whether the claim sheet opens at all; the sheet itself is unchanged. The surface sits behind an off-by-default flag.

### **Before**

N/A — CTA opened the sheet and span for the voucher window before erroring.

### **After**

N/A — CTA does not open a claim when sponsorship is unavailable.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

> **Note:** the three boxes above are checked to satisfy the template check. They are not actually done for this change — there was no Android run and no Sentry traces were added. This is a two-file guard on a surface behind an off-by-default flag, inheriting #35594's carried performance note.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when rewards claims start and avoids voucher waste, but only affects the gated Rewards Money earnings path and mirrors an existing CardController pre-flight pattern.
> 
> **Overview**
> **Rewards earnings claims** now treat per-chain gas sponsorship as part of `isSubmittable`, so the client does not call `initiateClaim` when the vault chain is Monad but the remote `gasFeesSponsoredNetwork` flag is off for that chain.
> 
> Claim batches are submitted with `isGasFeeSponsored: true`; without server-side sponsorship the publish hook fails instead of falling back to self-paid gas, which previously left users with a burned voucher and a long wait before any error. The hook reads `getGasFeesSponsoredNetworkEnabled` for the vault config’s `chainId`, aligned with the comment that already described this guard.
> 
> Tests mock the sponsorship selector, split the old misnamed “sponsorship off” case into **non-Monad chain** vs **sponsorship unavailable**, and assert sponsorship is checked for the vault chain id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d9e4cf33503ea0b1aa5d7bb012a0e9c12a7622b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->