### PR TITLE
feat(card): add UK migration Update badge on Accounts menu

### DIFF
--- a/app/components/UI/Card/hooks/useCardUkMigrationUpdateBadge.test.ts
+++ b/app/components/UI/Card/hooks/useCardUkMigrationUpdateBadge.test.ts
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import {
+  getCardUkMigrationUpdateBadgeSeverity,
+  isCardUkMigrationEligible,
+  type CardUkMigrationState,
+} from '../../../../selectors/featureFlagController/card';
+import { useCardUkMigrationState } from './useCardUkMigrationState';
+import { useCardUkMigrationUpdateBadge } from './useCardUkMigrationUpdateBadge';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/cardController', () => ({
+  selectCardActiveProviderId: jest.fn(),
+  selectCardCountryOfResidence: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/featureFlagController/card', () => ({
+  getCardUkMigrationUpdateBadgeSeverity: jest.fn(),
+  isCardUkMigrationEligible: jest.fn(),
+}));
+
+jest.mock('./useCardUkMigrationState', () => ({
+  useCardUkMigrationState: jest.fn(),
+}));
+
+const mockUseSelector = jest.mocked(useSelector);
+const mockIsCardUkMigrationEligible = jest.mocked(isCardUkMigrationEligible);
+const mockGetCardUkMigrationUpdateBadgeSeverity = jest.mocked(
+  getCardUkMigrationUpdateBadgeSeverity,
+);
+const mockUseCardUkMigrationState = jest.mocked(useCardUkMigrationState);
+
+const migrationState: CardUkMigrationState = {
+  phase: 'soft',
+  isActive: true,
+  deadline: new Date('2026-09-30T23:59:59.999Z'),
+};
+
+describe('useCardUkMigrationUpdateBadge', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelector.mockReturnValueOnce('baanx').mockReturnValueOnce('GB');
+    mockUseCardUkMigrationState.mockReturnValue({
+      state: migrationState,
+      refresh: jest.fn(),
+    });
+  });
+
+  it('returns schedule severity for an eligible Baanx UK user', () => {
+    mockIsCardUkMigrationEligible.mockReturnValue(true);
+    mockGetCardUkMigrationUpdateBadgeSeverity.mockReturnValue('warning');
+
+    const { result } = renderHook(() => useCardUkMigrationUpdateBadge());
+
+    expect(mockIsCardUkMigrationEligible).toHaveBeenCalledWith(migrationState, {
+      providerId: 'baanx',
+      regionCode: 'GB',
+    });
+    expect(result.current).toBe('warning');
+  });
+
+  it('returns null without evaluating severity for an ineligible user', () => {
+    mockIsCardUkMigrationEligible.mockReturnValue(false);
+
+    const { result } = renderHook(() => useCardUkMigrationUpdateBadge());
+
+    expect(mockGetCardUkMigrationUpdateBadgeSeverity).not.toHaveBeenCalled();
+    expect(result.current).toBeNull();
+  });
+});

--- a/app/components/UI/Card/hooks/useCardUkMigrationUpdateBadge.ts
+++ b/app/components/UI/Card/hooks/useCardUkMigrationUpdateBadge.ts
@@ -1,0 +1,30 @@
+import { useSelector } from 'react-redux';
+import {
+  selectCardActiveProviderId,
+  selectCardCountryOfResidence,
+} from '../../../../selectors/cardController';
+import {
+  getCardUkMigrationUpdateBadgeSeverity,
+  isCardUkMigrationEligible,
+  type CardUkMigrationUpdateBadgeSeverity,
+} from '../../../../selectors/featureFlagController/card';
+import { useCardUkMigrationState } from './useCardUkMigrationState';
+
+/**
+ * Resolves the Accounts menu update badge for eligible Baanx UK users.
+ *
+ * Keeps Card provider, residency, feature flag, and schedule details inside
+ * the Card feature boundary.
+ */
+export function useCardUkMigrationUpdateBadge(): CardUkMigrationUpdateBadgeSeverity | null {
+  const activeProviderId = useSelector(selectCardActiveProviderId);
+  const countryOfResidence = useSelector(selectCardCountryOfResidence);
+  const { state } = useCardUkMigrationState();
+
+  const isEligible = isCardUkMigrationEligible(state, {
+    providerId: activeProviderId,
+    regionCode: countryOfResidence,
+  });
+
+  return isEligible ? getCardUkMigrationUpdateBadgeSeverity(state) : null;
+}

--- a/app/components/Views/AccountsMenu/AccountsMenu.test.tsx
+++ b/app/components/Views/AccountsMenu/AccountsMenu.test.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../../selectors/notifications';
 import { selectIsBackupAndSyncEnabled } from '../../../selectors/identity';
 import { METAMASK_SUPPORT_URL } from '../../../constants/urls';
+import { useCardUkMigrationUpdateBadge } from '../../UI/Card/hooks/useCardUkMigrationUpdateBadge';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -95,6 +96,10 @@ jest.mock('../../../util/notifications', () => ({
   isNotificationsFeatureEnabled: jest.fn(() => false),
 }));
 
+jest.mock('../../UI/Card/hooks/useCardUkMigrationUpdateBadge', () => ({
+  useCardUkMigrationUpdateBadge: jest.fn(() => null),
+}));
+
 jest.mock('../../../selectors/notifications', () => ({
   selectIsMetamaskNotificationsEnabled: jest.fn(),
   getMetamaskNotificationsUnreadCount: jest.fn(),
@@ -112,11 +117,17 @@ const mockGetBetaSupportUrl = jest.fn();
 jest.mock('./AccountsMenu.utils', () => ({
   getBetaSupportUrl: () => mockGetBetaSupportUrl(),
 }));
+
+const mockUseCardUkMigrationUpdateBadge = jest.mocked(
+  useCardUkMigrationUpdateBadge,
+);
+
 describe('AccountsMenu', () => {
   let mockAlert: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseCardUkMigrationUpdateBadge.mockReturnValue(null);
     // Default to the beta branch so pre-existing tests that don't care about
     // support consent keep their prior (beta) behavior; consent tests below
     // override this to '' to exercise the non-beta branch.
@@ -182,6 +193,26 @@ describe('AccountsMenu', () => {
 
       expect(mockTrackEvent).toHaveBeenCalled();
       expect(mockNavigate).toHaveBeenCalledWith('CardScreens');
+    });
+
+    it('shows Update badge when user is UK migration eligible', () => {
+      mockUseCardUkMigrationUpdateBadge.mockReturnValueOnce('warning');
+
+      const { getByTestId } = render(<AccountsMenu />);
+
+      expect(
+        getByTestId(AccountsMenuSelectorsIDs.MANAGE_CARD_UPDATE_BADGE),
+      ).toBeOnTheScreen();
+    });
+
+    it('hides Update badge when user is not UK migration eligible', () => {
+      mockUseCardUkMigrationUpdateBadge.mockReturnValueOnce(null);
+
+      const { queryByTestId } = render(<AccountsMenu />);
+
+      expect(
+        queryByTestId(AccountsMenuSelectorsIDs.MANAGE_CARD_UPDATE_BADGE),
+      ).toBeNull();
     });
   });
 

--- a/app/components/Views/AccountsMenu/AccountsMenu.testIds.ts
+++ b/app/components/Views/AccountsMenu/AccountsMenu.testIds.ts
@@ -14,6 +14,7 @@ export const AccountsMenuSelectorsIDs = {
 
   // Manage Card
   MANAGE_CARD: 'manage-card',
+  MANAGE_CARD_UPDATE_BADGE: 'card-uk-migration-update-badge',
 
   // Settings Link
   SETTINGS: 'settings-link',

--- a/app/components/Views/AccountsMenu/AccountsMenu.tsx
+++ b/app/components/Views/AccountsMenu/AccountsMenu.tsx
@@ -42,6 +42,8 @@ import {
 } from '../../../selectors/notifications';
 import { METAMASK_SUPPORT_URL } from '../../../constants/urls';
 import { getBetaSupportUrl } from './AccountsMenu.utils';
+import { useCardUkMigrationUpdateBadge } from '../../UI/Card/hooks/useCardUkMigrationUpdateBadge';
+import CardUkMigrationUpdateBadge from './components/CardUkMigrationUpdateBadge/CardUkMigrationUpdateBadge';
 
 const AccountsMenu = () => {
   const tw = useTailwind();
@@ -60,6 +62,7 @@ const AccountsMenu = () => {
     getMetamaskNotificationsUnreadCount,
   );
   const readNotificationCount = useSelector(getMetamaskNotificationsReadCount);
+  const cardUpdateBadgeSeverity = useCardUkMigrationUpdateBadge();
 
   const onPressDeposit = useCallback(() => {
     trackEvent(
@@ -294,6 +297,22 @@ const AccountsMenu = () => {
     tw,
   ]);
 
+  const cardUpdateBadge = cardUpdateBadgeSeverity ? (
+    <CardUkMigrationUpdateBadge
+      severity={cardUpdateBadgeSeverity}
+      testID={AccountsMenuSelectorsIDs.MANAGE_CARD_UPDATE_BADGE}
+    />
+  ) : null;
+
+  const cardRowEndAccessory = cardUpdateBadge ? (
+    <Box twClassName="flex-row items-center gap-2">
+      {cardUpdateBadge}
+      {arrowRightIcon}
+    </Box>
+  ) : (
+    arrowRightIcon
+  );
+
   return (
     <SafeAreaView
       edges={{ bottom: 'additive' }}
@@ -348,7 +367,7 @@ const AccountsMenu = () => {
           startAccessory={<Icon name={IconName.Card} size={IconSize.Lg} />}
           label={strings('accounts_menu.card_title')}
           onPress={onPressManageWallet}
-          endAccessory={arrowRightIcon}
+          endAccessory={cardRowEndAccessory}
           testID={AccountsMenuSelectorsIDs.MANAGE_CARD}
         />
 

--- a/app/components/Views/AccountsMenu/components/CardUkMigrationUpdateBadge/CardUkMigrationUpdateBadge.test.tsx
+++ b/app/components/Views/AccountsMenu/components/CardUkMigrationUpdateBadge/CardUkMigrationUpdateBadge.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import CardUkMigrationUpdateBadge from './CardUkMigrationUpdateBadge';
+import { CardUkMigrationUpdateBadgeSelectors } from './CardUkMigrationUpdateBadge.testIds';
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: (key: string) =>
+    key === 'accounts_menu.card_update_badge' ? 'Update' : key,
+}));
+
+describe('CardUkMigrationUpdateBadge', () => {
+  it.each(['info', 'warning', 'danger'] as const)(
+    'renders Update label for %s severity',
+    (severity) => {
+      const { getByTestId, getByText } = render(
+        <CardUkMigrationUpdateBadge severity={severity} />,
+      );
+
+      expect(
+        getByTestId(CardUkMigrationUpdateBadgeSelectors.BADGE),
+      ).toBeOnTheScreen();
+      expect(getByText('Update')).toBeOnTheScreen();
+    },
+  );
+});

--- a/app/components/Views/AccountsMenu/components/CardUkMigrationUpdateBadge/CardUkMigrationUpdateBadge.testIds.ts
+++ b/app/components/Views/AccountsMenu/components/CardUkMigrationUpdateBadge/CardUkMigrationUpdateBadge.testIds.ts
@@ -1,0 +1,3 @@
+export const CardUkMigrationUpdateBadgeSelectors = {
+  BADGE: 'card-uk-migration-update-badge',
+};

--- a/app/components/Views/AccountsMenu/components/CardUkMigrationUpdateBadge/CardUkMigrationUpdateBadge.tsx
+++ b/app/components/Views/AccountsMenu/components/CardUkMigrationUpdateBadge/CardUkMigrationUpdateBadge.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Tag, TagSeverity } from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { CardUkMigrationUpdateBadgeSelectors } from './CardUkMigrationUpdateBadge.testIds';
+
+type CardUkMigrationUpdateBadgeSeverity = 'info' | 'warning' | 'danger';
+
+export interface CardUkMigrationUpdateBadgeProps {
+  severity: CardUkMigrationUpdateBadgeSeverity;
+  testID?: string;
+}
+
+const TAG_SEVERITY: Record<CardUkMigrationUpdateBadgeSeverity, TagSeverity> = {
+  info: TagSeverity.Info,
+  warning: TagSeverity.Warning,
+  danger: TagSeverity.Danger,
+};
+
+/**
+ * "Update" tag for the Accounts menu MetaMask Card row during UK (Baanx) migration.
+ * Uses design-system Tag (`rounded-md`), not TagBase pill.
+ */
+const CardUkMigrationUpdateBadge = ({
+  severity,
+  testID = CardUkMigrationUpdateBadgeSelectors.BADGE,
+}: CardUkMigrationUpdateBadgeProps) => (
+  <Tag severity={TAG_SEVERITY[severity]} testID={testID}>
+    {strings('accounts_menu.card_update_badge')}
+  </Tag>
+);
+
+export default CardUkMigrationUpdateBadge;

--- a/app/selectors/featureFlagController/card/index.ts
+++ b/app/selectors/featureFlagController/card/index.ts
@@ -24,7 +24,9 @@ export * from './types';
 export {
   CARD_PROVIDER_FLAGS,
   CARD_UK_MIGRATION_COUNTRY_CODE,
+  CARD_UK_MIGRATION_UPDATE_BADGE_WARNING_DAYS,
   FALLBACK_CARD_PROVIDER_ID,
+  getCardUkMigrationUpdateBadgeSeverity,
   isCardUkMigrationEligible,
   readCardFeatureFlag,
   readCardProviderChains,
@@ -35,6 +37,7 @@ export {
   resolveCardProviderForCountry,
   resolveCardUkMigrationState,
   type CardRemoteFeatureFlags,
+  type CardUkMigrationUpdateBadgeSeverity,
 } from './read';
 
 /**

--- a/app/selectors/featureFlagController/card/read.test.ts
+++ b/app/selectors/featureFlagController/card/read.test.ts
@@ -6,6 +6,7 @@ import {
   defaultCardFeatureFlag,
 } from './defaults';
 import {
+  getCardUkMigrationUpdateBadgeSeverity,
   isCardUkMigrationEligible,
   readCardFeatureFlag,
   readCardProviderChains,
@@ -548,6 +549,64 @@ describe('card feature flag readers', () => {
           regionCode: 'US',
         }),
       ).toBe(false);
+    });
+  });
+
+  describe('getCardUkMigrationUpdateBadgeSeverity', () => {
+    const deadline = new Date('2026-09-30T23:59:59.999Z');
+
+    it('returns null when migration is inactive', () => {
+      expect(
+        getCardUkMigrationUpdateBadgeSeverity({
+          phase: 'off',
+          isActive: false,
+          deadline,
+        }),
+      ).toBeNull();
+    });
+
+    it('returns info when soft period started more than 7 days before end', () => {
+      expect(
+        getCardUkMigrationUpdateBadgeSeverity(
+          { phase: 'soft', isActive: true, deadline },
+          new Date('2026-09-20T00:00:00.000Z'),
+        ),
+      ).toBe('info');
+    });
+
+    it('returns warning when soft period is within 7 days of end', () => {
+      expect(
+        getCardUkMigrationUpdateBadgeSeverity(
+          { phase: 'soft', isActive: true, deadline },
+          new Date('2026-09-24T00:00:00.000Z'),
+        ),
+      ).toBe('warning');
+      expect(
+        getCardUkMigrationUpdateBadgeSeverity(
+          { phase: 'soft', isActive: true, deadline },
+          new Date('2026-09-30T12:00:00.000Z'),
+        ),
+      ).toBe('warning');
+    });
+
+    it('returns danger when soft period has ended (forced)', () => {
+      expect(
+        getCardUkMigrationUpdateBadgeSeverity(
+          { phase: 'forced', isActive: true, deadline },
+          new Date('2026-10-01T00:00:00.000Z'),
+        ),
+      ).toBe('danger');
+    });
+
+    it('returns danger after deadline when cached phase remains soft', () => {
+      const state = { phase: 'soft' as const, isActive: true, deadline };
+
+      const severity = getCardUkMigrationUpdateBadgeSeverity(
+        state,
+        new Date('2026-10-01T00:00:00.000Z'),
+      );
+
+      expect(severity).toBe('danger');
     });
   });
 });

--- a/app/selectors/featureFlagController/card/read.ts
+++ b/app/selectors/featureFlagController/card/read.ts
@@ -373,3 +373,47 @@ export function isCardUkMigrationEligible(
   }
   return params.regionCode?.toUpperCase() === CARD_UK_MIGRATION_COUNTRY_CODE;
 }
+
+/** Soft-period window that elevates the Accounts menu badge to warning. */
+export const CARD_UK_MIGRATION_UPDATE_BADGE_WARNING_DAYS = 7;
+
+export type CardUkMigrationUpdateBadgeSeverity = 'info' | 'warning' | 'danger';
+
+/**
+ * Accounts menu "Update" badge severity for eligible Baanx UK users:
+ * - `info` while soft migration has started (more than 7 days before end)
+ * - `warning` within 7 days of `endDate`
+ * - `danger` once the soft period has ended (`forced`)
+ */
+export function getCardUkMigrationUpdateBadgeSeverity(
+  state: CardUkMigrationState,
+  now: Date = new Date(),
+): CardUkMigrationUpdateBadgeSeverity | null {
+  if (!state.isActive) {
+    return null;
+  }
+
+  // The phase can remain `soft` while a focused screen is mounted across the
+  // deadline. Let the current clock take precedence over that cached phase.
+  if (state.deadline && now >= state.deadline) {
+    return 'danger';
+  }
+
+  if (state.phase === 'forced') {
+    return 'danger';
+  }
+
+  if (state.phase !== 'soft' || !state.deadline) {
+    return null;
+  }
+
+  const msUntilDeadline = state.deadline.getTime() - now.getTime();
+  const warningWindowMs =
+    CARD_UK_MIGRATION_UPDATE_BADGE_WARNING_DAYS * 24 * 60 * 60 * 1000;
+
+  if (msUntilDeadline <= warningWindowMs) {
+    return 'warning';
+  }
+
+  return 'info';
+}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4228,6 +4228,7 @@
     "resources": "Resources",
     "permissions": "Permissions",
     "card_title": "MetaMask Card",
+    "card_update_badge": "Update",
     "settings": "Settings",
     "networks": "Networks",
     "log_out": "Log out",


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

UK Baanx Card users in an active `cardUkMigration` window need a visible cue on Profile → Accounts that Card still requires an update, without Accounts menu pulling Card selectors and eligibility helpers.

This PR adds a design-system `Tag` (“Update”) on the MetaMask Card row. Visibility and severity stay inside Card: `useCardUkMigrationUpdateBadge` composes migration state, Baanx + GB eligibility, and schedule. The tag is hidden when the flag is off / inactive. Severity is **info** after start, **warning** within 7 days of `endDate`, and **danger** after the period ends (including when a cached `soft` phase is past the deadline).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added an Update badge on MetaMask Card in the Accounts menu for UK Card migration

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: CARD-505

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Accounts menu UK Card migration Update badge

  Background:
    Given I am logged into MetaMask Mobile
    And I open Profile then Accounts menu

  Scenario: badge is hidden when migration is off
    Given cardUkMigration is disabled or not yet started
    And I am a Baanx user in GB

    When I view the MetaMask Card row
    Then the Update badge is not shown

  Scenario: info badge during early soft period
    Given cardUkMigration is enabled with startDate in the past
    And endDate is more than 7 days in the future
    And I am a Baanx user with country of residence GB

    When I view the MetaMask Card row
    Then an Update tag is shown next to the chevron
    And the tag uses info severity (rounded-md, not a pill)

  Scenario: warning badge within 7 days of end
    Given I am an eligible Baanx GB user
    And now is within 7 days of endDate and still before endDate

    When I view the MetaMask Card row
    Then the Update tag uses warning severity

  Scenario: danger badge after the period ended
    Given I am an eligible Baanx GB user
    And now is on or after endDate

    When I view the MetaMask Card row
    Then the Update tag uses danger severity

  Scenario: non-UK or non-Baanx users
    Given migration is active
    And my provider is not Baanx or my country is not GB

    When I view the MetaMask Card row
    Then the Update badge is not shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

 <img width="260" alt="image" src="https://github.com/user-attachments/assets/e2509c1e-9d91-4084-ba5c-6561296a4694" />


### **After**

<!-- [screenshots/recordings] -->




<img width="260" alt="info" src="https://github.com/user-attachments/assets/5c5cf2c3-c3fc-4ecf-9c69-6a3c10a7785e" /><img width="260" alt="warning" src="https://github.com/user-attachments/assets/936e03c3-eeb6-4da5-8061-7793c6247691" /><img width="260" alt="error" src="https://github.com/user-attachments/assets/352ea0d4-1379-4cf6-9c5d-21e91cd081bf" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Accounts menu surfacing of existing UK migration flags; schedule logic is covered by tests and gated to Baanx GB users.
> 
> **Overview**
> Adds an **Update** design-system tag on the Accounts menu **MetaMask Card** row for eligible **Baanx UK** users during an active `cardUkMigration` window, without embedding Card flag logic in Accounts.
> 
> **`getCardUkMigrationUpdateBadgeSeverity`** maps migration schedule to **info** (early soft period), **warning** (within 7 days of `endDate`), or **danger** (forced or past deadline, including when cached phase is still `soft`). **`useCardUkMigrationUpdateBadge`** composes migration state, Baanx + GB eligibility, and that severity; ineligible users get no badge. **`CardUkMigrationUpdateBadge`** renders the localized **Update** label with the matching tag severity beside the row chevron.
> 
> Includes unit tests for severity rules, the hook, the badge component, and Accounts menu show/hide behavior, plus `accounts_menu.card_update_badge` in English.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 015e95544870d842d5383f32bf0eb0b9b39b9db0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->