### PR TITLE
fix(appium): give each Android pool worker its own adb server

### DIFF
--- a/tests/docs/android-appium-device-pool.md
+++ b/tests/docs/android-appium-device-pool.md
@@ -122,6 +122,12 @@ Two mechanisms carry the port:
 - `applyAndroidDevicePoolToWorker` exports `ANDROID_ADB_SERVER_PORT`. `adb`
   reads it natively, so every adb client the worker spawns inherits it and no
   call site needs a `-P` flag.
+- `resolveWorkerAdbServerPort` covers the window before that export exists.
+  The `deviceProvider` fixture is lazy, so a `beforeAll` doing `adb reverse`
+  runs first; without the fallback it would carry the right `-s` serial to the
+  default 5037 server and put the worker straight back on worker 0's daemon.
+  `adbDeviceArgs()` therefore emits `-P <port> -s <serial>`, matching the
+  `TEST_PARALLEL_INDEX` fallback the serial and host ports already use.
 - `EmulatorConfigBuilder` sets `appium:adbPort`. Appium is a separate process
   serving all sessions, so only a per-session capability can point its internal
   adb calls at the right server.

--- a/tests/docs/android-appium-device-pool.md
+++ b/tests/docs/android-appium-device-pool.md
@@ -26,13 +26,13 @@ fixed so adb serials and Appium auxiliary ports never overlap:
 
 - Worker 0: `-port 5554`, `emulator-5554`, `systemPort=8200`,
   `chromedriverPort=9100`, `mjpegServerPort=7810`, Chrome CDP `9222`,
-  WebView CDP `9223`
+  WebView CDP `9223`, adb server `5037`
 - Worker 1: `-port 5556`, `emulator-5556`, `systemPort=8201`,
   `chromedriverPort=9101`, `mjpegServerPort=7811`, Chrome CDP `9232`,
-  WebView CDP `9233`
+  WebView CDP `9233`, adb server `5038`
 - Worker 2: `-port 5558`, `emulator-5558`, `systemPort=8202`,
   `chromedriverPort=9102`, `mjpegServerPort=7812`, Chrome CDP `9242`,
-  WebView CDP `9243`
+  WebView CDP `9243`, adb server `5039`
 
 Local test-dapp servers keep the **device** URL (`localhost:8093` and similar)
 and listen on a worker-offset **host** port (`8093` / `8193` / `8293`). `adb reverse`
@@ -108,12 +108,32 @@ device fails only its assigned Playwright worker; the provider does not kill
 or restart the sibling emulator. Appium retries use `parallelIndex`, so a
 replacement worker keeps the same serial and ports.
 
-Workers share one host `adb` server. `withFixtures` therefore skips
-`adb reverse --remove` when `ANDROID_DEVICE_POOL_SIZE >= 2`. Removing
-reverses from one worker can protocol-fault the daemon and restart it
-(`daemon not running; starting now`), which takes UiAutomator2 down on
-every emulator in the job. New tests overwrite the mappings they need
-via `adb reverse tcp:<fallback> tcp:<actual>`.
+## Per-worker adb servers
+
+Each worker gets its own host `adb` server (`5037` + worker index), started and
+verified during global setup. A single shared server was a job-wide single point
+of failure: uncoordinated adb traffic from the framework, Appium, and screen
+recording could protocol-fault the daemon, and the restart wiped every `adb
+forward` mapping, so one worker's fault surfaced as `instrumentation process is
+not running` on all emulators.
+
+Two mechanisms carry the port:
+
+- `applyAndroidDevicePoolToWorker` exports `ANDROID_ADB_SERVER_PORT`. `adb`
+  reads it natively, so every adb client the worker spawns inherits it and no
+  call site needs a `-P` flag.
+- `EmulatorConfigBuilder` sets `appium:adbPort`. Appium is a separate process
+  serving all sessions, so only a per-session capability can point its internal
+  adb calls at the right server.
+
+Every adb server still sees every emulator — adb always scans upward from port
+5555, so the range cannot be partitioned. That is fine: workers select their
+device with `-s`, and a fault only drops the transports and forwards owned by
+that one server.
+
+`withFixtures` still skips `adb reverse --remove` when
+`ANDROID_DEVICE_POOL_SIZE >= 2`. New tests overwrite the mappings they need via
+`adb reverse tcp:<fallback> tcp:<actual>`.
 
 ## Measuring impact
 

--- a/tests/framework/e2eWorkerPorts.test.ts
+++ b/tests/framework/e2eWorkerPorts.test.ts
@@ -5,6 +5,7 @@ import {
   isIosAppiumSmokeEnv,
   metamaskWebViewCdpForwardPort,
   resolveE2eWorkerIndex,
+  resolveWorkerAdbServerPort,
   resolveWorkerAndroidSerial,
   webviewCdpForwardPort,
 } from './e2eWorkerPorts.ts';
@@ -100,13 +101,66 @@ describe('e2eWorkerPorts', () => {
       expect(args).toEqual(['-s', 'emulator-5556']);
     });
 
-    it('pins adb to the pool device when ANDROID_SERIAL is not exported yet', () => {
+    it('pins adb to the pool device and server when ANDROID_SERIAL is not exported yet', () => {
       const args = adbDeviceArgs({
         ANDROID_DEVICE_POOL_SIZE: '2',
         TEST_PARALLEL_INDEX: '1',
       });
 
-      expect(args).toEqual(['-s', 'emulator-5556']);
+      expect(args).toEqual(['-P', '5038', '-s', 'emulator-5556']);
+    });
+
+    it('pins adb to the exported worker adb server port', () => {
+      const args = adbDeviceArgs({
+        ANDROID_SERIAL: 'emulator-5558',
+        ANDROID_ADB_SERVER_PORT: '5039',
+      });
+
+      expect(args).toEqual(['-P', '5039', '-s', 'emulator-5558']);
+    });
+  });
+
+  describe('resolveWorkerAdbServerPort', () => {
+    it('returns no port on the single emulator path', () => {
+      const port = resolveWorkerAdbServerPort({});
+
+      expect(port).toBeUndefined();
+    });
+
+    it('prefers the exported port', () => {
+      const port = resolveWorkerAdbServerPort({
+        ANDROID_ADB_SERVER_PORT: '5038',
+      });
+
+      expect(port).toBe(5038);
+    });
+
+    it('falls back to the pool assignment before the deviceProvider fixture runs', () => {
+      const port = resolveWorkerAdbServerPort({
+        ANDROID_DEVICE_POOL_SIZE: '3',
+        TEST_PARALLEL_INDEX: '2',
+      });
+
+      expect(port).toBe(5039);
+    });
+
+    it('never targets an adb server on an iOS Appium worker', () => {
+      const port = resolveWorkerAdbServerPort({
+        ANDROID_DEVICE_POOL_SIZE: '2',
+        TEST_PARALLEL_INDEX: '1',
+        IOS_SIMULATOR_UDID: '11111111-1111-1111-1111-111111111111',
+      });
+
+      expect(port).toBeUndefined();
+    });
+
+    it('rejects a non-numeric exported port', () => {
+      const resolveInvalidPort = () =>
+        resolveWorkerAdbServerPort({ ANDROID_ADB_SERVER_PORT: 'not-a-port' });
+
+      expect(resolveInvalidPort).toThrow(
+        'Invalid ANDROID_ADB_SERVER_PORT "not-a-port"',
+      );
     });
   });
 

--- a/tests/framework/e2eWorkerPorts.ts
+++ b/tests/framework/e2eWorkerPorts.ts
@@ -108,9 +108,42 @@ export function isIosAppiumSmokeEnv(
   return Number.isInteger(iosPoolSize) && iosPoolSize > 1;
 }
 
+/**
+ * Host adb server port for this worker. Falls back to the pool assignment for
+ * the same reason the serial does: `beforeAll` hooks run before the
+ * `deviceProvider` fixture exports `ANDROID_ADB_SERVER_PORT`, and an early
+ * `adb reverse` that lands on the default 5037 server puts this worker back on
+ * worker 0's daemon — the shared failure domain per-worker servers remove.
+ */
+export function resolveWorkerAdbServerPort(
+  env: Record<string, string | undefined> = process.env,
+): number | undefined {
+  if (isIosAppiumSmokeEnv(env)) {
+    return undefined;
+  }
+
+  const explicit = env.ANDROID_ADB_SERVER_PORT?.trim();
+  if (explicit) {
+    const port = Number(explicit);
+    if (!Number.isInteger(port) || port < 1) {
+      throw new Error(
+        `Invalid ANDROID_ADB_SERVER_PORT "${explicit}". Expected a positive integer.`,
+      );
+    }
+    return port;
+  }
+  return deviceForWorker(resolveE2eWorkerIndex(env), env)?.adbServerPort;
+}
+
 export function adbDeviceArgs(
   env: Record<string, string | undefined> = process.env,
 ): string[] {
   const serial = resolveWorkerAndroidSerial(env);
-  return serial ? ['-s', serial] : [];
+  if (!serial) {
+    return [];
+  }
+  const adbServerPort = resolveWorkerAdbServerPort(env);
+  return adbServerPort === undefined
+    ? ['-s', serial]
+    : ['-P', String(adbServerPort), '-s', serial];
 }

--- a/tests/framework/fixtures/FixtureUtils.ts
+++ b/tests/framework/fixtures/FixtureUtils.ts
@@ -21,7 +21,7 @@ import {
 import { ACCOUNT_ACTIVITY_WS } from '../../websocket/constants.ts';
 import { DEFAULT_ANVIL_PORT } from '../../seeder/anvil-manager.ts';
 import { PlatformDetector } from '../PlatformLocator.ts';
-import { resolveWorkerAndroidSerial } from '../e2eWorkerPorts.ts';
+import { adbDeviceArgs } from '../e2eWorkerPorts.ts';
 import {
   isAdbTransportFault,
   withAdbHostLock,
@@ -91,8 +91,7 @@ export async function cleanupAllAndroidPortForwarding(): Promise<void> {
     return;
   }
 
-  const serial = resolveWorkerAndroidSerial();
-  const deviceFlag = serial ? `-s ${serial}` : '';
+  const deviceFlag = adbDeviceArgs().join(' ');
 
   // Clean up only the specific fallback ports we use
   // This prevents conflicts with Detox's own port management
@@ -207,8 +206,7 @@ async function setupAndroidPortForwarding(
     fallbackPort += instanceIndex;
   }
 
-  const serial = resolveWorkerAndroidSerial();
-  const deviceFlag = serial ? `-s ${serial}` : '';
+  const deviceFlag = adbDeviceArgs().join(' ');
 
   const command = `adb ${deviceFlag} reverse tcp:${fallbackPort} tcp:${actualPort}`;
 

--- a/tests/framework/services/appium/EmulatorHelpers.ts
+++ b/tests/framework/services/appium/EmulatorHelpers.ts
@@ -14,6 +14,7 @@ import {
   resolveAndroidBootMode,
   writeGoldenSnapshotFingerprint,
 } from './AndroidGoldenSnapshot.ts';
+import { androidAdbServerPorts } from '../providers/emulator/android/androidDevicePool.ts';
 
 export {
   ANDROID_EMULATOR_GOLDEN_SNAPSHOT_NAME,
@@ -47,6 +48,8 @@ const DEFAULT_ANDROID_SNAPSHOT_BOOT_TIMEOUT_MS = 90_000;
 const DEFAULT_IOS_POST_BOOT_SETTLE_MS = 15_000;
 const UI_AUTOMATOR_DUMP_PATH = '/sdcard/window_dump.xml';
 const ANDROID_NETWORK_PING_HOST = '8.8.8.8';
+const ADB_SERVER_DISCOVERY_TIMEOUT_MS = 60_000;
+const ADB_SERVER_DISCOVERY_POLL_MS = 1_000;
 
 /** Play Store / GMS packages disabled after cold boot — not needed for Appium E2E. */
 export const ANDROID_E2E_PACKAGES_TO_DISABLE = [
@@ -223,6 +226,56 @@ async function ensureAdbServer(): Promise<void> {
   await enqueueAdb(async () => {
     await execAsync('adb start-server');
   });
+}
+
+/**
+ * Give every pool worker its own host adb server so a `protocol fault` on one
+ * server cannot restart the daemon shared by the rest of the shard. Every adb
+ * server still discovers every emulator (adb always scans upward from 5555),
+ * so isolation comes from which server a worker talks to, not from what each
+ * server can see. Workers always select their device with `-s`.
+ */
+async function ensureAndroidPoolAdbServers(serials: string[]): Promise<void> {
+  const ports = androidAdbServerPorts({
+    ANDROID_DEVICE_POOL: serials.join(','),
+  });
+  await Promise.all(
+    ports.map(async (port, index) => {
+      const serial = serials[index];
+      await enqueueAdb(async () => {
+        await execAsync(`adb -P ${port} start-server`);
+      });
+      await waitForAdbServerToSeeSerial(port, serial);
+      logger.info(`adb server on port ${port} is serving ${serial}.`);
+    }),
+  );
+}
+
+async function waitForAdbServerToSeeSerial(
+  port: number,
+  serial: string,
+): Promise<void> {
+  const deadline = Date.now() + ADB_SERVER_DISCOVERY_TIMEOUT_MS;
+  let lastSeen = '';
+  while (Date.now() < deadline) {
+    const devices = await enqueueAdb(async () => {
+      const { stdout } = await execAsync(`adb -P ${port} devices`);
+      return parseAdbDevices(stdout);
+    });
+    lastSeen = devices.map((adbDevice) => adbDevice.serial).join(',') || 'none';
+    if (
+      devices.some(
+        (adbDevice) =>
+          adbDevice.serial === serial && adbDevice.state === 'device',
+      )
+    ) {
+      return;
+    }
+    await sleep(ADB_SERVER_DISCOVERY_POLL_MS);
+  }
+  throw new Error(
+    `adb server on port ${port} never saw ${serial} within ${ADB_SERVER_DISCOVERY_TIMEOUT_MS / 1000}s (saw: ${lastSeen}).`,
+  );
 }
 
 async function listAdbDevices(): Promise<AdbDevice[]> {
@@ -865,6 +918,7 @@ export async function startAndroidEmulatorPool(
       return serial;
     },
   );
+  await ensureAndroidPoolAdbServers(serials);
   logger.info(
     `Android emulator pool ready in ${Date.now() - bootStartedAt}ms: ${serials.join(',')}.`,
   );

--- a/tests/framework/services/providers/emulator/EmulatorConfigBuilder.test.ts
+++ b/tests/framework/services/providers/emulator/EmulatorConfigBuilder.test.ts
@@ -38,6 +38,7 @@ describe('EmulatorConfigBuilder', () => {
     'ANDROID_UIAUTOMATOR2_SYSTEM_PORT',
     'ANDROID_CHROMEDRIVER_PORT',
     'ANDROID_MJPEG_SERVER_PORT',
+    'ANDROID_ADB_SERVER_PORT',
     'IOS_WDA_LOCAL_PORT',
     'IOS_MJPEG_SERVER_PORT',
   ] as const;
@@ -62,12 +63,14 @@ describe('EmulatorConfigBuilder', () => {
     expect(config.capabilities).not.toHaveProperty('appium:systemPort');
     expect(config.capabilities).not.toHaveProperty('appium:chromedriverPort');
     expect(config.capabilities).not.toHaveProperty('appium:mjpegServerPort');
+    expect(config.capabilities).not.toHaveProperty('appium:adbPort');
   });
 
   it('pins Android server ports exported for the worker', () => {
     process.env.ANDROID_UIAUTOMATOR2_SYSTEM_PORT = '8201';
     process.env.ANDROID_CHROMEDRIVER_PORT = '9101';
     process.env.ANDROID_MJPEG_SERVER_PORT = '7811';
+    process.env.ANDROID_ADB_SERVER_PORT = '5038';
 
     const config = new EmulatorConfigBuilder(createAndroidProject()).build();
 
@@ -75,6 +78,7 @@ describe('EmulatorConfigBuilder', () => {
       'appium:systemPort': 8201,
       'appium:chromedriverPort': 9101,
       'appium:mjpegServerPort': 7811,
+      'appium:adbPort': 5038,
     });
   });
 

--- a/tests/framework/services/providers/emulator/EmulatorConfigBuilder.ts
+++ b/tests/framework/services/providers/emulator/EmulatorConfigBuilder.ts
@@ -88,6 +88,10 @@ export class EmulatorConfigBuilder {
     const androidMjpegServerPort = readOptionalPort(
       'ANDROID_MJPEG_SERVER_PORT',
     );
+    // Pool workers each run their own adb server. Without this the single
+    // Appium process would drive every session through the default 5037
+    // server, so one server fault would kill UiAutomator2 on all emulators.
+    const androidAdbPort = readOptionalPort('ANDROID_ADB_SERVER_PORT');
     const iosWdaLocalPort =
       platformName === Platform.IOS
         ? readOptionalPort('IOS_WDA_LOCAL_PORT')
@@ -127,6 +131,9 @@ export class EmulatorConfigBuilder {
               ...(androidMjpegServerPort === undefined
                 ? {}
                 : { 'appium:mjpegServerPort': androidMjpegServerPort }),
+              ...(androidAdbPort === undefined
+                ? {}
+                : { 'appium:adbPort': androidAdbPort }),
             }
           : {
               'appium:bundleId': this.project.use.app?.appId,

--- a/tests/framework/services/providers/emulator/android/androidDevicePool.test.ts
+++ b/tests/framework/services/providers/emulator/android/androidDevicePool.test.ts
@@ -1,4 +1,5 @@
 import {
+  androidAdbServerPorts,
   applyAndroidDevicePoolToWorker,
   assertAndroidDevicePoolMatchesWorkers,
   deviceForWorker,
@@ -152,15 +153,40 @@ describe('androidDevicePool', () => {
         systemPort: 8200,
         chromedriverPort: 9100,
         mjpegServerPort: 7810,
+        adbServerPort: 5037,
       });
       expect(second).toEqual({
         serial: 'emulator-5556',
         systemPort: 8201,
         chromedriverPort: 9101,
         mjpegServerPort: 7811,
+        adbServerPort: 5038,
       });
       expect(first?.serial).not.toBe(second?.serial);
       expect(first?.systemPort).not.toBe(second?.systemPort);
+      expect(first?.adbServerPort).not.toBe(second?.adbServerPort);
+    });
+
+    it('gives each pooled worker its own adb server port', () => {
+      const result = androidAdbServerPorts({
+        ANDROID_DEVICE_POOL: 'emulator-5554,emulator-5556,emulator-5558',
+      });
+
+      expect(result).toEqual([5037, 5038, 5039]);
+    });
+
+    it('reports no dedicated adb servers outside pool mode', () => {
+      const result = androidAdbServerPorts({ ANDROID_DEVICE_POOL_SIZE: '1' });
+
+      expect(result).toEqual([]);
+    });
+
+    it('keeps worker zero on the default adb server port', () => {
+      const assignment = deviceForWorker(0, {
+        ANDROID_DEVICE_POOL: 'emulator-5554,emulator-5556,emulator-5558',
+      });
+
+      expect(assignment?.adbServerPort).toBe(5037);
     });
 
     it('rejects a worker index outside the configured pool', () => {
@@ -191,6 +217,7 @@ describe('androidDevicePool', () => {
         ANDROID_UIAUTOMATOR2_SYSTEM_PORT: '8201',
         ANDROID_CHROMEDRIVER_PORT: '9101',
         ANDROID_MJPEG_SERVER_PORT: '7811',
+        ANDROID_ADB_SERVER_PORT: '5038',
       });
     });
 

--- a/tests/framework/services/providers/emulator/android/androidDevicePool.ts
+++ b/tests/framework/services/providers/emulator/android/androidDevicePool.ts
@@ -4,12 +4,18 @@ const ANDROID_EMULATOR_SERIAL_PATTERN = /^emulator-\d+$/;
 const UIAUTOMATOR2_SYSTEM_PORT_BASE = 8200;
 const CHROMEDRIVER_PORT_BASE = 9100;
 const MJPEG_SERVER_PORT_BASE = 7810;
+/**
+ * Worker 0 keeps adb's default 5037 so global setup, local runs, and any
+ * tooling that shells out to a bare `adb` all target the same server.
+ */
+const ADB_SERVER_PORT_BASE = 5037;
 
 export interface AndroidWorkerDevice {
   serial: string;
   systemPort: number;
   chromedriverPort: number;
   mjpegServerPort: number;
+  adbServerPort: number;
 }
 
 /**
@@ -139,7 +145,19 @@ export function deviceForWorker(
     systemPort: UIAUTOMATOR2_SYSTEM_PORT_BASE + workerIndex,
     chromedriverPort: CHROMEDRIVER_PORT_BASE + workerIndex,
     mjpegServerPort: MJPEG_SERVER_PORT_BASE + workerIndex,
+    adbServerPort: ADB_SERVER_PORT_BASE + workerIndex,
   };
+}
+
+/**
+ * Host adb server ports backing a pool, ordered by worker index.
+ * Empty outside pool mode, where the default server is the only one.
+ */
+export function androidAdbServerPorts(
+  env: Record<string, string | undefined> = process.env,
+): number[] {
+  const serials = androidDevicePoolSerials(env);
+  return serials.map((_serial, index) => ADB_SERVER_PORT_BASE + index);
 }
 
 /**
@@ -164,5 +182,9 @@ export function applyAndroidDevicePoolToWorker(
   env.ANDROID_UIAUTOMATOR2_SYSTEM_PORT = String(assignment.systemPort);
   env.ANDROID_CHROMEDRIVER_PORT = String(assignment.chromedriverPort);
   env.ANDROID_MJPEG_SERVER_PORT = String(assignment.mjpegServerPort);
+  // Every adb client this worker spawns inherits the port, so the ~60 call
+  // sites across the framework need no `-P` flag. Appium is a separate
+  // process and gets the same value via the `appium:adbPort` capability.
+  env.ANDROID_ADB_SERVER_PORT = String(assignment.adbServerPort);
   return assignment;
 }


### PR DESCRIPTION
## **Description**

Pooled Android Appium jobs (`ANDROID_DEVICE_POOL_SIZE >= 2`) used one host `adb` server. A `protocol fault` restarted that daemon, wiped every `adb forward` mapping, and surfaced as `instrumentation process is not running` on sibling workers.

This PR gives each worker its own adb server (`5037 + workerIndex`), started in global setup. Workers inherit `ANDROID_ADB_SERVER_PORT`; Appium gets it via `appium:adbPort`. Early `beforeAll` hooks resolve the port from `TEST_PARALLEL_INDEX` the same way serials already do.

Remaining single-worker `protocol fault`s on the default 5037 server (bare `adb` call sites racing Appium) are follow-up work, not this PR.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/actions/runs/34088934820/job/101640185129
Refs: https://github.com/MetaMask/metamask-mobile/pull/35799

## **Manual testing steps**

N/A — Appium CI infrastructure. Proof is the Android smoke run on this PR ([ci run 34135949528](https://github.com/MetaMask/metamask-mobile/actions/runs/34135949528)).

```gherkin
Feature: Per-worker adb servers on pooled Android smoke

  Scenario: Global setup starts one adb server per emulator
    Given ANDROID_DEVICE_POOL_SIZE=3
    When global setup finishes
    Then logs show port 5037 serving emulator-5554
    And port 5038 serving emulator-5556
    And port 5039 serving emulator-5558

  Scenario: Workers talk to their own server
    Given three Playwright workers are running
    Then reverse calls use adb -P 5037|5038|5039 with the matching serial
```

## **Screenshots/Recordings**

CI evidence from [run 34135949528](https://github.com/MetaMask/metamask-mobile/actions/runs/34135949528) (commit `a6f8dee`). All Android Appium smoke jobs passed.

### **Before**

One shared daemon. A fault on any worker took UiAutomator2 down across the shard:

```
'POST /element' cannot be proxied to UiAutomator2 server because the
instrumentation process is not running (probably crashed).
```

### **After**

Global setup (snaps / perps / wallet-platform / confirmations / accounts):

```
Android device pool size=3 workers=3
adb server on port 5037 is serving emulator-5554.
adb server on port 5038 is serving emulator-5556.
adb server on port 5039 is serving emulator-5558.
Android emulator pool ready … emulator-5554,emulator-5556,emulator-5558.
```

Workers used the matching server:

```
[w0 emulator-5554] adb -P 5037 -s emulator-5554 reverse …
[w1 emulator-5556] adb -P 5038 -s emulator-5556 reverse …
[w2 emulator-5558] adb -P 5039 -s emulator-5558 reverse …
```

On perps, a `protocol fault` still restarted **only** `tcp:5037`. Instrumentation crash was tagged `[w0 emulator-5554]`; worker 1 kept serving mocks. The job passed on retry. Snaps, confirmations, and accounts had zero protocol faults.

Unit tests: `androidDevicePool`, `EmulatorConfigBuilder`, `e2eWorkerPorts` (including the pre-fixture `-P` fallback).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

Performance items are N/A: test-harness only, no app code. Android coverage is the Appium smoke jobs on this PR.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
