### PR TITLE
feat(whats-happening): add fetch and TTC Sentry spans

### DIFF
--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
@@ -7,7 +7,12 @@ import {
 } from '../../../../constants/digestQuery';
 import Engine from '../../../../core/Engine';
 import { formatRelativeTime } from '../utils/marketInsightsFormatting';
-import { trace, TraceName, TraceOperation } from '../../../../util/trace';
+import {
+  getDigestCacheState,
+  isDigestObserverPending,
+  withDigestFetchSpan,
+} from '../../../../util/digestPerformance';
+import { TraceName, TraceOperation } from '../../../../util/trace';
 import {
   getMarketInsightsTraceTags,
   type MarketInsightsCacheState,
@@ -67,7 +72,7 @@ export const useMarketInsights = (
     ]);
     cacheStateRef.current = {
       assetIdentifier: queryAssetIdentifier,
-      state: cachedReport ? 'warm' : 'cold',
+      state: getDigestCacheState(cachedReport),
     };
   }
 
@@ -82,7 +87,7 @@ export const useMarketInsights = (
   const query = useQuery<MarketInsightsReport | null, unknown>({
     queryKey: [MARKET_INSIGHTS_QUERY_KEY, queryAssetIdentifier],
     queryFn: ({ signal }) =>
-      trace(
+      withDigestFetchSpan(
         {
           name: TraceName.MarketInsightsFetch,
           op: TraceOperation.MarketInsightsFetch,
@@ -91,40 +96,11 @@ export const useMarketInsights = (
             cacheState,
           ),
         },
-        async (span) => {
-          let wasCancelled = signal.aborted;
-          const markCancelled = () => {
-            wasCancelled = true;
-            span?.setAttribute('result', 'cancelled');
-            span?.setAttribute('success', false);
-          };
-
-          if (wasCancelled) {
-            markCancelled();
-          } else {
-            signal.addEventListener('abort', markCancelled, { once: true });
-          }
-
-          try {
-            const result =
-              await Engine.context.AiDigestController.fetchMarketInsights(
-                queryAssetIdentifier,
-              );
-            if (!wasCancelled) {
-              span?.setAttribute('result', result ? 'success' : 'empty');
-              span?.setAttribute('success', true);
-            }
-            return result;
-          } catch (error) {
-            if (!wasCancelled) {
-              span?.setAttribute('result', 'error');
-              span?.setAttribute('success', false);
-            }
-            throw error;
-          } finally {
-            signal.removeEventListener('abort', markCancelled);
-          }
-        },
+        signal,
+        () =>
+          Engine.context.AiDigestController.fetchMarketInsights(
+            queryAssetIdentifier,
+          ),
       ),
     enabled: isQueryEnabled,
     retry: false,
@@ -159,7 +135,11 @@ export const useMarketInsights = (
   // until that first fetch settles so TTC does not close at ~0ms. After
   // this observer has fetched, a later focus refetch must not flip loading
   // or the entry-card skeleton returns.
-  const isLoading = isQueryEnabled && !report && !query.isFetchedAfterMount;
+  const isLoading = isDigestObserverPending({
+    enabled: isQueryEnabled,
+    hasContent: Boolean(report),
+    isFetchedAfterMount: query.isFetchedAfterMount,
+  });
 
   const timeAgo = useMemo(
     () => (report ? formatRelativeTime(report.generatedAt) : ''),

--- a/app/components/UI/MarketInsights/hooks/useViewportTracking.test.ts
+++ b/app/components/UI/MarketInsights/hooks/useViewportTracking.test.ts
@@ -349,4 +349,36 @@ describe('useViewportTracking', () => {
       }),
     );
   });
+
+  it('skips Sentry viewport spans when emitTrace is false', () => {
+    const onVisible = jest.fn();
+    const { result, unmount } = renderHook(() =>
+      useViewportTracking(onVisible, 0.5, {
+        source: 'unknown',
+        stage: 'entry_card',
+        emitTrace: false,
+      }),
+    );
+
+    const mockMeasureInWindow = jest.fn(
+      (cb: (x: number, y: number, w: number, h: number) => void) => {
+        cb(0, 100, 300, 100);
+      },
+    );
+    (result.current.ref as { current: unknown }).current = {
+      measureInWindow: mockMeasureInWindow,
+    };
+
+    act(() => {
+      result.current.onLayout();
+    });
+
+    expect(onVisible).toHaveBeenCalledTimes(1);
+    expect(mockTrace).not.toHaveBeenCalled();
+    expect(mockEndTrace).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(mockEndTrace).not.toHaveBeenCalled();
+  });
 });

--- a/app/components/UI/MarketInsights/hooks/useViewportTracking.ts
+++ b/app/components/UI/MarketInsights/hooks/useViewportTracking.ts
@@ -25,6 +25,7 @@ const DEFAULT_AREA_THRESHOLD = 0.5;
  *
  * @param onVisible - Callback fired once when visibility threshold is met.
  * @param areaThreshold - Fraction of the component height that must be visible.
+ * @param context - Bounded source/stage tags. Set `emitTrace: false` to keep visibility callbacks without Market Insights viewport Sentry spans.
  * @returns A ref and onLayout callback to attach to the tracked view.
  */
 export const useViewportTracking = (
@@ -33,8 +34,10 @@ export const useViewportTracking = (
   context: {
     source: MarketInsightsSource;
     stage: MarketInsightsStage;
+    emitTrace?: boolean;
   } = { source: 'unknown', stage: 'entry_card' },
 ) => {
+  const emitTrace = context.emitTrace !== false;
   const ref = useRef<View>(null);
   const hasFired = useRef(false);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -71,35 +74,39 @@ export const useViewportTracking = (
           intervalRef.current = null;
         }
 
-        endTrace({
-          name: TraceName.MarketInsightsViewportTracking,
-          data: {
-            measure_calls: measureCountRef.current,
-            resolved_by: 'visibility_threshold',
-            result: 'success',
-            success: true,
-            source: context.source,
-            stage: context.stage,
-          },
-        });
+        if (emitTrace) {
+          endTrace({
+            name: TraceName.MarketInsightsViewportTracking,
+            data: {
+              measure_calls: measureCountRef.current,
+              resolved_by: 'visibility_threshold',
+              result: 'success',
+              success: true,
+              source: context.source,
+              stage: context.stage,
+            },
+          });
+        }
 
         onVisibleRef.current();
       }
     });
-  }, [areaThreshold, context.source, context.stage]);
+  }, [areaThreshold, context.source, context.stage, emitTrace]);
 
   const onLayout = useCallback(() => {
     if (!traceStartedRef.current) {
       traceStartedRef.current = true;
-      trace({
-        name: TraceName.MarketInsightsViewportTracking,
-        op: TraceOperation.MarketInsightsViewportTracking,
-        tags: {
-          feature: 'market_insights',
-          source: context.source,
-          stage: context.stage,
-        },
-      });
+      if (emitTrace) {
+        trace({
+          name: TraceName.MarketInsightsViewportTracking,
+          op: TraceOperation.MarketInsightsViewportTracking,
+          tags: {
+            feature: 'market_insights',
+            source: context.source,
+            stage: context.stage,
+          },
+        });
+      }
     }
 
     checkVisibility();
@@ -107,7 +114,7 @@ export const useViewportTracking = (
     if (!hasFired.current && !intervalRef.current) {
       intervalRef.current = setInterval(checkVisibility, POLL_INTERVAL_MS);
     }
-  }, [checkVisibility, context.source, context.stage]);
+  }, [checkVisibility, context.source, context.stage, emitTrace]);
 
   useEffect(
     () => () => {
@@ -116,7 +123,7 @@ export const useViewportTracking = (
         intervalRef.current = null;
       }
 
-      if (traceStartedRef.current && !hasFired.current) {
+      if (emitTrace && traceStartedRef.current && !hasFired.current) {
         endTrace({
           name: TraceName.MarketInsightsViewportTracking,
           data: {
@@ -131,7 +138,7 @@ export const useViewportTracking = (
         });
       }
     },
-    [context.source, context.stage],
+    [context.source, context.stage, emitTrace],
   );
 
   return { ref, onLayout };

--- a/app/components/UI/MarketInsights/utils/marketInsightsPerformance.ts
+++ b/app/components/UI/MarketInsights/utils/marketInsightsPerformance.ts
@@ -1,10 +1,15 @@
 import type { TraceValue } from '../../../../util/trace';
+import {
+  getDigestTraceEndData,
+  type DigestCacheState,
+  type DigestResult,
+} from '../../../../util/digestPerformance';
 
 export type MarketInsightsSource = 'token_details' | 'perps' | 'unknown';
 export type MarketInsightsStage = 'entry_card' | 'full_view';
 export type MarketInsightsAssetType = 'token' | 'perps';
-export type MarketInsightsCacheState = 'warm' | 'cold';
-export type MarketInsightsResult = 'success' | 'empty' | 'error' | 'cancelled';
+export type MarketInsightsCacheState = DigestCacheState;
+export type MarketInsightsResult = DigestResult;
 
 export interface MarketInsightsTelemetryContext {
   source: MarketInsightsSource;
@@ -29,20 +34,4 @@ export const getMarketInsightsTraceTags = (
   cache_state: cacheState,
 });
 
-export const getMarketInsightsTraceEndData = (
-  result: MarketInsightsResult,
-): Record<string, TraceValue> => ({
-  result,
-  success: result === 'success' || result === 'empty',
-  ...(result !== 'cancelled'
-    ? {
-        content_state:
-          result === 'success'
-            ? 'filled'
-            : result === 'empty'
-              ? 'empty'
-              : 'error',
-      }
-    : {}),
-  ...(result === 'cancelled' ? { reason: 'owner_cancelled' } : {}),
-});
+export const getMarketInsightsTraceEndData = getDigestTraceEndData;

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -217,7 +217,12 @@ const PerpsHomeView = () => {
       isLoading: topMoversFeed.isLoading,
       data: topMoversFeed.data,
     });
-  const whatsHappeningFeed = useWhatsHappening();
+  const whatsHappeningFeed = useWhatsHappening({
+    telemetryContext: {
+      source: WhatsHappeningSource.Perps,
+      stage: 'carousel',
+    },
+  });
   const isWhatsHappeningVisible =
     isWhatsHappeningEnabled &&
     isWhatsHappeningSectionVisible({

--- a/app/components/UI/WhatsHappening/WhatsHappeningSection.test.tsx
+++ b/app/components/UI/WhatsHappening/WhatsHappeningSection.test.tsx
@@ -11,6 +11,7 @@ import {
 } from './constants';
 import { WhatsHappeningSelectorsIDs } from './WhatsHappening.testIds';
 
+const mockTrace = jest.fn();
 const mockNavigate = jest.fn();
 const mockTrackEvent = jest.fn();
 const mockCreateEventBuilder = jest.fn((eventName: string) => ({
@@ -18,6 +19,11 @@ const mockCreateEventBuilder = jest.fn((eventName: string) => ({
     build: jest.fn(() => ({ category: eventName, properties })),
   })),
   build: jest.fn(() => ({ category: eventName })),
+}));
+
+jest.mock('../../../util/trace', () => ({
+  ...jest.requireActual('../../../util/trace'),
+  trace: (...args: unknown[]) => mockTrace(...args),
 }));
 
 jest.mock('@react-navigation/native', () => {
@@ -92,6 +98,21 @@ describe('WhatsHappeningSection', () => {
       isLoading: false,
       error: null,
       refresh: jest.fn(),
+    });
+  });
+
+  it('passes carousel telemetry context to the feed observer', () => {
+    mockUseWhatsHappening.mockReturnValue({
+      items: [mockItem],
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    renderWithProvider(<WhatsHappeningSection {...defaultProps} />);
+
+    expect(mockUseWhatsHappening).toHaveBeenCalledWith({
+      enabled: true,
+      telemetryContext: { source: 'homepage', stage: 'carousel' },
     });
   });
 
@@ -249,6 +270,17 @@ describe('WhatsHappeningSection', () => {
     expect(mockNavigate).toHaveBeenCalledWith(Routes.WHATS_HAPPENING_DETAIL, {
       initialIndex: 0,
       source: 'homepage',
+    });
+    expect(mockTrace).toHaveBeenCalledWith({
+      name: "What's Happening View Load",
+      op: 'whats_happening.load',
+      id: 'homepage:expanded',
+      tags: {
+        feature: 'whats_happening',
+        source: 'homepage',
+        stage: 'expanded',
+        cache_state: 'warm',
+      },
     });
   });
 

--- a/app/components/UI/WhatsHappening/WhatsHappeningSection.tsx
+++ b/app/components/UI/WhatsHappening/WhatsHappeningSection.tsx
@@ -30,6 +30,11 @@ import { PerpsStreamProvider } from '../Perps/providers/PerpsStreamManager';
 import MarketInsightsDisclaimerBottomSheet from '../MarketInsights/components/MarketInsightsEntryCard/MarketInsightsDisclaimerBottomSheet';
 import { strings } from '../../../../locales/i18n';
 import Routes from '../../../constants/navigation/Routes';
+import { trace, TraceName, TraceOperation } from '../../../util/trace';
+import {
+  getWhatsHappeningTraceId,
+  getWhatsHappeningTraceTags,
+} from './utils/whatsHappeningPerformance';
 import {
   SKELETON_CARD_COUNT,
   WHATS_HAPPENING_CARD_MIN_HEIGHT,
@@ -94,8 +99,10 @@ const WhatsHappeningSection = forwardRef<
 
   const internalFeed = useWhatsHappening({
     enabled: feed === undefined,
+    telemetryContext: { source, stage: 'carousel' },
   });
-  const { items, isLoading, error, refresh } = feed ?? internalFeed;
+  const { items, isLoading, error, refresh, carouselTraceId } =
+    feed ?? internalFeed;
 
   const snapOffsets = useMemo(
     () =>
@@ -112,6 +119,12 @@ const WhatsHappeningSection = forwardRef<
 
   const navigateToDetail = useCallback(
     (initialIndex: number) => {
+      trace({
+        name: TraceName.WhatsHappeningViewLoad,
+        op: TraceOperation.WhatsHappeningLoad,
+        id: getWhatsHappeningTraceId(source, 'expanded'),
+        tags: getWhatsHappeningTraceTags({ source, stage: 'expanded' }, 'warm'),
+      });
       navigation.navigate(Routes.WHATS_HAPPENING_DETAIL, {
         initialIndex,
         source,
@@ -230,6 +243,7 @@ const WhatsHappeningSection = forwardRef<
                 item={item}
                 cardIndex={index}
                 source={source}
+                carouselTraceId={carouselTraceId}
                 onPress={() => handleCardPress(index)}
               />
             ))}

--- a/app/components/UI/WhatsHappening/components/WhatsHappeningCard.test.tsx
+++ b/app/components/UI/WhatsHappening/components/WhatsHappeningCard.test.tsx
@@ -13,10 +13,23 @@ const mockCreateEventBuilder = jest.fn((eventName: string) => ({
   build: jest.fn(() => ({ category: eventName })),
 }));
 
+const mockEndTrace = jest.fn();
+
+jest.mock('../../../../util/trace', () => ({
+  ...jest.requireActual('../../../../util/trace'),
+  endTrace: (...args: unknown[]) => mockEndTrace(...args),
+}));
+
 let capturedOnVisible: (() => void) | null = null;
+let capturedViewportContext: { emitTrace?: boolean } | undefined;
 jest.mock('../../MarketInsights/hooks/useViewportTracking', () => ({
-  useViewportTracking: (onVisible: () => void) => {
+  useViewportTracking: (
+    onVisible: () => void,
+    _areaThreshold?: number,
+    context?: { emitTrace?: boolean },
+  ) => {
     capturedOnVisible = onVisible;
+    capturedViewportContext = context;
     return { ref: { current: null }, onLayout: jest.fn() };
   },
 }));
@@ -100,6 +113,7 @@ describe('WhatsHappeningCard', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedOnVisible = null;
+    capturedViewportContext = undefined;
   });
 
   it('renders title and description', () => {
@@ -284,6 +298,50 @@ describe('WhatsHappeningCard', () => {
     expect(() =>
       fireEvent.press(screen.getByText(baseItem.title)),
     ).not.toThrow();
+  });
+
+  it('ends carousel time to content when the first card commits', () => {
+    renderWithProvider(
+      <WhatsHappeningCard
+        item={baseItem}
+        cardIndex={0}
+        source="explore"
+        carouselTraceId="explore:carousel"
+      />,
+    );
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: "What's Happening Carousel Load",
+      id: 'explore:carousel',
+      data: {
+        result: 'success',
+        success: true,
+        content_state: 'filled',
+      },
+    });
+  });
+
+  it('does not end carousel time to content for later cards', () => {
+    renderWithProvider(
+      <WhatsHappeningCard
+        item={baseItem}
+        cardIndex={1}
+        source="explore"
+        carouselTraceId="explore:carousel"
+      />,
+    );
+
+    expect(mockEndTrace).not.toHaveBeenCalled();
+  });
+
+  it('does not emit Market Insights viewport spans', () => {
+    renderWithProvider(
+      <WhatsHappeningCard item={baseItem} cardIndex={0} source="homepage" />,
+    );
+
+    expect(capturedViewportContext).toEqual(
+      expect.objectContaining({ emitTrace: false }),
+    );
   });
 
   it('tracks Whats Happening Card Scrolled to View when card becomes visible', () => {

--- a/app/components/UI/WhatsHappening/components/WhatsHappeningCard.tsx
+++ b/app/components/UI/WhatsHappening/components/WhatsHappeningCard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, memo } from 'react';
+import React, { useCallback, useEffect, useMemo, memo } from 'react';
 import { Pressable, View } from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
@@ -16,8 +16,10 @@ import type { WhatsHappeningItem } from '../types';
 import { getImpactLabel, getImpactTagSeverity } from '../util/impact';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
+import { endTrace, TraceName } from '../../../../util/trace';
 import { useViewportTracking } from '../../MarketInsights/hooks/useViewportTracking';
 import { formatRelativeTime } from '../../MarketInsights/utils/marketInsightsFormatting';
+import { getWhatsHappeningTraceEndData } from '../utils/whatsHappeningPerformance';
 import { getWhatsHappeningEventProps } from '../eventProperties';
 import {
   WHATS_HAPPENING_CARD_MIN_HEIGHT,
@@ -30,6 +32,8 @@ interface WhatsHappeningCardProps {
   item: WhatsHappeningItem;
   cardIndex: number;
   source: WhatsHappeningSourceValue;
+  /** Carousel time-to-content id owned by the feed observer. */
+  carouselTraceId?: string;
   onPress?: (item: WhatsHappeningItem) => void;
 }
 
@@ -37,6 +41,7 @@ const WhatsHappeningCard: React.FC<WhatsHappeningCardProps> = ({
   item,
   cardIndex,
   source,
+  carouselTraceId,
   onPress,
 }) => {
   const tw = useTailwind();
@@ -49,6 +54,18 @@ const WhatsHappeningCard: React.FC<WhatsHappeningCardProps> = ({
 
   const handlePress = () => onPress?.(item);
 
+  useEffect(() => {
+    if (cardIndex !== 0 || !carouselTraceId) {
+      return;
+    }
+
+    endTrace({
+      name: TraceName.WhatsHappeningCarouselLoad,
+      id: carouselTraceId,
+      data: getWhatsHappeningTraceEndData('success'),
+    });
+  }, [cardIndex, carouselTraceId]);
+
   const handleVisible = useCallback(() => {
     trackEvent(
       createEventBuilder(
@@ -59,8 +76,11 @@ const WhatsHappeningCard: React.FC<WhatsHappeningCardProps> = ({
     );
   }, [trackEvent, createEventBuilder, item, cardIndex, source]);
 
-  const { ref: cardRef, onLayout: onVisibilityLayout } =
-    useViewportTracking(handleVisible);
+  const { ref: cardRef, onLayout: onVisibilityLayout } = useViewportTracking(
+    handleVisible,
+    undefined,
+    { source: 'unknown', stage: 'entry_card', emitTrace: false },
+  );
 
   return (
     <View ref={cardRef} collapsable={false} onLayout={onVisibilityLayout}>

--- a/app/components/UI/WhatsHappening/hooks/index.ts
+++ b/app/components/UI/WhatsHappening/hooks/index.ts
@@ -2,6 +2,7 @@ export {
   useWhatsHappening,
   isWhatsHappeningSectionVisible,
 } from './useWhatsHappening';
+export { useWhatsHappeningLoadTrace } from './useWhatsHappeningLoadTrace';
 export type {
   UseWhatsHappeningResult,
   UseWhatsHappeningOptions,

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
@@ -940,6 +940,76 @@ describe('useWhatsHappening', () => {
     expect(second.result.current.isLoading).toBe(false);
   });
 
+  it('closes empty time to content on remount of a cached empty overview', async () => {
+    const emptyOverview = { ...mockOverview, trends: [] };
+    mockFetchMarketOverview.mockResolvedValue(emptyOverview);
+
+    const first = renderWhatsHappeningHook();
+    await waitFor(() => expect(first.result.current.isLoading).toBe(false));
+    expect(first.result.current.items).toHaveLength(0);
+    first.unmount();
+    mockEndTrace.mockClear();
+    mockFetchMarketOverview.mockClear();
+
+    const second = renderWhatsHappeningHook();
+
+    expect(second.result.current.isGenerationPending).toBe(false);
+    expect(mockFetchMarketOverview).not.toHaveBeenCalled();
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: "What's Happening Carousel Load",
+      id: 'unknown:carousel',
+      data: {
+        result: 'empty',
+        success: true,
+        content_state: 'empty',
+      },
+    });
+  });
+
+  it('keeps expanded time to content open until a deeplink front-page item settles', async () => {
+    mockFetchMarketOverview.mockResolvedValue({ ...mockOverview, trends: [] });
+    let resolveFrontPage: ((value: null) => void) | undefined;
+    mockFetchFrontPageItem.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFrontPage = resolve;
+        }),
+    );
+
+    const { result } = renderWhatsHappeningHook({
+      outdatedItemId: 'front-page-1',
+      telemetryContext: {
+        source: WhatsHappeningSource.Deeplink,
+        stage: 'expanded',
+      },
+    });
+
+    await waitFor(() => expect(mockFetchMarketOverview).toHaveBeenCalled());
+
+    expect(result.current.isGenerationPending).toBe(true);
+    expect(mockEndTrace).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "What's Happening View Load",
+        data: expect.objectContaining({ result: 'empty' }),
+      }),
+    );
+
+    await act(async () => {
+      resolveFrontPage?.(null);
+    });
+    await waitFor(() => expect(result.current.isGenerationPending).toBe(false));
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: "What's Happening View Load",
+      id: 'deeplink:expanded',
+      data: {
+        result: 'empty',
+        success: true,
+        content_state: 'empty',
+      },
+    });
+  });
+
   it('does not flip loading during a background refetch of a settled empty feed', async () => {
     mockFetchMarketOverview.mockResolvedValueOnce(null);
 

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
@@ -151,8 +151,6 @@ describe('useWhatsHappening', () => {
         op: 'whats_happening.fetch',
         tags: {
           feature: 'whats_happening',
-          source: 'unknown',
-          stage: 'carousel',
           cache_state: 'cold',
           fetch_kind: 'overview',
         },
@@ -454,6 +452,27 @@ describe('useWhatsHappening', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('cancels a caller-started view load when the feature is disabled', () => {
+    configureSelectors({ enabled: false });
+
+    renderWhatsHappeningHook({
+      telemetryContext: {
+        source: WhatsHappeningSource.Deeplink,
+        stage: 'expanded',
+      },
+    });
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: "What's Happening View Load",
+      id: 'deeplink:expanded',
+      data: {
+        result: 'cancelled',
+        success: false,
+        reason: 'owner_cancelled',
+      },
+    });
+  });
+
   describe('deep-linked outdated front-page item', () => {
     const mockFrontPage = {
       id: 'a3f1c2d4-5e6f-4a7b-8c9d-0e1f2a3b4c5d',
@@ -579,6 +598,8 @@ describe('useWhatsHappening', () => {
       expect(result.current.items).toHaveLength(1);
       expect(result.current.items[0].isOutdated).toBeUndefined();
       expect(result.current.error).toBeNull();
+      expect(mockSetAttribute).toHaveBeenCalledWith('result', 'error');
+      expect(mockSetAttribute).toHaveBeenCalledWith('success', false);
     });
 
     it('falls back to the latest items when the front page is not found', async () => {
@@ -753,7 +774,7 @@ describe('useWhatsHappening', () => {
     expect(result.current.items[0]?.isOutdated).toBeUndefined();
   });
 
-  it('tags overview fetch with the observer source', async () => {
+  it('omits observer source from the shared overview fetch span', async () => {
     const { result } = renderWhatsHappeningHook({
       telemetryContext: {
         source: WhatsHappeningSource.Explore,
@@ -767,14 +788,23 @@ describe('useWhatsHappening', () => {
     expect(mockTrace).toHaveBeenCalledWith(
       expect.objectContaining({
         name: "What's Happening Fetch",
-        tags: expect.objectContaining({
-          source: 'explore',
-          stage: 'carousel',
+        tags: {
+          feature: 'whats_happening',
+          cache_state: 'cold',
           fetch_kind: 'overview',
-        }),
+        },
       }),
       expect.any(Function),
     );
+    expect(mockTrace).toHaveBeenCalledWith({
+      name: "What's Happening Carousel Load",
+      op: 'whats_happening.load',
+      id: 'explore:carousel',
+      tags: expect.objectContaining({
+        source: 'explore',
+        stage: 'carousel',
+      }),
+    });
   });
 
   it('starts a front-page fetch span for a deep-linked item', async () => {

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
@@ -7,11 +7,29 @@ import {
   isWhatsHappeningSectionVisible,
   useWhatsHappening,
   WHATS_HAPPENING_FETCH_FAILED,
+  WHATS_HAPPENING_QUERY_KEY,
   type UseWhatsHappeningOptions,
 } from './useWhatsHappening';
+import { WhatsHappeningSource } from '../constants';
 
 const mockFetchMarketOverview = jest.fn();
 const mockFetchFrontPageItem = jest.fn();
+const mockSetAttribute = jest.fn();
+const mockTrace = jest.fn((...args: unknown[]) => {
+  const callback = args[1] as
+    | ((context: { setAttribute: typeof mockSetAttribute }) => unknown)
+    | undefined;
+  if (typeof callback === 'function') {
+    return callback({ setAttribute: mockSetAttribute });
+  }
+});
+const mockEndTrace = jest.fn();
+
+jest.mock('../../../../util/trace', () => ({
+  ...jest.requireActual('../../../../util/trace'),
+  trace: (...args: unknown[]) => mockTrace(...args),
+  endTrace: (...args: unknown[]) => mockEndTrace(...args),
+}));
 
 jest.mock('../../../../core/Engine', () => ({
   __esModule: true,
@@ -126,6 +144,34 @@ describe('useWhatsHappening', () => {
       mockTrend.relatedAssets,
     );
     expect(result.current.error).toBeNull();
+    expect(result.current.cacheState).toBe('cold');
+    expect(mockTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "What's Happening Fetch",
+        op: 'whats_happening.fetch',
+        tags: {
+          feature: 'whats_happening',
+          source: 'unknown',
+          stage: 'carousel',
+          cache_state: 'cold',
+          fetch_kind: 'overview',
+        },
+      }),
+      expect.any(Function),
+    );
+    expect(mockSetAttribute).toHaveBeenCalledWith('result', 'success');
+    expect(mockSetAttribute).toHaveBeenCalledWith('success', true);
+    expect(mockTrace).toHaveBeenCalledWith({
+      name: "What's Happening Carousel Load",
+      op: 'whats_happening.load',
+      id: 'unknown:carousel',
+      tags: {
+        feature: 'whats_happening',
+        source: 'unknown',
+        stage: 'carousel',
+        cache_state: 'cold',
+      },
+    });
   });
 
   it('uses overview generatedAt as item date', async () => {
@@ -144,6 +190,17 @@ describe('useWhatsHappening', () => {
 
     expect(result.current.items).toHaveLength(0);
     expect(result.current.error).toBeNull();
+    expect(mockSetAttribute).toHaveBeenCalledWith('result', 'empty');
+    expect(mockSetAttribute).toHaveBeenCalledWith('success', true);
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: "What's Happening Carousel Load",
+      id: 'unknown:carousel',
+      data: {
+        result: 'empty',
+        success: true,
+        content_state: 'empty',
+      },
+    });
   });
 
   it('sets empty items when trends array is empty', async () => {
@@ -178,6 +235,17 @@ describe('useWhatsHappening', () => {
     expect(result.current.items).toHaveLength(0);
     expect(result.current.error).toBe('Network error');
     expect(mockLoggerError).toHaveBeenCalled();
+    expect(mockSetAttribute).toHaveBeenCalledWith('result', 'error');
+    expect(mockSetAttribute).toHaveBeenCalledWith('success', false);
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: "What's Happening Carousel Load",
+      id: 'unknown:carousel',
+      data: {
+        result: 'error',
+        success: false,
+        content_state: 'error',
+      },
+    });
   });
 
   it('sets fallback error flag for non-Error rejections', async () => {
@@ -683,6 +751,259 @@ describe('useWhatsHappening', () => {
       ),
     ).toBe(false);
     expect(result.current.items[0]?.isOutdated).toBeUndefined();
+  });
+
+  it('tags overview fetch with the observer source', async () => {
+    const { result } = renderWhatsHappeningHook({
+      telemetryContext: {
+        source: WhatsHappeningSource.Explore,
+        stage: 'carousel',
+      },
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.carouselTraceId).toBe('explore:carousel');
+    expect(mockTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "What's Happening Fetch",
+        tags: expect.objectContaining({
+          source: 'explore',
+          stage: 'carousel',
+          fetch_kind: 'overview',
+        }),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('starts a front-page fetch span for a deep-linked item', async () => {
+    mockFetchFrontPageItem.mockResolvedValue({
+      id: 'front-page-1',
+      item: {
+        title: 'Older headline',
+        description: 'Older item',
+        category: 'macro',
+        impact: 'neutral',
+        relatedAssets: [],
+        articles: [],
+      },
+      ctaTitle: 'CTA',
+      ctaDescription: 'CTA description',
+      createdAt: '2026-02-01T00:00:00.000Z',
+    });
+
+    const { result } = renderWhatsHappeningHook({
+      outdatedItemId: 'front-page-1',
+      telemetryContext: {
+        source: WhatsHappeningSource.Deeplink,
+        stage: 'expanded',
+      },
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "What's Happening Front Page Fetch",
+        op: 'whats_happening.fetch',
+        tags: {
+          feature: 'whats_happening',
+          source: 'deeplink',
+          stage: 'expanded',
+          cache_state: 'cold',
+          fetch_kind: 'front_page',
+        },
+      }),
+      expect.any(Function),
+    );
+    expect(mockTrace).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "What's Happening Carousel Load",
+      }),
+    );
+    expect(mockTrace).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "What's Happening View Load",
+      }),
+    );
+  });
+
+  it('ends expanded time to content as empty without starting a new span', async () => {
+    mockFetchMarketOverview.mockResolvedValue(null);
+
+    const { result } = renderWhatsHappeningHook({
+      telemetryContext: {
+        source: WhatsHappeningSource.Deeplink,
+        stage: 'expanded',
+      },
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: "What's Happening View Load",
+      id: 'deeplink:expanded',
+      data: {
+        result: 'empty',
+        success: true,
+        content_state: 'empty',
+      },
+    });
+    expect(mockTrace).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "What's Happening View Load",
+      }),
+    );
+  });
+
+  it('returns warm cache state without starting a fetch span', async () => {
+    queryClient.setQueryData([WHATS_HAPPENING_QUERY_KEY], mockOverview);
+
+    const { result } = renderWhatsHappeningHook({
+      telemetryContext: {
+        source: WhatsHappeningSource.Perps,
+        stage: 'carousel',
+      },
+    });
+
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+
+    expect(result.current.cacheState).toBe('warm');
+    expect(result.current.isLoading).toBe(false);
+    expect(mockFetchMarketOverview).not.toHaveBeenCalled();
+    expect(mockTrace).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: "What's Happening Fetch" }),
+      expect.any(Function),
+    );
+  });
+
+  it('marks the fetch as cancelled when its last observer unmounts', async () => {
+    let resolveOverview: (overview: typeof mockOverview) => void = () =>
+      undefined;
+    const request = new Promise<typeof mockOverview>((resolve) => {
+      resolveOverview = resolve;
+    });
+    mockFetchMarketOverview.mockReturnValue(request);
+
+    const { unmount } = renderWhatsHappeningHook();
+    await waitFor(() => expect(mockFetchMarketOverview).toHaveBeenCalled());
+
+    unmount();
+
+    expect(mockSetAttribute).toHaveBeenCalledWith('result', 'cancelled');
+    expect(mockSetAttribute).toHaveBeenCalledWith('success', false);
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: "What's Happening Carousel Load",
+      id: 'unknown:carousel',
+      data: {
+        result: 'cancelled',
+        success: false,
+        reason: 'owner_cancelled',
+      },
+    });
+
+    await act(async () => {
+      resolveOverview(mockOverview);
+      await request;
+    });
+  });
+
+  it('keeps generation pending on remount while a cached null miss refetches', async () => {
+    mockFetchMarketOverview.mockResolvedValueOnce(null);
+
+    const first = renderWhatsHappeningHook();
+    await waitFor(() => expect(first.result.current.isLoading).toBe(false));
+    expect(first.result.current.items).toHaveLength(0);
+    first.unmount();
+
+    let resolveOverview: (overview: typeof mockOverview) => void = () =>
+      undefined;
+    const request = new Promise<typeof mockOverview>((resolve) => {
+      resolveOverview = resolve;
+    });
+    mockFetchMarketOverview.mockReturnValueOnce(request);
+
+    const second = renderWhatsHappeningHook();
+
+    expect(second.result.current.items).toHaveLength(0);
+    expect(second.result.current.isLoading).toBe(false);
+    expect(second.result.current.isGenerationPending).toBe(true);
+
+    await act(async () => {
+      resolveOverview(mockOverview);
+      await request;
+    });
+    await waitFor(() => expect(second.result.current.items).toHaveLength(1));
+
+    expect(second.result.current.isGenerationPending).toBe(false);
+    expect(second.result.current.isLoading).toBe(false);
+  });
+
+  it('does not flip loading during a background refetch of a settled empty feed', async () => {
+    mockFetchMarketOverview.mockResolvedValueOnce(null);
+
+    const { result } = renderWhatsHappeningHook();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isGenerationPending).toBe(false);
+
+    let resolveOverview: (overview: typeof mockOverview | null) => void = () =>
+      undefined;
+    const request = new Promise<typeof mockOverview | null>((resolve) => {
+      resolveOverview = resolve;
+    });
+    mockFetchMarketOverview.mockReturnValueOnce(request);
+
+    let refetchPromise: Promise<unknown> = Promise.resolve();
+    await act(async () => {
+      refetchPromise = queryClient.refetchQueries({
+        queryKey: [WHATS_HAPPENING_QUERY_KEY],
+        exact: true,
+      });
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isGenerationPending).toBe(false);
+
+    await act(async () => {
+      resolveOverview(null);
+      await refetchPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isGenerationPending).toBe(false);
+  });
+
+  it('keeps generation pending on remount while a cached error refetches', async () => {
+    mockFetchMarketOverview.mockRejectedValueOnce(new Error('Network error'));
+
+    const first = renderWhatsHappeningHook();
+    await waitFor(() =>
+      expect(first.result.current.error).toBe('Network error'),
+    );
+    expect(first.result.current.isLoading).toBe(false);
+    first.unmount();
+
+    let resolveOverview: (overview: typeof mockOverview) => void = () =>
+      undefined;
+    const request = new Promise<typeof mockOverview>((resolve) => {
+      resolveOverview = resolve;
+    });
+    mockFetchMarketOverview.mockReturnValueOnce(request);
+
+    const second = renderWhatsHappeningHook();
+
+    expect(second.result.current.items).toHaveLength(0);
+    expect(second.result.current.isGenerationPending).toBe(true);
+
+    await act(async () => {
+      resolveOverview(mockOverview);
+      await request;
+    });
+    await waitFor(() => expect(second.result.current.items).toHaveLength(1));
+
+    expect(second.result.current.isGenerationPending).toBe(false);
+    expect(second.result.current.error).toBeNull();
   });
 });
 

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
@@ -13,7 +13,19 @@ import Engine from '../../../../core/Engine';
 import { selectWhatsHappeningEnabled } from '../../../../selectors/featureFlagController/whatsHappening';
 import Logger from '../../../../util/Logger';
 import { ensureError } from '../../../../util/errorUtils';
+import {
+  getDigestCacheState,
+  isDigestObserverPending,
+  withDigestFetchSpan,
+} from '../../../../util/digestPerformance';
+import { TraceName, TraceOperation } from '../../../../util/trace';
+import { WhatsHappeningSource } from '../constants';
 import type { WhatsHappeningItem } from '../types';
+import {
+  getWhatsHappeningTraceTags,
+  type WhatsHappeningTelemetryContext,
+} from '../utils/whatsHappeningPerformance';
+import { useWhatsHappeningLoadTrace } from './useWhatsHappeningLoadTrace';
 
 /** Internal error flag when fetch rejects with a non-Error value (not shown in UI). */
 export const WHATS_HAPPENING_FETCH_FAILED = 'WHATS_HAPPENING_FETCH_FAILED';
@@ -30,6 +42,12 @@ export interface UseWhatsHappeningResult {
   isLoading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
+  /** Cache state when this overview observer generation began. */
+  cacheState: 'warm' | 'cold';
+  /** True until this observer has fetched and still lacks items or an error. */
+  isGenerationPending: boolean;
+  /** Carousel time-to-content trace id, when this observer owns the entry span. */
+  carouselTraceId?: string;
 }
 
 export interface UseWhatsHappeningOptions {
@@ -41,6 +59,8 @@ export interface UseWhatsHappeningOptions {
    * detail view passes it, so the Explore/Perps carousels are unaffected.
    */
   outdatedItemId?: string | null;
+  /** Bounded Sentry context for fetch and carousel time-to-content spans. */
+  telemetryContext?: WhatsHappeningTelemetryContext;
 }
 
 export const isWhatsHappeningSectionVisible = ({
@@ -179,10 +199,44 @@ export const useWhatsHappening = (
   const queryClient = useQueryClient();
   const pendingRefreshRef = useRef<(() => void) | null>(null);
   const [isManualRefreshing, setIsManualRefreshing] = useState(false);
+  const resolvedTelemetryContext: WhatsHappeningTelemetryContext =
+    options?.telemetryContext ?? {
+      source: WhatsHappeningSource.Unknown,
+      stage: 'carousel',
+    };
+  const cacheStateRef = useRef<{
+    active: boolean;
+    state: 'warm' | 'cold';
+  } | null>(null);
+
+  if (!cacheStateRef.current || cacheStateRef.current.active !== isActive) {
+    const cachedOverview = queryClient.getQueryData<MarketOverview | null>([
+      WHATS_HAPPENING_QUERY_KEY,
+    ]);
+    cacheStateRef.current = {
+      active: isActive,
+      state: getDigestCacheState(cachedOverview),
+    };
+  }
+
+  const cacheState = cacheStateRef.current.state;
 
   const overviewQuery = useQuery<MarketOverview | null, Error>({
     queryKey: [WHATS_HAPPENING_QUERY_KEY],
-    queryFn: fetchMarketOverview,
+    queryFn: ({ signal }) =>
+      withDigestFetchSpan(
+        {
+          name: TraceName.WhatsHappeningFetch,
+          op: TraceOperation.WhatsHappeningFetch,
+          tags: getWhatsHappeningTraceTags(
+            resolvedTelemetryContext,
+            cacheState,
+            { fetch_kind: 'overview' },
+          ),
+        },
+        signal,
+        fetchMarketOverview,
+      ),
     enabled: isActive,
     retry: false,
     networkMode: 'always',
@@ -192,7 +246,18 @@ export const useWhatsHappening = (
 
   const frontPageQuery = useQuery<WhatsHappeningItem | null, Error>({
     queryKey: [WHATS_HAPPENING_FRONT_PAGE_QUERY_KEY, outdatedItemId],
-    queryFn: () => fetchOutdatedItem(outdatedItemId ?? ''),
+    queryFn: ({ signal }) =>
+      withDigestFetchSpan(
+        {
+          name: TraceName.WhatsHappeningFrontPageFetch,
+          op: TraceOperation.WhatsHappeningFetch,
+          tags: getWhatsHappeningTraceTags(resolvedTelemetryContext, 'cold', {
+            fetch_kind: 'front_page',
+          }),
+        },
+        signal,
+        () => fetchOutdatedItem(outdatedItemId ?? ''),
+      ),
     enabled: isActive && Boolean(outdatedItemId),
     retry: false,
     networkMode: 'always',
@@ -268,9 +333,36 @@ export const useWhatsHappening = (
 
   const isFrontPageLoading =
     Boolean(outdatedItemId) && frontPageQuery.isLoading;
+  const visibleItems = isActive && !error ? items : [];
+  const isGenerationPending = isDigestObserverPending({
+    enabled: isActive,
+    hasContent: visibleItems.length > 0,
+    isFetchedAfterMount: overviewQuery.isFetchedAfterMount,
+  });
+  const carouselTraceId = useWhatsHappeningLoadTrace({
+    name: TraceName.WhatsHappeningCarouselLoad,
+    enabled: isActive && resolvedTelemetryContext.stage === 'carousel',
+    source: resolvedTelemetryContext.source,
+    stage: 'carousel',
+    cacheState,
+    isGenerationPending,
+    hasContent: visibleItems.length > 0,
+    error,
+  });
+  useWhatsHappeningLoadTrace({
+    name: TraceName.WhatsHappeningViewLoad,
+    enabled: isActive && resolvedTelemetryContext.stage === 'expanded',
+    start: false,
+    source: resolvedTelemetryContext.source,
+    stage: 'expanded',
+    cacheState,
+    isGenerationPending,
+    hasContent: visibleItems.length > 0,
+    error,
+  });
 
   return {
-    items: isActive && !error ? items : [],
+    items: visibleItems,
     // isFetching is true for background refetches (new observer, stale mount).
     // Only the initial load and an explicit refresh should show skeletons.
     isLoading:
@@ -278,6 +370,9 @@ export const useWhatsHappening = (
       (overviewQuery.isLoading || isFrontPageLoading || isManualRefreshing),
     error,
     refresh,
+    cacheState,
+    isGenerationPending,
+    carouselTraceId,
   };
 };
 

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
@@ -334,10 +334,27 @@ export const useWhatsHappening = (
   const isFrontPageLoading =
     Boolean(outdatedItemId) && frontPageQuery.isLoading;
   const visibleItems = isActive && !error ? items : [];
+  // A warm cached overview (including `{ trends: [] }`) does not refetch, so
+  // `isFetchedAfterMount` stays false. Treat a non-fetching cached payload as
+  // settled so empty TTC can close. A cached `null` miss is stale and stays
+  // pending until this observer fetches. When a deeplink front-page item is
+  // in flight, wait for that query too so expanded TTC does not close empty
+  // before the only card arrives.
+  const hasOverviewSettled =
+    overviewQuery.isFetchedAfterMount ||
+    Boolean(
+      overviewQuery.isFetched &&
+        !overviewQuery.isFetching &&
+        overviewQuery.data,
+    );
+  const hasFrontPageSettled =
+    !outdatedItemId ||
+    frontPageQuery.isFetchedAfterMount ||
+    (frontPageQuery.isFetched && !frontPageQuery.isFetching);
   const isGenerationPending = isDigestObserverPending({
     enabled: isActive,
     hasContent: visibleItems.length > 0,
-    isFetchedAfterMount: overviewQuery.isFetchedAfterMount,
+    isFetchedAfterMount: hasOverviewSettled && hasFrontPageSettled,
   });
   const carouselTraceId = useWhatsHappeningLoadTrace({
     name: TraceName.WhatsHappeningCarouselLoad,

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
@@ -22,6 +22,7 @@ import { TraceName, TraceOperation } from '../../../../util/trace';
 import { WhatsHappeningSource } from '../constants';
 import type { WhatsHappeningItem } from '../types';
 import {
+  getWhatsHappeningFetchTags,
   getWhatsHappeningTraceTags,
   type WhatsHappeningTelemetryContext,
 } from '../utils/whatsHappeningPerformance';
@@ -100,7 +101,7 @@ const mapFrontPageToItem = (
  * Fetches the deep-linked "outdated" front-page item, if any.
  *
  * @param outdatedItemId - The front-page item id from the deep link.
- * @returns The mapped outdated item, or `null` when there is none / on failure.
+ * @returns The mapped outdated item, or `null` when the id is a miss.
  */
 const fetchOutdatedItem = async (
   outdatedItemId: string,
@@ -111,9 +112,12 @@ const fetchOutdatedItem = async (
         outdatedItemId,
       );
     return frontPage ? mapFrontPageToItem(frontPage) : null;
-  } catch {
-    // Non-fatal: fall back to rendering just the latest market overview items.
-    return null;
+  } catch (err) {
+    Logger.error(ensureError(err, 'useWhatsHappening.fetchOutdatedItem'), {
+      tags: { feature: 'WhatsHappening' },
+      extra: { hook: 'useWhatsHappening' },
+    });
+    throw err instanceof Error ? err : new Error(WHATS_HAPPENING_FETCH_FAILED);
   }
 };
 
@@ -228,11 +232,7 @@ export const useWhatsHappening = (
         {
           name: TraceName.WhatsHappeningFetch,
           op: TraceOperation.WhatsHappeningFetch,
-          tags: getWhatsHappeningTraceTags(
-            resolvedTelemetryContext,
-            cacheState,
-            { fetch_kind: 'overview' },
-          ),
+          tags: getWhatsHappeningFetchTags(cacheState, 'overview'),
         },
         signal,
         fetchMarketOverview,
@@ -370,6 +370,7 @@ export const useWhatsHappening = (
     name: TraceName.WhatsHappeningViewLoad,
     enabled: isActive && resolvedTelemetryContext.stage === 'expanded',
     start: false,
+    closeWhenDisabled: resolvedTelemetryContext.stage === 'expanded',
     source: resolvedTelemetryContext.source,
     stage: 'expanded',
     cacheState,

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappeningLoadTrace.test.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappeningLoadTrace.test.ts
@@ -114,4 +114,45 @@ describe('useWhatsHappeningLoadTrace', () => {
       },
     });
   });
+
+  it('ends a caller-started expanded span when the observer is inactive', () => {
+    renderHook(() =>
+      useWhatsHappeningLoadTrace({
+        ...defaultParams,
+        name: TraceName.WhatsHappeningViewLoad,
+        enabled: false,
+        start: false,
+        closeWhenDisabled: true,
+        source: WhatsHappeningSource.Deeplink,
+        stage: 'expanded',
+      }),
+    );
+
+    expect(mockTrace).not.toHaveBeenCalled();
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: "What's Happening View Load",
+      id: 'deeplink:expanded',
+      data: {
+        result: 'cancelled',
+        success: false,
+        reason: 'owner_cancelled',
+      },
+    });
+  });
+
+  it('does not close a caller-started span from an inactive carousel observer', () => {
+    renderHook(() =>
+      useWhatsHappeningLoadTrace({
+        ...defaultParams,
+        name: TraceName.WhatsHappeningViewLoad,
+        enabled: false,
+        start: false,
+        source: WhatsHappeningSource.Explore,
+        stage: 'expanded',
+      }),
+    );
+
+    expect(mockTrace).not.toHaveBeenCalled();
+    expect(mockEndTrace).not.toHaveBeenCalled();
+  });
 });

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappeningLoadTrace.test.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappeningLoadTrace.test.ts
@@ -1,0 +1,117 @@
+import { renderHook } from '@testing-library/react-native';
+import { TraceName } from '../../../../util/trace';
+import { useWhatsHappeningLoadTrace } from './useWhatsHappeningLoadTrace';
+import { WhatsHappeningSource } from '../constants';
+
+const mockTrace = jest.fn();
+const mockEndTrace = jest.fn();
+
+jest.mock('../../../../util/trace', () => ({
+  ...jest.requireActual('../../../../util/trace'),
+  trace: (...args: unknown[]) => mockTrace(...args),
+  endTrace: (...args: unknown[]) => mockEndTrace(...args),
+}));
+
+const defaultParams = {
+  name: TraceName.WhatsHappeningCarouselLoad,
+  enabled: true,
+  source: WhatsHappeningSource.Explore,
+  stage: 'carousel' as const,
+  cacheState: 'cold' as const,
+  isGenerationPending: true,
+  hasContent: false,
+  error: null,
+};
+
+describe('useWhatsHappeningLoadTrace', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('starts carousel time to content with bounded attributes', () => {
+    const { result } = renderHook(() =>
+      useWhatsHappeningLoadTrace(defaultParams),
+    );
+
+    expect(result.current).toBe('explore:carousel');
+    expect(mockTrace).toHaveBeenCalledWith({
+      name: "What's Happening Carousel Load",
+      op: 'whats_happening.load',
+      id: 'explore:carousel',
+      tags: {
+        feature: 'whats_happening',
+        source: 'explore',
+        stage: 'carousel',
+        cache_state: 'cold',
+      },
+    });
+  });
+
+  it('does not start a span when start is false', () => {
+    renderHook(() =>
+      useWhatsHappeningLoadTrace({
+        ...defaultParams,
+        start: false,
+      }),
+    );
+
+    expect(mockTrace).not.toHaveBeenCalled();
+  });
+
+  it('ends carousel time to content with an empty result', () => {
+    renderHook(() =>
+      useWhatsHappeningLoadTrace({
+        ...defaultParams,
+        isGenerationPending: false,
+      }),
+    );
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: "What's Happening Carousel Load",
+      id: 'explore:carousel',
+      data: {
+        result: 'empty',
+        success: true,
+        content_state: 'empty',
+      },
+    });
+  });
+
+  it('ends carousel time to content with an error result', () => {
+    renderHook(() =>
+      useWhatsHappeningLoadTrace({
+        ...defaultParams,
+        isGenerationPending: false,
+        error: 'request failed',
+      }),
+    );
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: "What's Happening Carousel Load",
+      id: 'explore:carousel',
+      data: {
+        result: 'error',
+        success: false,
+        content_state: 'error',
+      },
+    });
+  });
+
+  it('ends carousel time to content as cancelled on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useWhatsHappeningLoadTrace(defaultParams),
+    );
+
+    unmount();
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: "What's Happening Carousel Load",
+      id: 'explore:carousel',
+      data: {
+        result: 'cancelled',
+        success: false,
+        reason: 'owner_cancelled',
+      },
+    });
+  });
+});

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappeningLoadTrace.test.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappeningLoadTrace.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../../../util/trace', () => ({
 }));
 
 const defaultParams = {
-  name: TraceName.WhatsHappeningCarouselLoad,
+  name: TraceName.WhatsHappeningCarouselLoad as const,
   enabled: true,
   source: WhatsHappeningSource.Explore,
   stage: 'carousel' as const,

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappeningLoadTrace.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappeningLoadTrace.ts
@@ -19,6 +19,13 @@ interface UseWhatsHappeningLoadTraceParams {
   enabled: boolean;
   /** When false, only close empty/error/cancel. Used when press/deeplink already started the span. */
   start?: boolean;
+  /**
+   * Close a caller-started span when this observer is inactive. Used for
+   * expanded View Load so a deeplink/press span cannot outlive a flagged-off
+   * or unmounted detail observer. Must stay false on carousel observers that
+   * also call this hook with `start: false`.
+   */
+  closeWhenDisabled?: boolean;
   source: WhatsHappeningSourceValue;
   stage: WhatsHappeningStage;
   cacheState: DigestCacheState;
@@ -35,6 +42,7 @@ export const useWhatsHappeningLoadTrace = ({
   name,
   enabled,
   start = true,
+  closeWhenDisabled = false,
   source,
   stage,
   cacheState,
@@ -58,7 +66,18 @@ export const useWhatsHappeningLoadTrace = ({
   }, [cacheState, enabled, name, source, stage, start, traceId]);
 
   useEffect(() => {
-    if (!enabled || isGenerationPending || hasContent) {
+    if (!enabled) {
+      if (closeWhenDisabled) {
+        endTrace({
+          name,
+          id: traceId,
+          data: getWhatsHappeningTraceEndData('cancelled'),
+        });
+      }
+      return;
+    }
+
+    if (isGenerationPending || hasContent) {
       return;
     }
 
@@ -67,11 +86,19 @@ export const useWhatsHappeningLoadTrace = ({
       id: traceId,
       data: getWhatsHappeningTraceEndData(error ? 'error' : 'empty'),
     });
-  }, [enabled, error, hasContent, isGenerationPending, name, traceId]);
+  }, [
+    closeWhenDisabled,
+    enabled,
+    error,
+    hasContent,
+    isGenerationPending,
+    name,
+    traceId,
+  ]);
 
   useEffect(
     () => () => {
-      if (!enabled) {
+      if (!enabled && !closeWhenDisabled) {
         return;
       }
 
@@ -81,7 +108,7 @@ export const useWhatsHappeningLoadTrace = ({
         data: getWhatsHappeningTraceEndData('cancelled'),
       });
     },
-    [enabled, name, traceId],
+    [closeWhenDisabled, enabled, name, traceId],
   );
 
   return enabled ? traceId : undefined;

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappeningLoadTrace.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappeningLoadTrace.ts
@@ -1,0 +1,88 @@
+import { useEffect, useMemo } from 'react';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../util/trace';
+import type { DigestCacheState } from '../../../../util/digestPerformance';
+import {
+  getWhatsHappeningTraceEndData,
+  getWhatsHappeningTraceId,
+  getWhatsHappeningTraceTags,
+  type WhatsHappeningStage,
+} from '../utils/whatsHappeningPerformance';
+import type { WhatsHappeningSourceValue } from '../constants';
+
+interface UseWhatsHappeningLoadTraceParams {
+  name: TraceName.WhatsHappeningCarouselLoad | TraceName.WhatsHappeningViewLoad;
+  enabled: boolean;
+  /** When false, only close empty/error/cancel. Used when press/deeplink already started the span. */
+  start?: boolean;
+  source: WhatsHappeningSourceValue;
+  stage: WhatsHappeningStage;
+  cacheState: DigestCacheState;
+  isGenerationPending: boolean;
+  hasContent: boolean;
+  error: string | null;
+}
+
+/**
+ * Owns a What's Happening time-to-content span for one observer generation.
+ * Cards and the expanded view close successful traces after first commit.
+ */
+export const useWhatsHappeningLoadTrace = ({
+  name,
+  enabled,
+  start = true,
+  source,
+  stage,
+  cacheState,
+  isGenerationPending,
+  hasContent,
+  error,
+}: UseWhatsHappeningLoadTraceParams): string | undefined => {
+  const traceId = getWhatsHappeningTraceId(source, stage);
+
+  useMemo(() => {
+    if (!enabled || !start) {
+      return;
+    }
+
+    trace({
+      name,
+      op: TraceOperation.WhatsHappeningLoad,
+      id: traceId,
+      tags: getWhatsHappeningTraceTags({ source, stage }, cacheState),
+    });
+  }, [cacheState, enabled, name, source, stage, start, traceId]);
+
+  useEffect(() => {
+    if (!enabled || isGenerationPending || hasContent) {
+      return;
+    }
+
+    endTrace({
+      name,
+      id: traceId,
+      data: getWhatsHappeningTraceEndData(error ? 'error' : 'empty'),
+    });
+  }, [enabled, error, hasContent, isGenerationPending, name, traceId]);
+
+  useEffect(
+    () => () => {
+      if (!enabled) {
+        return;
+      }
+
+      endTrace({
+        name,
+        id: traceId,
+        data: getWhatsHappeningTraceEndData('cancelled'),
+      });
+    },
+    [enabled, name, traceId],
+  );
+
+  return enabled ? traceId : undefined;
+};

--- a/app/components/UI/WhatsHappening/utils/whatsHappeningPerformance.ts
+++ b/app/components/UI/WhatsHappening/utils/whatsHappeningPerformance.ts
@@ -26,4 +26,22 @@ export const getWhatsHappeningTraceTags = (
   ...extra,
 });
 
+/**
+ * Overview fetch is one shared React Query generation. Do not stamp
+ * observer `source` / `stage` — whichever mount ran `queryFn` is not the
+ * network caller.
+ *
+ * @param cacheState - Cache state when this generation began.
+ * @param fetchKind - Overview or deeplink front-page request.
+ * @returns Bounded fetch-span tags.
+ */
+export const getWhatsHappeningFetchTags = (
+  cacheState: 'warm' | 'cold',
+  fetchKind: 'overview' | 'front_page',
+): Record<string, TraceValue> => ({
+  feature: 'whats_happening',
+  cache_state: cacheState,
+  fetch_kind: fetchKind,
+});
+
 export const getWhatsHappeningTraceEndData = getDigestTraceEndData;

--- a/app/components/UI/WhatsHappening/utils/whatsHappeningPerformance.ts
+++ b/app/components/UI/WhatsHappening/utils/whatsHappeningPerformance.ts
@@ -1,0 +1,29 @@
+import type { TraceValue } from '../../../../util/trace';
+import { getDigestTraceEndData } from '../../../../util/digestPerformance';
+import type { WhatsHappeningSourceValue } from '../constants';
+
+export type WhatsHappeningStage = 'carousel' | 'expanded';
+
+export interface WhatsHappeningTelemetryContext {
+  source: WhatsHappeningSourceValue;
+  stage: WhatsHappeningStage;
+}
+
+export const getWhatsHappeningTraceId = (
+  source: WhatsHappeningSourceValue,
+  stage: WhatsHappeningStage,
+) => `${source}:${stage}`;
+
+export const getWhatsHappeningTraceTags = (
+  context: WhatsHappeningTelemetryContext,
+  cacheState: 'warm' | 'cold',
+  extra?: Record<string, TraceValue>,
+): Record<string, TraceValue> => ({
+  feature: 'whats_happening',
+  source: context.source,
+  stage: context.stage,
+  cache_state: cacheState,
+  ...extra,
+});
+
+export const getWhatsHappeningTraceEndData = getDigestTraceEndData;

--- a/app/components/Views/TrendingView/tabs/NowTab.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.tsx
@@ -226,7 +226,12 @@ const NowTabContent: React.FC<TabProps> = ({
   const isWhatsHappeningEnabled = useSelector(selectWhatsHappeningEnabled);
   const isEarnSectionVisible = useSelector(selectIsExploreEarnSectionVisible);
 
-  const whatsHappening = useWhatsHappening();
+  const whatsHappening = useWhatsHappening({
+    telemetryContext: {
+      source: WhatsHappeningSource.Explore,
+      stage: 'carousel',
+    },
+  });
   const refreshWhatsHappening = whatsHappening.refresh;
 
   useEffect(() => {

--- a/app/components/Views/WhatsHappeningDetailView/WhatsHappeningDetailView.test.tsx
+++ b/app/components/Views/WhatsHappeningDetailView/WhatsHappeningDetailView.test.tsx
@@ -18,6 +18,7 @@ import {
 const GAP = 12;
 const SNAP_INTERVAL_FOR_TEST = CARD_WIDTH + GAP;
 
+const mockEndTrace = jest.fn();
 const mockGoBack = jest.fn();
 const mockRefresh = jest.fn();
 const mockTrackEvent = jest.fn();
@@ -26,6 +27,11 @@ const mockCreateEventBuilder = jest.fn((eventName: string) => ({
     build: jest.fn(() => ({ category: eventName, properties })),
   })),
   build: jest.fn(() => ({ category: eventName })),
+}));
+
+jest.mock('../../../util/trace', () => ({
+  ...jest.requireActual('../../../util/trace'),
+  endTrace: (...args: unknown[]) => mockEndTrace(...args),
 }));
 
 jest.mock('@react-navigation/native', () => ({
@@ -212,6 +218,15 @@ describe('WhatsHappeningDetailView', () => {
       nativeEvent: { layout: { height: 600, width: 375, x: 0, y: 0 } },
     });
     expect(screen.getByTestId('mock-expanded-card')).toBeOnTheScreen();
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: "What's Happening View Load",
+      id: 'homepage:expanded',
+      data: {
+        result: 'success',
+        success: true,
+        content_state: 'filled',
+      },
+    });
   });
 
   it('does not show the skeleton or error when items are loaded', () => {

--- a/app/components/Views/WhatsHappeningDetailView/WhatsHappeningDetailView.tsx
+++ b/app/components/Views/WhatsHappeningDetailView/WhatsHappeningDetailView.tsx
@@ -14,7 +14,12 @@ import { Box, HeaderStandard } from '@metamask/design-system-react-native';
 import type { Article } from '@metamask/ai-controllers';
 import type { WhatsHappeningItem } from '../../UI/WhatsHappening/types';
 import { strings } from '../../../../locales/i18n';
+import { endTrace, TraceName } from '../../../util/trace';
 import { useWhatsHappening } from '../../UI/WhatsHappening/hooks';
+import {
+  getWhatsHappeningTraceEndData,
+  getWhatsHappeningTraceId,
+} from '../../UI/WhatsHappening/utils/whatsHappeningPerformance';
 import WhatsHappeningExpandedCardSkeleton from './components/WhatsHappeningExpandedCardSkeleton';
 import {
   SKELETON_CARD_COUNT,
@@ -72,6 +77,7 @@ const WhatsHappeningDetailView = () => {
 
   const { items, isLoading, error, refresh } = useWhatsHappening({
     outdatedItemId,
+    telemetryContext: { source, stage: 'expanded' },
   });
 
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
@@ -243,6 +249,18 @@ const WhatsHappeningDetailView = () => {
   );
 
   const hasError = !isLoading && items.length === 0 && !!error;
+
+  useEffect(() => {
+    if (cardHeight <= 0 || items.length === 0) {
+      return;
+    }
+
+    endTrace({
+      name: TraceName.WhatsHappeningViewLoad,
+      id: getWhatsHappeningTraceId(source, 'expanded'),
+      data: getWhatsHappeningTraceEndData('success'),
+    });
+  }, [cardHeight, items.length, source]);
 
   return (
     // The top edge is deliberately off: a native SafeAreaView top padding is

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleWhatsHappeningUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleWhatsHappeningUrl.test.ts
@@ -4,6 +4,13 @@ import DevLogger from '../../../../SDKConnect/utils/DevLogger';
 import { WhatsHappeningSource } from '../../../../../components/UI/WhatsHappening/constants';
 import { handleWhatsHappeningUrl } from '../handleWhatsHappeningUrl';
 
+const mockTrace = jest.fn();
+
+jest.mock('../../../../../util/trace', () => ({
+  ...jest.requireActual('../../../../../util/trace'),
+  trace: (...args: unknown[]) => mockTrace(...args),
+}));
+
 jest.mock('../../../../NavigationService', () => ({
   navigation: {
     navigate: jest.fn(),
@@ -28,6 +35,17 @@ describe('handleWhatsHappeningUrl', () => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.WHATS_HAPPENING_DETAIL, {
         source: WhatsHappeningSource.Deeplink,
         initialIndex: 0,
+      });
+      expect(mockTrace).toHaveBeenCalledWith({
+        name: "What's Happening View Load",
+        op: 'whats_happening.load',
+        id: 'deeplink:expanded',
+        tags: {
+          feature: 'whats_happening',
+          source: 'deeplink',
+          stage: 'expanded',
+          cache_state: 'cold',
+        },
       });
     });
 

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleWhatsHappeningUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleWhatsHappeningUrl.test.ts
@@ -5,10 +5,12 @@ import { WhatsHappeningSource } from '../../../../../components/UI/WhatsHappenin
 import { handleWhatsHappeningUrl } from '../handleWhatsHappeningUrl';
 
 const mockTrace = jest.fn();
+const mockEndTrace = jest.fn();
 
 jest.mock('../../../../../util/trace', () => ({
   ...jest.requireActual('../../../../../util/trace'),
   trace: (...args: unknown[]) => mockTrace(...args),
+  endTrace: (...args: unknown[]) => mockEndTrace(...args),
 }));
 
 jest.mock('../../../../NavigationService', () => ({
@@ -69,6 +71,15 @@ describe('handleWhatsHappeningUrl', () => {
         '[handleWhatsHappeningUrl] Failed to handle deeplink:',
         expect.any(Error),
       );
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: "What's Happening View Load",
+        id: 'deeplink:expanded',
+        data: {
+          result: 'cancelled',
+          success: false,
+          reason: 'owner_cancelled',
+        },
+      });
     });
   });
 

--- a/app/core/DeeplinkManager/handlers/legacy/handleWhatsHappeningUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleWhatsHappeningUrl.ts
@@ -2,6 +2,11 @@ import NavigationService from '../../../NavigationService';
 import Routes from '../../../../constants/navigation/Routes';
 import DevLogger from '../../../SDKConnect/utils/DevLogger';
 import { WhatsHappeningSource } from '../../../../components/UI/WhatsHappening/constants';
+import {
+  getWhatsHappeningTraceId,
+  getWhatsHappeningTraceTags,
+} from '../../../../components/UI/WhatsHappening/utils/whatsHappeningPerformance';
+import { trace, TraceName, TraceOperation } from '../../../../util/trace';
 
 interface HandleWhatsHappeningUrlParams {
   /**
@@ -34,6 +39,15 @@ export const handleWhatsHappeningUrl = ({
   DevLogger.log('[handleWhatsHappeningUrl] Starting deeplink handling', { id });
 
   try {
+    trace({
+      name: TraceName.WhatsHappeningViewLoad,
+      op: TraceOperation.WhatsHappeningLoad,
+      id: getWhatsHappeningTraceId(WhatsHappeningSource.Deeplink, 'expanded'),
+      tags: getWhatsHappeningTraceTags(
+        { source: WhatsHappeningSource.Deeplink, stage: 'expanded' },
+        'cold',
+      ),
+    });
     NavigationService.navigation.navigate(Routes.WHATS_HAPPENING_DETAIL, {
       source: WhatsHappeningSource.Deeplink,
       initialIndex: 0,

--- a/app/core/DeeplinkManager/handlers/legacy/handleWhatsHappeningUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleWhatsHappeningUrl.ts
@@ -3,10 +3,16 @@ import Routes from '../../../../constants/navigation/Routes';
 import DevLogger from '../../../SDKConnect/utils/DevLogger';
 import { WhatsHappeningSource } from '../../../../components/UI/WhatsHappening/constants';
 import {
+  getWhatsHappeningTraceEndData,
   getWhatsHappeningTraceId,
   getWhatsHappeningTraceTags,
 } from '../../../../components/UI/WhatsHappening/utils/whatsHappeningPerformance';
-import { trace, TraceName, TraceOperation } from '../../../../util/trace';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../util/trace';
 
 interface HandleWhatsHappeningUrlParams {
   /**
@@ -54,6 +60,11 @@ export const handleWhatsHappeningUrl = ({
       ...(id ? { outdatedItemId: id } : {}),
     });
   } catch (error) {
+    endTrace({
+      name: TraceName.WhatsHappeningViewLoad,
+      id: getWhatsHappeningTraceId(WhatsHappeningSource.Deeplink, 'expanded'),
+      data: getWhatsHappeningTraceEndData('cancelled'),
+    });
     DevLogger.log(
       '[handleWhatsHappeningUrl] Failed to handle deeplink:',
       error,

--- a/app/util/digestPerformance.test.ts
+++ b/app/util/digestPerformance.test.ts
@@ -1,0 +1,97 @@
+import {
+  getDigestCacheState,
+  getDigestTraceEndData,
+  isDigestObserverPending,
+  withDigestFetchSpan,
+} from './digestPerformance';
+import { TraceName, TraceOperation } from './trace';
+
+const mockSetAttribute = jest.fn();
+const mockTrace = jest.fn((...args: unknown[]) => {
+  const callback = args[1] as (context: {
+    setAttribute: typeof mockSetAttribute;
+  }) => unknown;
+  return callback({ setAttribute: mockSetAttribute });
+});
+
+jest.mock('./trace', () => ({
+  ...jest.requireActual('./trace'),
+  trace: (...args: unknown[]) => mockTrace(...args),
+}));
+
+describe('digestPerformance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('treats a truthy cache payload as warm', () => {
+    expect(getDigestCacheState({ headline: 'ok' })).toBe('warm');
+  });
+
+  it('treats a null or missing cache payload as cold', () => {
+    expect(getDigestCacheState(null)).toBe('cold');
+    expect(getDigestCacheState(undefined)).toBe('cold');
+  });
+
+  it('returns filled end data for a successful result', () => {
+    expect(getDigestTraceEndData('success')).toEqual({
+      result: 'success',
+      success: true,
+      content_state: 'filled',
+    });
+  });
+
+  it('returns empty end data as a successful resolution', () => {
+    expect(getDigestTraceEndData('empty')).toEqual({
+      result: 'empty',
+      success: true,
+      content_state: 'empty',
+    });
+  });
+
+  it('returns cancelled end data without a content state', () => {
+    expect(getDigestTraceEndData('cancelled')).toEqual({
+      result: 'cancelled',
+      success: false,
+      reason: 'owner_cancelled',
+    });
+  });
+
+  it('stays pending until this observer has fetched', () => {
+    expect(
+      isDigestObserverPending({
+        enabled: true,
+        hasContent: false,
+        isFetchedAfterMount: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('is not pending after this observer has fetched without content', () => {
+    expect(
+      isDigestObserverPending({
+        enabled: true,
+        hasContent: false,
+        isFetchedAfterMount: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('marks a digest fetch as cancelled when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await withDigestFetchSpan(
+      {
+        name: TraceName.MarketInsightsFetch,
+        op: TraceOperation.MarketInsightsFetch,
+        tags: { feature: 'market_insights' },
+      },
+      controller.signal,
+      async () => ({ headline: 'ok' }),
+    );
+
+    expect(mockSetAttribute).toHaveBeenCalledWith('result', 'cancelled');
+    expect(mockSetAttribute).toHaveBeenCalledWith('success', false);
+  });
+});

--- a/app/util/digestPerformance.ts
+++ b/app/util/digestPerformance.ts
@@ -1,0 +1,111 @@
+import {
+  trace,
+  type TraceName,
+  type TraceOperation,
+  type TraceValue,
+} from './trace';
+
+export type DigestCacheState = 'warm' | 'cold';
+export type DigestResult = 'success' | 'empty' | 'error' | 'cancelled';
+
+/**
+ * Cache state for one React Query generation. A cached `null` miss is cold
+ * because `digestQueryStaleTime` treats it as immediately stale.
+ *
+ * @param cached - Current query data, if any.
+ * @returns `warm` when a truthy payload is already cached.
+ */
+export const getDigestCacheState = (cached: unknown): DigestCacheState =>
+  cached ? 'warm' : 'cold';
+
+/**
+ * Terminal attributes shared by digest time-to-content and fetch spans.
+ *
+ * @param result - Bounded terminal outcome.
+ * @returns Sentry end-data attributes.
+ */
+export const getDigestTraceEndData = (
+  result: DigestResult,
+): Record<string, TraceValue> => ({
+  result,
+  success: result === 'success' || result === 'empty',
+  ...(result !== 'cancelled'
+    ? {
+        content_state:
+          result === 'success'
+            ? 'filled'
+            : result === 'empty'
+              ? 'empty'
+              : 'error',
+      }
+    : {}),
+  ...(result === 'cancelled' ? { reason: 'owner_cancelled' } : {}),
+});
+
+/**
+ * Whether this observer still lacks settled content. Used for TTC empty/error
+ * closes. A remount of a cached miss or error stays pending until this
+ * observer fetches; a later focus refetch does not.
+ *
+ * @param params - Observer enablement, content, and fetch-after-mount state.
+ * @returns True while TTC must stay open.
+ */
+export const isDigestObserverPending = ({
+  enabled,
+  hasContent,
+  isFetchedAfterMount,
+}: {
+  enabled: boolean;
+  hasContent: boolean;
+  isFetchedAfterMount: boolean;
+}): boolean => enabled && !hasContent && !isFetchedAfterMount;
+
+/**
+ * Wrap a digest controller call in a Sentry fetch span with cancel / empty /
+ * error attributes.
+ *
+ * @param request - Span name, operation, and start tags.
+ * @param signal - React Query abort signal.
+ * @param fetchFn - Controller call that returns a payload or null.
+ * @returns The controller result.
+ */
+export const withDigestFetchSpan = <T>(
+  request: {
+    name: TraceName;
+    op: TraceOperation;
+    tags: Record<string, TraceValue>;
+  },
+  signal: AbortSignal,
+  fetchFn: () => Promise<T | null>,
+): Promise<T | null> =>
+  trace(request, async (span) => {
+    let wasCancelled = signal.aborted;
+    const markCancelled = () => {
+      wasCancelled = true;
+      span?.setAttribute('result', 'cancelled');
+      span?.setAttribute('success', false);
+    };
+
+    if (wasCancelled) {
+      markCancelled();
+    } else {
+      signal.addEventListener('abort', markCancelled, { once: true });
+    }
+
+    try {
+      const result = await fetchFn();
+      if (!wasCancelled) {
+        span?.setAttribute('result', result ? 'success' : 'empty');
+        span?.setAttribute('success', true);
+      }
+      return result;
+    } catch (error) {
+      if (!wasCancelled) {
+        span?.setAttribute('result', 'error');
+        span?.setAttribute('success', false);
+      }
+      throw error;
+    } finally {
+      signal.removeEventListener('abort', markCancelled);
+    }
+  });

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -286,6 +286,10 @@ export enum TraceName {
   MarketInsightsEntryCardLoad = 'Market Insights Entry Card Load',
   MarketInsightsViewLoad = 'Market Insights View Load',
   MarketInsightsViewportTracking = 'Market Insights Viewport Tracking',
+  WhatsHappeningFetch = "What's Happening Fetch",
+  WhatsHappeningFrontPageFetch = "What's Happening Front Page Fetch",
+  WhatsHappeningCarouselLoad = "What's Happening Carousel Load",
+  WhatsHappeningViewLoad = "What's Happening View Load",
   // Homepage Section Performance
   HomepageSectionTimeToContent = 'Homepage Section Time To Content',
   HomepageSectionDataFetch = 'Homepage Section Data Fetch',
@@ -373,6 +377,8 @@ export enum TraceOperation {
   MarketInsightsFetch = 'market_insights.fetch',
   MarketInsightsLoad = 'market_insights.load',
   MarketInsightsViewportTracking = 'market_insights.viewport_tracking',
+  WhatsHappeningFetch = 'whats_happening.fetch',
+  WhatsHappeningLoad = 'whats_happening.load',
   // Homepage Section Performance
   HomepageSectionPerformance = 'homepage.section.performance',
   // Money Home Performance

--- a/docs/ai/whats-happening-sentry-reference.md
+++ b/docs/ai/whats-happening-sentry-reference.md
@@ -1,0 +1,141 @@
+# What's Happening Sentry Performance
+
+Sentry duration telemetry for the What's Happening carousel and expanded
+detail view. Product analytics events are separate and must not be used as
+duration boundaries. Viewport tracking is not measured for this feature.
+
+## Measurement model
+
+Fetch duration and time to content are separate spans. A cold time-to-content
+span normally overlaps a fetch span. A warm time-to-content span can complete
+without a fetch because React Query already has a market overview.
+
+Do not subtract aggregate fetch percentiles from aggregate time-to-content
+percentiles. The populations differ because cache hits do not emit fetch spans.
+
+| Span description                    | Operation               | Start                                                         | Successful end              |
+| ----------------------------------- | ----------------------- | ------------------------------------------------------------- | --------------------------- |
+| `What's Happening Fetch`            | `whats_happening.fetch` | Immediately before `AiDigestController.fetchMarketOverview()` | Controller promise resolves |
+| `What's Happening Front Page Fetch` | `whats_happening.fetch` | Immediately before `fetchFrontPageItem()` (deeplink only)     | Promise resolves            |
+| `What's Happening Carousel Load`    | `whats_happening.load`  | Feed observer starts (`useWhatsHappening` + source)           | First carousel card commits |
+| `What's Happening View Load`        | `whats_happening.load`  | User presses a card/header, or detail mounts from deeplink    | First expanded card commits |
+
+Carousel and expanded spans also terminate for valid empty responses, errors,
+and owner cancellation. Empty and error closes wait until the current observer
+settles: a cached `null` miss or error is immediately stale and refetches on
+remount, so that remount must not close before the refetch completes. A later
+focus refetch of an already-settled result must not flip UI loading or reopen
+carousel skeletons. Latency widgets must use `result:success`; reliability
+widgets count every result.
+
+Explore and Perps hide the section until `isWhatsHappeningSectionVisible`. A
+settled empty miss never mounts the section. Carousel TTC therefore starts in
+`useWhatsHappening` (which knows the query) and ends as `empty` from the hook
+when the generation settles with no items and no error.
+
+What's Happening cards reuse Market Insights viewport visibility for MetaMetrics
+`WHATS_HAPPENING_CARD_SCROLLED_TO_VIEW` only. They must not emit Market Insights
+or What's Happening viewport Sentry spans.
+
+## Attributes
+
+All attributes are bounded and safe for dashboard grouping.
+
+| Attribute       | Values                                                | Notes                                                |
+| --------------- | ----------------------------------------------------- | ---------------------------------------------------- |
+| `feature`       | `whats_happening`                                     | Common dashboard filter                              |
+| `source`        | `homepage`, `explore`, `perps`, `deeplink`, `unknown` | `unknown` is reserved for routes without attribution |
+| `stage`         | `carousel`, `expanded`                                | Journey phase                                        |
+| `cache_state`   | `cold`, `warm`                                        | Cache state when the query generation began          |
+| `fetch_kind`    | `overview`, `front_page`                              | Present on fetch spans only                          |
+| `result`        | `success`, `empty`, `error`, `cancelled`              | Terminal outcome                                     |
+| `success`       | `true`, `false`                                       | `empty` is a valid successful resolution             |
+| `content_state` | `filled`, `empty`, `error`                            | Omitted for cancellation                             |
+| `reason`        | `owner_cancelled`                                     | Present for cancellation                             |
+
+Item titles and front-page IDs are intentionally not tags because they are
+high-cardinality values. Trace ids are `${source}:${stage}`.
+
+## Dashboard queries
+
+Use the spans dataset. Keep the dashboard environment filter unset by default so
+all environments are included. Add dashboard filters for `environment`,
+`platform`, `release`, `source`, `stage`, and `cache_state`.
+
+### Latency
+
+Use `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`, and
+`count()`:
+
+```text
+span.description:"What's Happening Fetch" success:true
+```
+
+```text
+span.description:"What's Happening Carousel Load" result:success
+```
+
+```text
+span.description:"What's Happening View Load" result:success
+```
+
+Split time-series widgets by `source`. The carousel widget compares Explore and
+Perps. The full-view widget compares the same sources plus deeplink from the
+press or navigate boundary.
+
+### Reliability and cache behavior
+
+```text
+span.op:[whats_happening.fetch,whats_happening.load] result:[empty,error,cancelled]
+```
+
+Group by `span.description`, `result`, and `source`.
+
+Compare TTC counts grouped by `cache_state` with fetch counts. A warm TTC with no
+matching fetch is expected and represents a cache hit, not missing telemetry.
+
+## Recommended dashboard layout
+
+1. **Journey health:** event volume, p50/p75/p95 fetch, carousel TTC,
+   full-view TTC, and error/cancellation counts.
+2. **Duration trends:** one time series per authoritative span, split by source.
+3. **Cache and outcomes:** TTC grouped by cache state; outcomes grouped by
+   result and source.
+4. **Diagnostics:** a table of slow or unsuccessful spans.
+
+Dashboard latency values are release-pending until an identifiable mobile
+release emits the new attributes. Missing pre-adoption data is not a zero.
+
+## Dashboard build sheet
+
+Create the dashboard in organization `metamask`, project `metamask-mobile` with
+the title **Mobile — Social & AI — What's Happening**. Use the spans dataset for
+every widget, a default period of 14 days, and no default environment
+restriction.
+
+| Widget                     | Visualization | Query                                                                                                                                              | Fields / grouping                                                                                                                    |
+| -------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Journey latency            | Table         | `feature:whats_happening result:success span.description:["What's Happening Fetch","What's Happening Carousel Load","What's Happening View Load"]` | Group by `span.description`, `source`; show `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`, `count()`              |
+| Fetch duration             | Time series   | `span.description:"What's Happening Fetch" success:true`                                                                                           | `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`; group by `source`                                                  |
+| Carousel TTC               | Time series   | `span.description:"What's Happening Carousel Load" result:success`                                                                                 | `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`; group by `source`                                                  |
+| Full-view TTC              | Time series   | `span.description:"What's Happening View Load" result:success`                                                                                     | `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`; group by `source`                                                  |
+| Journey outcomes           | Table         | `feature:whats_happening span.op:[whats_happening.fetch,whats_happening.load]`                                                                     | Group by `span.description`, `result`, `source`; show `count()`                                                                      |
+| Cache behavior             | Table         | `span.op:whats_happening.load`                                                                                                                     | Group by `span.description`, `cache_state`, `source`; show `count()`, `p75(span.duration)`, `p95(span.duration)`                     |
+| Slow or unsuccessful spans | Table         | `feature:whats_happening (success:false OR span.duration:>2000)`                                                                                   | Show `timestamp`, `span.description`, `span.duration`, `source`, `stage`, `cache_state`, `result`, `release`, `environment`, `trace` |
+
+Add dashboard filters for:
+
+```text
+environment
+platform
+release
+source
+stage
+cache_state
+```
+
+The live dashboard has not been created yet. Sentry MCP can read dashboards
+but cannot create them, and this environment has no scoped write token. Use
+the build sheet above in org `metamask`, project `metamask-mobile`
+(`2299799`), 14d, no environment filter. After creation, add the dashboard URL
+here.

--- a/docs/ai/whats-happening-sentry-reference.md
+++ b/docs/ai/whats-happening-sentry-reference.md
@@ -41,17 +41,17 @@ or What's Happening viewport Sentry spans.
 
 All attributes are bounded and safe for dashboard grouping.
 
-| Attribute       | Values                                                | Notes                                                |
-| --------------- | ----------------------------------------------------- | ---------------------------------------------------- |
-| `feature`       | `whats_happening`                                     | Common dashboard filter                              |
-| `source`        | `homepage`, `explore`, `perps`, `deeplink`, `unknown` | `unknown` is reserved for routes without attribution |
-| `stage`         | `carousel`, `expanded`                                | Journey phase                                        |
-| `cache_state`   | `cold`, `warm`                                        | Cache state when the query generation began          |
-| `fetch_kind`    | `overview`, `front_page`                              | Present on fetch spans only                          |
-| `result`        | `success`, `empty`, `error`, `cancelled`              | Terminal outcome                                     |
-| `success`       | `true`, `false`                                       | `empty` is a valid successful resolution             |
-| `content_state` | `filled`, `empty`, `error`                            | Omitted for cancellation                             |
-| `reason`        | `owner_cancelled`                                     | Present for cancellation                             |
+| Attribute       | Values                                                | Notes                                                                |
+| --------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
+| `feature`       | `whats_happening`                                     | Common dashboard filter                                              |
+| `source`        | `homepage`, `explore`, `perps`, `deeplink`, `unknown` | Per-observer TTC and front-page fetch only. Overview fetch omits it. |
+| `stage`         | `carousel`, `expanded`                                | Per-observer TTC and front-page fetch only. Overview fetch omits it. |
+| `cache_state`   | `cold`, `warm`                                        | Cache state when the query generation began                          |
+| `fetch_kind`    | `overview`, `front_page`                              | Present on fetch spans only                                          |
+| `result`        | `success`, `empty`, `error`, `cancelled`              | Terminal outcome                                                     |
+| `success`       | `true`, `false`                                       | `empty` is a valid successful resolution                             |
+| `content_state` | `filled`, `empty`, `error`                            | Omitted for cancellation                                             |
+| `reason`        | `owner_cancelled`                                     | Present for cancellation                                             |
 
 Item titles and front-page IDs are intentionally not tags because they are
 high-cardinality values. Trace ids are `${source}:${stage}`.
@@ -68,7 +68,7 @@ Use `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`, and
 `count()`:
 
 ```text
-span.description:"What's Happening Fetch" success:true
+span.description:"What's Happening Fetch" result:success
 ```
 
 ```text
@@ -79,9 +79,11 @@ span.description:"What's Happening Carousel Load" result:success
 span.description:"What's Happening View Load" result:success
 ```
 
-Split time-series widgets by `source`. The carousel widget compares Explore and
-Perps. The full-view widget compares the same sources plus deeplink from the
-press or navigate boundary.
+Split TTC time-series widgets by `source`. The carousel widget compares Explore
+and Perps. The full-view widget compares the same sources plus deeplink from the
+press or navigate boundary. Do not group overview fetch by `source`: one shared
+React Query generation serves every observer, so the mount that ran `queryFn`
+is not a meaningful caller.
 
 ### Reliability and cache behavior
 
@@ -91,8 +93,10 @@ span.op:[whats_happening.fetch,whats_happening.load] result:[empty,error,cancell
 
 Group by `span.description`, `result`, and `source`.
 
-Compare TTC counts grouped by `cache_state` with fetch counts. A warm TTC with no
-matching fetch is expected and represents a cache hit, not missing telemetry.
+Compare TTC counts grouped by `cache_state` with overview fetch counts. Do not
+join those series on `source`. A warm TTC with no matching fetch is a cache
+hit. Two cold TTC rows (Explore and Perps) against one unattributed overview
+fetch is the shared request, not missing telemetry.
 
 ## Recommended dashboard layout
 
@@ -116,7 +120,7 @@ restriction.
 | Widget                     | Visualization | Query                                                                                                                                              | Fields / grouping                                                                                                                    |
 | -------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | Journey latency            | Table         | `feature:whats_happening result:success span.description:["What's Happening Fetch","What's Happening Carousel Load","What's Happening View Load"]` | Group by `span.description`, `source`; show `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`, `count()`              |
-| Fetch duration             | Time series   | `span.description:"What's Happening Fetch" success:true`                                                                                           | `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`; group by `source`                                                  |
+| Fetch duration             | Time series   | `span.description:"What's Happening Fetch" result:success`                                                                                         | `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`; group by `cache_state`                                             |
 | Carousel TTC               | Time series   | `span.description:"What's Happening Carousel Load" result:success`                                                                                 | `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`; group by `source`                                                  |
 | Full-view TTC              | Time series   | `span.description:"What's Happening View Load" result:success`                                                                                     | `p50(span.duration)`, `p75(span.duration)`, `p95(span.duration)`; group by `source`                                                  |
 | Journey outcomes           | Table         | `feature:whats_happening span.op:[whats_happening.fetch,whats_happening.load]`                                                                     | Group by `span.description`, `result`, `source`; show `count()`                                                                      |
@@ -134,8 +138,7 @@ stage
 cache_state
 ```
 
-The live dashboard has not been created yet. Sentry MCP can read dashboards
-but cannot create them, and this environment has no scoped write token. Use
-the build sheet above in org `metamask`, project `metamask-mobile`
-(`2299799`), 14d, no environment filter. After creation, add the dashboard URL
-here.
+The dashboard described above is live at
+[Mobile — Social & AI — What's Happening](https://metamask.sentry.io/dashboard/9989431/).
+Keep this build sheet in sync when widgets change. Widgets will stay empty
+until a mobile release emits the What's Happening spans.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

What's Happening had no dedicated Sentry duration spans, so we could not tell fetch time from time-to-content, and carousel cards were writing Market Insights viewport spans.

This adds the same measurement model as Market Insights: fetch duration and time-to-content are separate spans. Shared digest helpers live in `digestPerformance.ts`. Carousel TTC starts in `useWhatsHappening` so settled empty misses that never mount the Explore/Perps section still record. View Load starts on card/header press or deeplink. WH cards keep MetaMetrics scroll-to-view and no longer emit Market Insights viewport spans.

Dashboard build sheet: `docs/ai/whats-happening-sentry-reference.md`. Live dashboard creation is pending a scoped Sentry write token.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: What's Happening Sentry telemetry

  Background:
    Given I am logged into MetaMask Mobile
    And What's Happening is enabled

  Scenario: carousel still loads on Explore and Perps
    Given I open the Explore Now tab or Perps Home
    When the What's Happening feed settles with items
    Then the carousel cards render as before
    And tapping a card or the section header opens the expanded detail view

  Scenario: empty feed stays hidden
    Given the market overview returns no items and no error
    When I open Explore Now or Perps Home
    Then the What's Happening section is not shown

  Scenario: deeplink opens the expanded view
    Given I open a what's-happening deeplink
    Then the expanded detail view opens
    And the first expanded card renders when items are available
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large observability and React Query lifecycle surface area with a behavior change on front-page fetch failures; no auth or payments, but incorrect span or pending logic could skew metrics or briefly affect deeplink error UX.
> 
> **Overview**
> Introduces **What's Happening** Sentry performance spans (overview/front-page **fetch**, carousel and expanded **time-to-content**) aligned with Market Insights, plus shared **`digestPerformance`** helpers used by both features for cache tagging, fetch spans with abort handling, observer pending state, and trace end attributes.
> 
> **`useWhatsHappening`** now accepts **`telemetryContext`**, exposes **`cacheState`**, **`isGenerationPending`**, and **`carouselTraceId`**, and wires **`useWhatsHappeningLoadTrace`** so empty/error/cancel outcomes close correctly on remount and deeplink front-page loads. Entry points pass source/stage (Explore, Perps, homepage carousel, detail expanded); card press and deeplink **start View Load**; the first carousel card and expanded layout **end success** TTC. **`useViewportTracking`** gains **`emitTrace: false`** so What's Happening cards keep scroll analytics without Market Insights viewport spans.
> 
> Market Insights fetch/loading logic is **refactored** onto the same digest helpers (no product behavior called out beyond shared TTC pending rules). Deep-linked **front-page fetch failures** now **surface as errors** (logged and rethrown) instead of silently falling back. Adds trace name/operation enums, tests, and **`docs/ai/whats-happening-sentry-reference.md`** (dashboard build sheet).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45c99f5db78049472fab11e03d6286e1d8c9cf6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->