### PR TITLE
fix(metamask-pay): use exact balance in all max flows

### DIFF
--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.test.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.test.tsx
@@ -4,6 +4,7 @@ import { DepositKeyboard, DepositKeyboardProps } from './deposit-keyboard';
 import { merge, noop } from 'lodash';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { otherControllersMock } from '../../__mocks__/controllers/other-controllers-mock';
+import { KeypadTestIds } from '../../../../Base/Keypad/Keypad.testIds';
 
 function render(props: Partial<DepositKeyboardProps> = {}) {
   return renderWithProvider(
@@ -33,6 +34,34 @@ describe('DepositKeyboard', () => {
     fireEvent.press(getByText('1'));
 
     expect(onChangeMock).toHaveBeenCalledWith('1');
+  });
+
+  it('edits from the amount as displayed when the value carries full precision', () => {
+    // Max stores the exact balance, so editing the raw value would make the
+    // user backspace away hidden decimals before the displayed amount moved.
+    const onChangeMock = jest.fn();
+
+    const { getByTestId } = render({
+      onChange: onChangeMock,
+      value: '50.389',
+    });
+
+    fireEvent.press(getByTestId(KeypadTestIds.DELETE_BUTTON));
+
+    expect(onChangeMock).toHaveBeenCalledWith('50.3');
+  });
+
+  it('drops the hidden decimals when a digit is rejected at the decimal cap', () => {
+    // The digit is still refused, since the displayed amount is already at
+    // two decimals, but the value it reports back no longer carries the
+    // precision the user cannot see.
+    const onChangeMock = jest.fn();
+
+    const { getByText } = render({ onChange: onChangeMock, value: '50.3891' });
+
+    fireEvent.press(getByText('7'));
+
+    expect(onChangeMock).toHaveBeenCalledWith('50.38');
   });
 
   it('hides done button if input is empty', () => {

--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
@@ -10,6 +10,7 @@ import { View } from 'react-native';
 import { PERPS_CURRENCY } from '../../constants/perps';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import Keypad from '../../../../Base/Keypad/components';
+import { formatAmountForDisplay } from '../../utils/transaction-pay';
 
 const PERCENTAGE_BUTTONS = [
   {
@@ -61,7 +62,7 @@ export const DepositKeyboard = memo(
   }: DepositKeyboardProps) => {
     const currentCurrency = PERPS_CURRENCY;
     const { styles } = useStyles(styleSheet, {});
-    const valueString = value.toString();
+    const valueString = formatAmountForDisplay(value.toString());
 
     const handleChange = useCallback(
       (data: KeypadChangeData) => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -39,6 +39,7 @@ import { TransactionPayRequiredToken } from '@metamask/transaction-pay-controlle
 import { useRoute } from '@react-navigation/native';
 import { getMoneyAccountDepositIntent } from '../../../../../UI/Money/hooks/useMoneyAccount';
 import { fireEvent } from '@testing-library/react-native';
+import { KeypadTestIds } from '../../../../../Base/Keypad/Keypad.testIds';
 import { Platform } from 'react-native';
 import { TransactionType } from '@metamask/transaction-controller';
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
@@ -465,6 +466,26 @@ describe('CustomAmountInfo', () => {
   it('renders payment token', () => {
     const { getByText } = render();
     expect(getByText('0 TST')).toBeDefined();
+  });
+
+  it('edits the keypad from the truncated amount rather than the full-precision one', () => {
+    // Regression: Max stores the exact balance, so feeding the raw value to
+    // the keypad left hidden decimals that had to be backspaced away one at a
+    // time before the displayed amount changed.
+    const updatePendingAmount = jest.fn();
+    useTransactionCustomAmountMock.mockReturnValue({
+      ...useTransactionCustomAmountMock(),
+      amountFiat: '50.389',
+      updatePendingAmount,
+    });
+
+    const { getByText, getByTestId } = render();
+
+    expect(getByText('50.38')).toBeOnTheScreen();
+
+    fireEvent.press(getByTestId(KeypadTestIds.DELETE_BUTTON));
+
+    expect(updatePendingAmount).toHaveBeenCalledWith('50.3');
   });
 
   it('sets up back swipe rejection', () => {

--- a/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
@@ -7,26 +7,23 @@ import { transactionApprovalControllerMock } from '../../../__mocks__/controller
 import {
   useIsTransactionPayLoading,
   useTransactionPayIsMaxAmount,
+  useTransactionPayQuotesRaw,
   useTransactionPayRequiredTokens,
   useTransactionPayTotals,
 } from '../../../hooks/pay/useTransactionPayData';
-import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
 import {
-  TransactionPaymentToken,
+  TransactionPayStrategy,
   TransactionPayTotals,
 } from '@metamask/transaction-pay-controller';
 import { TransactionType } from '@metamask/transaction-controller';
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
 
 jest.mock('../../../hooks/pay/useTransactionPayData');
-jest.mock('../../../hooks/pay/useTransactionPayToken');
 jest.mock('../../../hooks/pay/useTransactionPayWithdraw');
 
 const TOTAL_FIAT_MOCK = '$123.46';
 const RECEIVE_FIAT_MOCK = '$99.38';
-const MUSD_ADDRESS_MOCK = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
-const MUSD_CHAIN_ID_MOCK = '0x1';
 
 function render(options: { type?: TransactionType } = {}) {
   const state = merge(
@@ -56,11 +53,13 @@ describe('TotalRow', () => {
   const useTransactionPayIsMaxAmountMock = jest.mocked(
     useTransactionPayIsMaxAmount,
   );
+  const useTransactionPayWithdrawMock = jest.mocked(useTransactionPayWithdraw);
+  const useTransactionPayQuotesRawMock = jest.mocked(
+    useTransactionPayQuotesRaw,
+  );
   const useTransactionPayRequiredTokensMock = jest.mocked(
     useTransactionPayRequiredTokens,
   );
-  const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
-  const useTransactionPayWithdrawMock = jest.mocked(useTransactionPayWithdraw);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -69,13 +68,6 @@ describe('TotalRow', () => {
       total: { usd: '123.456' },
       targetAmount: { usd: '99.38', fiat: '99.38' },
     } as unknown as TransactionPayTotals);
-    useTransactionPayRequiredTokensMock.mockReturnValue([]);
-    useTransactionPayTokenMock.mockReturnValue({
-      payToken: {
-        address: MUSD_ADDRESS_MOCK,
-        chainId: MUSD_CHAIN_ID_MOCK,
-      } as unknown as TransactionPaymentToken,
-    } as ReturnType<typeof useTransactionPayToken>);
 
     useIsTransactionPayLoadingMock.mockReturnValue(false);
 
@@ -185,7 +177,7 @@ describe('TotalRow', () => {
       expect(getByTestId('receive-row-skeleton')).toBeDefined();
     });
 
-    it('renders the target amount even when it is zero and no required amount exists', () => {
+    it('renders the target amount even when it is zero', () => {
       useTransactionPayWithdrawMock.mockReturnValue({
         isWithdraw: true,
         canSelectWithdrawToken: true,
@@ -194,64 +186,110 @@ describe('TotalRow', () => {
         total: { usd: '123.456' },
         targetAmount: { usd: '0', fiat: '0' },
       } as unknown as TransactionPayTotals);
-      useTransactionPayRequiredTokensMock.mockReturnValue([]);
 
       const { getByText } = render();
 
       expect(getByText('$0')).toBeOnTheScreen();
     });
+  });
 
-    it('falls back to required token amount when targetAmount is 0 for direct same-token withdraw routes', () => {
+  describe('no-op quote routes', () => {
+    beforeEach(() => {
       useTransactionPayWithdrawMock.mockReturnValue({
         isWithdraw: true,
         canSelectWithdrawToken: true,
       });
+      // A no-op quote is excluded from totals, so targetAmount stays at 0.
       useTransactionPayTotalsMock.mockReturnValue({
-        total: { usd: '0' },
+        total: { usd: '123.456' },
         targetAmount: { usd: '0', fiat: '0' },
       } as unknown as TransactionPayTotals);
       useTransactionPayRequiredTokensMock.mockReturnValue([
-        {
-          address: MUSD_ADDRESS_MOCK,
-          chainId: MUSD_CHAIN_ID_MOCK,
-          amountUsd: '27.51',
-          skipIfBalance: false,
-        },
-      ] as never);
-
-      const { getByText, queryByText } = render();
-
-      expect(getByText('$27.51')).toBeOnTheScreen();
-      expect(queryByText('$0')).toBeNull();
+        { amountUsd: '27.51', skipIfBalance: false },
+      ] as unknown as ReturnType<typeof useTransactionPayRequiredTokens>);
     });
 
-    it('does not fall back to required token amount for cross-token routes when targetAmount is 0', () => {
-      useTransactionPayWithdrawMock.mockReturnValue({
-        isWithdraw: true,
-        canSelectWithdrawToken: true,
-      });
-      useTransactionPayTotalsMock.mockReturnValue({
-        total: { usd: '0' },
-        targetAmount: { usd: '0', fiat: '0' },
-      } as unknown as TransactionPayTotals);
+    it('falls back to the required token amount when the route needs no conversion', () => {
+      useTransactionPayQuotesRawMock.mockReturnValue([
+        { strategy: TransactionPayStrategy.None },
+      ] as unknown as ReturnType<typeof useTransactionPayQuotesRaw>);
+
+      const { getByText } = render();
+
+      expect(getByText('$27.51')).toBeOnTheScreen();
+    });
+
+    it('falls back regardless of the required token address and chain', () => {
+      // The no-op quote itself is the signal that nothing is converted, so the
+      // row must not re-derive routing by comparing token address and chain.
+      useTransactionPayQuotesRawMock.mockReturnValue([
+        { strategy: TransactionPayStrategy.None },
+      ] as unknown as ReturnType<typeof useTransactionPayQuotesRaw>);
       useTransactionPayRequiredTokensMock.mockReturnValue([
         {
-          address: MUSD_ADDRESS_MOCK,
-          chainId: MUSD_CHAIN_ID_MOCK,
+          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
           amountUsd: '27.51',
+          chainId: '0x1',
           skipIfBalance: false,
         },
-      ] as never);
-      useTransactionPayTokenMock.mockReturnValue({
-        payToken: {
-          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-          chainId: MUSD_CHAIN_ID_MOCK,
-        } as unknown as TransactionPaymentToken,
-      } as ReturnType<typeof useTransactionPayToken>);
+      ] as unknown as ReturnType<typeof useTransactionPayRequiredTokens>);
+
+      const { getByText } = render();
+
+      expect(getByText('$27.51')).toBeOnTheScreen();
+    });
+
+    it('skips required tokens that are covered by balance', () => {
+      useTransactionPayQuotesRawMock.mockReturnValue([
+        { strategy: TransactionPayStrategy.None },
+      ] as unknown as ReturnType<typeof useTransactionPayQuotesRaw>);
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        { amountUsd: '99.99', skipIfBalance: true },
+        { amountUsd: '27.51', skipIfBalance: false },
+      ] as unknown as ReturnType<typeof useTransactionPayRequiredTokens>);
+
+      const { getByText } = render();
+
+      expect(getByText('$27.51')).toBeOnTheScreen();
+    });
+
+    it('does not show the required amount when the route needs a conversion', () => {
+      // A conversion route with no usable quote must not present the source
+      // amount as the amount received.
+      useTransactionPayQuotesRawMock.mockReturnValue([
+        { strategy: TransactionPayStrategy.Relay },
+      ] as unknown as ReturnType<typeof useTransactionPayQuotesRaw>);
 
       const { getByText, queryByText } = render();
 
       expect(getByText('$0')).toBeOnTheScreen();
+      expect(queryByText('$27.51')).toBeNull();
+    });
+
+    it('does not show the required amount when there are no quotes at all', () => {
+      useTransactionPayQuotesRawMock.mockReturnValue(
+        undefined as unknown as ReturnType<typeof useTransactionPayQuotesRaw>,
+      );
+
+      const { getByText, queryByText } = render();
+
+      expect(getByText('$0')).toBeOnTheScreen();
+      expect(queryByText('$27.51')).toBeNull();
+    });
+
+    it('prefers the quote-derived target amount when one is available', () => {
+      useTransactionPayTotalsMock.mockReturnValue({
+        total: { usd: '123.456' },
+        targetAmount: { usd: '99.38', fiat: '99.38' },
+      } as unknown as TransactionPayTotals);
+      useTransactionPayQuotesRawMock.mockReturnValue([
+        { strategy: TransactionPayStrategy.None },
+        { strategy: TransactionPayStrategy.Relay },
+      ] as unknown as ReturnType<typeof useTransactionPayQuotesRaw>);
+
+      const { getByText, queryByText } = render();
+
+      expect(getByText(RECEIVE_FIAT_MOCK)).toBeOnTheScreen();
       expect(queryByText('$27.51')).toBeNull();
     });
   });

--- a/app/components/Views/confirmations/components/rows/total-row/total-row.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.tsx
@@ -6,10 +6,11 @@ import { BigNumber } from 'bignumber.js';
 import {
   useIsTransactionPayLoading,
   useTransactionPayIsMaxAmount,
+  useTransactionPayQuotesRaw,
   useTransactionPayRequiredTokens,
   useTransactionPayTotals,
 } from '../../../hooks/pay/useTransactionPayData';
-import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
+import { isNoOpQuote } from '../../../../../../selectors/transactionPayController';
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
 import { isTransactionPayWithdraw } from '../../../utils/transaction';
 import { InfoRowSkeleton, InfoRowVariant } from '../../UI/info-row/info-row';
@@ -22,20 +23,6 @@ import {
   TextVariant,
   TextColor,
 } from '@metamask/design-system-react-native';
-
-function isSameTokenAddressAndChain(
-  left: { address?: string; chainId?: string } | undefined,
-  right: { address?: string; chainId?: string } | undefined,
-): boolean {
-  if (!left?.address || !left.chainId || !right?.address || !right.chainId) {
-    return false;
-  }
-
-  return (
-    left.address.toLowerCase() === right.address.toLowerCase() &&
-    left.chainId.toLowerCase() === right.chainId.toLowerCase()
-  );
-}
 
 /**
  * Row component that owns the bottom line of the totals section.
@@ -108,19 +95,17 @@ function TotalFeesRow() {
 /**
  * Displays "You'll receive" for withdrawal, input-based, and Max flows.
  *
- * Prefers `totals.targetAmount.usd` from executable quotes (after fees). Direct
- * same-token routes only produce a None-strategy no-op quote, which is excluded
- * from totals and leaves targetAmount at 0 — fall back to the required token
- * amount only when the destination payment token matches that required token
- * (same-chain mUSD Money Account withdraw). Cross-token routes must not show
- * the source amount as received when the quote is missing.
+ * Prefers `totals.targetAmount.usd` from executable quotes (after fees). A
+ * route needing no conversion only produces a no-op quote, which is excluded
+ * from totals and leaves `targetAmount` at 0 — nothing is converted, so the
+ * required token amount is what gets received.
  */
 function ReceiveRow() {
   const formatFiat = useFiatFormatter({ currency: 'usd' });
   const isLoading = useIsTransactionPayLoading();
   const totals = useTransactionPayTotals();
   const requiredTokens = useTransactionPayRequiredTokens();
-  const { payToken } = useTransactionPayToken();
+  const rawQuotes = useTransactionPayQuotesRaw();
 
   const receiveUsd = useMemo(() => {
     const targetAmountUsd = totals?.targetAmount?.usd;
@@ -131,28 +116,24 @@ function ReceiveRow() {
       return formatFiat(targetBn);
     }
 
-    const primaryRequiredToken = (requiredTokens ?? []).find(
+    const isNoOpRoute = (rawQuotes ?? []).some(isNoOpQuote);
+
+    const requiredAmountUsd = (requiredTokens ?? []).find(
       (token) => !token.skipIfBalance,
-    );
-    const isDirectSameTokenRoute = isSameTokenAddressAndChain(
-      primaryRequiredToken,
-      payToken,
-    );
+    )?.amountUsd;
 
     if (
-      isDirectSameTokenRoute &&
-      primaryRequiredToken?.amountUsd &&
-      new BigNumber(primaryRequiredToken.amountUsd).gt(0)
+      isNoOpRoute &&
+      requiredAmountUsd &&
+      new BigNumber(requiredAmountUsd).gt(0)
     ) {
-      return formatFiat(new BigNumber(primaryRequiredToken.amountUsd));
+      return formatFiat(new BigNumber(requiredAmountUsd));
     }
 
-    if (targetBn == null) {
-      return '';
-    }
+    if (targetBn == null) return '';
 
     return formatFiat(targetBn);
-  }, [formatFiat, payToken, requiredTokens, totals?.targetAmount?.usd]);
+  }, [formatFiat, rawQuotes, requiredTokens, totals?.targetAmount?.usd]);
 
   if (isLoading) {
     return <InfoRowSkeleton testId="receive-row-skeleton" />;

--- a/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
+++ b/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
@@ -103,4 +103,67 @@ describe('CustomAmount', () => {
 
     expect(queryByTestId('custom-amount-cursor')).toBeNull();
   });
+
+  describe('display-only decimal rounding', () => {
+    it('rounds full-precision amounts down to two decimals', () => {
+      const { getByText } = renderWithProvider(
+        <CustomAmount amountFiat="500.123456" />,
+      );
+
+      expect(getByText('500.12')).toBeOnTheScreen();
+    });
+
+    it('rounds half up', () => {
+      const { getByText } = renderWithProvider(
+        <CustomAmount amountFiat="10.375107" />,
+      );
+
+      expect(getByText('10.38')).toBeOnTheScreen();
+    });
+
+    it('rounds up and carries into the whole part', () => {
+      const { getByText } = renderWithProvider(
+        <CustomAmount amountFiat="1.999" />,
+      );
+
+      expect(getByText('2.00')).toBeOnTheScreen();
+    });
+
+    it('rounds before applying locale separators', () => {
+      renderWithProvider(<CustomAmount amountFiat="1234.987654" />);
+
+      expect(mockFormatAmountWithLocaleSeparators).toHaveBeenCalledWith(
+        '1234.99',
+      );
+    });
+
+    it('normalises a comma decimal separator to a period', () => {
+      // formatAmountWithLocaleSeparators splits on `.` and applies the locale
+      // separator itself, so handing it a comma would drop the decimals.
+      const { getByText } = renderWithProvider(
+        <CustomAmount amountFiat="500,987654" />,
+      );
+
+      expect(getByText('500.99')).toBeOnTheScreen();
+    });
+
+    it('renders malformed input unchanged rather than NaN', () => {
+      const { getByText } = renderWithProvider(
+        <CustomAmount amountFiat="1.2.3456" />,
+      );
+
+      expect(getByText('1.2.3456')).toBeOnTheScreen();
+    });
+
+    it.each(['500', '1000000', '123.45', '123.4', '0.10', '12.'])(
+      'leaves keypad input %s exactly as typed',
+      (amountFiat) => {
+        const { getByText } = renderWithProvider(
+          <CustomAmount amountFiat={amountFiat} />,
+        );
+
+        expect(getByText(amountFiat)).toBeOnTheScreen();
+      },
+    );
+  });
 });

--- a/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
+++ b/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
@@ -104,8 +104,8 @@ describe('CustomAmount', () => {
     expect(queryByTestId('custom-amount-cursor')).toBeNull();
   });
 
-  describe('display-only decimal rounding', () => {
-    it('rounds full-precision amounts down to two decimals', () => {
+  describe('cents truncation', () => {
+    it('truncates full-precision amounts to two decimals', () => {
       const { getByText } = renderWithProvider(
         <CustomAmount amountFiat="500.123456" />,
       );
@@ -113,27 +113,29 @@ describe('CustomAmount', () => {
       expect(getByText('500.12')).toBeOnTheScreen();
     });
 
-    it('rounds half up', () => {
+    it('truncates rather than rounding up', () => {
+      // The rendered value is re-typable through the keypad, so rounding up
+      // would let the user enter an amount above their balance.
       const { getByText } = renderWithProvider(
-        <CustomAmount amountFiat="10.375107" />,
+        <CustomAmount amountFiat="10.379" />,
       );
 
-      expect(getByText('10.38')).toBeOnTheScreen();
+      expect(getByText('10.37')).toBeOnTheScreen();
     });
 
-    it('rounds up and carries into the whole part', () => {
+    it('never carries into the whole part', () => {
       const { getByText } = renderWithProvider(
         <CustomAmount amountFiat="1.999" />,
       );
 
-      expect(getByText('2.00')).toBeOnTheScreen();
+      expect(getByText('1.99')).toBeOnTheScreen();
     });
 
-    it('rounds before applying locale separators', () => {
+    it('truncates before applying locale separators', () => {
       renderWithProvider(<CustomAmount amountFiat="1234.987654" />);
 
       expect(mockFormatAmountWithLocaleSeparators).toHaveBeenCalledWith(
-        '1234.99',
+        '1234.98',
       );
     });
 
@@ -144,7 +146,7 @@ describe('CustomAmount', () => {
         <CustomAmount amountFiat="500,987654" />,
       );
 
-      expect(getByText('500.99')).toBeOnTheScreen();
+      expect(getByText('500.98')).toBeOnTheScreen();
     });
 
     it('renders malformed input unchanged rather than NaN', () => {

--- a/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.tsx
+++ b/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Animated, View } from 'react-native';
+import { BigNumber } from 'bignumber.js';
 import { useStyles } from '../../../../../../component-library/hooks';
 import styleSheet from './custom-amount.styles';
 import { getCurrencySymbol } from '../../../../../../util/number';
@@ -37,7 +38,11 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo((props) => {
   const selectedCurrency = useSelector(selectCurrentCurrency);
   const currency = currencyProp ?? selectedCurrency;
   const fiatSymbol = getCurrencySymbol(currency);
-  const formattedAmount = formatAmountWithLocaleSeparators(amountFiat);
+
+  const formattedAmount = formatAmountWithLocaleSeparators(
+    roundFiatForDisplay(amountFiat),
+  );
+
   const amountLength = formattedAmount.length;
 
   const { styles } = useStyles(styleSheet, {
@@ -91,4 +96,31 @@ export function CustomAmountSkeleton() {
       <Skeleton height={70} width={80} />
     </View>
   );
+}
+
+/**
+ * Rounds the fiat amount to two decimals for display only, since `amountFiat`
+ * carries full precision so that Max spends the entire balance.
+ *
+ * Amounts already within two decimals are returned as-is, so keypad input
+ * renders exactly as typed and a mid-edit `12.` is never rewritten to `12.00`.
+ */
+function roundFiatForDisplay(amountFiat: string): string {
+  const separatorIndex = amountFiat.search(/[.,]/u);
+
+  if (separatorIndex === -1) {
+    return amountFiat;
+  }
+
+  const decimalCount = amountFiat.length - separatorIndex - 1;
+
+  if (decimalCount <= 2) {
+    return amountFiat;
+  }
+
+  const value = new BigNumber(amountFiat.replace(',', '.'));
+
+  return value.isFinite()
+    ? value.toFixed(2, BigNumber.ROUND_HALF_UP)
+    : amountFiat;
 }

--- a/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.tsx
+++ b/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Animated, View } from 'react-native';
-import { BigNumber } from 'bignumber.js';
 import { useStyles } from '../../../../../../component-library/hooks';
 import styleSheet from './custom-amount.styles';
 import { getCurrencySymbol } from '../../../../../../util/number';
@@ -11,6 +10,7 @@ import { selectCurrentCurrency } from '../../../../../../selectors/currencyRateC
 import { useConfirmationContext } from '../../../context/confirmation-context';
 import { useBlinkingCursor } from '../../../../../UI/Ramp/hooks/useBlinkingCursor';
 import { Text } from '@metamask/design-system-react-native';
+import { formatAmountForDisplay } from '../../../utils/transaction-pay';
 
 export interface CustomAmountProps {
   amountFiat: string;
@@ -40,7 +40,7 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo((props) => {
   const fiatSymbol = getCurrencySymbol(currency);
 
   const formattedAmount = formatAmountWithLocaleSeparators(
-    roundFiatForDisplay(amountFiat),
+    formatAmountForDisplay(amountFiat),
   );
 
   const amountLength = formattedAmount.length;
@@ -96,31 +96,4 @@ export function CustomAmountSkeleton() {
       <Skeleton height={70} width={80} />
     </View>
   );
-}
-
-/**
- * Rounds the fiat amount to two decimals for display only, since `amountFiat`
- * carries full precision so that Max spends the entire balance.
- *
- * Amounts already within two decimals are returned as-is, so keypad input
- * renders exactly as typed and a mid-edit `12.` is never rewritten to `12.00`.
- */
-function roundFiatForDisplay(amountFiat: string): string {
-  const separatorIndex = amountFiat.search(/[.,]/u);
-
-  if (separatorIndex === -1) {
-    return amountFiat;
-  }
-
-  const decimalCount = amountFiat.length - separatorIndex - 1;
-
-  if (decimalCount <= 2) {
-    return amountFiat;
-  }
-
-  const value = new BigNumber(amountFiat.replace(',', '.'));
-
-  return value.isFinite()
-    ? value.toFixed(2, BigNumber.ROUND_HALF_UP)
-    : amountFiat;
 }

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -906,7 +906,7 @@ describe('useTransactionCustomAmount', () => {
         result.current.updatePendingAmountPercentage(43);
       });
 
-      expect(result.current.amountFiat).toBe('530.86');
+      expect(result.current.amountFiat).toBe('530.8608');
     });
 
     it('to percentage of token balance converted to usd if overridden', async () => {
@@ -918,7 +918,7 @@ describe('useTransactionCustomAmount', () => {
         result.current.updatePendingAmountPercentage(43);
       });
 
-      expect(result.current.amountFiat).toBe('530.86');
+      expect(result.current.amountFiat).toBe('530.8608');
     });
 
     it('to 100 percent of balance when selecting max', async () => {
@@ -949,7 +949,7 @@ describe('useTransactionCustomAmount', () => {
         result.current.updatePendingAmountPercentage(43);
       });
 
-      expect(result.current.amountFiat).toBe('1858.12');
+      expect(result.current.amountFiat).toBe('1858.1289');
     });
 
     it('to total predict balance when selecting max', async () => {
@@ -1001,7 +1001,7 @@ describe('useTransactionCustomAmount', () => {
       });
 
       // Predict balance is treated as USD 1:1, ignoring the pay-token fiat rate.
-      expect(result.current.amountFiat).toBe('2160.61');
+      expect(result.current.amountFiat).toBe('2160.615');
     });
 
     it('uses full predict balance for predictWithdraw max even when payment override is MoneyAccount', async () => {
@@ -1066,10 +1066,12 @@ describe('useTransactionCustomAmount', () => {
       expect(result.current.amountFiat).toBe('250');
     });
 
-    it('truncates the Max amount for perps withdraw down to 2 decimals so the input field matches the displayed balance', async () => {
-      // Real HL balances often have 3+ decimals (e.g. 50.389).
-      // Max must truncate — not halfExpand — otherwise the typed value could
-      // exceed the balance and trip the insufficient-balance alert.
+    it('keeps the full precision of the Max amount for perps withdraw', async () => {
+      // Real HL balances often have 3+ decimals (e.g. 50.389). Max must apply
+      // the balance exactly so the withdraw encodes the whole position;
+      // truncating to 2dp left dust behind. The amount can never exceed the
+      // balance because it is the balance. Rounding to cents is display-only,
+      // in custom-amount.tsx.
       const { result } = runHook({
         transactionMeta: {
           type: TransactionType.perpsWithdraw,
@@ -1092,7 +1094,7 @@ describe('useTransactionCustomAmount', () => {
         result.current.updatePendingAmountPercentage(100);
       });
 
-      expect(result.current.amountFiat).toBe('50.38');
+      expect(result.current.amountFiat).toBe('50.389');
     });
 
     it('sets isMaxAmount=true for perps withdraw when Max is pressed', async () => {
@@ -1210,34 +1212,10 @@ describe('useTransactionCustomAmount', () => {
       expect(result.current.amountFiat).toBe('500');
     });
 
-    it('does not set isMaxAmount for money account withdraw when Max is pressed', async () => {
-      // Max still fills the full withdrawable amount, but must not arm
-      // isMaxAmount — post-quote would otherwise treat destination payment
-      // token balance as the source amount instead of nested-tx mUSD.
-      useTokenFiatRateMock.mockReturnValue(1);
-      useMoneyAccountBalanceMock.mockReturnValue({
-        withdrawableMusd: new BigNumber(500),
-      } as ReturnType<typeof useMoneyAccountBalance>);
-
-      const { result } = runHook({
-        transactionMeta: {
-          type: TransactionType.moneyAccountWithdraw,
-        },
-        stateOverrides: getMoneyAccountState('500000000'),
-      });
-
-      await act(async () => {
-        result.current.updatePendingAmountPercentage(100);
-      });
-
-      expect(result.current.amountFiat).toBe('500');
-      expect(setTransactionConfigMock).not.toHaveBeenCalled();
-    });
-
-    it('uses exact fractional redeemable balance for money account withdraw Max without isMaxAmount', async () => {
-      // Fiat ROUND_DOWN to 2 decimals would leave dust (500.12 from
-      // 500.123456). Max must keep full balanceRaw precision while still
-      // leaving isMaxAmount unset.
+    it('keeps full precision for money account withdraw Max so the encoded withdraw matches the quote', async () => {
+      // Cent-rounding here made the withdraw smaller than the amount the quote
+      // had sized against the exact balance, reverting with
+      // InsufficientBalance. The amount input truncates for display instead.
       useTokenFiatRateMock.mockReturnValue(1);
       useMoneyAccountBalanceMock.mockReturnValue({
         withdrawableMusd: new BigNumber('500.123456'),
@@ -1255,7 +1233,52 @@ describe('useTransactionCustomAmount', () => {
       });
 
       expect(result.current.amountFiat).toBe('500.123456');
-      expect(setTransactionConfigMock).not.toHaveBeenCalled();
+    });
+
+    it('pads a lone decimal up to cents without losing precision', async () => {
+      useTokenFiatRateMock.mockReturnValue(1);
+      useMoneyAccountBalanceMock.mockReturnValue({
+        withdrawableMusd: new BigNumber('1000.2'),
+      } as ReturnType<typeof useMoneyAccountBalance>);
+
+      const { result } = runHook({
+        transactionMeta: {
+          type: TransactionType.moneyAccountWithdraw,
+        },
+        stateOverrides: getMoneyAccountState('1000200000'),
+      });
+
+      await act(async () => {
+        result.current.updatePendingAmountPercentage(50);
+      });
+
+      expect(result.current.amountFiat).toBe('500.10');
+    });
+
+    it('sets isMaxAmount=true for money account withdraw when Max is pressed', async () => {
+      // The mUSD + vmUSD aggregate balance is resolved by TPC's getBalance
+      // callback, so the Max button always arms isMaxAmount here too.
+      useTokenFiatRateMock.mockReturnValue(1);
+      useMoneyAccountBalanceMock.mockReturnValue({
+        withdrawableMusd: new BigNumber(500),
+      } as ReturnType<typeof useMoneyAccountBalance>);
+
+      const { result } = runHook({
+        transactionMeta: {
+          type: TransactionType.moneyAccountWithdraw,
+        },
+        stateOverrides: getMoneyAccountState('500000000'),
+      });
+
+      await act(async () => {
+        result.current.updatePendingAmountPercentage(100);
+      });
+
+      expect(result.current.amountFiat).toBe('500');
+
+      const config = { isMaxAmount: false };
+      setTransactionConfigMock.mock.calls[0][1](config);
+      expect(config.isMaxAmount).toBe(true);
     });
 
     it('returns 0 for money account withdraw when withdrawableMusd is undefined', async () => {
@@ -1452,8 +1475,8 @@ describe('useTransactionCustomAmount', () => {
         result.current.updateTokenAmount();
       });
 
-      // 100% of 2.246912 rounded down = 2.24, ÷ 2 (fiat rate) = 1.12
-      expect(updateTransactionPayAmountMock).toHaveBeenCalledWith('1.12');
+      // 100% of 2.246912 = 2.246912, ÷ 2 (fiat rate) = 1.123456
+      expect(updateTransactionPayAmountMock).toHaveBeenCalledWith('1.123456');
     });
 
     it('updateTokenAmount uses fiat-derived amount for sub-100% deposit', async () => {
@@ -1479,8 +1502,8 @@ describe('useTransactionCustomAmount', () => {
         result.current.updateTokenAmount();
       });
 
-      // 50% of 2.246912 rounded down = 1.12, ÷ 2 (fiat rate) = 0.56
-      expect(updateTransactionPayAmountMock).toHaveBeenCalledWith('0.56');
+      // 50% of 2.246912 = 1.123456, ÷ 2 (fiat rate) = 0.561728
+      expect(updateTransactionPayAmountMock).toHaveBeenCalledWith('0.561728');
     });
 
     it('manual input clears the deposit max override', async () => {
@@ -1537,8 +1560,8 @@ describe('useTransactionCustomAmount', () => {
       });
 
       // Non-deposit type → fiat-derived amount
-      // 100% of 2.246912 rounded down = 2.24, ÷ 2 = 1.12
-      expect(updateTransactionPayAmountMock).toHaveBeenCalledWith('1.12');
+      // 100% of 2.246912 = 2.246912, ÷ 2 = 1.123456
+      expect(updateTransactionPayAmountMock).toHaveBeenCalledWith('1.123456');
     });
 
     it('resets deposit max when payToken changes', async () => {
@@ -1580,7 +1603,7 @@ describe('useTransactionCustomAmount', () => {
       });
 
       // payToken change resets Max state → uses fiat-derived amount
-      expect(updateTransactionPayAmountMock).toHaveBeenCalledWith('1.12');
+      expect(updateTransactionPayAmountMock).toHaveBeenCalledWith('1.123456');
     });
   });
 

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -15,7 +15,6 @@ import { useParams } from '../../../../../util/navigation/navUtils';
 import { debounce } from 'lodash';
 import {
   MUSD_CONVERSION_DEFAULT_CHAIN_ID,
-  MUSD_DECIMALS,
   MUSD_TOKEN_ADDRESS,
 } from '../../../../UI/Earn/constants/musd';
 import Engine from '../../../../../core/Engine';
@@ -41,6 +40,7 @@ import { useDepositPrefillAmount } from './useDepositPrefillAmount';
 
 export const MAX_LENGTH = 28;
 const DEBOUNCE_DELAY = 300;
+const MIN_FIAT_AMOUNT = 0.01;
 
 interface DepositPrefetchQuoteRequest {
   amountHuman: string;
@@ -48,10 +48,6 @@ interface DepositPrefetchQuoteRequest {
   isAmountPrepared: boolean;
   quoteBaseline: number | undefined;
   sawQuoteLoading: boolean;
-}
-
-function formatFiatAmount(value: BigNumber): string {
-  return value.isInteger() ? value.toString(10) : value.toFixed(2);
 }
 
 export function useTransactionCustomAmount({
@@ -126,7 +122,7 @@ export function useTransactionCustomAmount({
   const tokenFiatRate = isMoneyAccountWithdraw
     ? musdFiatRate
     : payTokenFiatRate;
-  const { balanceRaw, balanceUsd } = useTransactionPayBalance({ currency });
+  const { balanceUsd } = useTransactionPayBalance({ currency });
   const { payToken } = useTransactionPayToken();
   const payTokenKey = `${payToken?.chainId ?? ''}:${
     payToken?.address.toLowerCase() ?? ''
@@ -354,32 +350,22 @@ export function useTransactionCustomAmount({
         return false;
       }
 
-      // Money-account withdraw Max must not arm isMaxAmount (post-quote would
-      // treat destination payment-token balance as the source). Use the exact
-      // redeemable balanceRaw instead of fiat rounded to cents so Max does not
-      // leave dust.
-      let newAmount: string;
-      if (percentage === 100 && isMoneyAccountWithdraw && balanceRaw) {
-        const exactHuman = new BigNumber(balanceRaw).shiftedBy(-MUSD_DECIMALS);
-        if (!exactHuman.isFinite() || exactHuman.lte(0)) {
-          return false;
-        }
-        const exactFiat = tokenFiatRate
-          ? exactHuman.multipliedBy(tokenFiatRate)
-          : exactHuman;
-        newAmount = exactFiat.toFixed();
-      } else {
-        newAmount = formatFiatAmount(
-          new BigNumber(percentage)
-            .dividedBy(100)
-            .multipliedBy(balanceUsd)
-            .decimalPlaces(2, BigNumber.ROUND_DOWN),
-        );
-      }
+      const rawAmount = new BigNumber(percentage)
+        .dividedBy(100)
+        .multipliedBy(balanceUsd);
 
-      // Sub-cent / dust balances ROUND_DOWN to $0. Treat that like no balance
-      // so Max does not arm auto-submit and strand the page on Loading.
-      if (new BigNumber(newAmount).lte(0)) {
+      // Pad a lone decimal to cents (`500.1` -> `500.10`).
+      // Anything more precise keeps every digit.
+      const newAmount =
+        rawAmount.decimalPlaces() === 1
+          ? rawAmount.toFixed(2)
+          : rawAmount.toFixed();
+
+      // Sub-cent dust renders as $0.00 and cannot produce a usable quote, so
+      // treat it like no balance rather than arming auto-submit and stranding
+      // the page on Loading. Checked against the raw amount because the
+      // applied amount deliberately keeps full precision.
+      if (rawAmount.lt(MIN_FIAT_AMOUNT)) {
         return false;
       }
 
@@ -392,12 +378,7 @@ export function useTransactionCustomAmount({
         },
       });
 
-      // Arm isMaxAmount on a full (100%) selection so TPC can resolve the exact
-      // source balance via getBalance (perps HyperLiquid, predict Polymarket,
-      // money-account deposit mUSD + vmUSD). Money-account withdraws are the
-      // exception: Max must keep the explicit nested-tx amount, not treat the
-      // destination payment token balance as the source amount in post-quote.
-      if (percentage === 100 && !isMoneyAccountWithdraw) {
+      if (percentage === 100) {
         setIsMax(true);
       } else if (isMaxAmount) {
         setIsMax(false);
@@ -406,15 +387,7 @@ export function useTransactionCustomAmount({
       setAmountFiat(newAmount);
       return true;
     },
-    [
-      balanceRaw,
-      balanceUsd,
-      isMaxAmount,
-      isMoneyAccountWithdraw,
-      setConfirmationMetric,
-      setIsMax,
-      tokenFiatRate,
-    ],
+    [balanceUsd, isMaxAmount, setIsMax, setConfirmationMetric],
   );
 
   const prevHasPrefilled = useRef(depositPrefill.hasPrefilled);

--- a/app/components/Views/confirmations/utils/transaction-pay.test.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@metamask/transaction-controller';
 import {
   applyMoneyAccountOverride,
+  formatAmountForDisplay,
   getAvailableTokens,
   getBlockedTokensForTransactionType,
   getRequiredBalance,
@@ -1035,6 +1036,41 @@ describe('Transaction Pay Utils', () => {
       updateFiatPaymentMock.mock.calls[0][0].callback(fp as never);
 
       expect(fp.selectedPaymentMethodId).toBeUndefined();
+    });
+  });
+
+  describe('formatAmountForDisplay', () => {
+    it('returns whole numbers unchanged', () => {
+      expect(formatAmountForDisplay('500')).toBe('500');
+    });
+
+    it.each(['12.', '12.3', '12.34', '0.05'])(
+      'returns %s unchanged when already within two decimals',
+      (amount) => {
+        expect(formatAmountForDisplay(amount)).toBe(amount);
+      },
+    );
+
+    it('truncates rather than rounds so the result never exceeds the balance', () => {
+      // The displayed value is re-typable through the keypad, so rounding up
+      // would let the user enter an amount above their balance.
+      expect(formatAmountForDisplay('50.389')).toBe('50.38');
+    });
+
+    it('never carries into the whole part', () => {
+      expect(formatAmountForDisplay('1.999')).toBe('1.99');
+    });
+
+    it('truncates a long exact balance to cents', () => {
+      expect(formatAmountForDisplay('2160.6159999')).toBe('2160.61');
+    });
+
+    it('truncates an amount using a comma separator', () => {
+      expect(formatAmountForDisplay('50,389')).toBe('50.38');
+    });
+
+    it('returns the input unchanged when it is not a parseable number', () => {
+      expect(formatAmountForDisplay('1.2.3')).toBe('1.2.3');
     });
   });
 });

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -372,3 +372,33 @@ export function getTotalPayFeesUsd(
     .plus(fees.targetNetwork?.usd ?? 0)
     .plus(fees.metaMask?.usd ?? 0);
 }
+
+/**
+ * Truncates a fiat amount to two decimals for rendering and for the keypad
+ * buffer, since the stored amount carries full precision so that Max spends
+ * the entire balance.
+ *
+ * Truncates rather than rounds because the result is re-typable: the user can
+ * read the value off the screen and enter it back through the keypad, and
+ * rounding up would produce an amount greater than the balance.
+ *
+ * Amounts already within two decimals are returned as-is, so keypad input
+ * renders exactly as typed and a mid-edit `12.` is never rewritten to `12.00`.
+ */
+export function formatAmountForDisplay(amountFiat: string): string {
+  const separatorIndex = amountFiat.search(/[.,]/u);
+
+  if (separatorIndex === -1) {
+    return amountFiat;
+  }
+
+  const decimalCount = amountFiat.length - separatorIndex - 1;
+
+  if (decimalCount <= 2) {
+    return amountFiat;
+  }
+
+  const value = new BigNumber(amountFiat.replace(',', '.'));
+
+  return value.isFinite() ? value.toFixed(2, BigNumber.ROUND_DOWN) : amountFiat;
+}


### PR DESCRIPTION
## **Description**

Percentage and Max selections derive a fiat amount from the balance and round it down to two decimals before storing it. Where a withdraw leg is present, that stored amount is what gets encoded into its transaction data, so the withdrawal moves the rounded-down figure and leaves the remainder behind. The rounding does not reach the quote under Max — with `isMaxAmount` armed the source amount is resolved from the real balance — so it surfaces specifically in the encoded withdraw leg.

Money-account withdraw is exempt from the rounding via a bespoke branch that reads the exact redeemable balance, and which additionally avoids arming `isMaxAmount` so its explicit amount survives into the nested transaction. This PR generalises that one-off exemption into the behaviour for every flow.

- The derived amount keeps full precision, and rounding to cents happens only when rendering the input. The encoded withdraw amount is therefore the exact balance, which removes the need for the bespoke branch and lets `isMaxAmount` arm uniformly.
- The sub-cent guard that suppresses Max for dust balances compares the raw amount against one cent directly, rather than relying on the two-decimal rounding it previously sat behind.
- "You'll receive" identifies a route that needs no conversion from the quote strategy itself, instead of inferring it by comparing the payment token's address and chain against the required token. Totals exclude no-op quotes, so this is the case where nothing is converted and the required amount is what arrives.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Max amount precision

  Scenario: user withdraws the maximum from a Money Account
    Given user holds a balance with more than two decimal places
    And user is on the Money Account withdraw amount screen

    When user taps Max
    Then the input displays the balance rounded to cents
    And the "You'll receive" row shows a non-zero amount
    And confirming the withdrawal empties the balance with no remainder left

  Scenario: user withdraws the maximum from a Perps account
    Given user holds a Perps balance with three or more decimal places

    When user taps Max
    Then confirming the withdrawal transfers the entire balance

  Scenario: user selects a percentage of the balance
    When user taps 50%
    Then the input displays half the balance rounded to cents
    And the amount submitted is half the balance at full precision

  Scenario: user has only dust
    Given user holds a balance below one cent

    When user taps Max
    Then no amount is applied and the screen does not enter a loading state
```

## **Screenshots/Recordings**

N/A

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Max/percentage fiat amounts are stored and submitted across withdraw and pay flows, which can affect encoded transaction amounts and quote alignment; display/keypad behavior also changes for high-precision balances.
> 
> **Overview**
> **Max and percentage amounts** now keep the full derived fiat precision in state (so withdraw legs encode the exact balance), while **cent truncation is display-only** via new `formatAmountForDisplay` in `CustomAmount`, `DepositKeyboard`, and related tests.
> 
> `useTransactionCustomAmount` drops the old 2-decimal `ROUND_DOWN` path and the money-account-withdraw special case; **100% always arms `isMaxAmount`** (including money account withdraw), dust Max is blocked when the raw amount is under **$0.01**, and lone-decimal values are padded to cents without stripping extra precision elsewhere.
> 
> The **"You'll receive"** row falls back to the required-token USD amount when quotes include a **no-op** (`TransactionPayStrategy.None`) route, instead of inferring same-token routing from pay-token address/chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e7cd2ea0ac81a3803c7d622ece4e5410cd756b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->