### PR TITLE
test: integration-test ai-analyzer#54 mode-driven comments and labels [DO NOT MERGE]

### DIFF
--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -31,12 +31,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      # TEMPORARY - DO NOT MERGE: pinned to the ai-analyzer branch for
+      # MetaMask/ai-analyzer#54 so this PR integration-tests the mode-driven
+      # comment/label pipeline. Restore the pinned release SHA before merging:
       # https://github.com/MetaMask/ai-analyzer/releases
       - name: Checkout AI Analyzer
         uses: actions/checkout@v6
         with:
           repository: MetaMask/ai-analyzer
-          ref: f9a82c6ae0bfdadb352b9b736d26174705fe6348
+          ref: feat/mode-driven-post-actions
           path: .ai-analyzer-action
           token: ${{ secrets.AI_ANALYZER_TOKEN }}
 
@@ -44,7 +47,10 @@ jobs:
         uses: ./.ai-analyzer-action
         with:
           mode: pr-risk-analysis
-          add-comment: false
+          # TEMPORARY - DO NOT MERGE: production value is false. Enabled
+          # here so the new declarative comment policy is exercised; without
+          # it the comment rendering path in ai-analyzer#54 never runs.
+          add-comment: true
           add-label: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           litellm-api-key: ${{ secrets.AI_ANALYZER_LITELLM_KEY }}

--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -62,3 +62,5 @@ jobs:
           gate-override-base-pattern: '^release/'
           gate-override-author: 'runway-github[bot]'
           gate-override-title-pattern: 'cherry.?pick'
+
+# Integration-test re-run: verifies in-place comment update and risk:* label reconciliation.


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — integration test only

Integration test for **MetaMask/ai-analyzer#54** ("drive PR comments and labels from mode config"). This PR exists only to exercise that branch against a real mobile PR. Close it once verification is done.

### What this PR changes

Only `.github/workflows/ai-pr-risk-analysis.yml`, both changes marked `TEMPORARY - DO NOT MERGE`:

| Change | Why |
| --- | --- |
| `ref:` pinned to `feat/mode-driven-post-actions` instead of the release SHA `f9a82c6` | Runs the branch under test |
| `add-comment: false` → `true` | Production is `false`, so the new comment rendering path would otherwise never execute |

`add-label: true` is unchanged from production.

### Why this repo is a meaningful test

Mobile carries `.ai-pr-analyzer/modes/pr-risk-analysis/hard-rules.json` with **no `mode.yaml`**, which makes it a tier-2 "extend" overlay of the builtin mode. Under ai-analyzer#54 it must inherit the builtin's `comment` and `labels` policies untouched. That inheritance path is exactly what the PR reworked, and a silent regression there would mean no comment and no labels.

### What to verify on this PR

1. **Comment content comes from mode YAML, not hardcoded risk fields.** The comment under the `<!-- ai-pr-analysis -->` marker should render the four fields declared in the builtin `mode.yaml`, in order: Merge safe, Risk, Merge decision, Summary.
2. **Label is derived from the declared policy.** `labels.field: risk_level` with `prefix: "risk:"` should produce a single `risk:<level>` label, created with the color configured in `mode.yaml` if it does not already exist.
3. **Comment updates in place on re-push.** Push another commit; the existing comment should be `PATCH`ed rather than deleted and recreated (no notification spam).
4. **Stale managed labels are reconciled.** Manually add a bogus `risk:critical` label, then re-run. The `managedPrefix: "risk:"` cleanup should remove it and leave only the current level.
5. **Gate check run** `AI PR Analyzer / Gate` still reports as before.

`.github/workflows/` is in mobile's `critical.paths`, so this should be analyzed rather than scope-skipped, while staying under `criticalFileThreshold` so it runs on the default (cheaper) model tier.

### Before closing

Nothing to restore — this branch is throwaway. Mobile's `main` still points at the pinned release SHA with `add-comment: false`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to a throwaway branch and marked do-not-merge; risk is mainly accidental merge, which would point all PR analysis at an unpinned analyzer branch and enable PR comments fleet-wide.
> 
> **Overview**
> **Temporary integration test** for MetaMask/ai-analyzer#54 — only `.github/workflows/ai-pr-risk-analysis.yml`, with explicit `TEMPORARY - DO NOT MERGE` notes.
> 
> The workflow **checks out `MetaMask/ai-analyzer` at `feat/mode-driven-post-actions`** instead of the release pin `f9a82c6…`, so CI runs the mode-driven comment/label pipeline under test. **`add-comment` is set to `true`** (production stays `false`) so the new declarative comment path actually runs; `add-label: true` is unchanged.
> 
> A trailing workflow comment documents a **re-run scenario** for in-place comment updates and `risk:*` label reconciliation. Nothing else in the repo changes; `main` is expected to keep the release SHA and `add-comment: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60639ab52640ca52ef9dd4ba8125ea3603798eb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->