### PR TITLE
fix(notifications): backfill legacy notification consent

### DIFF
--- a/android/app/src/main/java/io/metamask/nativeModules/BrazePushModule.kt
+++ b/android/app/src/main/java/io/metamask/nativeModules/BrazePushModule.kt
@@ -1,7 +1,6 @@
 package io.metamask.nativeModules
 
 import com.braze.Braze
-import com.braze.push.BrazePushUnregistrationException
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
@@ -59,11 +58,8 @@ class BrazePushModule(context: ReactApplicationContext) : ReactContextBaseJavaMo
 
     private fun failureResult(error: Throwable) =
         Arguments.createMap().apply {
-            val pushError = error as? BrazePushUnregistrationException
             putBoolean("success", false)
             putString("message", error.message ?: "Failed to unregister Braze push")
-            putBoolean("isRetriable", pushError?.isRetriable == true)
-            pushError?.httpStatusCode?.let { putInt("httpStatusCode", it) }
         }
 
     companion object {

--- a/app/actions/notification/helpers/index.test.tsx
+++ b/app/actions/notification/helpers/index.test.tsx
@@ -93,6 +93,18 @@ describe('helpers - enableNotificationServices()', () => {
       Engine.context.NotificationServicesController.enableMetamaskNotifications,
     ).toHaveBeenCalledWith({ registerPushNotifications: false });
   });
+
+  it('enables NaaP when Braze registration-state persistence fails', async () => {
+    jest
+      .mocked(markBrazePushRegistrationDesired)
+      .mockRejectedValue(new Error('Storage unavailable'));
+
+    await enableNotifications();
+
+    expect(
+      Engine.context.NotificationServicesController.enableMetamaskNotifications,
+    ).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('helpers - hasNotificationPreferences()', () => {
@@ -267,6 +279,18 @@ describe('helpers - enablePushNotifications()', () => {
     expect(
       Engine.context.NotificationServicesController.enablePushNotifications,
     ).toHaveBeenCalled();
+  });
+
+  it('enables NaaP push when Braze registration-state persistence fails', async () => {
+    jest
+      .mocked(markBrazePushRegistrationDesired)
+      .mockRejectedValue(new Error('Storage unavailable'));
+
+    await enablePushNotifications();
+
+    expect(
+      Engine.context.NotificationServicesController.enablePushNotifications,
+    ).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/app/actions/notification/helpers/index.test.tsx
+++ b/app/actions/notification/helpers/index.test.tsx
@@ -18,6 +18,7 @@ import {
 } from '.';
 import Engine from '../../../core/Engine';
 import { unregisterBrazePush } from '../../../core/Braze/unregisterPush';
+import { markBrazePushRegistrationDesired } from '../../../core/Braze/pushRegistrationState';
 jest.mock('../../../util/notifications', () => ({
   isNotificationsFeatureEnabled: () => true,
 }));
@@ -53,6 +54,10 @@ jest.mock('../../../core/Braze/unregisterPush', () => ({
   unregisterBrazePush: jest.fn().mockResolvedValue(true),
 }));
 
+jest.mock('../../../core/Braze/pushRegistrationState', () => ({
+  markBrazePushRegistrationDesired: jest.fn().mockResolvedValue(undefined),
+}));
+
 beforeEach(() => {
   jest.clearAllMocks();
   jest.resetAllMocks();
@@ -63,6 +68,8 @@ beforeEach(() => {
 describe('helpers - enableNotificationServices()', () => {
   it('invoke notification services method', async () => {
     await enableNotifications();
+
+    expect(markBrazePushRegistrationDesired).toHaveBeenCalledTimes(1);
     expect(
       Engine.context.NotificationServicesController.enableMetamaskNotifications,
     ).toHaveBeenCalled();
@@ -80,6 +87,8 @@ describe('helpers - enableNotificationServices()', () => {
 
   it('forwards enable notification options', async () => {
     await enableNotifications({ registerPushNotifications: false });
+
+    expect(markBrazePushRegistrationDesired).not.toHaveBeenCalled();
     expect(
       Engine.context.NotificationServicesController.enableMetamaskNotifications,
     ).toHaveBeenCalledWith({ registerPushNotifications: false });
@@ -165,11 +174,25 @@ describe('helpers - setMarketingNotificationPreferencesEnabled()', () => {
 });
 
 describe('helpers - disableNotificationServices()', () => {
-  it('invoke notification services method', async () => {
+  it('unregisters Braze directly before global disable without an FCM token', async () => {
     await disableNotifications();
+
+    expect(unregisterBrazePush).toHaveBeenCalledTimes(1);
     expect(
       Engine.context.NotificationServicesController.disableNotificationServices,
-    ).toHaveBeenCalled();
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates Braze unregistration to global disable with an FCM token', async () => {
+    Engine.context.NotificationServicesPushController.state.fcmToken =
+      'fcm-token';
+
+    await disableNotifications();
+
+    expect(unregisterBrazePush).not.toHaveBeenCalled();
+    expect(
+      Engine.context.NotificationServicesController.disableNotificationServices,
+    ).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -239,6 +262,8 @@ describe('helpers - markMetamaskNotificationsAsRead()', () => {
 describe('helpers - enablePushNotifications()', () => {
   it('invoke notification services method', async () => {
     await enablePushNotifications();
+
+    expect(markBrazePushRegistrationDesired).toHaveBeenCalledTimes(1);
     expect(
       Engine.context.NotificationServicesController.enablePushNotifications,
     ).toHaveBeenCalled();
@@ -274,18 +299,14 @@ describe('helpers - disablePushNotifications()', () => {
     ).toHaveBeenCalled();
   });
 
-  it('does not disable NaaP push when direct Braze unregister fails', async () => {
-    jest
-      .mocked(unregisterBrazePush)
-      .mockRejectedValueOnce(new Error('Failed to unregister Braze push'));
+  it('continues disabling NaaP when Braze unregistration remains pending', async () => {
+    jest.mocked(unregisterBrazePush).mockResolvedValueOnce(false);
 
-    await expect(disablePushNotifications()).rejects.toThrow(
-      'Failed to unregister Braze push',
-    );
+    await disablePushNotifications();
 
     expect(
       Engine.context.NotificationServicesController.disablePushNotifications,
-    ).not.toHaveBeenCalled();
+    ).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/app/actions/notification/helpers/index.ts
+++ b/app/actions/notification/helpers/index.ts
@@ -6,6 +6,7 @@ import type {
 import Engine from '../../../core/Engine';
 import { unregisterBrazePush } from '../../../core/Braze/unregisterPush';
 import { markBrazePushRegistrationDesired } from '../../../core/Braze/pushRegistrationState';
+import Logger from '../../../util/Logger';
 import { isNotificationsFeatureEnabled } from '../../../util/notifications';
 
 const CLIENT_TYPE = 'mobile' as const;
@@ -44,6 +45,17 @@ export const assertIsFeatureEnabled = () => {
   }
 };
 
+const markBrazePushRegistrationDesiredSafely = async (): Promise<void> => {
+  try {
+    await markBrazePushRegistrationDesired();
+  } catch (error) {
+    Logger.error(
+      error instanceof Error ? error : new Error(String(error)),
+      '[Braze] Failed to persist push registration intent',
+    );
+  }
+};
+
 /**
  * Enable Notifications Switch
  * - This is used during onboarding and for the notifications settings toggle
@@ -54,7 +66,7 @@ export const enableNotifications = async (
 ) => {
   assertIsFeatureEnabled();
   if (options?.registerPushNotifications !== false) {
-    await markBrazePushRegistrationDesired();
+    await markBrazePushRegistrationDesiredSafely();
   }
   await Engine.context.NotificationServicesController.enableMetamaskNotifications(
     options,
@@ -118,7 +130,7 @@ export const disableNotifications = async () => {
  */
 export const enablePushNotifications = async () => {
   assertIsFeatureEnabled();
-  await markBrazePushRegistrationDesired();
+  await markBrazePushRegistrationDesiredSafely();
   await Engine.context.NotificationServicesController.enablePushNotifications();
 };
 

--- a/app/actions/notification/helpers/index.ts
+++ b/app/actions/notification/helpers/index.ts
@@ -5,6 +5,7 @@ import type {
 } from '@metamask/notification-services-controller/notification-services';
 import Engine from '../../../core/Engine';
 import { unregisterBrazePush } from '../../../core/Braze/unregisterPush';
+import { markBrazePushRegistrationDesired } from '../../../core/Braze/pushRegistrationState';
 import { isNotificationsFeatureEnabled } from '../../../util/notifications';
 
 const CLIENT_TYPE = 'mobile' as const;
@@ -52,6 +53,9 @@ export const enableNotifications = async (
   options?: NotificationServicesControllerEnableNotificationsOptions,
 ) => {
   assertIsFeatureEnabled();
+  if (options?.registerPushNotifications !== false) {
+    await markBrazePushRegistrationDesired();
+  }
   await Engine.context.NotificationServicesController.enableMetamaskNotifications(
     options,
   );
@@ -101,6 +105,9 @@ export const setMarketingNotificationPreferencesEnabled = async (
  */
 export const disableNotifications = async () => {
   assertIsFeatureEnabled();
+  if (!Engine.context.NotificationServicesPushController.state.fcmToken) {
+    await unregisterBrazePush();
+  }
   await Engine.context.NotificationServicesController.disableNotificationServices();
 };
 
@@ -111,6 +118,7 @@ export const disableNotifications = async () => {
  */
 export const enablePushNotifications = async () => {
   assertIsFeatureEnabled();
+  await markBrazePushRegistrationDesired();
   await Engine.context.NotificationServicesController.enablePushNotifications();
 };
 
@@ -119,8 +127,7 @@ export const enablePushNotifications = async () => {
  * - Allows us to disable push notifications
  * When NaaP has no FCM token, unregisters Braze here because the push
  * controller otherwise returns before invoking its token-deletion callback.
- * Retriable failures persist for retry on the next app launch.
- * @throws if Braze push fails permanently for this device
+ * Failures persist for retry on the next app session.
  */
 export const disablePushNotifications = async () => {
   assertIsFeatureEnabled();

--- a/app/constants/storage.ts
+++ b/app/constants/storage.ts
@@ -47,6 +47,7 @@ export const LAST_INCOMING_TX_BLOCK_INFO = `${prefix}lastIncomingTxBlockInfo`;
 
 export const PUSH_NOTIFICATIONS_PROMPT_COUNT = `${prefix}pushNotificationsPromptCount`;
 export const PUSH_NOTIFICATIONS_PROMPT_TIME = `${prefix}pushNotificationsPromptTime`;
+export const BRAZE_PUSH_DESIRED_STATE = `${prefix}brazePushDesiredState`;
 export const BRAZE_PUSH_UNREGISTRATION_PENDING = `${prefix}brazePushUnregistrationPending`;
 export const LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING = `${prefix}legacyNotificationAusBackfillPending`;
 

--- a/app/constants/storage.ts
+++ b/app/constants/storage.ts
@@ -47,8 +47,7 @@ export const LAST_INCOMING_TX_BLOCK_INFO = `${prefix}lastIncomingTxBlockInfo`;
 
 export const PUSH_NOTIFICATIONS_PROMPT_COUNT = `${prefix}pushNotificationsPromptCount`;
 export const PUSH_NOTIFICATIONS_PROMPT_TIME = `${prefix}pushNotificationsPromptTime`;
-export const BRAZE_PUSH_DESIRED_STATE = `${prefix}brazePushDesiredState`;
-export const BRAZE_PUSH_UNREGISTRATION_PENDING = `${prefix}brazePushUnregistrationPending`;
+export const BRAZE_PUSH_REGISTRATION_STATE = `${prefix}brazePushRegistrationState`;
 export const LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING = `${prefix}legacyNotificationAusBackfillPending`;
 
 export const LANGUAGE = `${prefix}language`;

--- a/app/constants/storage.ts
+++ b/app/constants/storage.ts
@@ -48,6 +48,7 @@ export const LAST_INCOMING_TX_BLOCK_INFO = `${prefix}lastIncomingTxBlockInfo`;
 export const PUSH_NOTIFICATIONS_PROMPT_COUNT = `${prefix}pushNotificationsPromptCount`;
 export const PUSH_NOTIFICATIONS_PROMPT_TIME = `${prefix}pushNotificationsPromptTime`;
 export const BRAZE_PUSH_UNREGISTRATION_PENDING = `${prefix}brazePushUnregistrationPending`;
+export const LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING = `${prefix}legacyNotificationAusBackfillPending`;
 
 export const LANGUAGE = `${prefix}language`;
 

--- a/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.test.ts
+++ b/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.test.ts
@@ -176,9 +176,8 @@ describe('useBrazeIdentity', () => {
 
     renderHook(() => useBrazeIdentity());
 
-    await waitFor(() =>
-      expect(mockRetryPendingBrazePushUnregistration).toHaveBeenCalledTimes(1),
-    );
+    await waitFor(() => expect(mockSetBrazeUser).toHaveBeenCalledTimes(1));
+    expect(mockRetryPendingBrazePushUnregistration).not.toHaveBeenCalled();
     expect(mockRegisterBrazePush).not.toHaveBeenCalled();
   });
 
@@ -228,9 +227,13 @@ describe('useBrazeIdentity', () => {
     expect(mockRefreshBrazeBanners).not.toHaveBeenCalled();
   });
 
-  it('defers identity changes while push unregistration remains pending', async () => {
+  it('identifies the user without registering while launch unregistration remains pending', async () => {
     mockIsSignedIn = true;
     mockCanonicalProfileId = 'canonical-123';
+    mockAreNotificationsEnabled = true;
+    mockIsPushEnabled = true;
+    mockFcmToken = 'fcm-token';
+    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(true);
     mockRetryPendingBrazePushUnregistration.mockResolvedValue(false);
 
     renderHook(() => useBrazeIdentity());
@@ -238,13 +241,14 @@ describe('useBrazeIdentity', () => {
     await waitFor(() =>
       expect(mockRetryPendingBrazePushUnregistration).toHaveBeenCalled(),
     );
-    expect(mockSetBrazeUser).not.toHaveBeenCalled();
+    expect(mockSetBrazeUser).toHaveBeenCalledWith('canonical-123');
     expect(mockRegisterBrazePush).not.toHaveBeenCalled();
   });
 
   it('checks pending unregistration only once per app session', async () => {
     mockIsSignedIn = true;
     mockCanonicalProfileId = 'canonical-123';
+    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(true);
     mockRetryPendingBrazePushUnregistration.mockResolvedValue(false);
     const { rerender } = renderHook(() => useBrazeIdentity());
 
@@ -256,13 +260,14 @@ describe('useBrazeIdentity', () => {
     rerender({});
 
     expect(mockRetryPendingBrazePushUnregistration).toHaveBeenCalledTimes(1);
-    expect(mockSetBrazeUser).not.toHaveBeenCalled();
+    await waitFor(() => expect(mockSetBrazeUser).toHaveBeenCalledTimes(2));
   });
 
-  it('supersedes a failed launch retry when push is re-enabled', async () => {
+  it('registers after an explicit enable clears a failed launch intent', async () => {
     mockIsSignedIn = true;
     mockCanonicalProfileId = 'canonical-123';
     mockFcmToken = 'fcm-token';
+    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(true);
     mockRetryPendingBrazePushUnregistration.mockResolvedValue(false);
     const { rerender } = renderHook(() => useBrazeIdentity());
 
@@ -270,6 +275,7 @@ describe('useBrazeIdentity', () => {
       expect(mockRetryPendingBrazePushUnregistration).toHaveBeenCalledTimes(1),
     );
 
+    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(false);
     mockIsPushEnabled = true;
     rerender({});
 
@@ -281,6 +287,10 @@ describe('useBrazeIdentity', () => {
 
   it('clears deferred Braze data after a launch retry succeeds', async () => {
     mockHasPendingBrazePushUnregistrationSync.mockReturnValue(true);
+    mockRetryPendingBrazePushUnregistration.mockImplementation(async () => {
+      mockHasPendingBrazePushUnregistrationSync.mockReturnValue(false);
+      return true;
+    });
 
     renderHook(() => useBrazeIdentity());
 
@@ -288,5 +298,26 @@ describe('useBrazeIdentity', () => {
     expect(
       mockRetryPendingBrazePushUnregistration.mock.invocationCallOrder[0],
     ).toBeLessThan(mockClearBrazeUser.mock.invocationCallOrder[0]);
+  });
+
+  it('retries a persisted unregistration before registering enabled push', async () => {
+    mockIsSignedIn = true;
+    mockCanonicalProfileId = 'canonical-123';
+    mockIsPushEnabled = true;
+    mockFcmToken = 'fcm-token';
+    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(true);
+    mockRetryPendingBrazePushUnregistration.mockImplementation(async () => {
+      mockHasPendingBrazePushUnregistrationSync.mockReturnValue(false);
+      return true;
+    });
+
+    renderHook(() => useBrazeIdentity());
+
+    await waitFor(() =>
+      expect(mockRegisterBrazePush).toHaveBeenCalledWith('fcm-token'),
+    );
+    expect(
+      mockRetryPendingBrazePushUnregistration.mock.invocationCallOrder[0],
+    ).toBeLessThan(mockRegisterBrazePush.mock.invocationCallOrder[0]);
   });
 });

--- a/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.test.ts
+++ b/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.test.ts
@@ -47,6 +47,7 @@ const mockUseSelector = jest.mocked(useSelector);
 
 let mockIsSignedIn = false;
 let mockCanonicalProfileId: string | undefined;
+let mockAreNotificationsEnabled = true;
 let mockIsPushEnabled = false;
 let mockFcmToken = '';
 
@@ -77,6 +78,10 @@ const createState = (isSignedIn: boolean, canonicalProfileId?: string) =>
               }
             : {}),
         },
+        NotificationServicesController: {
+          ...backgroundState.NotificationServicesController,
+          isNotificationServicesEnabled: mockAreNotificationsEnabled,
+        },
         NotificationServicesPushController: {
           isPushEnabled: mockIsPushEnabled,
           fcmToken: mockFcmToken,
@@ -90,6 +95,7 @@ describe('useBrazeIdentity', () => {
   beforeEach(() => {
     mockIsSignedIn = false;
     mockCanonicalProfileId = undefined;
+    mockAreNotificationsEnabled = true;
     mockIsPushEnabled = false;
     mockFcmToken = '';
     jest.clearAllMocks();
@@ -158,6 +164,21 @@ describe('useBrazeIdentity', () => {
     renderHook(() => useBrazeIdentity());
 
     await waitFor(() => expect(mockSetBrazeUser).toHaveBeenCalledTimes(1));
+    expect(mockRegisterBrazePush).not.toHaveBeenCalled();
+  });
+
+  it('does not register push when master notifications are disabled', async () => {
+    mockIsSignedIn = true;
+    mockCanonicalProfileId = 'canonical-123';
+    mockAreNotificationsEnabled = false;
+    mockIsPushEnabled = true;
+    mockFcmToken = 'fcm-token';
+
+    renderHook(() => useBrazeIdentity());
+
+    await waitFor(() =>
+      expect(mockRetryPendingBrazePushUnregistration).toHaveBeenCalledTimes(1),
+    );
     expect(mockRegisterBrazePush).not.toHaveBeenCalled();
   });
 

--- a/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.ts
+++ b/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.ts
@@ -5,6 +5,7 @@ import {
   selectIsSignedIn,
 } from '../../../../selectors/identity';
 import {
+  selectIsMetamaskNotificationsEnabled,
   selectIsMetaMaskPushNotificationsEnabled,
   selectMetaMaskPushNotificationToken,
 } from '../../../../selectors/notifications';
@@ -34,6 +35,9 @@ import Logger from '../../../../util/Logger';
 export function useBrazeIdentity(): void {
   const isSignedIn = useSelector(selectIsSignedIn);
   const canonicalProfileId = useSelector(selectCanonicalProfileId);
+  const areNotificationsEnabled = useSelector(
+    selectIsMetamaskNotificationsEnabled,
+  );
   const isPushEnabled = useSelector(selectIsMetaMaskPushNotificationsEnabled);
   const fcmToken = useSelector(selectMetaMaskPushNotificationToken);
   const hasBeenSignedInRef = useRef(false);
@@ -49,12 +53,16 @@ export function useBrazeIdentity(): void {
     let cancelled = false;
 
     const syncIdentity = async () => {
-      startupUnregistrationRetryRef.current ??= isPushEnabled
-        ? Promise.resolve(true)
-        : retryPendingBrazePushUnregistration();
+      startupUnregistrationRetryRef.current ??=
+        areNotificationsEnabled && isPushEnabled
+          ? Promise.resolve(true)
+          : retryPendingBrazePushUnregistration();
       const unregistrationComplete =
         await startupUnregistrationRetryRef.current;
-      if (cancelled || (!unregistrationComplete && !isPushEnabled)) {
+      if (
+        cancelled ||
+        (!unregistrationComplete && !(areNotificationsEnabled && isPushEnabled))
+      ) {
         return;
       }
 
@@ -86,12 +94,19 @@ export function useBrazeIdentity(): void {
     return () => {
       cancelled = true;
     };
-  }, [isSignedIn, canonicalProfileId, identifiedProfileId, isPushEnabled]);
+  }, [
+    isSignedIn,
+    canonicalProfileId,
+    identifiedProfileId,
+    areNotificationsEnabled,
+    isPushEnabled,
+  ]);
 
   useEffect(() => {
     if (
       !isSignedIn ||
       identifiedProfileId !== canonicalProfileId ||
+      !areNotificationsEnabled ||
       !isPushEnabled ||
       !fcmToken
     ) {
@@ -108,6 +123,7 @@ export function useBrazeIdentity(): void {
     isSignedIn,
     canonicalProfileId,
     identifiedProfileId,
+    areNotificationsEnabled,
     isPushEnabled,
     fcmToken,
   ]);

--- a/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.ts
+++ b/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.ts
@@ -59,10 +59,19 @@ export function useBrazeIdentity(): void {
           : retryPendingBrazePushUnregistration();
       const unregistrationComplete =
         await startupUnregistrationRetryRef.current;
+      if (cancelled) {
+        Logger.log(
+          '[Braze] Identity effect cancelled before unregistration retry resolved',
+        );
+        return;
+      }
       if (
-        cancelled ||
-        (!unregistrationComplete && !(areNotificationsEnabled && isPushEnabled))
+        !unregistrationComplete &&
+        !(areNotificationsEnabled && isPushEnabled)
       ) {
+        Logger.log(
+          '[Braze] Launch retry incomplete; deferring identity sync until unregistration succeeds',
+        );
         return;
       }
 
@@ -110,6 +119,16 @@ export function useBrazeIdentity(): void {
       !isPushEnabled ||
       !fcmToken
     ) {
+      Logger.log(
+        '[Braze] Push registration skipped',
+        JSON.stringify({
+          isSignedIn,
+          hasIdentifiedProfile: identifiedProfileId === canonicalProfileId,
+          areNotificationsEnabled,
+          isPushEnabled,
+          hasFcmToken: Boolean(fcmToken),
+        }),
+      );
       return;
     }
 

--- a/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.ts
+++ b/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.ts
@@ -54,23 +54,13 @@ export function useBrazeIdentity(): void {
 
     const syncIdentity = async () => {
       startupUnregistrationRetryRef.current ??=
-        areNotificationsEnabled && isPushEnabled
-          ? Promise.resolve(true)
-          : retryPendingBrazePushUnregistration();
-      const unregistrationComplete =
-        await startupUnregistrationRetryRef.current;
+        hadPendingUnregistrationAtLaunchRef.current
+          ? retryPendingBrazePushUnregistration()
+          : Promise.resolve(true);
+      await startupUnregistrationRetryRef.current;
       if (cancelled) {
         Logger.log(
           '[Braze] Identity effect cancelled before unregistration retry resolved',
-        );
-        return;
-      }
-      if (
-        !unregistrationComplete &&
-        !(areNotificationsEnabled && isPushEnabled)
-      ) {
-        Logger.log(
-          '[Braze] Launch retry incomplete; deferring identity sync until unregistration succeeds',
         );
         return;
       }
@@ -103,13 +93,7 @@ export function useBrazeIdentity(): void {
     return () => {
       cancelled = true;
     };
-  }, [
-    isSignedIn,
-    canonicalProfileId,
-    identifiedProfileId,
-    areNotificationsEnabled,
-    isPushEnabled,
-  ]);
+  }, [isSignedIn, canonicalProfileId, identifiedProfileId]);
 
   useEffect(() => {
     if (
@@ -117,7 +101,8 @@ export function useBrazeIdentity(): void {
       identifiedProfileId !== canonicalProfileId ||
       !areNotificationsEnabled ||
       !isPushEnabled ||
-      !fcmToken
+      !fcmToken ||
+      hasPendingBrazePushUnregistrationSync()
     ) {
       Logger.log(
         '[Braze] Push registration skipped',

--- a/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.ts
+++ b/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.ts
@@ -59,9 +59,6 @@ export function useBrazeIdentity(): void {
           : Promise.resolve(true);
       await startupUnregistrationRetryRef.current;
       if (cancelled) {
-        Logger.log(
-          '[Braze] Identity effect cancelled before unregistration retry resolved',
-        );
         return;
       }
 
@@ -104,16 +101,6 @@ export function useBrazeIdentity(): void {
       !fcmToken ||
       hasPendingBrazePushUnregistrationSync()
     ) {
-      Logger.log(
-        '[Braze] Push registration skipped',
-        JSON.stringify({
-          isSignedIn,
-          hasIdentifiedProfile: identifiedProfileId === canonicalProfileId,
-          areNotificationsEnabled,
-          isPushEnabled,
-          hasFcmToken: Boolean(fcmToken),
-        }),
-      );
       return;
     }
 

--- a/app/core/Braze/index.ts
+++ b/app/core/Braze/index.ts
@@ -64,9 +64,6 @@ export async function clearBrazeUser(): Promise<boolean> {
 
   getBrazePlugin().setBrazeProfileId(undefined);
   if (hasPendingBrazePushUnregistrationSync()) {
-    Logger.log(
-      '[Braze] Deferred local SDK data clearing until push unregistration succeeds',
-    );
     return false;
   }
 

--- a/app/core/Braze/pushRegistrationState.test.ts
+++ b/app/core/Braze/pushRegistrationState.test.ts
@@ -1,24 +1,18 @@
 import StorageWrapper from '../../store/storage-wrapper';
 import {
-  clearPendingBrazePushUnregistration,
-  getBrazePushDesiredState,
+  getBrazePushRegistrationState,
   hasPendingBrazePushUnregistrationSync,
   markBrazePushRegistrationDesired,
   markBrazePushUnregistrationPending,
-  resetBrazePushOperationCoordinatorForTests,
-  runLatestBrazePushOperation,
+  markBrazePushUnregistered,
 } from './pushRegistrationState';
-import {
-  BRAZE_PUSH_DESIRED_STATE,
-  BRAZE_PUSH_UNREGISTRATION_PENDING,
-} from '../../constants/storage';
+import { BRAZE_PUSH_REGISTRATION_STATE } from '../../constants/storage';
 
 jest.mock('../../store/storage-wrapper', () => ({
   __esModule: true,
   default: {
     getItemSync: jest.fn(),
     setItem: jest.fn(),
-    removeItem: jest.fn(),
   },
 }));
 
@@ -28,23 +22,23 @@ describe('Braze push registration state', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetAllMocks();
-    resetBrazePushOperationCoordinatorForTests();
   });
 
-  it('persists and clears pending unregistration', async () => {
+  it('persists pending unregistration', async () => {
     await markBrazePushUnregistrationPending();
-    await clearPendingBrazePushUnregistration();
 
     expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
-      BRAZE_PUSH_UNREGISTRATION_PENDING,
-      'true',
+      BRAZE_PUSH_REGISTRATION_STATE,
+      'unregistration-pending',
     );
+  });
+
+  it('persists confirmed unregistration', async () => {
+    await markBrazePushUnregistered();
+
     expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
-      BRAZE_PUSH_DESIRED_STATE,
+      BRAZE_PUSH_REGISTRATION_STATE,
       'unregistered',
-    );
-    expect(mockStorageWrapper.removeItem).toHaveBeenCalledWith(
-      BRAZE_PUSH_UNREGISTRATION_PENDING,
     );
   });
 
@@ -52,98 +46,22 @@ describe('Braze push registration state', () => {
     await markBrazePushRegistrationDesired();
 
     expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
-      BRAZE_PUSH_DESIRED_STATE,
+      BRAZE_PUSH_REGISTRATION_STATE,
       'registered',
     );
-    expect(mockStorageWrapper.removeItem).toHaveBeenCalledWith(
-      BRAZE_PUSH_UNREGISTRATION_PENDING,
-    );
-    expect(getBrazePushDesiredState()).toBe('registered');
   });
 
-  it('reads the persisted desired state after a process restart', () => {
-    mockStorageWrapper.getItemSync.mockImplementation((key) =>
-      key === BRAZE_PUSH_DESIRED_STATE ? 'unregistered' : null,
-    );
+  it('reads the persisted registration state', () => {
+    mockStorageWrapper.getItemSync.mockReturnValue('unregistered');
 
-    expect(getBrazePushDesiredState()).toBe('unregistered');
+    expect(getBrazePushRegistrationState()).toBe('unregistered');
   });
 
-  it('reads pending state synchronously', () => {
-    mockStorageWrapper.getItemSync.mockReturnValue('true');
+  it('reports only unconfirmed unregistration as pending', () => {
+    mockStorageWrapper.getItemSync.mockReturnValue('unregistration-pending');
 
     expect(hasPendingBrazePushUnregistrationSync()).toBe(true);
-  });
-
-  it('runs the latest different intent after an in-flight operation', async () => {
-    let finishFirstOperation: (() => void) | undefined;
-    const calls: string[] = [];
-    const firstOperation = runLatestBrazePushOperation({
-      key: 'unregister',
-      supersededResult: undefined,
-      operation: () =>
-        new Promise<void>((resolve) => {
-          calls.push('unregister-start');
-          finishFirstOperation = () => {
-            calls.push('unregister-finish');
-            resolve();
-          };
-        }),
-    });
-    const secondOperation = runLatestBrazePushOperation({
-      key: 'register:token',
-      supersededResult: undefined,
-      operation: async () => {
-        calls.push('register');
-      },
-    });
-
-    await Promise.resolve();
-    expect(calls).toEqual(['unregister-start']);
-
-    finishFirstOperation?.();
-    await Promise.all([firstOperation, secondOperation]);
-
-    expect(calls).toEqual([
-      'unregister-start',
-      'unregister-finish',
-      'register',
-    ]);
-  });
-
-  it('replaces a pending intent when the active intent becomes latest again', async () => {
-    let finishUnregister: (() => void) | undefined;
-    const registerOperation = jest.fn();
-    const unregisterOperation = jest.fn(
-      () =>
-        new Promise<boolean>((resolve) => {
-          finishUnregister = () => resolve(true);
-        }),
-    );
-
-    const firstUnregister = runLatestBrazePushOperation({
-      key: 'unregister',
-      supersededResult: false,
-      operation: unregisterOperation,
-    });
-    await Promise.resolve();
-    const register = runLatestBrazePushOperation({
-      key: 'register:token',
-      supersededResult: undefined,
-      operation: registerOperation,
-    });
-    const latestUnregister = runLatestBrazePushOperation({
-      key: 'unregister',
-      supersededResult: false,
-      operation: unregisterOperation,
-    });
-
-    await expect(register).resolves.toBeUndefined();
-    finishUnregister?.();
-    await expect(
-      Promise.all([firstUnregister, latestUnregister]),
-    ).resolves.toEqual([true, true]);
-    expect(unregisterOperation).toHaveBeenCalledTimes(1);
-    expect(registerOperation).not.toHaveBeenCalled();
+    mockStorageWrapper.getItemSync.mockReturnValue('unregistered');
+    expect(hasPendingBrazePushUnregistrationSync()).toBe(false);
   });
 });

--- a/app/core/Braze/pushRegistrationState.test.ts
+++ b/app/core/Braze/pushRegistrationState.test.ts
@@ -1,11 +1,17 @@
 import StorageWrapper from '../../store/storage-wrapper';
 import {
   clearPendingBrazePushUnregistration,
+  getBrazePushDesiredState,
   hasPendingBrazePushUnregistrationSync,
+  markBrazePushRegistrationDesired,
   markBrazePushUnregistrationPending,
   resetBrazePushOperationCoordinatorForTests,
   runLatestBrazePushOperation,
 } from './pushRegistrationState';
+import {
+  BRAZE_PUSH_DESIRED_STATE,
+  BRAZE_PUSH_UNREGISTRATION_PENDING,
+} from '../../constants/storage';
 
 jest.mock('../../store/storage-wrapper', () => ({
   __esModule: true,
@@ -30,12 +36,37 @@ describe('Braze push registration state', () => {
     await clearPendingBrazePushUnregistration();
 
     expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
-      expect.any(String),
+      BRAZE_PUSH_UNREGISTRATION_PENDING,
       'true',
     );
-    expect(mockStorageWrapper.removeItem).toHaveBeenCalledWith(
-      expect.any(String),
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_DESIRED_STATE,
+      'unregistered',
     );
+    expect(mockStorageWrapper.removeItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_UNREGISTRATION_PENDING,
+    );
+  });
+
+  it('persists registration as the latest explicit desired state', async () => {
+    await markBrazePushRegistrationDesired();
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_DESIRED_STATE,
+      'registered',
+    );
+    expect(mockStorageWrapper.removeItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_UNREGISTRATION_PENDING,
+    );
+    expect(getBrazePushDesiredState()).toBe('registered');
+  });
+
+  it('reads the persisted desired state after a process restart', () => {
+    mockStorageWrapper.getItemSync.mockImplementation((key) =>
+      key === BRAZE_PUSH_DESIRED_STATE ? 'unregistered' : null,
+    );
+
+    expect(getBrazePushDesiredState()).toBe('unregistered');
   });
 
   it('reads pending state synchronously', () => {

--- a/app/core/Braze/pushRegistrationState.ts
+++ b/app/core/Braze/pushRegistrationState.ts
@@ -1,6 +1,11 @@
-import { BRAZE_PUSH_UNREGISTRATION_PENDING } from '../../constants/storage';
+import {
+  BRAZE_PUSH_DESIRED_STATE,
+  BRAZE_PUSH_UNREGISTRATION_PENDING,
+} from '../../constants/storage';
 import StorageWrapper from '../../store/storage-wrapper';
 import Logger from '../../util/Logger';
+
+export type BrazePushDesiredState = 'registered' | 'unregistered';
 
 export interface BrazePushOperationContext {
   isCurrent: () => boolean;
@@ -22,6 +27,19 @@ interface ActiveOperation {
 let latestOperationKey: string | undefined;
 let activeOperation: ActiveOperation | undefined;
 let pendingOperation: PendingOperation<unknown> | undefined;
+let desiredStateOverride: BrazePushDesiredState | undefined;
+
+const isBrazePushDesiredState = (
+  value: string | null,
+): value is BrazePushDesiredState =>
+  value === 'registered' || value === 'unregistered';
+
+async function persistBrazePushDesiredState(
+  desiredState: BrazePushDesiredState,
+): Promise<void> {
+  desiredStateOverride = desiredState;
+  await StorageWrapper.setItem(BRAZE_PUSH_DESIRED_STATE, desiredState);
+}
 
 function runPendingOperation(): void {
   if (activeOperation || !pendingOperation) {
@@ -109,9 +127,36 @@ export function hasPendingBrazePushUnregistrationSync(): boolean {
   return isPending;
 }
 
+export function getBrazePushDesiredState(): BrazePushDesiredState | undefined {
+  if (desiredStateOverride) {
+    return desiredStateOverride;
+  }
+
+  const storedState = StorageWrapper.getItemSync(BRAZE_PUSH_DESIRED_STATE);
+  return isBrazePushDesiredState(storedState) ? storedState : undefined;
+}
+
+/**
+ * Record a newer explicit registration intent before enabling NaaP push.
+ * Persisting the desired state before clearing stale unregistration work lets
+ * startup reconciliation recover if the app closes between these writes.
+ */
+export async function markBrazePushRegistrationDesired(): Promise<void> {
+  await persistBrazePushDesiredState('registered');
+  await clearPendingBrazePushUnregistration();
+}
+
+export async function ensureBrazePushUnregistrationDesired(): Promise<void> {
+  if (getBrazePushDesiredState() === undefined) {
+    await persistBrazePushDesiredState('unregistered');
+  }
+}
+
 export async function markBrazePushUnregistrationPending(): Promise<void> {
   Logger.log('[Braze] Marking push unregistration pending');
+  desiredStateOverride = 'unregistered';
   await StorageWrapper.setItem(BRAZE_PUSH_UNREGISTRATION_PENDING, 'true');
+  await persistBrazePushDesiredState('unregistered');
 }
 
 export async function clearPendingBrazePushUnregistration(): Promise<void> {
@@ -124,4 +169,5 @@ export function resetBrazePushOperationCoordinatorForTests(): void {
   latestOperationKey = undefined;
   activeOperation = undefined;
   pendingOperation = undefined;
+  desiredStateOverride = undefined;
 }

--- a/app/core/Braze/pushRegistrationState.ts
+++ b/app/core/Braze/pushRegistrationState.ts
@@ -3,7 +3,6 @@ import {
   BRAZE_PUSH_UNREGISTRATION_PENDING,
 } from '../../constants/storage';
 import StorageWrapper from '../../store/storage-wrapper';
-import Logger from '../../util/Logger';
 
 export type BrazePushDesiredState = 'registered' | 'unregistered';
 
@@ -109,10 +108,6 @@ export function runLatestBrazePushOperation<T>({
 
   if (pendingOperation) {
     pendingOperation.resolve(pendingOperation.supersededResult);
-    Logger.log(
-      '[Braze] Dropping pending operation in favor of newer request',
-      pendingOperation.key,
-    );
   }
   pendingOperation = nextOperation as PendingOperation<unknown>;
   runPendingOperation();
@@ -153,14 +148,12 @@ export async function ensureBrazePushUnregistrationDesired(): Promise<void> {
 }
 
 export async function markBrazePushUnregistrationPending(): Promise<void> {
-  Logger.log('[Braze] Marking push unregistration pending');
   desiredStateOverride = 'unregistered';
   await StorageWrapper.setItem(BRAZE_PUSH_UNREGISTRATION_PENDING, 'true');
   await persistBrazePushDesiredState('unregistered');
 }
 
 export async function clearPendingBrazePushUnregistration(): Promise<void> {
-  Logger.log('[Braze] Clearing push unregistration pending marker');
   await StorageWrapper.removeItem(BRAZE_PUSH_UNREGISTRATION_PENDING);
 }
 

--- a/app/core/Braze/pushRegistrationState.ts
+++ b/app/core/Braze/pushRegistrationState.ts
@@ -1,5 +1,6 @@
 import { BRAZE_PUSH_UNREGISTRATION_PENDING } from '../../constants/storage';
 import StorageWrapper from '../../store/storage-wrapper';
+import Logger from '../../util/Logger';
 
 export interface BrazePushOperationContext {
   isCurrent: () => boolean;
@@ -90,6 +91,10 @@ export function runLatestBrazePushOperation<T>({
 
   if (pendingOperation) {
     pendingOperation.resolve(pendingOperation.supersededResult);
+    Logger.log(
+      '[Braze] Dropping pending operation in favor of newer request',
+      pendingOperation.key,
+    );
   }
   pendingOperation = nextOperation as PendingOperation<unknown>;
   runPendingOperation();
@@ -98,14 +103,19 @@ export function runLatestBrazePushOperation<T>({
 }
 
 export function hasPendingBrazePushUnregistrationSync(): boolean {
-  return Boolean(StorageWrapper.getItemSync(BRAZE_PUSH_UNREGISTRATION_PENDING));
+  const isPending = Boolean(
+    StorageWrapper.getItemSync(BRAZE_PUSH_UNREGISTRATION_PENDING),
+  );
+  return isPending;
 }
 
 export async function markBrazePushUnregistrationPending(): Promise<void> {
+  Logger.log('[Braze] Marking push unregistration pending');
   await StorageWrapper.setItem(BRAZE_PUSH_UNREGISTRATION_PENDING, 'true');
 }
 
 export async function clearPendingBrazePushUnregistration(): Promise<void> {
+  Logger.log('[Braze] Clearing push unregistration pending marker');
   await StorageWrapper.removeItem(BRAZE_PUSH_UNREGISTRATION_PENDING);
 }
 

--- a/app/core/Braze/pushRegistrationState.ts
+++ b/app/core/Braze/pushRegistrationState.ts
@@ -1,166 +1,46 @@
-import {
-  BRAZE_PUSH_DESIRED_STATE,
-  BRAZE_PUSH_UNREGISTRATION_PENDING,
-} from '../../constants/storage';
+import { BRAZE_PUSH_REGISTRATION_STATE } from '../../constants/storage';
 import StorageWrapper from '../../store/storage-wrapper';
 
-export type BrazePushDesiredState = 'registered' | 'unregistered';
+type BrazePushRegistrationState =
+  | 'registered'
+  | 'unregistered'
+  | 'unregistration-pending';
 
-export interface BrazePushOperationContext {
-  isCurrent: () => boolean;
-}
-
-interface PendingOperation<T> {
-  key: string;
-  operation: (context: BrazePushOperationContext) => Promise<T>;
-  resolve: (result: T) => void;
-  reject: (error: unknown) => void;
-  supersededResult: T;
-}
-
-interface ActiveOperation {
-  key: string;
-  promise: Promise<unknown>;
-}
-
-let latestOperationKey: string | undefined;
-let activeOperation: ActiveOperation | undefined;
-let pendingOperation: PendingOperation<unknown> | undefined;
-let desiredStateOverride: BrazePushDesiredState | undefined;
-
-const isBrazePushDesiredState = (
+const isBrazePushRegistrationState = (
   value: string | null,
-): value is BrazePushDesiredState =>
-  value === 'registered' || value === 'unregistered';
+): value is BrazePushRegistrationState =>
+  value === 'registered' ||
+  value === 'unregistered' ||
+  value === 'unregistration-pending';
 
-async function persistBrazePushDesiredState(
-  desiredState: BrazePushDesiredState,
+async function persistBrazePushRegistrationState(
+  state: BrazePushRegistrationState,
 ): Promise<void> {
-  desiredStateOverride = desiredState;
-  await StorageWrapper.setItem(BRAZE_PUSH_DESIRED_STATE, desiredState);
+  await StorageWrapper.setItem(BRAZE_PUSH_REGISTRATION_STATE, state);
 }
 
-function runPendingOperation(): void {
-  if (activeOperation || !pendingOperation) {
-    return;
-  }
-
-  const operation = pendingOperation;
-  pendingOperation = undefined;
-  const promise = Promise.resolve().then(() =>
-    operation.operation({
-      isCurrent: () => latestOperationKey === operation.key,
-    }),
-  );
-  activeOperation = { key: operation.key, promise };
-
-  promise.then(operation.resolve, operation.reject).finally(() => {
-    if (activeOperation?.promise === promise) {
-      activeOperation = undefined;
-    }
-    runPendingOperation();
-  });
-}
-
-/**
- * Run at most one Braze push operation at a time while retaining only the
- * latest requested state. An in-flight native call is allowed to finish, then
- * the latest different state is applied.
- *
- * Calls requesting the active state share its result. A pending operation that
- * is replaced resolves with its own `supersededResult`.
- *
- * @param options - Operation identity, implementation, and superseded result.
- * @returns The result of applying or superseding this request.
- */
-export function runLatestBrazePushOperation<T>({
-  key,
-  operation,
-  supersededResult,
-}: {
-  key: string;
-  operation: (context: BrazePushOperationContext) => Promise<T>;
-  supersededResult: T;
-}): Promise<T> {
-  latestOperationKey = key;
-
-  if (activeOperation?.key === key) {
-    if (pendingOperation) {
-      pendingOperation.resolve(pendingOperation.supersededResult);
-      pendingOperation = undefined;
-    }
-    return activeOperation.promise as Promise<T>;
-  }
-
-  let resolveOperation: (result: T) => void = () => undefined;
-  let rejectOperation: (error: unknown) => void = () => undefined;
-  const promise = new Promise<T>((resolve, reject) => {
-    resolveOperation = resolve;
-    rejectOperation = reject;
-  });
-  const nextOperation: PendingOperation<T> = {
-    key,
-    operation,
-    resolve: resolveOperation,
-    reject: rejectOperation,
-    supersededResult,
-  };
-
-  if (pendingOperation) {
-    pendingOperation.resolve(pendingOperation.supersededResult);
-  }
-  pendingOperation = nextOperation as PendingOperation<unknown>;
-  runPendingOperation();
-
-  return promise;
+export function getBrazePushRegistrationState():
+  | BrazePushRegistrationState
+  | undefined {
+  const storedState = StorageWrapper.getItemSync(BRAZE_PUSH_REGISTRATION_STATE);
+  return isBrazePushRegistrationState(storedState) ? storedState : undefined;
 }
 
 export function hasPendingBrazePushUnregistrationSync(): boolean {
-  const isPending = Boolean(
-    StorageWrapper.getItemSync(BRAZE_PUSH_UNREGISTRATION_PENDING),
-  );
-  return isPending;
-}
-
-export function getBrazePushDesiredState(): BrazePushDesiredState | undefined {
-  if (desiredStateOverride) {
-    return desiredStateOverride;
-  }
-
-  const storedState = StorageWrapper.getItemSync(BRAZE_PUSH_DESIRED_STATE);
-  return isBrazePushDesiredState(storedState) ? storedState : undefined;
+  return getBrazePushRegistrationState() === 'unregistration-pending';
 }
 
 /**
  * Record a newer explicit registration intent before enabling NaaP push.
- * Persisting the desired state before clearing stale unregistration work lets
- * startup reconciliation recover if the app closes between these writes.
  */
 export async function markBrazePushRegistrationDesired(): Promise<void> {
-  await persistBrazePushDesiredState('registered');
-  await clearPendingBrazePushUnregistration();
-}
-
-export async function ensureBrazePushUnregistrationDesired(): Promise<void> {
-  if (getBrazePushDesiredState() === undefined) {
-    await persistBrazePushDesiredState('unregistered');
-  }
+  await persistBrazePushRegistrationState('registered');
 }
 
 export async function markBrazePushUnregistrationPending(): Promise<void> {
-  desiredStateOverride = 'unregistered';
-  await StorageWrapper.setItem(BRAZE_PUSH_UNREGISTRATION_PENDING, 'true');
-  await persistBrazePushDesiredState('unregistered');
+  await persistBrazePushRegistrationState('unregistration-pending');
 }
 
-export async function clearPendingBrazePushUnregistration(): Promise<void> {
-  await StorageWrapper.removeItem(BRAZE_PUSH_UNREGISTRATION_PENDING);
-}
-
-export function resetBrazePushOperationCoordinatorForTests(): void {
-  pendingOperation?.resolve(pendingOperation.supersededResult);
-  latestOperationKey = undefined;
-  activeOperation = undefined;
-  pendingOperation = undefined;
-  desiredStateOverride = undefined;
+export async function markBrazePushUnregistered(): Promise<void> {
+  await persistBrazePushRegistrationState('unregistered');
 }

--- a/app/core/Braze/registerPush.test.ts
+++ b/app/core/Braze/registerPush.test.ts
@@ -58,9 +58,6 @@ describe('registerBrazePush', () => {
     await registerBrazePush('fcm-token');
 
     expect(mockRegisterPush).toHaveBeenCalledWith('fcm-token');
-    expect(Logger.log).toHaveBeenCalledWith(
-      '[Braze] Registered this device for Braze push',
-    );
   });
 
   it('does not pass the FCM token to iOS', async () => {

--- a/app/core/Braze/registerPush.test.ts
+++ b/app/core/Braze/registerPush.test.ts
@@ -14,10 +14,12 @@ jest.mock('../../util/Logger', () => ({
   },
 }));
 
-const mockClearPendingBrazePushUnregistration = jest.fn();
+const mockGetBrazePushDesiredState = jest.fn();
+const mockHasPendingBrazePushUnregistrationSync = jest.fn();
 jest.mock('./pushRegistrationState', () => ({
-  clearPendingBrazePushUnregistration: () =>
-    mockClearPendingBrazePushUnregistration(),
+  getBrazePushDesiredState: () => mockGetBrazePushDesiredState(),
+  hasPendingBrazePushUnregistrationSync: () =>
+    mockHasPendingBrazePushUnregistrationSync(),
   runLatestBrazePushOperation: ({
     operation,
   }: {
@@ -35,7 +37,8 @@ describe('registerBrazePush', () => {
     NativeModules.BrazePushModule = {
       registerPush: mockRegisterPush,
     };
-    mockClearPendingBrazePushUnregistration.mockResolvedValue(undefined);
+    mockGetBrazePushDesiredState.mockReturnValue('registered');
+    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(false);
     mockRegisterPush.mockResolvedValue(undefined);
   });
 
@@ -55,7 +58,6 @@ describe('registerBrazePush', () => {
     await registerBrazePush('fcm-token');
 
     expect(mockRegisterPush).toHaveBeenCalledWith('fcm-token');
-    expect(mockClearPendingBrazePushUnregistration).toHaveBeenCalledTimes(1);
     expect(Logger.log).toHaveBeenCalledWith(
       '[Braze] Registered this device for Braze push',
     );
@@ -95,5 +97,21 @@ describe('registerBrazePush', () => {
       nativeError,
       '[Braze] Failed to register push',
     );
+  });
+
+  it('does not register while unregistration remains pending', async () => {
+    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(true);
+
+    await registerBrazePush('fcm-token');
+
+    expect(mockRegisterPush).not.toHaveBeenCalled();
+  });
+
+  it('does not register when unregistration is the latest desired state', async () => {
+    mockGetBrazePushDesiredState.mockReturnValue('unregistered');
+
+    await registerBrazePush('fcm-token');
+
+    expect(mockRegisterPush).not.toHaveBeenCalled();
   });
 });

--- a/app/core/Braze/registerPush.test.ts
+++ b/app/core/Braze/registerPush.test.ts
@@ -14,17 +14,9 @@ jest.mock('../../util/Logger', () => ({
   },
 }));
 
-const mockGetBrazePushDesiredState = jest.fn();
-const mockHasPendingBrazePushUnregistrationSync = jest.fn();
+const mockGetBrazePushRegistrationState = jest.fn();
 jest.mock('./pushRegistrationState', () => ({
-  getBrazePushDesiredState: () => mockGetBrazePushDesiredState(),
-  hasPendingBrazePushUnregistrationSync: () =>
-    mockHasPendingBrazePushUnregistrationSync(),
-  runLatestBrazePushOperation: ({
-    operation,
-  }: {
-    operation: () => Promise<unknown>;
-  }) => operation(),
+  getBrazePushRegistrationState: () => mockGetBrazePushRegistrationState(),
 }));
 
 const mockRegisterPush = jest.fn();
@@ -37,8 +29,7 @@ describe('registerBrazePush', () => {
     NativeModules.BrazePushModule = {
       registerPush: mockRegisterPush,
     };
-    mockGetBrazePushDesiredState.mockReturnValue('registered');
-    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(false);
+    mockGetBrazePushRegistrationState.mockReturnValue('registered');
     mockRegisterPush.mockResolvedValue(undefined);
   });
 
@@ -97,7 +88,7 @@ describe('registerBrazePush', () => {
   });
 
   it('does not register while unregistration remains pending', async () => {
-    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(true);
+    mockGetBrazePushRegistrationState.mockReturnValue('unregistration-pending');
 
     await registerBrazePush('fcm-token');
 
@@ -105,7 +96,7 @@ describe('registerBrazePush', () => {
   });
 
   it('does not register when unregistration is the latest desired state', async () => {
-    mockGetBrazePushDesiredState.mockReturnValue('unregistered');
+    mockGetBrazePushRegistrationState.mockReturnValue('unregistered');
 
     await registerBrazePush('fcm-token');
 

--- a/app/core/Braze/registerPush.ts
+++ b/app/core/Braze/registerPush.ts
@@ -1,11 +1,7 @@
 import { NativeModules, Platform } from 'react-native';
 import Logger from '../../util/Logger';
 import { hasTestOverrides } from '../../util/test/utils';
-import {
-  getBrazePushDesiredState,
-  hasPendingBrazePushUnregistrationSync,
-  runLatestBrazePushOperation,
-} from './pushRegistrationState';
+import { getBrazePushRegistrationState } from './pushRegistrationState';
 
 interface BrazePushNativeModule {
   registerPush: (fcmToken?: string) => Promise<void>;
@@ -36,9 +32,10 @@ export async function registerBrazePush(fcmToken: string): Promise<void> {
     return;
   }
 
+  const registrationState = getBrazePushRegistrationState();
   if (
-    hasPendingBrazePushUnregistrationSync() ||
-    getBrazePushDesiredState() === 'unregistered'
+    registrationState === 'unregistration-pending' ||
+    registrationState === 'unregistered'
   ) {
     return;
   }
@@ -51,25 +48,13 @@ export async function registerBrazePush(fcmToken: string): Promise<void> {
   }
 
   try {
-    await runLatestBrazePushOperation({
-      key: `register:${Platform.OS}:${Platform.OS === 'android' ? fcmToken : ''}`,
-      supersededResult: undefined,
-      operation: async () => {
-        if (
-          hasPendingBrazePushUnregistrationSync() ||
-          getBrazePushDesiredState() === 'unregistered'
-        ) {
-          return;
-        }
-        if (Platform.OS === 'ios') {
-          await brazePushModule.registerPush();
-        } else if (Platform.OS === 'android') {
-          await brazePushModule.registerPush(fcmToken);
-        } else {
-          throw new Error(`Unsupported Braze push platform: ${Platform.OS}`);
-        }
-      },
-    });
+    if (Platform.OS === 'ios') {
+      await brazePushModule.registerPush();
+    } else if (Platform.OS === 'android') {
+      await brazePushModule.registerPush(fcmToken);
+    } else {
+      throw new Error(`Unsupported Braze push platform: ${Platform.OS}`);
+    }
   } catch (nativeError) {
     const error = toError(nativeError);
     Logger.error(error, '[Braze] Failed to register push');

--- a/app/core/Braze/registerPush.ts
+++ b/app/core/Braze/registerPush.ts
@@ -2,7 +2,8 @@ import { NativeModules, Platform } from 'react-native';
 import Logger from '../../util/Logger';
 import { hasTestOverrides } from '../../util/test/utils';
 import {
-  clearPendingBrazePushUnregistration,
+  getBrazePushDesiredState,
+  hasPendingBrazePushUnregistrationSync,
   runLatestBrazePushOperation,
 } from './pushRegistrationState';
 
@@ -35,6 +36,16 @@ export async function registerBrazePush(fcmToken: string): Promise<void> {
     return;
   }
 
+  if (
+    hasPendingBrazePushUnregistrationSync() ||
+    getBrazePushDesiredState() === 'unregistered'
+  ) {
+    Logger.log(
+      '[Braze] Push registration skipped because unregistration is desired',
+    );
+    return;
+  }
+
   const brazePushModule = nativeModules.BrazePushModule;
   if (!brazePushModule) {
     const error = new Error('BrazePushModule is not available');
@@ -47,10 +58,15 @@ export async function registerBrazePush(fcmToken: string): Promise<void> {
       key: `register:${Platform.OS}:${Platform.OS === 'android' ? fcmToken : ''}`,
       supersededResult: undefined,
       operation: async () => {
-        Logger.log(
-          '[Braze] Register operation clearing any pending unregistration marker',
-        );
-        await clearPendingBrazePushUnregistration();
+        if (
+          hasPendingBrazePushUnregistrationSync() ||
+          getBrazePushDesiredState() === 'unregistered'
+        ) {
+          Logger.log(
+            '[Braze] Superseded push registration skipped before native call',
+          );
+          return;
+        }
         if (Platform.OS === 'ios') {
           await brazePushModule.registerPush();
         } else if (Platform.OS === 'android') {

--- a/app/core/Braze/registerPush.ts
+++ b/app/core/Braze/registerPush.ts
@@ -40,9 +40,6 @@ export async function registerBrazePush(fcmToken: string): Promise<void> {
     hasPendingBrazePushUnregistrationSync() ||
     getBrazePushDesiredState() === 'unregistered'
   ) {
-    Logger.log(
-      '[Braze] Push registration skipped because unregistration is desired',
-    );
     return;
   }
 
@@ -62,9 +59,6 @@ export async function registerBrazePush(fcmToken: string): Promise<void> {
           hasPendingBrazePushUnregistrationSync() ||
           getBrazePushDesiredState() === 'unregistered'
         ) {
-          Logger.log(
-            '[Braze] Superseded push registration skipped before native call',
-          );
           return;
         }
         if (Platform.OS === 'ios') {
@@ -76,7 +70,6 @@ export async function registerBrazePush(fcmToken: string): Promise<void> {
         }
       },
     });
-    Logger.log('[Braze] Registered this device for Braze push');
   } catch (nativeError) {
     const error = toError(nativeError);
     Logger.error(error, '[Braze] Failed to register push');

--- a/app/core/Braze/registerPush.ts
+++ b/app/core/Braze/registerPush.ts
@@ -47,6 +47,9 @@ export async function registerBrazePush(fcmToken: string): Promise<void> {
       key: `register:${Platform.OS}:${Platform.OS === 'android' ? fcmToken : ''}`,
       supersededResult: undefined,
       operation: async () => {
+        Logger.log(
+          '[Braze] Register operation clearing any pending unregistration marker',
+        );
         await clearPendingBrazePushUnregistration();
         if (Platform.OS === 'ios') {
           await brazePushModule.registerPush();

--- a/app/core/Braze/unregisterPush.test.ts
+++ b/app/core/Braze/unregisterPush.test.ts
@@ -1,5 +1,4 @@
 import { NativeModules } from 'react-native';
-import Logger from '../../util/Logger';
 import StorageWrapper from '../../store/storage-wrapper';
 import {
   retryPendingBrazePushUnregistration,
@@ -80,9 +79,6 @@ describe('unregisterBrazePush', () => {
     expect(mockStorageWrapper.removeItem).toHaveBeenCalledTimes(1);
     expect(pendingValue).toBeNull();
     expect(desiredValue).toBe('unregistered');
-    expect(Logger.log).toHaveBeenCalledWith(
-      '[Braze] Unregistered this device from Braze push',
-    );
   });
 
   it('keeps the intent pending after a retriable failure', async () => {

--- a/app/core/Braze/unregisterPush.test.ts
+++ b/app/core/Braze/unregisterPush.test.ts
@@ -4,11 +4,7 @@ import {
   retryPendingBrazePushUnregistration,
   unregisterBrazePush,
 } from './unregisterPush';
-import { resetBrazePushOperationCoordinatorForTests } from './pushRegistrationState';
-import {
-  BRAZE_PUSH_DESIRED_STATE,
-  BRAZE_PUSH_UNREGISTRATION_PENDING,
-} from '../../constants/storage';
+import { BRAZE_PUSH_REGISTRATION_STATE } from '../../constants/storage';
 
 jest.mock('../../util/test/utils', () => ({
   hasTestOverrides: false,
@@ -27,42 +23,29 @@ jest.mock('../../store/storage-wrapper', () => ({
   default: {
     getItemSync: jest.fn(),
     setItem: jest.fn(),
-    removeItem: jest.fn(),
   },
 }));
 
 const mockUnregisterPush = jest.fn();
 const mockStorageWrapper = jest.mocked(StorageWrapper);
-let pendingValue: string | null;
-let desiredValue: string | null;
+let registrationState: string | null;
 
 describe('unregisterBrazePush', () => {
   beforeEach(() => {
     jest.useRealTimers();
     jest.clearAllMocks();
     jest.resetAllMocks();
-    pendingValue = null;
-    desiredValue = null;
-    resetBrazePushOperationCoordinatorForTests();
+    registrationState = null;
     mockStorageWrapper.getItemSync.mockImplementation((key) => {
-      if (key === BRAZE_PUSH_UNREGISTRATION_PENDING) {
-        return pendingValue;
-      }
-      if (key === BRAZE_PUSH_DESIRED_STATE) {
-        return desiredValue;
+      if (key === BRAZE_PUSH_REGISTRATION_STATE) {
+        return registrationState;
       }
       return null;
     });
     mockStorageWrapper.setItem.mockImplementation(async (key, value) => {
-      if (key === BRAZE_PUSH_UNREGISTRATION_PENDING) {
-        pendingValue = value;
+      if (key === BRAZE_PUSH_REGISTRATION_STATE) {
+        registrationState = value;
       }
-      if (key === BRAZE_PUSH_DESIRED_STATE) {
-        desiredValue = value;
-      }
-    });
-    mockStorageWrapper.removeItem.mockImplementation(async () => {
-      pendingValue = null;
     });
     NativeModules.BrazePushModule = {
       unregisterPush: mockUnregisterPush,
@@ -76,71 +59,41 @@ describe('unregisterBrazePush', () => {
 
     expect(mockUnregisterPush).toHaveBeenCalledTimes(1);
     expect(mockStorageWrapper.setItem).toHaveBeenCalledTimes(2);
-    expect(mockStorageWrapper.removeItem).toHaveBeenCalledTimes(1);
-    expect(pendingValue).toBeNull();
-    expect(desiredValue).toBe('unregistered');
+    expect(registrationState).toBe('unregistered');
   });
 
-  it('keeps the intent pending after a retriable failure', async () => {
+  it('keeps the intent pending after a native failure', async () => {
     mockUnregisterPush.mockResolvedValue({
       success: false,
-      message: 'Rate limited',
-      isRetriable: true,
+      message: 'Request failed',
     });
 
     await expect(unregisterBrazePush()).resolves.toBe(false);
 
     expect(mockUnregisterPush).toHaveBeenCalledTimes(1);
-    expect(pendingValue).not.toBeNull();
+    expect(registrationState).toBe('unregistration-pending');
   });
 
-  it('retains a persisted intent after a permanent retry failure', async () => {
-    pendingValue = 'true';
+  it('retains a persisted intent after a retry failure', async () => {
+    registrationState = 'unregistration-pending';
     mockUnregisterPush.mockResolvedValue({
       success: false,
-      message: 'Unauthorized',
-      isRetriable: false,
-      httpStatusCode: 401,
+      message: 'Request failed',
     });
 
     await expect(retryPendingBrazePushUnregistration()).resolves.toBe(false);
 
-    expect(pendingValue).not.toBeNull();
+    expect(registrationState).toBe('unregistration-pending');
   });
 
   it('retries a persisted intent and clears it on success', async () => {
-    pendingValue = 'true';
+    registrationState = 'unregistration-pending';
     mockUnregisterPush.mockResolvedValue({ success: true });
 
     await expect(retryPendingBrazePushUnregistration()).resolves.toBe(true);
 
     expect(mockUnregisterPush).toHaveBeenCalledTimes(1);
-    expect(pendingValue).toBeNull();
-  });
-
-  it('preserves a newer registration intent while finishing a stale unregister', async () => {
-    pendingValue = 'true';
-    desiredValue = 'registered';
-    mockUnregisterPush.mockResolvedValue({ success: true });
-
-    await expect(retryPendingBrazePushUnregistration()).resolves.toBe(true);
-
-    expect(desiredValue).toBe('registered');
-    expect(pendingValue).toBeNull();
-  });
-
-  it('keeps the intent pending after a permanent native failure', async () => {
-    mockUnregisterPush.mockResolvedValue({
-      success: false,
-      message: 'Unauthorized',
-      isRetriable: false,
-      httpStatusCode: 401,
-    });
-
-    await expect(unregisterBrazePush()).resolves.toBe(false);
-
-    expect(pendingValue).toBe('true');
-    expect(desiredValue).toBe('unregistered');
+    expect(registrationState).toBe('unregistered');
   });
 
   it('keeps the intent pending when the native module is missing', async () => {
@@ -148,6 +101,6 @@ describe('unregisterBrazePush', () => {
 
     await expect(unregisterBrazePush()).resolves.toBe(false);
 
-    expect(pendingValue).toBe('true');
+    expect(registrationState).toBe('unregistration-pending');
   });
 });

--- a/app/core/Braze/unregisterPush.test.ts
+++ b/app/core/Braze/unregisterPush.test.ts
@@ -2,11 +2,14 @@ import { NativeModules } from 'react-native';
 import Logger from '../../util/Logger';
 import StorageWrapper from '../../store/storage-wrapper';
 import {
-  BrazePushUnregistrationError,
   retryPendingBrazePushUnregistration,
   unregisterBrazePush,
 } from './unregisterPush';
 import { resetBrazePushOperationCoordinatorForTests } from './pushRegistrationState';
+import {
+  BRAZE_PUSH_DESIRED_STATE,
+  BRAZE_PUSH_UNREGISTRATION_PENDING,
+} from '../../constants/storage';
 
 jest.mock('../../util/test/utils', () => ({
   hasTestOverrides: false,
@@ -32,6 +35,7 @@ jest.mock('../../store/storage-wrapper', () => ({
 const mockUnregisterPush = jest.fn();
 const mockStorageWrapper = jest.mocked(StorageWrapper);
 let pendingValue: string | null;
+let desiredValue: string | null;
 
 describe('unregisterBrazePush', () => {
   beforeEach(() => {
@@ -39,10 +43,24 @@ describe('unregisterBrazePush', () => {
     jest.clearAllMocks();
     jest.resetAllMocks();
     pendingValue = null;
+    desiredValue = null;
     resetBrazePushOperationCoordinatorForTests();
-    mockStorageWrapper.getItemSync.mockImplementation(() => pendingValue);
-    mockStorageWrapper.setItem.mockImplementation(async (_key, value) => {
-      pendingValue = value;
+    mockStorageWrapper.getItemSync.mockImplementation((key) => {
+      if (key === BRAZE_PUSH_UNREGISTRATION_PENDING) {
+        return pendingValue;
+      }
+      if (key === BRAZE_PUSH_DESIRED_STATE) {
+        return desiredValue;
+      }
+      return null;
+    });
+    mockStorageWrapper.setItem.mockImplementation(async (key, value) => {
+      if (key === BRAZE_PUSH_UNREGISTRATION_PENDING) {
+        pendingValue = value;
+      }
+      if (key === BRAZE_PUSH_DESIRED_STATE) {
+        desiredValue = value;
+      }
     });
     mockStorageWrapper.removeItem.mockImplementation(async () => {
       pendingValue = null;
@@ -58,9 +76,10 @@ describe('unregisterBrazePush', () => {
     await expect(unregisterBrazePush()).resolves.toBe(true);
 
     expect(mockUnregisterPush).toHaveBeenCalledTimes(1);
-    expect(mockStorageWrapper.setItem).toHaveBeenCalledTimes(1);
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledTimes(2);
     expect(mockStorageWrapper.removeItem).toHaveBeenCalledTimes(1);
     expect(pendingValue).toBeNull();
+    expect(desiredValue).toBe('unregistered');
     expect(Logger.log).toHaveBeenCalledWith(
       '[Braze] Unregistered this device from Braze push',
     );
@@ -103,7 +122,18 @@ describe('unregisterBrazePush', () => {
     expect(pendingValue).toBeNull();
   });
 
-  it('throws a permanent native failure and removes the uncommitted intent', async () => {
+  it('preserves a newer registration intent while finishing a stale unregister', async () => {
+    pendingValue = 'true';
+    desiredValue = 'registered';
+    mockUnregisterPush.mockResolvedValue({ success: true });
+
+    await expect(retryPendingBrazePushUnregistration()).resolves.toBe(true);
+
+    expect(desiredValue).toBe('registered');
+    expect(pendingValue).toBeNull();
+  });
+
+  it('keeps the intent pending after a permanent native failure', async () => {
     mockUnregisterPush.mockResolvedValue({
       success: false,
       message: 'Unauthorized',
@@ -111,26 +141,17 @@ describe('unregisterBrazePush', () => {
       httpStatusCode: 401,
     });
 
-    const error = await unregisterBrazePush().catch(
-      (caughtError: unknown) => caughtError,
-    );
+    await expect(unregisterBrazePush()).resolves.toBe(false);
 
-    expect(error).toBeInstanceOf(BrazePushUnregistrationError);
-    expect(error).toMatchObject({
-      message: 'Unauthorized',
-      isRetriable: false,
-      httpStatusCode: 401,
-    });
-    expect(pendingValue).toBeNull();
+    expect(pendingValue).toBe('true');
+    expect(desiredValue).toBe('unregistered');
   });
 
-  it('throws when the native module is missing', async () => {
+  it('keeps the intent pending when the native module is missing', async () => {
     delete NativeModules.BrazePushModule;
 
-    await expect(unregisterBrazePush()).rejects.toThrow(
-      'BrazePushModule is not available',
-    );
+    await expect(unregisterBrazePush()).resolves.toBe(false);
 
-    expect(pendingValue).toBeNull();
+    expect(pendingValue).toBe('true');
   });
 });

--- a/app/core/Braze/unregisterPush.ts
+++ b/app/core/Braze/unregisterPush.ts
@@ -2,12 +2,9 @@ import { NativeModules } from 'react-native';
 import Logger from '../../util/Logger';
 import { hasTestOverrides } from '../../util/test/utils';
 import {
-  type BrazePushOperationContext,
-  clearPendingBrazePushUnregistration,
-  ensureBrazePushUnregistrationDesired,
   hasPendingBrazePushUnregistrationSync,
   markBrazePushUnregistrationPending,
-  runLatestBrazePushOperation,
+  markBrazePushUnregistered,
 } from './pushRegistrationState';
 
 interface BrazePushNativeModule {
@@ -17,36 +14,11 @@ interface BrazePushNativeModule {
 interface BrazePushUnregistrationResult {
   success: boolean;
   message?: string;
-  isRetriable?: boolean;
-  httpStatusCode?: number;
 }
 
 const nativeModules = NativeModules as {
   BrazePushModule?: BrazePushNativeModule;
 };
-
-const UNREGISTER_OPERATION_KEY = 'unregister';
-
-export class BrazePushUnregistrationError extends Error {
-  readonly isRetriable: boolean;
-
-  readonly httpStatusCode?: number;
-
-  constructor({
-    message,
-    isRetriable,
-    httpStatusCode,
-  }: {
-    message: string;
-    isRetriable: boolean;
-    httpStatusCode?: number;
-  }) {
-    super(message);
-    this.name = 'BrazePushUnregistrationError';
-    this.isRetriable = isRetriable;
-    this.httpStatusCode = httpStatusCode;
-  }
-}
 
 const toError = (error: unknown): Error =>
   error instanceof Error
@@ -66,46 +38,21 @@ async function unregisterOnce(): Promise<void> {
     return;
   }
 
-  throw new BrazePushUnregistrationError({
-    message: result.message ?? 'Failed to unregister Braze push',
-    isRetriable: result.isRetriable === true,
-    ...(result.httpStatusCode === undefined
-      ? {}
-      : { httpStatusCode: result.httpStatusCode }),
-  });
+  throw new Error(result.message ?? 'Failed to unregister Braze push');
 }
 
-async function attemptPendingUnregistration({
-  context,
-}: {
-  context: BrazePushOperationContext;
-}): Promise<boolean> {
+async function attemptPendingUnregistration(): Promise<boolean> {
   if (!hasPendingBrazePushUnregistrationSync()) {
     return true;
-  }
-  if (!context.isCurrent()) {
-    return false;
   }
 
   try {
     await unregisterOnce();
-    await clearPendingBrazePushUnregistration();
+    await markBrazePushUnregistered();
     return true;
   } catch (nativeError) {
     const error = toError(nativeError);
-    const isRetriable =
-      error instanceof BrazePushUnregistrationError && error.isRetriable;
-
-    if (!context.isCurrent()) {
-      return false;
-    }
-    if (!isRetriable) {
-      Logger.error(
-        error,
-        '[Braze] Push unregistration reported a non-retriable failure',
-      );
-    }
-
+    Logger.error(error, '[Braze] Push unregistration remains pending');
     return false;
   }
 }
@@ -125,14 +72,8 @@ export async function unregisterBrazePush(): Promise<boolean> {
   }
 
   try {
-    return await runLatestBrazePushOperation({
-      key: UNREGISTER_OPERATION_KEY,
-      supersededResult: false,
-      operation: async (context) => {
-        await markBrazePushUnregistrationPending();
-        return attemptPendingUnregistration({ context });
-      },
-    });
+    await markBrazePushUnregistrationPending();
+    return await attemptPendingUnregistration();
   } catch (nativeError) {
     const error = toError(nativeError);
     Logger.error(error, '[Braze] Failed to unregister push');
@@ -153,18 +94,5 @@ export async function retryPendingBrazePushUnregistration(): Promise<boolean> {
     return true;
   }
 
-  try {
-    return await runLatestBrazePushOperation({
-      key: UNREGISTER_OPERATION_KEY,
-      supersededResult: false,
-      operation: async (context) => {
-        await ensureBrazePushUnregistrationDesired();
-        return attemptPendingUnregistration({ context });
-      },
-    });
-  } catch (nativeError) {
-    const error = toError(nativeError);
-    Logger.error(error, '[Braze] Failed to retry push unregistration');
-    return false;
-  }
+  return attemptPendingUnregistration();
 }

--- a/app/core/Braze/unregisterPush.ts
+++ b/app/core/Braze/unregisterPush.ts
@@ -4,6 +4,7 @@ import { hasTestOverrides } from '../../util/test/utils';
 import {
   type BrazePushOperationContext,
   clearPendingBrazePushUnregistration,
+  ensureBrazePushUnregistrationDesired,
   hasPendingBrazePushUnregistrationSync,
   markBrazePushUnregistrationPending,
   runLatestBrazePushOperation,
@@ -76,10 +77,8 @@ async function unregisterOnce(): Promise<void> {
 
 async function attemptPendingUnregistration({
   context,
-  throwOnPermanentFailure,
 }: {
   context: BrazePushOperationContext;
-  throwOnPermanentFailure: boolean;
 }): Promise<boolean> {
   if (!hasPendingBrazePushUnregistrationSync()) {
     Logger.log(
@@ -124,14 +123,15 @@ async function attemptPendingUnregistration({
       return false;
     }
     if (!isRetriable) {
-      Logger.error(error, '[Braze] Push unregistration cannot be retried');
-      if (throwOnPermanentFailure) {
-        throw error;
-      }
-      return false;
+      Logger.error(
+        error,
+        '[Braze] Push unregistration reported a non-retriable failure',
+      );
     }
 
-    Logger.log('[Braze] Push unregistration remains pending until next launch');
+    Logger.log(
+      '[Braze] Push unregistration remains pending until the next session',
+    );
     return false;
   }
 }
@@ -139,9 +139,9 @@ async function attemptPendingUnregistration({
 /**
  * Unregister this device from Braze push before disabling NaaP push.
  *
- * Retriable failures remain persisted for the next app launch, allowing the
- * local notification preference to turn off without waiting.
- * Permanent failures reject so the UI can roll the preference back on.
+ * Failures remain persisted for the next app session, allowing the local
+ * notification preference to turn off without losing the device-scoped
+ * consent intent.
  *
  * @returns Whether Braze confirmed unregistration during this call.
  */
@@ -156,20 +156,16 @@ export async function unregisterBrazePush(): Promise<boolean> {
       supersededResult: false,
       operation: async (context) => {
         await markBrazePushUnregistrationPending();
-        return attemptPendingUnregistration({
-          context,
-          throwOnPermanentFailure: true,
-        });
+        return attemptPendingUnregistration({ context });
       },
     });
   } catch (nativeError) {
-    await clearPendingBrazePushUnregistration();
     const error = toError(nativeError);
     Logger.error(error, '[Braze] Failed to unregister push');
     Logger.log(
-      '[Braze] Permanent unregistration failure cleared the pending marker',
+      '[Braze] Push unregistration intent remains pending after failure',
     );
-    throw error;
+    return false;
   }
 }
 
@@ -194,11 +190,10 @@ export async function retryPendingBrazePushUnregistration(): Promise<boolean> {
     return await runLatestBrazePushOperation({
       key: UNREGISTER_OPERATION_KEY,
       supersededResult: false,
-      operation: (context) =>
-        attemptPendingUnregistration({
-          context,
-          throwOnPermanentFailure: false,
-        }),
+      operation: async (context) => {
+        await ensureBrazePushUnregistrationDesired();
+        return attemptPendingUnregistration({ context });
+      },
     });
   } catch (nativeError) {
     const error = toError(nativeError);

--- a/app/core/Braze/unregisterPush.ts
+++ b/app/core/Braze/unregisterPush.ts
@@ -81,45 +81,22 @@ async function attemptPendingUnregistration({
   context: BrazePushOperationContext;
 }): Promise<boolean> {
   if (!hasPendingBrazePushUnregistrationSync()) {
-    Logger.log(
-      '[Braze] Unregistration attempt skipped: pending marker already cleared',
-    );
     return true;
   }
   if (!context.isCurrent()) {
-    Logger.log(
-      '[Braze] Unregistration attempt superseded by a newer push operation',
-    );
     return false;
   }
 
   try {
     await unregisterOnce();
     await clearPendingBrazePushUnregistration();
-    Logger.log('[Braze] Unregistered this device from Braze push');
     return true;
   } catch (nativeError) {
     const error = toError(nativeError);
     const isRetriable =
       error instanceof BrazePushUnregistrationError && error.isRetriable;
 
-    Logger.log(
-      '[Braze] Unregistration attempt failed',
-      JSON.stringify({
-        retriable: isRetriable,
-        httpStatusCode:
-          error instanceof BrazePushUnregistrationError
-            ? error.httpStatusCode
-            : undefined,
-        message: error.message,
-        current: context.isCurrent(),
-      }),
-    );
-
     if (!context.isCurrent()) {
-      Logger.log(
-        '[Braze] Unregistration attempt superseded; pending marker preserved for the newer request',
-      );
       return false;
     }
     if (!isRetriable) {
@@ -129,9 +106,6 @@ async function attemptPendingUnregistration({
       );
     }
 
-    Logger.log(
-      '[Braze] Push unregistration remains pending until the next session',
-    );
     return false;
   }
 }
@@ -162,9 +136,6 @@ export async function unregisterBrazePush(): Promise<boolean> {
   } catch (nativeError) {
     const error = toError(nativeError);
     Logger.error(error, '[Braze] Failed to unregister push');
-    Logger.log(
-      '[Braze] Push unregistration intent remains pending after failure',
-    );
     return false;
   }
 }
@@ -181,10 +152,6 @@ export async function retryPendingBrazePushUnregistration(): Promise<boolean> {
   if (hasTestOverrides || !hasPendingBrazePushUnregistrationSync()) {
     return true;
   }
-
-  Logger.log(
-    '[Braze] Retrying pending push unregistration left by a previous session',
-  );
 
   try {
     return await runLatestBrazePushOperation({

--- a/app/core/Braze/unregisterPush.ts
+++ b/app/core/Braze/unregisterPush.ts
@@ -82,9 +82,15 @@ async function attemptPendingUnregistration({
   throwOnPermanentFailure: boolean;
 }): Promise<boolean> {
   if (!hasPendingBrazePushUnregistrationSync()) {
+    Logger.log(
+      '[Braze] Unregistration attempt skipped: pending marker already cleared',
+    );
     return true;
   }
   if (!context.isCurrent()) {
+    Logger.log(
+      '[Braze] Unregistration attempt superseded by a newer push operation',
+    );
     return false;
   }
 
@@ -98,7 +104,23 @@ async function attemptPendingUnregistration({
     const isRetriable =
       error instanceof BrazePushUnregistrationError && error.isRetriable;
 
+    Logger.log(
+      '[Braze] Unregistration attempt failed',
+      JSON.stringify({
+        retriable: isRetriable,
+        httpStatusCode:
+          error instanceof BrazePushUnregistrationError
+            ? error.httpStatusCode
+            : undefined,
+        message: error.message,
+        current: context.isCurrent(),
+      }),
+    );
+
     if (!context.isCurrent()) {
+      Logger.log(
+        '[Braze] Unregistration attempt superseded; pending marker preserved for the newer request',
+      );
       return false;
     }
     if (!isRetriable) {
@@ -144,6 +166,9 @@ export async function unregisterBrazePush(): Promise<boolean> {
     await clearPendingBrazePushUnregistration();
     const error = toError(nativeError);
     Logger.error(error, '[Braze] Failed to unregister push');
+    Logger.log(
+      '[Braze] Permanent unregistration failure cleared the pending marker',
+    );
     throw error;
   }
 }
@@ -160,6 +185,10 @@ export async function retryPendingBrazePushUnregistration(): Promise<boolean> {
   if (hasTestOverrides || !hasPendingBrazePushUnregistrationSync()) {
     return true;
   }
+
+  Logger.log(
+    '[Braze] Retrying pending push unregistration left by a previous session',
+  );
 
   try {
     return await runLatestBrazePushOperation({

--- a/app/core/Engine/controllers/notifications/push-utils.test.ts
+++ b/app/core/Engine/controllers/notifications/push-utils.test.ts
@@ -86,18 +86,6 @@ describe('deleteRegToken', () => {
 
     expect(FCMService.deleteRegToken).toHaveBeenCalled();
   });
-
-  it('does not delete the FCM token when Braze unregister fails', async () => {
-    jest
-      .mocked(unregisterBrazePush)
-      .mockRejectedValue(new Error('Failed to unregister Braze push'));
-
-    await expect(deleteRegToken()).rejects.toThrow(
-      'Failed to unregister Braze push',
-    );
-
-    expect(FCMService.deleteRegToken).not.toHaveBeenCalled();
-  });
 });
 
 describe('shouldDisplayForegroundPushNotification', () => {

--- a/app/core/Engine/controllers/notifications/push-utils.ts
+++ b/app/core/Engine/controllers/notifications/push-utils.ts
@@ -9,8 +9,8 @@ export const createRegToken = FCMService.createRegToken;
 
 /**
  * Unregister this device from Braze before deleting the FCM token.
- * Retriable failures are persisted for retry on the next app launch. Permanent
- * failures throw so NaaP keeps the in-app toggle enabled.
+ * Braze failures remain persisted for retry during a later app session while
+ * FCM deletion continues so the local preference can turn off immediately.
  */
 export const deleteRegToken = async (): Promise<boolean> => {
   await unregisterBrazePush();

--- a/app/store/migrations/153.test.ts
+++ b/app/store/migrations/153.test.ts
@@ -1,5 +1,6 @@
 import { captureException } from '@sentry/react-native';
 import {
+  BRAZE_PUSH_DESIRED_STATE,
   BRAZE_PUSH_UNREGISTRATION_PENDING,
   LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
 } from '../../constants/storage';
@@ -82,6 +83,10 @@ describe(`Migration ${migrationVersion}: mark legacy notification backfills`, ()
       LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
       'true',
     );
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_DESIRED_STATE,
+      'registered',
+    );
     expect(mockStorageWrapper.setItem).not.toHaveBeenCalledWith(
       BRAZE_PUSH_UNREGISTRATION_PENDING,
       expect.anything(),
@@ -100,6 +105,10 @@ describe(`Migration ${migrationVersion}: mark legacy notification backfills`, ()
       BRAZE_PUSH_UNREGISTRATION_PENDING,
       'true',
     );
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_DESIRED_STATE,
+      'unregistered',
+    );
   });
 
   it('marks devices with master notifications disabled for Braze unregistration', async () => {
@@ -110,10 +119,13 @@ describe(`Migration ${migrationVersion}: mark legacy notification backfills`, ()
 
     await migrate(state);
 
-    expect(mockStorageWrapper.setItem).toHaveBeenCalledTimes(1);
     expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
       BRAZE_PUSH_UNREGISTRATION_PENDING,
       'true',
+    );
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_DESIRED_STATE,
+      'unregistered',
     );
   });
 
@@ -163,7 +175,7 @@ describe(`Migration ${migrationVersion}: mark legacy notification backfills`, ()
     });
 
     await expect(migrate(state)).rejects.toThrow(
-      'Failed to persist pending marker(s): legacy notification AUS backfill',
+      'Failed to persist backfill value(s): legacy notification AUS backfill',
     );
 
     expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
@@ -174,6 +186,27 @@ describe(`Migration ${migrationVersion}: mark legacy notification backfills`, ()
       expect.objectContaining({
         message: expect.stringContaining('AUS marker write failed'),
       }),
+    );
+  });
+
+  it('keeps the unregister marker when desired-state persistence fails', async () => {
+    const state = createState({
+      notificationsEnabled: false,
+      pushEnabled: false,
+    });
+    mockStorageWrapper.setItem.mockImplementation(async (key) => {
+      if (key === BRAZE_PUSH_DESIRED_STATE) {
+        throw new Error('Desired state write failed');
+      }
+    });
+
+    await expect(migrate(state)).rejects.toThrow(
+      'Failed to persist backfill value(s): Braze push desired state',
+    );
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_UNREGISTRATION_PENDING,
+      'true',
     );
   });
 });

--- a/app/store/migrations/153.test.ts
+++ b/app/store/migrations/153.test.ts
@@ -1,7 +1,6 @@
 import { captureException } from '@sentry/react-native';
 import {
-  BRAZE_PUSH_DESIRED_STATE,
-  BRAZE_PUSH_UNREGISTRATION_PENDING,
+  BRAZE_PUSH_REGISTRATION_STATE,
   LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
 } from '../../constants/storage';
 import StorageWrapper from '../storage-wrapper';
@@ -84,12 +83,8 @@ describe(`Migration ${migrationVersion}: mark legacy notification backfills`, ()
       'true',
     );
     expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
-      BRAZE_PUSH_DESIRED_STATE,
+      BRAZE_PUSH_REGISTRATION_STATE,
       'registered',
-    );
-    expect(mockStorageWrapper.setItem).not.toHaveBeenCalledWith(
-      BRAZE_PUSH_UNREGISTRATION_PENDING,
-      expect.anything(),
     );
   });
 
@@ -102,12 +97,8 @@ describe(`Migration ${migrationVersion}: mark legacy notification backfills`, ()
     await migrate(state);
 
     expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
-      BRAZE_PUSH_UNREGISTRATION_PENDING,
-      'true',
-    );
-    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
-      BRAZE_PUSH_DESIRED_STATE,
-      'unregistered',
+      BRAZE_PUSH_REGISTRATION_STATE,
+      'unregistration-pending',
     );
   });
 
@@ -120,12 +111,8 @@ describe(`Migration ${migrationVersion}: mark legacy notification backfills`, ()
     await migrate(state);
 
     expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
-      BRAZE_PUSH_UNREGISTRATION_PENDING,
-      'true',
-    );
-    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
-      BRAZE_PUSH_DESIRED_STATE,
-      'unregistered',
+      BRAZE_PUSH_REGISTRATION_STATE,
+      'unregistration-pending',
     );
   });
 
@@ -143,8 +130,8 @@ describe(`Migration ${migrationVersion}: mark legacy notification backfills`, ()
       'true',
     );
     expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
-      BRAZE_PUSH_UNREGISTRATION_PENDING,
-      'true',
+      BRAZE_PUSH_REGISTRATION_STATE,
+      'unregistration-pending',
     );
   });
 
@@ -154,8 +141,8 @@ describe(`Migration ${migrationVersion}: mark legacy notification backfills`, ()
     await migrate(state);
 
     expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
-      BRAZE_PUSH_UNREGISTRATION_PENDING,
-      'true',
+      BRAZE_PUSH_REGISTRATION_STATE,
+      'unregistration-pending',
     );
     expect(mockStorageWrapper.setItem).not.toHaveBeenCalledWith(
       LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
@@ -179,8 +166,8 @@ describe(`Migration ${migrationVersion}: mark legacy notification backfills`, ()
     );
 
     expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
-      BRAZE_PUSH_UNREGISTRATION_PENDING,
-      'true',
+      BRAZE_PUSH_REGISTRATION_STATE,
+      'unregistration-pending',
     );
     expect(mockCaptureException).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -189,24 +176,19 @@ describe(`Migration ${migrationVersion}: mark legacy notification backfills`, ()
     );
   });
 
-  it('keeps the unregister marker when desired-state persistence fails', async () => {
+  it('reports Braze registration-state persistence failures', async () => {
     const state = createState({
       notificationsEnabled: false,
       pushEnabled: false,
     });
     mockStorageWrapper.setItem.mockImplementation(async (key) => {
-      if (key === BRAZE_PUSH_DESIRED_STATE) {
-        throw new Error('Desired state write failed');
+      if (key === BRAZE_PUSH_REGISTRATION_STATE) {
+        throw new Error('Registration state write failed');
       }
     });
 
     await expect(migrate(state)).rejects.toThrow(
-      'Failed to persist backfill value(s): Braze push desired state',
-    );
-
-    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
-      BRAZE_PUSH_UNREGISTRATION_PENDING,
-      'true',
+      'Failed to persist backfill value(s): Braze push registration state',
     );
   });
 });

--- a/app/store/migrations/153.test.ts
+++ b/app/store/migrations/153.test.ts
@@ -1,0 +1,179 @@
+import { captureException } from '@sentry/react-native';
+import {
+  BRAZE_PUSH_UNREGISTRATION_PENDING,
+  LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+} from '../../constants/storage';
+import StorageWrapper from '../storage-wrapper';
+import migrate, { migrationVersion } from './153';
+import { ensureValidState } from './util';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('../storage-wrapper', () => ({
+  __esModule: true,
+  default: {
+    setItem: jest.fn(),
+  },
+}));
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+}));
+
+const mockCaptureException = jest.mocked(captureException);
+const mockEnsureValidState = jest.mocked(ensureValidState);
+const mockStorageWrapper = jest.mocked(StorageWrapper);
+
+const createState = ({
+  notificationsEnabled,
+  pushEnabled,
+  marketingConsent = false,
+}: {
+  notificationsEnabled?: boolean;
+  pushEnabled?: boolean;
+  marketingConsent?: boolean;
+}) => ({
+  security: {
+    dataCollectionForMarketing: marketingConsent,
+  },
+  engine: {
+    backgroundState: {
+      NotificationServicesController:
+        notificationsEnabled === undefined
+          ? undefined
+          : { isNotificationServicesEnabled: notificationsEnabled },
+      NotificationServicesPushController:
+        pushEnabled === undefined ? undefined : { isPushEnabled: pushEnabled },
+    },
+  },
+});
+
+describe(`Migration ${migrationVersion}: mark legacy notification backfills`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEnsureValidState.mockReturnValue(true);
+    mockStorageWrapper.setItem.mockResolvedValue(undefined);
+  });
+
+  it('returns state unchanged without writing markers when state is invalid', async () => {
+    const state = createState({
+      notificationsEnabled: false,
+      pushEnabled: false,
+    });
+    mockEnsureValidState.mockReturnValue(false);
+
+    const result = await migrate(state);
+
+    expect(result).toBe(state);
+    expect(mockStorageWrapper.setItem).not.toHaveBeenCalled();
+  });
+
+  it('marks enabled notification users for an AUS preferences backfill', async () => {
+    const state = createState({
+      notificationsEnabled: true,
+      pushEnabled: true,
+    });
+
+    await migrate(state);
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+      'true',
+    );
+    expect(mockStorageWrapper.setItem).not.toHaveBeenCalledWith(
+      BRAZE_PUSH_UNREGISTRATION_PENDING,
+      expect.anything(),
+    );
+  });
+
+  it('marks devices with push disabled for Braze unregistration', async () => {
+    const state = createState({
+      notificationsEnabled: true,
+      pushEnabled: false,
+    });
+
+    await migrate(state);
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_UNREGISTRATION_PENDING,
+      'true',
+    );
+  });
+
+  it('marks devices with master notifications disabled for Braze unregistration', async () => {
+    const state = createState({
+      notificationsEnabled: false,
+      pushEnabled: true,
+    });
+
+    await migrate(state);
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledTimes(1);
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_UNREGISTRATION_PENDING,
+      'true',
+    );
+  });
+
+  it('marks users with marketing consent for AUS backfill when notification state is disabled', async () => {
+    const state = createState({
+      notificationsEnabled: false,
+      pushEnabled: false,
+      marketingConsent: true,
+    });
+
+    await migrate(state);
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+      'true',
+    );
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_UNREGISTRATION_PENDING,
+      'true',
+    );
+  });
+
+  it('conservatively marks devices with missing notification state for Braze unregistration', async () => {
+    const state = createState({});
+
+    await migrate(state);
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_UNREGISTRATION_PENDING,
+      'true',
+    );
+    expect(mockStorageWrapper.setItem).not.toHaveBeenCalledWith(
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+      expect.anything(),
+    );
+  });
+
+  it('records each marker failure independently', async () => {
+    const state = createState({
+      notificationsEnabled: true,
+      pushEnabled: false,
+    });
+    mockStorageWrapper.setItem.mockImplementation(async (key) => {
+      if (key === LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING) {
+        throw new Error('AUS marker write failed');
+      }
+    });
+
+    await expect(migrate(state)).rejects.toThrow(
+      'Failed to persist pending marker(s): legacy notification AUS backfill',
+    );
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_UNREGISTRATION_PENDING,
+      'true',
+    );
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('AUS marker write failed'),
+      }),
+    );
+  });
+});

--- a/app/store/migrations/153.ts
+++ b/app/store/migrations/153.ts
@@ -1,0 +1,96 @@
+import { captureException } from '@sentry/react-native';
+import { hasProperty, isObject } from '@metamask/utils';
+import {
+  BRAZE_PUSH_UNREGISTRATION_PENDING,
+  LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+} from '../../constants/storage';
+import StorageWrapper from '../storage-wrapper';
+import { ensureValidState } from './util';
+
+export const migrationVersion = 153;
+
+async function setBackfillMarker(key: string, name: string): Promise<boolean> {
+  try {
+    await StorageWrapper.setItem(key, 'true');
+    return true;
+  } catch (error) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Failed to mark ${name} as pending: ${String(
+          error,
+        )}`,
+      ),
+    );
+    return false;
+  }
+}
+
+/**
+ * Migration 153: schedule independent notification consent backfills.
+ *
+ * Existing users with MetaMask notifications or marketing consent enabled are
+ * checked for missing AUS preferences after login. Devices without both
+ * notification switches enabled are scheduled for Braze push unregistration
+ * on the next launch.
+ */
+const migration = async (state: unknown): Promise<unknown> => {
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  const { backgroundState } = state.engine;
+  const notificationServicesState =
+    hasProperty(backgroundState, 'NotificationServicesController') &&
+    isObject(backgroundState.NotificationServicesController)
+      ? backgroundState.NotificationServicesController
+      : undefined;
+  const pushServicesState =
+    hasProperty(backgroundState, 'NotificationServicesPushController') &&
+    isObject(backgroundState.NotificationServicesPushController)
+      ? backgroundState.NotificationServicesPushController
+      : undefined;
+  const securityState =
+    hasProperty(state, 'security') && isObject(state.security)
+      ? state.security
+      : undefined;
+  const notificationsEnabled =
+    notificationServicesState?.isNotificationServicesEnabled === true;
+  const pushEnabled = pushServicesState?.isPushEnabled === true;
+  const hasMarketingConsent =
+    securityState?.dataCollectionForMarketing === true;
+  const failedMarkers: string[] = [];
+
+  if (notificationsEnabled || hasMarketingConsent) {
+    if (
+      !(await setBackfillMarker(
+        LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+        'legacy notification AUS backfill',
+      ))
+    ) {
+      failedMarkers.push('legacy notification AUS backfill');
+    }
+  }
+
+  if (!notificationsEnabled || !pushEnabled) {
+    if (
+      !(await setBackfillMarker(
+        BRAZE_PUSH_UNREGISTRATION_PENDING,
+        'Braze push unregistration',
+      ))
+    ) {
+      failedMarkers.push('Braze push unregistration');
+    }
+  }
+
+  if (failedMarkers.length > 0) {
+    throw new Error(
+      `Migration ${migrationVersion}: Failed to persist pending marker(s): ${failedMarkers.join(
+        ', ',
+      )}`,
+    );
+  }
+
+  return state;
+};
+
+export default migration;

--- a/app/store/migrations/153.ts
+++ b/app/store/migrations/153.ts
@@ -6,12 +6,14 @@ import {
 } from '../../constants/storage';
 import StorageWrapper from '../storage-wrapper';
 import { ensureValidState } from './util';
+import Logger from '../../util/Logger';
 
 export const migrationVersion = 153;
 
 async function setBackfillMarker(key: string, name: string): Promise<boolean> {
   try {
     await StorageWrapper.setItem(key, 'true');
+    Logger.log(`[Braze] Migration 153 marked ${name} as pending`);
     return true;
   } catch (error) {
     captureException(

--- a/app/store/migrations/153.ts
+++ b/app/store/migrations/153.ts
@@ -1,6 +1,7 @@
 import { captureException } from '@sentry/react-native';
 import { hasProperty, isObject } from '@metamask/utils';
 import {
+  BRAZE_PUSH_DESIRED_STATE,
   BRAZE_PUSH_UNREGISTRATION_PENDING,
   LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
 } from '../../constants/storage';
@@ -10,10 +11,14 @@ import Logger from '../../util/Logger';
 
 export const migrationVersion = 153;
 
-async function setBackfillMarker(key: string, name: string): Promise<boolean> {
+async function setBackfillValue(
+  key: string,
+  value: string,
+  name: string,
+): Promise<boolean> {
   try {
-    await StorageWrapper.setItem(key, 'true');
-    Logger.log(`[Braze] Migration 153 marked ${name} as pending`);
+    await StorageWrapper.setItem(key, value);
+    Logger.log(`[Braze] Migration 153 persisted ${name}`);
     return true;
   } catch (error) {
     captureException(
@@ -60,33 +65,47 @@ const migration = async (state: unknown): Promise<unknown> => {
   const pushEnabled = pushServicesState?.isPushEnabled === true;
   const hasMarketingConsent =
     securityState?.dataCollectionForMarketing === true;
-  const failedMarkers: string[] = [];
+  const failedValues: string[] = [];
 
   if (notificationsEnabled || hasMarketingConsent) {
     if (
-      !(await setBackfillMarker(
+      !(await setBackfillValue(
         LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+        'true',
         'legacy notification AUS backfill',
       ))
     ) {
-      failedMarkers.push('legacy notification AUS backfill');
+      failedValues.push('legacy notification AUS backfill');
     }
   }
 
   if (!notificationsEnabled || !pushEnabled) {
     if (
-      !(await setBackfillMarker(
+      !(await setBackfillValue(
         BRAZE_PUSH_UNREGISTRATION_PENDING,
+        'true',
         'Braze push unregistration',
       ))
     ) {
-      failedMarkers.push('Braze push unregistration');
+      failedValues.push('Braze push unregistration');
     }
   }
 
-  if (failedMarkers.length > 0) {
+  const desiredBrazePushState =
+    notificationsEnabled && pushEnabled ? 'registered' : 'unregistered';
+  if (
+    !(await setBackfillValue(
+      BRAZE_PUSH_DESIRED_STATE,
+      desiredBrazePushState,
+      'Braze push desired state',
+    ))
+  ) {
+    failedValues.push('Braze push desired state');
+  }
+
+  if (failedValues.length > 0) {
     throw new Error(
-      `Migration ${migrationVersion}: Failed to persist pending marker(s): ${failedMarkers.join(
+      `Migration ${migrationVersion}: Failed to persist backfill value(s): ${failedValues.join(
         ', ',
       )}`,
     );

--- a/app/store/migrations/153.ts
+++ b/app/store/migrations/153.ts
@@ -1,8 +1,7 @@
 import { captureException } from '@sentry/react-native';
 import { hasProperty, isObject } from '@metamask/utils';
 import {
-  BRAZE_PUSH_DESIRED_STATE,
-  BRAZE_PUSH_UNREGISTRATION_PENDING,
+  BRAZE_PUSH_REGISTRATION_STATE,
   LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
 } from '../../constants/storage';
 import StorageWrapper from '../storage-wrapper';
@@ -21,7 +20,7 @@ async function setBackfillValue(
   } catch (error) {
     captureException(
       new Error(
-        `Migration ${migrationVersion}: Failed to mark ${name} as pending: ${String(
+        `Migration ${migrationVersion}: Failed to persist ${name}: ${String(
           error,
         )}`,
       ),
@@ -77,28 +76,18 @@ const migration = async (state: unknown): Promise<unknown> => {
     }
   }
 
-  if (!notificationsEnabled || !pushEnabled) {
-    if (
-      !(await setBackfillValue(
-        BRAZE_PUSH_UNREGISTRATION_PENDING,
-        'true',
-        'Braze push unregistration',
-      ))
-    ) {
-      failedValues.push('Braze push unregistration');
-    }
-  }
-
-  const desiredBrazePushState =
-    notificationsEnabled && pushEnabled ? 'registered' : 'unregistered';
+  const brazePushRegistrationState =
+    notificationsEnabled && pushEnabled
+      ? 'registered'
+      : 'unregistration-pending';
   if (
     !(await setBackfillValue(
-      BRAZE_PUSH_DESIRED_STATE,
-      desiredBrazePushState,
-      'Braze push desired state',
+      BRAZE_PUSH_REGISTRATION_STATE,
+      brazePushRegistrationState,
+      'Braze push registration state',
     ))
   ) {
-    failedValues.push('Braze push desired state');
+    failedValues.push('Braze push registration state');
   }
 
   if (failedValues.length > 0) {

--- a/app/store/migrations/153.ts
+++ b/app/store/migrations/153.ts
@@ -7,7 +7,6 @@ import {
 } from '../../constants/storage';
 import StorageWrapper from '../storage-wrapper';
 import { ensureValidState } from './util';
-import Logger from '../../util/Logger';
 
 export const migrationVersion = 153;
 
@@ -18,7 +17,6 @@ async function setBackfillValue(
 ): Promise<boolean> {
   try {
     await StorageWrapper.setItem(key, value);
-    Logger.log(`[Braze] Migration 153 persisted ${name}`);
     return true;
   } catch (error) {
     captureException(

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -153,6 +153,7 @@ import migration149 from './149';
 import migration150 from './150';
 import migration151 from './151';
 import migration152 from './152';
+import migration153 from './153';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -325,6 +326,7 @@ export const migrationList: MigrationsList = {
   150: migration150,
   151: migration151,
   152: migration152,
+  153: migration153,
 };
 
 // Enable both synchronous and asynchronous migrations

--- a/app/store/sagas/backfillLegacyNotificationPreferences.test.ts
+++ b/app/store/sagas/backfillLegacyNotificationPreferences.test.ts
@@ -1,0 +1,195 @@
+import { expectSaga } from 'redux-saga-test-plan';
+import { UserActionType } from '../../actions/user';
+import {
+  HAS_USER_TURNED_OFF_ONCE_NOTIFICATIONS,
+  LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+} from '../../constants/storage';
+import Engine from '../../core/Engine';
+import Logger from '../../util/Logger';
+import initialRootState from '../../util/test/initial-root-state';
+import StorageWrapper from '../storage-wrapper';
+import { backfillLegacyNotificationPreferencesSaga } from './backfillLegacyNotificationPreferences';
+
+jest.mock('../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      NotificationServicesController: {
+        createOnChainTriggers: jest.fn(),
+      },
+    },
+  },
+}));
+
+jest.mock('../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('../storage-wrapper', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn().mockResolvedValue(undefined),
+    getItemSync: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const mockCreateOnChainTriggers = jest.mocked(
+  Engine.context.NotificationServicesController.createOnChainTriggers,
+);
+const mockStorageWrapper = jest.mocked(StorageWrapper);
+const loginAction = { type: UserActionType.LOGIN };
+
+const createState = ({
+  notificationsEnabled = true,
+  marketingConsent = true,
+  featureAnnouncementsEnabled = true,
+}: {
+  notificationsEnabled?: boolean;
+  marketingConsent?: boolean;
+  featureAnnouncementsEnabled?: boolean;
+} = {}) => ({
+  ...initialRootState,
+  security: {
+    ...initialRootState.security,
+    dataCollectionForMarketing: marketingConsent,
+  },
+  engine: {
+    ...initialRootState.engine,
+    backgroundState: {
+      ...initialRootState.engine.backgroundState,
+      NotificationServicesController: {
+        ...initialRootState.engine.backgroundState
+          .NotificationServicesController,
+        isNotificationServicesEnabled: notificationsEnabled,
+        isFeatureAnnouncementsEnabled: featureAnnouncementsEnabled,
+      },
+    },
+  },
+});
+
+describe('backfillLegacyNotificationPreferencesSaga', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStorageWrapper.getItemSync.mockImplementation((key) =>
+      key === LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING ? 'true' : null,
+    );
+    mockStorageWrapper.removeItem.mockResolvedValue(undefined);
+    mockCreateOnChainTriggers.mockResolvedValue(undefined);
+  });
+
+  it('does nothing when no AUS backfill marker exists', async () => {
+    mockStorageWrapper.getItemSync.mockReturnValue(null);
+
+    await expectSaga(backfillLegacyNotificationPreferencesSaga)
+      .withState(createState())
+      .dispatch(loginAction)
+      .run();
+
+    expect(mockCreateOnChainTriggers).not.toHaveBeenCalled();
+    expect(mockStorageWrapper.removeItem).not.toHaveBeenCalled();
+  });
+
+  it('clears the marker when notifications and marketing consent are disabled', async () => {
+    await expectSaga(backfillLegacyNotificationPreferencesSaga)
+      .withState(
+        createState({
+          notificationsEnabled: false,
+          marketingConsent: false,
+        }),
+      )
+      .dispatch(loginAction)
+      .run();
+
+    expect(mockCreateOnChainTriggers).not.toHaveBeenCalled();
+    expect(mockStorageWrapper.removeItem).toHaveBeenCalledWith(
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+    );
+  });
+
+  it('initializes preferences for a marketing-consented user with notifications disabled', async () => {
+    await expectSaga(backfillLegacyNotificationPreferencesSaga)
+      .withState(
+        createState({
+          notificationsEnabled: false,
+          marketingConsent: true,
+          featureAnnouncementsEnabled: false,
+        }),
+      )
+      .dispatch(loginAction)
+      .run();
+
+    expect(mockCreateOnChainTriggers).toHaveBeenCalledWith({
+      hasMarketingConsent: true,
+      productAnnouncementEnabled: false,
+      registerPushNotifications: false,
+    });
+    expect(mockStorageWrapper.removeItem).toHaveBeenCalledWith(
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+    );
+  });
+
+  it('does not override an explicit notification opt-out with marketing consent', async () => {
+    mockStorageWrapper.getItemSync.mockImplementation((key) =>
+      key === LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING ||
+      key === HAS_USER_TURNED_OFF_ONCE_NOTIFICATIONS
+        ? 'true'
+        : null,
+    );
+
+    await expectSaga(backfillLegacyNotificationPreferencesSaga)
+      .withState(
+        createState({
+          notificationsEnabled: false,
+          marketingConsent: true,
+        }),
+      )
+      .dispatch(loginAction)
+      .run();
+
+    expect(mockCreateOnChainTriggers).not.toHaveBeenCalled();
+    expect(mockStorageWrapper.removeItem).toHaveBeenCalledWith(
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+    );
+  });
+
+  it('initializes missing preferences from current notification consent', async () => {
+    await expectSaga(backfillLegacyNotificationPreferencesSaga)
+      .withState(
+        createState({
+          marketingConsent: false,
+          featureAnnouncementsEnabled: true,
+        }),
+      )
+      .dispatch(loginAction)
+      .run();
+
+    expect(mockCreateOnChainTriggers).toHaveBeenCalledWith({
+      hasMarketingConsent: false,
+      productAnnouncementEnabled: true,
+      registerPushNotifications: false,
+    });
+    expect(mockStorageWrapper.removeItem).toHaveBeenCalledWith(
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+    );
+  });
+
+  it('keeps the marker when preference initialization fails', async () => {
+    const error = new Error('AUS request failed');
+    mockCreateOnChainTriggers.mockRejectedValue(error);
+
+    await expectSaga(backfillLegacyNotificationPreferencesSaga)
+      .withState(createState())
+      .dispatch(loginAction)
+      .run();
+
+    expect(mockStorageWrapper.removeItem).not.toHaveBeenCalled();
+    expect(Logger.error).toHaveBeenCalledWith(
+      error,
+      'Failed to backfill legacy notification preferences',
+    );
+  });
+});

--- a/app/store/sagas/backfillLegacyNotificationPreferences.ts
+++ b/app/store/sagas/backfillLegacyNotificationPreferences.ts
@@ -1,0 +1,80 @@
+import { call, select, take } from 'redux-saga/effects';
+import {
+  HAS_USER_TURNED_OFF_ONCE_NOTIFICATIONS,
+  LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+  TRUE,
+} from '../../constants/storage';
+import { UserActionType } from '../../actions/user';
+import Engine from '../../core/Engine';
+import type { RootState } from '../../reducers';
+import {
+  selectIsFeatureAnnouncementsEnabled,
+  selectIsMetamaskNotificationsEnabled,
+} from '../../selectors/notifications';
+import Logger from '../../util/Logger';
+import StorageWrapper from '../storage-wrapper';
+
+/**
+ * Initialize missing AUS notification preferences once for eligible legacy
+ * users. Existing preferences are preserved by `createOnChainTriggers`.
+ */
+export function* backfillLegacyNotificationPreferencesSaga() {
+  yield take(UserActionType.LOGIN);
+
+  if (
+    StorageWrapper.getItemSync(LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING) !==
+    TRUE
+  ) {
+    return;
+  }
+
+  try {
+    const notificationsEnabled: boolean = yield select(
+      selectIsMetamaskNotificationsEnabled,
+    );
+    const hasMarketingConsent: boolean = yield select(
+      (state: RootState) => state.security.dataCollectionForMarketing === true,
+    );
+    const hasExplicitlyDisabledNotifications =
+      StorageWrapper.getItemSync(HAS_USER_TURNED_OFF_ONCE_NOTIFICATIONS) ===
+      TRUE;
+    // The legacy marketing-only onboarding path recorded consent without
+    // initializing notifications or AUS, so either signal makes this eligible.
+    // Never let that inference override a subsequent explicit in-app opt-out.
+    if (
+      !notificationsEnabled &&
+      (!hasMarketingConsent || hasExplicitlyDisabledNotifications)
+    ) {
+      yield call(
+        [StorageWrapper, StorageWrapper.removeItem],
+        LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+      );
+      return;
+    }
+
+    const productAnnouncementEnabled: boolean = yield select(
+      selectIsFeatureAnnouncementsEnabled,
+    );
+
+    yield call(
+      [
+        Engine.context.NotificationServicesController,
+        Engine.context.NotificationServicesController.createOnChainTriggers,
+      ],
+      {
+        hasMarketingConsent,
+        productAnnouncementEnabled,
+        registerPushNotifications: false,
+      },
+    );
+    yield call(
+      [StorageWrapper, StorageWrapper.removeItem],
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+    );
+  } catch (error) {
+    Logger.error(
+      error instanceof Error ? error : new Error(String(error)),
+      'Failed to backfill legacy notification preferences',
+    );
+  }
+}

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -51,6 +51,7 @@ import { AppState, AppStateStatus } from 'react-native';
 import trackErrorAsAnalytics from '../../util/metrics/TrackError/trackErrorAsAnalytics';
 import { providerErrors } from '@metamask/rpc-errors';
 import { backfillSocialLoginMarketingConsentSaga } from './backfillSocialLoginMarketingConsent';
+import { backfillLegacyNotificationPreferencesSaga } from './backfillLegacyNotificationPreferences';
 import { promptIosGoogleWarningSheetSaga } from './onboarding/legacyIosGoogleReminder';
 import {
   watchMarketingAttributionOnClearOnboarding,
@@ -536,6 +537,9 @@ export function* rootSaga() {
   // Send one-time analytics backfill for migrated social login users after
   // persisted state has been rehydrated and app services are available.
   yield fork(backfillSocialLoginMarketingConsentSaga);
+
+  // Initialize missing AUS notification preferences for migrated legacy users.
+  yield fork(backfillLegacyNotificationPreferencesSaga);
 
   yield fork(watchMarketingAttributionOnConsentChange);
   yield fork(watchMarketingAttributionOnClearOnboarding);

--- a/app/util/notifications/hooks/useNotifications.test.tsx
+++ b/app/util/notifications/hooks/useNotifications.test.tsx
@@ -274,8 +274,8 @@ describe('useNotifications - useDisableNotifications()', () => {
     const { mocks, result } = await arrangeAct();
 
     expect(result).toBe(true);
-    expect(mocks.mockUsePushNotificationsToggle).toHaveBeenCalled();
-    expect(mocks.mockTogglePushNotification).toHaveBeenCalled();
+    expect(mocks.mockUsePushNotificationsToggle).not.toHaveBeenCalled();
+    expect(mocks.mockTogglePushNotification).not.toHaveBeenCalled();
     expect(mocks.mockSelectLoading).toHaveBeenCalled();
     expect(mocks.mockSelectData).toHaveBeenCalled();
   });
@@ -289,21 +289,11 @@ describe('useNotifications - useDisableNotifications()', () => {
     expect(hook.result.current.error).toBeDefined();
   });
 
-  it('does not disable global notifications when push disable fails', async () => {
-    const mocks = arrangeMocks();
-    mocks.mockTogglePushNotification.mockResolvedValue(false);
-    const hook = renderHookWithProvider(() => useDisableNotifications());
+  it('delegates push and global disablement to one helper call', async () => {
+    const { mocks } = await arrangeAct();
 
-    let result: boolean | undefined;
-    await act(async () => {
-      result = await hook.result.current.disableNotifications();
-    });
-
-    expect(result).toBe(false);
-    expect(mocks.mockDisableNotifications).not.toHaveBeenCalled();
-    expect(hook.result.current.error).toBe(
-      'Failed to disable push notifications',
-    );
+    expect(mocks.mockDisableNotifications).toHaveBeenCalledTimes(1);
+    expect(mocks.mockTogglePushNotification).not.toHaveBeenCalled();
   });
 });
 

--- a/app/util/notifications/hooks/useNotifications.test.tsx
+++ b/app/util/notifications/hooks/useNotifications.test.tsx
@@ -135,8 +135,9 @@ describe('useNotifications - useEnableNotifications()', () => {
     expect(mocks.mockEnableNotifications).toHaveBeenCalledWith({
       hasMarketingConsent: false,
       productAnnouncementEnabled: true,
-      registerPushNotifications: true,
+      registerPushNotifications: false,
     });
+    expect(mocks.mockTogglePushNotification).toHaveBeenCalledTimes(1);
   });
 
   it('passes the current marketing consent when enabling notifications', async () => {
@@ -153,7 +154,7 @@ describe('useNotifications - useEnableNotifications()', () => {
     expect(mocks.mockEnableNotifications).toHaveBeenCalledWith({
       hasMarketingConsent: true,
       productAnnouncementEnabled: true,
-      registerPushNotifications: true,
+      registerPushNotifications: false,
     });
   });
 

--- a/app/util/notifications/hooks/useNotifications.ts
+++ b/app/util/notifications/hooks/useNotifications.ts
@@ -173,21 +173,12 @@ export function useEnableNotifications(props?: UseEnableNotificationsProps) {
  * @returns An object containing the `disableNotifications` function, loading state, and error state.
  */
 export function useDisableNotifications() {
-  const { togglePushNotification, loading: pushLoading } =
-    usePushNotificationsToggle();
-
   const data = useSelector(selectIsMetamaskNotificationsEnabled);
   const loading = useSelector(selectIsUpdatingMetamaskNotifications);
   const [error, setError] = useState<string | undefined>(undefined);
   const disableNotifications = useCallback(async () => {
     assertIsFeatureEnabled();
     setError(undefined);
-    const pushDisabled = await togglePushNotification(false);
-    if (!pushDisabled) {
-      const errorMessage = 'Failed to disable push notifications';
-      setError(errorMessage);
-      return false;
-    }
 
     try {
       await disableNotificationsHelper();
@@ -199,11 +190,11 @@ export function useDisableNotifications() {
 
     await setUserHasTurnedOffNotificationsOnce();
     return true;
-  }, [togglePushNotification]);
+  }, []);
 
   return {
     disableNotifications,
-    loading: loading && pushLoading,
+    loading,
     // This will be fixed in a separate PR to converge the types correctly
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     error: error as any,

--- a/app/util/notifications/hooks/useNotifications.ts
+++ b/app/util/notifications/hooks/useNotifications.ts
@@ -134,7 +134,9 @@ export function useEnableNotifications(props?: UseEnableNotificationsProps) {
       await enableNotificationsHelper({
         hasMarketingConsent,
         productAnnouncementEnabled,
-        registerPushNotifications: nudgeEnablePush,
+        // Push registration is performed once, below, after shared notification
+        // setup and the OS-permission check.
+        registerPushNotifications: false,
       });
     } catch (enableError) {
       setError(enableError);
@@ -147,7 +149,6 @@ export function useEnableNotifications(props?: UseEnableNotificationsProps) {
     });
     await updateNotificationSubscriptionExpiration();
   }, [
-    nudgeEnablePush,
     throwOnError,
     hasMarketingConsent,
     productAnnouncementEnabled,

--- a/ios/MetaMask/AppDelegate.swift
+++ b/ios/MetaMask/AppDelegate.swift
@@ -32,6 +32,7 @@ class AppDelegate: ExpoAppDelegate {
 
   @objc static var braze: Braze?
   @objc static var apnsDeviceToken: Data?
+  @objc static var brazePushRegistrationRequested = false
 
   // Detox's `+[ReactNativeSupport reloadApp]` does
   // `[appDelegate valueForKey:@"rootViewFactory"]` to grab RN's RootViewFactory
@@ -174,6 +175,9 @@ class AppDelegate: ExpoAppDelegate {
     didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
   ) {
     AppDelegate.apnsDeviceToken = deviceToken
+    if AppDelegate.brazePushRegistrationRequested {
+      AppDelegate.braze?.notifications.register(deviceToken: deviceToken)
+    }
     super.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
   }
 

--- a/ios/MetaMask/NativeModules/BrazePush/BrazePushModule.m
+++ b/ios/MetaMask/NativeModules/BrazePush/BrazePushModule.m
@@ -26,9 +26,12 @@ RCT_REMAP_METHOD(
     return;
   }
 
+  AppDelegate.brazePushRegistrationRequested = YES;
   NSData *deviceToken = AppDelegate.apnsDeviceToken;
   if (deviceToken == nil) {
-    reject(@"NO_APNS_TOKEN", @"APNs device token is not available", nil);
+    // APNs token delivery is asynchronous. AppDelegate completes registration
+    // when didRegisterForRemoteNotifications receives the token.
+    resolve(nil);
     return;
   }
 
@@ -41,6 +44,7 @@ RCT_REMAP_METHOD(
   unregisterPushWithResolver:(RCTPromiseResolveBlock)resolve
   rejecter:(RCTPromiseRejectBlock)reject
 ) {
+  AppDelegate.brazePushRegistrationRequested = NO;
   Braze *braze = AppDelegate.braze;
   if (braze == nil) {
     reject(@"SDK_UNAVAILABLE", @"Braze is not initialized", nil);

--- a/ios/MetaMask/NativeModules/BrazePush/BrazePushModule.m
+++ b/ios/MetaMask/NativeModules/BrazePush/BrazePushModule.m
@@ -59,19 +59,10 @@ RCT_REMAP_METHOD(
       return;
     }
 
-    NSNumber *isRetriable =
-      error.userInfo[BRZPushUnregistrationErrorUserInfoKey.isRetriable] ?: @NO;
-    NSNumber *httpStatusCode =
-      error.userInfo[BRZPushUnregistrationErrorUserInfoKey.httpStatusCode];
-    NSMutableDictionary *result = [@{
+    resolve(@{
       @"success": @NO,
-      @"message": error.localizedDescription,
-      @"isRetriable": isRetriable
-    } mutableCopy];
-    if (httpStatusCode != nil) {
-      result[@"httpStatusCode"] = httpStatusCode;
-    }
-    resolve(result);
+      @"message": error.localizedDescription
+    });
   }];
 }
 


### PR DESCRIPTION
## **Description**

Stacks on #35692.

Adds a one-time upgrade reconciliation for legacy notification consent:
- Migration 153 schedules Braze device unregistration when either persisted MetaMask notification switch is disabled or missing.
- The existing durable Braze pending-unregistration path performs and independently clears that device-scoped work.
- Eligible users are marked for an authenticated AUS preferences check. The worker delegates to `createOnChainTriggers`, which initializes missing preferences but preserves an existing AUS record.
- Historical marketing consent can recover users affected by #35387, while the explicit in-app opt-out marker prevents this inference from re-enabling users who later disabled notifications.
- Braze registration now also requires the master MetaMask notifications switch, preventing an inconsistent push-only state from re-registering the device.

The Braze and AUS markers are independent, so either reconciliation can complete without causing the other to repeat. Failed AUS work remains pending for the next authenticated app launch.

## **Changelog**

CHANGELOG entry: Fixed notification consent synchronization for existing users

## **Related issues**

Refs: #35387, #35692

## **Manual testing steps**

```gherkin
Feature: legacy notification consent reconciliation

  Scenario: upgraded user has disabled MetaMask notifications
    Given an installation from before migration 153 with OS push permission granted
    And the MetaMask master or push notification switch is disabled
    When the app is upgraded and opened
    Then the device is unregistered from Braze push
    And Braze push is not registered again while the master switch is disabled

  Scenario: upgraded eligible user has no AUS notification preferences
    Given an installation from before migration 153 with no AUS notification preferences
    And MetaMask notifications or historical marketing consent is enabled
    And the user has not explicitly disabled notifications in MetaMask
    When the app is upgraded and the user signs in
    Then AUS notification preferences are initialized from current consent
    And the backfill does not perform device push registration

  Scenario: upgraded user explicitly opted out
    Given an installation from before migration 153 with historical marketing consent
    And the user explicitly disabled notifications in MetaMask
    When the app is upgraded and the user signs in
    Then AUS initialization does not re-enable notifications
```

## **Screenshots/Recordings**

N/A — this is a migration and background reconciliation with no UI changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've assessed Android performance impact; no UI or hot-path work was added
- [x] I've assessed power-user impact; the jobs are one-time and marker-gated
- [x] I've assessed tracing needs; existing error reporting covers this migration and no performance trace is applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)