### PR TITLE
fix(homepage): hide Money breakdown row for geo-blocked users

### DIFF
--- a/app/components/Views/Homepage/BalanceBreakdown/hooks/slices/useMoneySlice.test.ts
+++ b/app/components/Views/Homepage/BalanceBreakdown/hooks/slices/useMoneySlice.test.ts
@@ -1,32 +1,51 @@
 import { renderHook } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
 import useMoneyAccountBalance from '../../../../../UI/Money/hooks/useMoneyAccountBalance';
 import useMoneyVaultApy from '../../../../../UI/Money/hooks/useMoneyVaultApy';
 import useMoneyAccountInfo from '../../../../../UI/Money/hooks/useMoneyAccountInfo';
+import { selectIsMoneyAccountVisible } from '../../../../../UI/Money/selectors/visibility';
 import { getMoneySliceStatus, useMoneySlice } from './useMoneySlice';
 
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
 jest.mock('../../../../../UI/Money/hooks/useMoneyAccountBalance');
 jest.mock('../../../../../UI/Money/hooks/useMoneyVaultApy');
 jest.mock('../../../../../UI/Money/hooks/useMoneyAccountInfo');
+jest.mock('../../../../../UI/Money/selectors/visibility', () => ({
+  selectIsMoneyAccountVisible: jest.fn(),
+}));
 
+const mockUseSelector = jest.mocked(useSelector);
 const mockUseMoneyAccountBalance = jest.mocked(useMoneyAccountBalance);
 const mockUseMoneyVaultApy = jest.mocked(useMoneyVaultApy);
 const mockUseMoneyAccountInfo = jest.mocked(useMoneyAccountInfo);
 
 const READY_INPUT = {
-  isFeatureEnabled: true,
+  isMoneyAccountVisible: true,
   hasMoneyAccount: true,
   isBalanceLoading: false,
   isBalanceFetchError: false,
   hasTokenTotal: true,
 };
 
+function mockMoneyAccountVisible(isVisible: boolean) {
+  mockUseSelector.mockImplementation((selector) => {
+    if (selector === selectIsMoneyAccountVisible) {
+      return isVisible;
+    }
+    return undefined;
+  });
+}
+
 describe('getMoneySliceStatus', () => {
-  it('requires the feature and an existing account', () => {
+  it('requires a visible Money account surface and an existing account', () => {
     expect(
       getMoneySliceStatus({ ...READY_INPUT, hasMoneyAccount: false }),
     ).toBe('ineligible');
     expect(
-      getMoneySliceStatus({ ...READY_INPUT, isFeatureEnabled: false }),
+      getMoneySliceStatus({ ...READY_INPUT, isMoneyAccountVisible: false }),
     ).toBe('ineligible');
   });
 
@@ -44,6 +63,7 @@ describe('getMoneySliceStatus', () => {
 describe('useMoneySlice', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockMoneyAccountVisible(true);
     mockUseMoneyAccountInfo.mockReturnValue({
       isMoneyAccountFeatureEnabled: true,
       hasMoneyAccount: true,
@@ -129,21 +149,23 @@ describe('useMoneySlice', () => {
     const { result } = renderHook(() => useMoneySlice((amount) => amount));
 
     expect(result.current.status).toBe('ineligible');
+    expect(result.current.isVisible).toBe(true);
     expect(result.current.apyPercent).toBe(4.1);
     expect(result.current.apyLoading).toBe(false);
   });
 
-  it('suppresses APY when the Money feature is disabled', () => {
+  it('excludes the Money balance when the account is not visible', () => {
+    mockMoneyAccountVisible(false);
     mockUseMoneyAccountInfo.mockReturnValue({
-      isMoneyAccountFeatureEnabled: false,
-      hasMoneyAccount: false,
+      isMoneyAccountFeatureEnabled: true,
+      hasMoneyAccount: true,
     } as ReturnType<typeof useMoneyAccountInfo>);
     mockUseMoneyVaultApy.mockReturnValue({
       apyPercent: 4.1,
       vaultApyQuery: { isLoading: false },
     } as ReturnType<typeof useMoneyVaultApy>);
     mockUseMoneyAccountBalance.mockReturnValue({
-      tokenTotal: undefined,
+      tokenTotal: { toNumber: () => 100 },
       isBalanceLoading: false,
       isBalanceFetchError: false,
     } as ReturnType<typeof useMoneyAccountBalance>);

--- a/app/components/Views/Homepage/BalanceBreakdown/hooks/slices/useMoneySlice.ts
+++ b/app/components/Views/Homepage/BalanceBreakdown/hooks/slices/useMoneySlice.ts
@@ -1,23 +1,25 @@
 import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import useMoneyAccountBalance from '../../../../../UI/Money/hooks/useMoneyAccountBalance';
 import useMoneyVaultApy from '../../../../../UI/Money/hooks/useMoneyVaultApy';
 import useMoneyAccountInfo from '../../../../../UI/Money/hooks/useMoneyAccountInfo';
+import { selectIsMoneyAccountVisible } from '../../../../../UI/Money/selectors/visibility';
 import type { BalanceSlice, FiatConverter, SliceStatus } from '../../types';
 
 export function getMoneySliceStatus({
-  isFeatureEnabled,
+  isMoneyAccountVisible,
   hasMoneyAccount,
   isBalanceLoading,
   isBalanceFetchError,
   hasTokenTotal,
 }: {
-  isFeatureEnabled: boolean;
+  isMoneyAccountVisible: boolean;
   hasMoneyAccount: boolean;
   isBalanceLoading: boolean;
   isBalanceFetchError: boolean;
   hasTokenTotal: boolean;
 }): SliceStatus {
-  if (!isFeatureEnabled || !hasMoneyAccount) {
+  if (!isMoneyAccountVisible || !hasMoneyAccount) {
     return 'ineligible';
   }
   if (isBalanceFetchError) return 'error';
@@ -26,15 +28,15 @@ export function getMoneySliceStatus({
 }
 
 export function useMoneySlice(toUserCurrency: FiatConverter): BalanceSlice {
-  const { isMoneyAccountFeatureEnabled, hasMoneyAccount } =
-    useMoneyAccountInfo();
+  const isMoneyAccountVisible = useSelector(selectIsMoneyAccountVisible);
+  const { hasMoneyAccount } = useMoneyAccountInfo();
   const { tokenTotal, isBalanceLoading, isBalanceFetchError } =
-    useMoneyAccountBalance({ enabled: isMoneyAccountFeatureEnabled });
+    useMoneyAccountBalance({ enabled: isMoneyAccountVisible });
   const { apyPercent, vaultApyQuery } = useMoneyVaultApy({
-    enabled: isMoneyAccountFeatureEnabled,
+    enabled: isMoneyAccountVisible,
   });
   const moneyStatus = getMoneySliceStatus({
-    isFeatureEnabled: isMoneyAccountFeatureEnabled,
+    isMoneyAccountVisible,
     hasMoneyAccount,
     isBalanceLoading,
     isBalanceFetchError,
@@ -50,27 +52,21 @@ export function useMoneySlice(toUserCurrency: FiatConverter): BalanceSlice {
       ? 'error'
       : moneyStatus;
   const valueFiat = status === 'ready' ? (convertedValue ?? 0) : 0;
-  const apyLoading = isMoneyAccountFeatureEnabled && vaultApyQuery.isLoading;
+  const apyLoading = isMoneyAccountVisible && vaultApyQuery.isLoading;
   const visibleApyPercent =
-    isMoneyAccountFeatureEnabled && !apyLoading && apyPercent !== undefined
+    isMoneyAccountVisible && !apyLoading && apyPercent !== undefined
       ? apyPercent
       : undefined;
 
   return useMemo(
     () => ({
       key: 'money',
-      isVisible: isMoneyAccountFeatureEnabled,
+      isVisible: isMoneyAccountVisible,
       valueFiat,
       status,
       apyPercent: visibleApyPercent,
       apyLoading,
     }),
-    [
-      apyLoading,
-      isMoneyAccountFeatureEnabled,
-      status,
-      valueFiat,
-      visibleApyPercent,
-    ],
+    [apyLoading, isMoneyAccountVisible, status, valueFiat, visibleApyPercent],
   );
 }

--- a/app/components/Views/Homepage/BalanceBreakdown/hooks/slices/usePerpsSlice.test.ts
+++ b/app/components/Views/Homepage/BalanceBreakdown/hooks/slices/usePerpsSlice.test.ts
@@ -25,7 +25,6 @@ describe('usePerpsSlice', () => {
     jest.clearAllMocks();
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectPerpsEnabledFlag) return true;
-      if (selector === selectPerpsEligibility) return true;
       if (selector === selectPerpsProvider) return 'hyperliquid';
       if (selector === selectPerpsBalances) {
         return {
@@ -56,7 +55,6 @@ describe('usePerpsSlice', () => {
   it('is ineligible when the feature is unavailable', () => {
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectPerpsEnabledFlag) return false;
-      if (selector === selectPerpsEligibility) return true;
       if (selector === selectPerpsBalances) return {};
       return undefined;
     });
@@ -70,6 +68,21 @@ describe('usePerpsSlice', () => {
     expect(result.current.status).toBe('ineligible');
     expect(result.current.isVisible).toBe(false);
     expect(result.current.valueFiat).toBe(0);
+  });
+
+  it('loads and displays the balance when the user is geo-blocked', () => {
+    const { result } = renderHook(() => usePerpsSlice((amount) => amount * 2));
+
+    expect(mockUsePerpsLiveAccount).toHaveBeenCalledWith({
+      enabled: true,
+      throttleMs: 1000,
+    });
+    expect(mockUseSelector).not.toHaveBeenCalledWith(selectPerpsEligibility);
+    expect(result.current).toMatchObject({
+      isVisible: true,
+      status: 'ready',
+      valueFiat: 200,
+    });
   });
 
   it('reports a connection error when no account data is available', () => {

--- a/app/components/Views/Homepage/BalanceBreakdown/hooks/slices/usePerpsSlice.ts
+++ b/app/components/Views/Homepage/BalanceBreakdown/hooks/slices/usePerpsSlice.ts
@@ -7,7 +7,6 @@ import { usePerpsConnection } from '../../../../../UI/Perps/hooks/usePerpsConnec
 import { selectPerpsEnabledFlag } from '../../../../../UI/Perps/selectors/featureFlags';
 import {
   selectPerpsBalances,
-  selectPerpsEligibility,
   selectPerpsProvider,
 } from '../../../../../UI/Perps/selectors/perpsController';
 import type { BalanceSlice, FiatConverter } from '../../types';
@@ -15,19 +14,17 @@ import { PERPS_HOMEPAGE_THROTTLE_MS } from '../../constants';
 
 export function usePerpsSlice(toUserCurrency: FiatConverter): BalanceSlice {
   const isEnabled = useSelector(selectPerpsEnabledFlag);
-  const isEligible = useSelector(selectPerpsEligibility);
   const perpsBalances = useSelector(selectPerpsBalances);
   const activeProvider = useSelector(selectPerpsProvider) as
     | PerpsActiveProviderMode
     | undefined;
+  // Keep portfolio reads available for geo-blocked users; eligibility only
+  // restricts Perps actions, matching PerpsHomeView.
   const { account, isInitialLoading } = usePerpsLiveAccount({
-    enabled: isEnabled && isEligible,
+    enabled: isEnabled,
     throttleMs: PERPS_HOMEPAGE_THROTTLE_MS,
   });
   const { error: connectionError } = usePerpsConnection();
-
-  // Perps is ineligible when the feature flag is off
-  const isIneligible = !isEnabled || !isEligible;
 
   const totalBalanceUsd = parseFloat(account?.totalBalance ?? '0') || 0;
   const convertedValue = toUserCurrency(totalBalanceUsd);
@@ -46,19 +43,13 @@ export function usePerpsSlice(toUserCurrency: FiatConverter): BalanceSlice {
   }, [activeProvider, perpsBalances, toUserCurrency]);
 
   const status = useMemo(() => {
-    if (isIneligible) return 'ineligible' as const;
+    if (!isEnabled) return 'ineligible' as const;
     if (!account && connectionError) return 'error' as const;
     if (isInitialLoading) return 'loading' as const;
     if (!account) return 'loading' as const;
     if (convertedValue === undefined) return 'error' as const;
     return 'ready' as const;
-  }, [
-    account,
-    connectionError,
-    convertedValue,
-    isIneligible,
-    isInitialLoading,
-  ]);
+  }, [account, connectionError, convertedValue, isEnabled, isInitialLoading]);
 
   return useMemo<BalanceSlice>(
     () => ({

--- a/app/components/Views/Homepage/BalanceBreakdown/hooks/slices/usePredictSlice.test.ts
+++ b/app/components/Views/Homepage/BalanceBreakdown/hooks/slices/usePredictSlice.test.ts
@@ -42,29 +42,44 @@ describe('usePredictSlice', () => {
     expect(result.current.valueFiat).toBe(120);
   });
 
-  it.each([
-    {
-      name: 'portfolio loading',
-      portfolio: createPortfolio({ isLoading: true }),
-      enabled: true,
-      expected: 'loading',
-    },
-    {
-      name: 'portfolio error',
-      portfolio: createPortfolio({ error: new Error('failed') }),
-      enabled: true,
-      expected: 'error',
-    },
-  ])('returns zero for $name', ({ portfolio, enabled, expected }) => {
-    mockUseSelector.mockReturnValue(enabled);
-    mockUsePredictPortfolio.mockReturnValue(portfolio);
+  it('returns zero while the portfolio is loading', () => {
+    mockUsePredictPortfolio.mockReturnValue(
+      createPortfolio({ isLoading: true }),
+    );
 
     const { result } = renderHook(() =>
       usePredictSlice((amount) => amount * 2),
     );
 
-    expect(result.current.status).toBe(expected);
+    expect(result.current.status).toBe('loading');
     expect(result.current.valueFiat).toBe(0);
+  });
+
+  it('keeps the resolved portfolio value when the portfolio request fails', () => {
+    mockUsePredictPortfolio.mockReturnValue(
+      createPortfolio({ error: new Error('failed'), portfolioValue: 60 }),
+    );
+
+    const { result } = renderHook(() =>
+      usePredictSlice((amount) => amount * 2),
+    );
+
+    expect(result.current.status).toBe('ready');
+    expect(result.current.valueFiat).toBe(120);
+  });
+
+  it('reports a zero balance instead of an error for a geo-blocked portfolio', () => {
+    mockUsePredictPortfolio.mockReturnValue(
+      createPortfolio({ error: new Error('geo blocked'), portfolioValue: 0 }),
+    );
+
+    const { result } = renderHook(() => usePredictSlice((amount) => amount));
+
+    expect(result.current).toMatchObject({
+      isVisible: true,
+      status: 'ready',
+      valueFiat: 0,
+    });
   });
 
   it('disables portfolio work and hides the slice with the feature off', () => {

--- a/app/components/Views/Homepage/BalanceBreakdown/hooks/slices/usePredictSlice.ts
+++ b/app/components/Views/Homepage/BalanceBreakdown/hooks/slices/usePredictSlice.ts
@@ -6,7 +6,10 @@ import type { BalanceSlice, FiatConverter } from '../../types';
 
 export function usePredictSlice(toUserCurrency: FiatConverter): BalanceSlice {
   const isEnabled = useSelector(selectPredictEnabledFlag);
-  const { portfolioValue, isLoading, error } = usePredictPortfolio({
+  // Portfolio request failures (e.g. geo-blocked Predict endpoints) are not
+  // propagated as a slice error: dashing this row and muting the wallet total
+  // would report a single product's outage as an unknown wallet balance.
+  const { portfolioValue, isLoading } = usePredictPortfolio({
     enabled: isEnabled,
     // PredictionsSection owns the homepage live-price subscription and updates
     // the shared positions query cache consumed by this aggregate.
@@ -17,11 +20,10 @@ export function usePredictSlice(toUserCurrency: FiatConverter): BalanceSlice {
 
   const status = useMemo(() => {
     if (!isEnabled) return 'ineligible' as const;
-    if (error) return 'error' as const;
     if (isLoading) return 'loading' as const;
     if (convertedValue === undefined) return 'error' as const;
     return 'ready' as const;
-  }, [convertedValue, error, isEnabled, isLoading]);
+  }, [convertedValue, isEnabled, isLoading]);
 
   const valueFiat = status === 'ready' ? (convertedValue ?? 0) : 0;
 


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

The homepage balance-breakdown Money row was gated only on `moneyEnableMoneyAccount`. The bottom tab uses `selectIsMoneyAccountVisible` (flag **and** geo eligibility), so a geo-blocked or geo-unknown user could still see the Money row (and have it counted in the hero total / allocation bar) even though the Money tab was replaced by Activity.

`useMoneySlice` now uses `selectIsMoneyAccountVisible` for row visibility, balance/APY fetches, and slice status. Geo-blocked users drop the row and the Money contribution from totals. Eligible users without an account still get the APY teaser.

Perps had the opposite mismatch: the row stayed visible while geo eligibility disabled `usePerpsLiveAccount` and marked the slice ineligible, producing `—` even when Perps Home showed a balance. `usePerpsSlice` now loads account data whenever the Perps flag is on; geo eligibility continues to guard Perps actions only.

Predict already fetches the same `usePredictPortfolio` aggregate as Predict Home with no geo gate on reads. Predict Home still maps `error` to `—` locally. The breakdown previously promoted that `error` to slice `error`, which dashed the Predictions row **and** muted the wallet hero. `usePredictSlice` now ignores portfolio `error` and reports `ready` with the resolved `portfolioValue` (the hook defaults failed queries with no cache to `0`). A Predict fetch failure — including geo-blocked endpoints that reject — no longer greys the aggregated balance. `usePredictPortfolio` and the Predict page are unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed homepage balance breakdown geo visibility for Money and geo-blocked Perps/Predict balances

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A — no dedicated ticket; follow-up to align the homepage balance-breakdown Money row with existing tab geo gating (`selectIsMoneyAccountVisible`).

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Homepage balance breakdown geo behavior

  Scenario: geo-eligible user sees the Money row
    Given the Money account feature flag is enabled
    And detected geolocation is a country that is not in moneyAccountGeoBlockedCountries
    And the homepage balance-breakdown treatment is active

    When user opens Wallet Home
    Then the Money row is visible in the balance breakdown
    And the Money tab is present in the bottom nav

  Scenario: geo-blocked user does not see the Money row
    Given the Money account feature flag is enabled
    And detected geolocation is a blocked country (e.g. GB, or unknown)
    And the homepage balance-breakdown treatment is active

    When user opens Wallet Home
    Then the Money row is not visible in the balance breakdown
    And Money is not included in the hero total or allocation bar
    And the bottom nav shows Activity instead of Money

  Scenario: geo-eligible user without a Money account still sees APY
    Given the Money account feature flag is enabled
    And the user is geo-eligible
    And no Money account exists yet

    When user opens Wallet Home
    Then the Money row is visible with APY
    And the slice does not add a Money balance to the total

  Scenario: geo-blocked user sees the Perps balance
    Given the Perps feature flag is enabled
    And the user is geo-blocked from Perps actions
    And the user has a Perps balance

    When user opens Wallet Home
    Then the Perps row is visible in the balance breakdown
    And the Perps row shows the same balance as Perps Home
    And the Perps balance is included in the aggregated balance

  Scenario: geo-blocked Predict user sees a numeric row, not a dashed/grey total
    Given the Predict feature flag is enabled
    And the user is geo-blocked from Predict
    And the Predict portfolio queries reject (empty cache → portfolioValue 0)

    When user opens Wallet Home
    Then the Predict row is visible in the balance breakdown
    And the Predict row shows $0.00 rather than a dash
    And the aggregated wallet balance is not muted
    And Predict Home may still show — for the same error (page unchanged)
    And Predict deposit / withdraw / claim remain geo-guarded

  Scenario: Predict portfolio request failure does not mute the total
    Given the homepage balance-breakdown treatment is active
    And the Predict portfolio request fails after a value has resolved

    When user opens Wallet Home
    Then the Predict row shows the resolved portfolioValue instead of a dash
    And the aggregated balance is not muted from a Predict error
```

Power-user: not applicable — visibility is geo/flag, not account/token count.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->


### **Before**


### **After**


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes homepage balance aggregation and visibility for Money, Perps, and Predict; incorrect gating could hide balances or include excluded products in the hero total.
> 
> **Overview**
> Aligns homepage **balance breakdown** slices with tab/geo rules so hero totals and rows match what users see elsewhere.
> 
> **Money:** `useMoneySlice` now gates visibility, balance/APY fetches, and eligibility on `selectIsMoneyAccountVisible` (feature flag **and** geo) instead of the feature flag alone. Geo-blocked users no longer see the Money row or its contribution to the aggregated balance; geo-eligible users without an account can still see the APY teaser.
> 
> **Perps:** `usePerpsSlice` stops using `selectPerpsEligibility` for homepage reads. Live account data loads whenever the Perps flag is on, so geo-blocked users with a balance get a numeric row (matching Perps Home) instead of ineligible/`—`.
> 
> **Predict:** `usePredictSlice` no longer maps portfolio fetch `error` to slice `error`. It reports `ready` with the resolved `portfolioValue` (including `0` on geo-blocked failures), so a Predict outage does not dash the row or mute the wallet hero total.
> 
> Unit tests for all three slices are updated to cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07fa0a3d8cda5812a5df690bcb60d80f28e86b63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->