### PR TITLE
ci(e2e): pack iOS Appium smoke onto fewer N=2 shards

### DIFF
--- a/.github/workflows/run-appium-smoke-tests-ios.yml
+++ b/.github/workflows/run-appium-smoke-tests-ios.yml
@@ -81,9 +81,9 @@ jobs:
          contains(fromJson(inputs.selected_tags || '["ALL"]'), 'SmokePerps'))
       }}
     strategy:
-      # Lite + Pro nearly doubled SmokePerps; 2 shards exceeded the 25m test step.
+      # N=2 pool: 4→3 keeps suite wall near pre-N=2; 4→2 estimated ~21m.
       matrix:
-        split: [1, 2, 3, 4]
+        split: [1, 2, 3]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -91,7 +91,7 @@ jobs:
       platform: ios
       test_suite_tag: SmokePerps
       split_number: ${{ matrix.split }}
-      total_splits: 4
+      total_splits: 3
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
@@ -160,8 +160,9 @@ jobs:
          contains(fromJson(inputs.selected_tags || '["ALL"]'), 'SmokeSnaps'))
       }}
     strategy:
+      # N=2 barely sped up Snaps test steps; 6→4 only (avoid 6→3 ~21m jobs).
       matrix:
-        split: [1, 2, 3, 4, 5, 6]
+        split: [1, 2, 3, 4]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -169,7 +170,7 @@ jobs:
       platform: ios
       test_suite_tag: SmokeSnaps
       split_number: ${{ matrix.split }}
-      total_splits: 6
+      total_splits: 4
       # Session reuse + denser shards; headroom vs former 25m single-shard load.
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
@@ -343,7 +344,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2, 3]
+        split: [1, 2]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -351,7 +352,7 @@ jobs:
       platform: ios
       test_suite_tag: SmokeConfirmations
       split_number: ${{ matrix.split }}
-      total_splits: 3
+      total_splits: 2
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
@@ -369,7 +370,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2, 3]
+        split: [1, 2]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -377,7 +378,7 @@ jobs:
       platform: ios
       test_suite_tag: SmokeMultiChainAPI
       split_number: ${{ matrix.split }}
-      total_splits: 3
+      total_splits: 2
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

After iOS Appium N=2 pooling landed (#35699), several smoke suites still run with pre-pool shard counts. This PR packs the suites with spare N=2 headroom onto fewer shards so we cut matrix jobs without pushing test steps toward the 25m timeout.

**Shard changes (33 → 28 jobs when ALL tags run):**
- `SmokeConfirmations`: 3 → 2
- `SmokeMultiChainAPI`: 3 → 2
- `SmokePerps`: 4 → 3
- `SmokeSnaps`: 6 → 4

Other suites unchanged. Snaps stays at 4 (not 3) because N=2 barely sped those jobs up.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: MMQA-2208
Refs: https://github.com/MetaMask/metamask-mobile/pull/35699

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — CI workflow matrix only. Validate via labeled Appium iOS smoke run on this PR (`run-appium-ios-tests`).

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI matrix-only changes with no app or test logic changes; main risk is longer individual shard runs if estimates are off.
> 
> **Overview**
> After **N=2 iOS device pooling**, several Appium smoke jobs still used pre-pool shard counts, which added matrix jobs without much wall-clock benefit and risked hitting the **25-minute** test step timeout on heavier suites.
> 
> This PR **reduces `matrix.split` and matching `total_splits`** in `run-appium-smoke-tests-ios.yml` for four tags: **SmokePerps** (4→3), **SmokeSnaps** (6→4), **SmokeConfirmations** (3→2), and **SmokeMultiChainAPI** (3→2). Inline comments document why Snaps stops at four shards and how Perps timing was estimated. **All-tags runs drop from 33 to 28 parallel jobs**; other smoke suites are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a68cdea63d47c03730e23621c8f063ef5b62627f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->