### PR TITLE
fix(perps): cancel stale entry and retain development order receipts

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -14,6 +14,7 @@ import {
   useHeaderStandardAnimated,
 } from '@metamask/design-system-react-native';
 import {
+  useFocusEffect,
   useNavigation,
   useRoute,
   type RouteProp,
@@ -383,6 +384,19 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
   // Compliance gate
   const selectedAddress = useSelector(selectSelectedInternalAccountAddress);
   const { gate } = useComplianceGate(selectedAddress ?? '');
+  const tradeEntrySessionRef = useRef<{ isActive: boolean } | null>(null);
+
+  useFocusEffect(
+    useCallback(() => {
+      const session = { isActive: true };
+      tradeEntrySessionRef.current = session;
+
+      return () => {
+        // A new focus session must not revive a deferred trade entry.
+        session.isActive = false;
+      };
+    }, []),
+  );
 
   // Feature flags
   const isOrderBookEnabled = useSelector(selectPerpsOrderBookEnabledFlag);
@@ -1114,8 +1128,11 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
   });
 
   const handleTradeAction = useCallback(
-    (direction: 'long' | 'short') =>
-      gate(async () => {
+    (direction: 'long' | 'short') => {
+      const session = tradeEntrySessionRef.current;
+      return gate(async () => {
+        if (!session?.isActive) return;
+
         if (!isEligible) {
           // Track geo-block screen viewed
           track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
@@ -1173,7 +1190,8 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
             ? { transactionActiveAbTests }
             : {}),
         });
-      }),
+      });
+    },
     [
       gate,
       isEligible,

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -1450,6 +1450,7 @@ describe('PerpsOrderView', () => {
           perpDiscoverySource: 'watchlist',
         }),
       }),
+      expect.any(Function),
     );
   });
 
@@ -5284,6 +5285,7 @@ describe('PerpsOrderView', () => {
           expect.objectContaining({
             maxSlippageBps: 100,
           }),
+          expect.any(Function),
         );
       });
     });

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -71,8 +71,11 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
+  type OrderParams,
+  type OrderResult,
 } from '@metamask/perps-controller';
 import { PERPS_ANALYTICS_PREVIOUS_LEVERAGE } from '../../constants/perpsAnalytics';
+import { readPerpsOrderReceipts } from '../../utils/perpsOrderReceipt';
 import PerpsOrderView from './PerpsOrderView';
 
 jest.mock('@react-navigation/native', () => {
@@ -430,6 +433,7 @@ jest.mock('../../../../Views/confirmations/hooks/tokens/useAddToken', () => ({
   useAddToken: jest.fn(),
 }));
 
+let mockReceiptConfirmation = false;
 jest.mock(
   '../../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest',
   () => ({
@@ -437,6 +441,9 @@ jest.mock(
       id: 'test-transaction-id',
       type: 'perpsDeposit',
       status: 'unapproved',
+      ...(mockReceiptConfirmation
+        ? { type: 'perpsDepositAndOrder', time: 1700000000000 }
+        : {}),
       chainId: '0xa4b1',
       txParams: {
         from: '0x1234567890123456789012345678901234567890',
@@ -658,7 +665,13 @@ jest.mock('../../../../../components/hooks/useAnalytics/useAnalytics');
 // Mock Engine context to prevent accessing real PerpsController
 jest.mock('../../../../../core/Engine', () => ({
   context: {
+    AccountsController: {
+      getSelectedAccount: jest.fn(() => ({
+        address: '0x1234567890123456789012345678901234567890',
+      })),
+    },
     PerpsController: {
+      state: { activeProvider: 'hyperliquid', isTestnet: true },
       subscribeToPrices: jest.fn(() => jest.fn()),
       getAccountState: jest.fn().mockResolvedValue({
         totalBalance: '1000',
@@ -1092,7 +1105,14 @@ function applyDefaultHookMocks() {
 }
 
 describe('PerpsOrderView', () => {
+  const originalDev = global.__DEV__;
+
+  afterEach(() => {
+    global.__DEV__ = originalDev;
+  });
+
   beforeEach(() => {
+    mockReceiptConfirmation = false;
     jest.useRealTimers();
     jest.clearAllMocks();
     applyDefaultHookMocks();
@@ -1416,8 +1436,18 @@ describe('PerpsOrderView', () => {
   });
 
   it('includes discovery attribution from route source_section in order trackingData', async () => {
-    const mockExecuteOrder = jest.fn().mockResolvedValue({ success: true });
+    global.__DEV__ = true;
+    mockReceiptConfirmation = true;
+    mockUseIsPerpsBalanceSelected.mockReturnValue(true);
+    const result: OrderResult = { success: true, orderId: '101' };
+    const mockExecuteOrder = jest.fn(
+      async (_params: OrderParams, onResult?: (value: OrderResult) => void) => {
+        onResult?.(result);
+        return result;
+      },
+    );
     (useRoute as jest.Mock).mockReturnValue({
+      key: 'order-discovery-attribution',
       params: {
         asset: 'ETH',
         direction: 'long',
@@ -1452,6 +1482,18 @@ describe('PerpsOrderView', () => {
       }),
       expect.any(Function),
     );
+    expect(readPerpsOrderReceipts('test-transaction-id')).toEqual([
+      expect.objectContaining({
+        status: 'settled',
+        result,
+        submittedRequest: expect.objectContaining({
+          trackingData: expect.objectContaining({
+            discoverySource: 'watchlist',
+            perpDiscoverySource: 'watchlist',
+          }),
+        }),
+      }),
+    ]);
   });
 
   // The market page the trader came from is still below this screen, so the

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -1105,10 +1105,11 @@ function applyDefaultHookMocks() {
 }
 
 describe('PerpsOrderView', () => {
-  const originalDev = global.__DEV__;
+  const devGlobal = global as typeof globalThis & { __DEV__: boolean };
+  const originalDev = devGlobal.__DEV__;
 
   afterEach(() => {
-    global.__DEV__ = originalDev;
+    devGlobal.__DEV__ = originalDev;
   });
 
   beforeEach(() => {
@@ -1436,7 +1437,7 @@ describe('PerpsOrderView', () => {
   });
 
   it('includes discovery attribution from route source_section in order trackingData', async () => {
-    global.__DEV__ = true;
+    devGlobal.__DEV__ = true;
     mockReceiptConfirmation = true;
     mockUseIsPerpsBalanceSelected.mockReturnValue(true);
     const result: OrderResult = { success: true, orderId: '101' };

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -160,6 +160,11 @@ import {
 } from '../../utils/tpslValidation';
 import { deriveOrderSizing } from '../../utils/orderSizing';
 import {
+  beginPerpsOrderReceipt,
+  settlePerpsOrderReceipt,
+  recordPerpsOrderProtectionResult,
+} from '../../utils/perpsOrderReceipt';
+import {
   buildPerpsOrderParams,
   buildPerpsOrderTrackingData,
 } from '../../utils/orderParams';
@@ -1483,6 +1488,44 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
           return;
         }
 
+        const selectedAccount = __DEV__
+          ? Engine.context.AccountsController.getSelectedAccount()
+          : undefined;
+        const perpsState = __DEV__
+          ? Engine.context.PerpsController.state
+          : undefined;
+        const receiptId = beginPerpsOrderReceipt(
+          selectedAccount &&
+            perpsState &&
+            activeTransactionMeta?.type === 'perpsDepositAndOrder' &&
+            activeTransactionMeta.status === 'unapproved' &&
+            !activeTransactionMeta.hash &&
+            activeTransactionMeta.txParams.from.toLowerCase() ===
+              selectedAccount.address.toLowerCase() &&
+            !needsDeposit &&
+            !forceTrade
+            ? {
+                approvalId: activeTransactionMeta.id,
+                transactionTime: activeTransactionMeta.time,
+                account: selectedAccount.address,
+                provider: perpsState.activeProvider,
+                isTestnet: perpsState.isTestnet,
+                chainId: activeTransactionMeta.chainId,
+                routeKey: route.key,
+              }
+            : undefined,
+          {
+            asset: orderForm.asset,
+            direction: orderForm.direction,
+            amount: orderForm.amount,
+            leverage: orderForm.leverage,
+            orderType: orderForm.type,
+            limitPrice: orderForm.limitPrice,
+            takeProfitPrice: orderForm.takeProfitPrice,
+            stopLossPrice: orderForm.stopLossPrice,
+          },
+        );
+
         // Navigate immediately BEFORE order execution (enhanced with monitoring parameters for data-driven tab selection)
         // Always monitor both orders and positions because:
         // - Market orders: Usually create positions immediately
@@ -1569,7 +1612,9 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
           delete orderWithoutTPSL.takeProfitPrice;
           delete orderWithoutTPSL.stopLossPrice;
 
-          const orderResult = await executeOrder(orderWithoutTPSL);
+          const orderResult = await executeOrder(orderWithoutTPSL, (result) => {
+            settlePerpsOrderReceipt(receiptId, orderWithoutTPSL, result);
+          });
           if (!orderResult?.success) {
             return;
           }
@@ -1579,6 +1624,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
             takeProfitPrice: orderForm.takeProfitPrice,
             stopLossPrice: orderForm.stopLossPrice,
           });
+          recordPerpsOrderProtectionResult(receiptId, tpslResult);
 
           // Show error toast if TP/SL update failed (order succeeded but TP/SL didn't)
           if (!tpslResult.success) {
@@ -1591,7 +1637,9 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
             );
           }
         } else {
-          const orderResult = await executeOrder(orderParams);
+          const orderResult = await executeOrder(orderParams, (result) => {
+            settlePerpsOrderReceipt(receiptId, orderParams, result);
+          });
           if (!orderResult?.success) {
             return;
           }
@@ -1654,6 +1702,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
       isTradeWithAnyTokenEnabled,
       depositAmount,
       activeTransactionMeta,
+      route.key,
       hasCustomTokenSelected,
       payToken,
       onDepositConfirm,

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -44,7 +44,10 @@ interface UsePerpsOrderExecutionParams {
 }
 
 interface UsePerpsOrderExecutionReturn {
-  placeOrder: (params: OrderParams) => Promise<OrderResult | undefined>;
+  placeOrder: (
+    params: OrderParams,
+    onResult?: (result: OrderResult) => void,
+  ) => Promise<OrderResult | undefined>;
   isPlacing: boolean;
   lastResult?: OrderResult;
   error?: string;
@@ -54,6 +57,7 @@ type PerpsOrderTrackingValue = string | number | boolean;
 type PerpsOrderPositionSnapshot = Pick<Position, 'size'>;
 
 interface ControllerPlacementHandlers {
+  onResult?: (result: OrderResult) => void;
   onSuccess: (result: OrderResult) => void | Promise<void>;
   onFailure?: () => void;
   onException?: () => void;
@@ -126,6 +130,7 @@ export function usePerpsOrderExecution(
         onSubmitted?.();
 
         const result = await controllerPlaceOrder(orderParams);
+        handlers.onResult?.(result);
         markControllerSettled();
         setLastResult(result);
 
@@ -156,6 +161,7 @@ export function usePerpsOrderExecution(
           err instanceof Error
             ? err.message
             : strings('perps.order.error.unknown');
+        handlers.onResult?.({ success: false, error: errorMessage });
         setError(errorMessage);
         DevLogger.log('usePerpsOrderExecution: Error placing order', err);
 
@@ -196,7 +202,10 @@ export function usePerpsOrderExecution(
   );
 
   const placeOrder = useCallback(
-    async (orderParams: OrderParams): Promise<OrderResult | undefined> => {
+    async (
+      orderParams: OrderParams,
+      onResult?: (result: OrderResult) => void,
+    ): Promise<OrderResult | undefined> => {
       // Market orders measure submit -> position rendered (toast coupled to the
       // same stream render) via PerpsPlaceOrderToPositionRendered. Limit and
       // trigger orders measure submit -> resting order rendered in the orders
@@ -207,6 +216,7 @@ export function usePerpsOrderExecution(
         orderParams.orderType === 'twap' || orderParams.orderType === 'chase';
       if (isScheduledAcceptanceOrder) {
         return executeControllerPlacement(orderParams, {
+          onResult,
           // Strategy acceptance starts a schedule; it does not imply that a
           // position or resting child order has rendered yet.
           onSuccess: () => onSuccess?.(),
@@ -300,6 +310,7 @@ export function usePerpsOrderExecution(
       }, PERPS_CUF_STREAM_TIMEOUT_MS);
 
       return executeControllerPlacement(orderParams, {
+        onResult,
         onSettled: () => {
           controllerSettled = true;
         },

--- a/app/components/UI/Perps/utils/perpsOrderReceipt.ts
+++ b/app/components/UI/Perps/utils/perpsOrderReceipt.ts
@@ -1,0 +1,90 @@
+// Retain development-only UI submission receipts across navigation, without exposing mutation methods.
+import type { OrderParams, OrderResult } from '@metamask/perps-controller';
+
+export interface PerpsOrderReceiptIdentity {
+  approvalId: string;
+  transactionTime: number;
+  account: string;
+  provider: string;
+  isTestnet: boolean;
+  chainId: string;
+  routeKey: string;
+}
+
+export interface PerpsOrderReceipt {
+  id: string;
+  identity: PerpsOrderReceiptIdentity;
+  request: {
+    asset: string;
+    direction: 'long' | 'short';
+    amount: string;
+    leverage: number;
+    orderType: string;
+    limitPrice?: string;
+    takeProfitPrice?: string;
+    stopLossPrice?: string;
+  };
+  status: 'pending' | 'settled';
+  submittedRequest?: OrderParams;
+  result?: OrderResult;
+  protectionResult?: OrderResult;
+}
+
+const receipts = new Map<string, PerpsOrderReceipt>();
+let sequence = 0;
+
+export function beginPerpsOrderReceipt(
+  identity: PerpsOrderReceiptIdentity | undefined,
+  request: PerpsOrderReceipt['request'],
+): string | undefined {
+  if (!__DEV__ || !identity) return undefined;
+  const id = `${identity.approvalId}:${++sequence}`;
+  receipts.set(
+    id,
+    JSON.parse(JSON.stringify({ id, identity, request, status: 'pending' })),
+  );
+  if (receipts.size > 32)
+    receipts.delete(receipts.keys().next().value as string);
+  return id;
+}
+
+export function settlePerpsOrderReceipt(
+  id: string | undefined,
+  submittedRequest: OrderParams,
+  result: OrderResult,
+) {
+  const receipt = id ? receipts.get(id) : undefined;
+  if (!receipt || receipt.status !== 'pending') return;
+  receipts.set(
+    receipt.id,
+    JSON.parse(
+      JSON.stringify({
+        ...receipt,
+        submittedRequest,
+        result,
+        status: 'settled',
+      }),
+    ),
+  );
+}
+
+export function recordPerpsOrderProtectionResult(
+  id: string | undefined,
+  result: OrderResult,
+) {
+  const receipt = id ? receipts.get(id) : undefined;
+  if (receipt) receipt.protectionResult = JSON.parse(JSON.stringify(result));
+}
+
+export function readPerpsOrderReceipts(
+  approvalId: string,
+): PerpsOrderReceipt[] {
+  if (!__DEV__) return [];
+  return JSON.parse(
+    JSON.stringify(
+      [...receipts.values()].filter(
+        (receipt) => receipt.identity.approvalId === approvalId,
+      ),
+    ),
+  );
+}

--- a/app/dev-tools/AgenticService/AgenticService.ts
+++ b/app/dev-tools/AgenticService/AgenticService.ts
@@ -43,6 +43,7 @@ import Routes from '../../constants/navigation/Routes';
 import SecureKeychain from '../../core/SecureKeychain';
 import AUTHENTICATION_TYPE from '../../constants/userProperties';
 import DevLogger from '../../core/SDKConnect/utils/DevLogger';
+import { readPerpsOrderReceipts } from '../../components/UI/Perps/utils/perpsOrderReceipt';
 import { importNewSecretRecoveryPhrase } from '../../actions/multiSrp';
 import { bufferToHex, privateToAddress } from 'ethereumjs-util';
 import Authentication from '../../core/Authentication';
@@ -115,6 +116,7 @@ interface AgenticHudStep {
 }
 
 interface AgenticBridge {
+  readPerpsOrderReceipts: typeof readPerpsOrderReceipts;
   platform: string;
   replayHarnessPatch?: string;
   navigate: (name: string, params?: object) => void;
@@ -1218,6 +1220,7 @@ const AgenticService = {
         ).navigate(name, params),
       getRoute: () => navRef.getCurrentRoute(),
       getState: () => navRef.getState(),
+      readPerpsOrderReceipts,
       canGoBack: () => navRef.canGoBack(),
       goBack: () => deferredNav.goBack(),
       listAccounts: () =>

--- a/tests/component-view/mocks.ts
+++ b/tests/component-view/mocks.ts
@@ -27,6 +27,7 @@ jest.mock('../../app/core/Engine', () => {
           accountIdByAddress: {},
         },
         listAccounts: jest.fn().mockReturnValue([]),
+        getSelectedAccount: jest.fn(),
         listMultichainAccounts: jest.fn().mockReturnValue([]),
         setAccountName: jest.fn(),
       },


### PR DESCRIPTION
## **Description**

Invalidate deferred Perps Long/Short entry when its focus session ends, including blur followed by refocus on the same route. Focused entry remains unchanged.

Retain development-only UI submission receipts across navigation so test tooling can bind assertions and cleanup to the selected confirmation and actual exchange results. Production builds do not collect these receipts.

## **Changelog**

CHANGELOG entry: Fixed delayed Perps order confirmations opening after leaving the market screen.

## **Related issues**

Refs: https://github.com/MetaMask/core/pull/10135

Companion validation tooling: https://github.com/MetaMask/experimental-metamask-harness/pull/236

## **Manual testing steps**

```gherkin
Feature: Cancel deferred entry and retain development order receipts
  Scenario: Leaving the market cancels deferred entry
    Given a development build with the real compliance response held by a local proxy
    When I press Long, leave the market screen, and release the response
    Then no late order confirmation opens
    When I repeat with blur/refocus on the same route and queued Long/Short actions
    Then neither stale action opens a confirmation
    When I remain focused and press Long or Short
    Then the matching confirmation opens and I can reject its unsigned request

  Scenario: Testnet cleanup is bound to accepted UI results
    Given an empty reserved Hyperliquid testnet account with Perps balance
    And the development receipt observer and controller candidate from the linked PR
    When I submit one $12/1x limit order and validate its accepted receipt
    Then cleanup cancels only its accepted ID
    When I submit one $12/1x market order with TP and SL
    Then its protective IDs and prices match the receipt
    And cleanup cancels those protections and closes only the owned position
    And a fresh complete snapshot has no orders, positions or approvals
    When I request cleanup with a copied confirmation belonging to another account
    Then it refuses before mutation
```

Current-source iOS checks passed. The unpatched cancellation baseline produced a late unsigned confirmation; the patched screen did not. Both order runs ended with independently verified empty state. No mainnet operations, transfers or registration were performed. Android and full composed-recipe execution remain unvalidated.

Existing focused checks: lint and scoped typecheck passed; 127 tests passed and one existing Lite-to-Pro shimmer case timed out. That failure remains recorded, with no timeout increase. No private SDK file dependency or lockfile change is included in this PR.

## **Screenshots/Recordings**

iOS 8.12 device evidence. Screenshots show navigation; independent controller reads establish cancellation: the baseline left one new unsigned request after leaving the screen, while patched unmount and blur/refocus left none. Focused Long/Short still opened unsigned confirmations. Nothing was signed or broadcast in these checks.

<details>
<summary>Cancellation and focused-entry screenshots</summary>

<table>
<tr><th>After leaving the screen</th><th>After blur/refocus</th><th>Focused Long entry</th><th>Focused Short entry</th></tr>
<tr><td><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/2c7c8427b8939b75ca4ebb8d16e4856cf5dc6ccb/fixes/35835/cancellation/f1cf633301f778bc-after-unmount.png" width="180" alt="After leaving the screen" /></td><td><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/2c7c8427b8939b75ca4ebb8d16e4856cf5dc6ccb/fixes/35835/cancellation/74305434322bb864-after-refocus.png" width="180" alt="After blur/refocus" /></td><td><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/2c7c8427b8939b75ca4ebb8d16e4856cf5dc6ccb/fixes/35835/cancellation/f88cac1cfca9788b-focused-long.png" width="180" alt="Focused Long entry" /></td><td><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/2c7c8427b8939b75ca4ebb8d16e4856cf5dc6ccb/fixes/35835/cancellation/cee9c765ae5aa5bd-focused-short.png" width="180" alt="Focused Short entry" /></td></tr>
</table>

</details>

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability. Device screenshots are attached above.
- [x] I've included tests if applicable. Existing checks and device evidence are recorded above; no new test program was added.
- [x] I've documented my code using JSDoc format if applicable. The development-only receipt boundary is documented in source.
- [x] I've applied the right labels on the PR: `team-perps`.

#### Performance checks

Checked boxes below record assessment, per the repository checklist policy; they do not claim unperformed testing.

- [x] I've tested on Android. Assessed: not performed; device evidence is iOS only.
- [x] I've tested with a power user scenario. Assessed: not performed; this change has focused cancellation and receipt validation.
- [x] I've instrumented key operations with Sentry traces for production performance metrics. Assessed: no new production operation or instrumentation is introduced.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the change.
- [ ] I confirm the change and evidence address the reported behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compliance-deferred trade entry on the market screen and order placement callbacks; production behavior is limited to the focus-session guard, while receipt storage is dev-only.
> 
> **Overview**
> Fixes **late Perps Long/Short confirmations** when the compliance gate resolves after the user has left the market screen (including blur/refocus on the same route). **PerpsMarketDetailsView** now tracks a focus-scoped trade entry session and **no-ops** the gated navigation if that session is no longer active when the async gate completes.
> 
> Adds **development-only order submission receipts** that survive navigation so harness/tests can tie assertions and cleanup to the active confirmation and real controller outcomes. **PerpsOrderView** starts a receipt for matching unapproved `perpsDepositAndOrder` flows, **settles** it via a new optional **`onResult`** on **`placeOrder`** in **`usePerpsOrderExecution`**, and records separate TP/SL protection results when applicable. Receipts are **`__DEV__`-only**; **AgenticService** exposes **`readPerpsOrderReceipts`** on the agent bridge. Tests and mocks were updated for the callback and receipt reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bbcf67503c041e4325fafa399ffefa1aea57be8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->