### PR TITLE
feat(walletconnect): add Solana chain adapter so external browsers connect

### DIFF
--- a/app/core/WalletConnect/multichain/helpers.test.ts
+++ b/app/core/WalletConnect/multichain/helpers.test.ts
@@ -361,12 +361,12 @@ describe('handleRequestByAdapter', () => {
         origin: 'channelId',
         originMetadata: MOCK_ORIGIN_METADATA,
         connectedAddresses: [],
-        scope: 'tron:0x2b6653dc',
+        scope: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
         requestId: 1,
-        method: 'tron_signMessage',
-        params: [],
+        method: 'solana_signMessage',
+        params: {},
       }),
-    ).rejects.toThrow('No WalletConnect adapter registered for tron');
+    ).rejects.toThrow('No WalletConnect adapter registered for solana');
   });
 });
 

--- a/app/core/WalletConnect/multichain/registry.test.ts
+++ b/app/core/WalletConnect/multichain/registry.test.ts
@@ -22,9 +22,14 @@ import {
   getAllAdapters,
   getAllRegisteredNamespaces,
 } from './registry';
+import { solanaAdapter } from './solana';
 import { tronAdapter } from './tron';
 
 describe('multichain/registry', () => {
+  it('registers the solana adapter under the solana CAIP-2 namespace', () => {
+    expect(getAdapter('solana')).toBe(solanaAdapter);
+  });
+
   it('registers the tron adapter under the tron CAIP-2 namespace', () => {
     expect(getAdapter('tron')).toBe(tronAdapter);
   });
@@ -34,13 +39,17 @@ describe('multichain/registry', () => {
     expect(getAdapter('cosmos')).toBeUndefined();
   });
 
-  it('exposes the tron namespace via getAllRegisteredNamespaces', () => {
-    expect(getAllRegisteredNamespaces()).toContain('tron');
+  it('exposes the solana and tron namespaces via getAllRegisteredNamespaces', () => {
+    expect(getAllRegisteredNamespaces()).toEqual(
+      expect.arrayContaining(['solana', 'tron']),
+    );
   });
 
-  it('exposes the tron adapter via getAllAdapters', () => {
+  it('exposes the solana and tron adapters via getAllAdapters', () => {
     const adapters = getAllAdapters();
 
-    expect(adapters).toContain(tronAdapter);
+    expect(adapters).toEqual(
+      expect.arrayContaining([solanaAdapter, tronAdapter]),
+    );
   });
 });

--- a/app/core/WalletConnect/multichain/registry.ts
+++ b/app/core/WalletConnect/multichain/registry.ts
@@ -10,6 +10,9 @@ import type { KnownCaipNamespace } from '@metamask/utils';
 
 import type { AnyChainAdapter } from './types';
 
+///: BEGIN:ONLY_INCLUDE_IF(solana)
+import { solanaAdapter } from './solana';
+///: END:ONLY_INCLUDE_IF
 ///: BEGIN:ONLY_INCLUDE_IF(tron)
 import { tronAdapter } from './tron';
 ///: END:ONLY_INCLUDE_IF
@@ -46,6 +49,9 @@ export function getAllRegisteredNamespaces(): KnownCaipNamespace[] {
   return Array.from(adapters.keys()) as KnownCaipNamespace[];
 }
 
+///: BEGIN:ONLY_INCLUDE_IF(solana)
+registerAdapter(solanaAdapter);
+///: END:ONLY_INCLUDE_IF
 ///: BEGIN:ONLY_INCLUDE_IF(tron)
 registerAdapter(tronAdapter);
 ///: END:ONLY_INCLUDE_IF

--- a/app/core/WalletConnect/multichain/solana/adapter.test.ts
+++ b/app/core/WalletConnect/multichain/solana/adapter.test.ts
@@ -1,0 +1,404 @@
+import {
+  getCaipAccountIdsFromCaip25CaveatValue,
+  type Caip25CaveatValue,
+} from '@metamask/chain-agnostic-permission';
+import { PermissionDoesNotExistError } from '@metamask/permission-controller';
+import type { CaipAccountId, CaipChainId } from '@metamask/utils';
+import { SolScope } from '@metamask/keyring-api';
+import { base58 } from 'ethers/lib/utils';
+
+import Engine from '../../../Engine';
+import { getPermittedCaipChainIds } from '../../../Permissions';
+import { createSnapCaller } from '../router';
+import {
+  enrichCaveatValue,
+  getScopedPermissions,
+  getSessionProperties,
+  normalizeCaipChainIdInbound,
+  normalizeCaipChainIdOutbound,
+  SOLANA_MAINNET_LEGACY_CAIP_CHAIN_ID,
+  solanaAdapter,
+} from './adapter';
+
+jest.mock('@metamask/chain-agnostic-permission', () => ({
+  ...jest.requireActual('@metamask/chain-agnostic-permission'),
+  getCaipAccountIdsFromCaip25CaveatValue: jest.fn(),
+}));
+
+jest.mock('../../../Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      AccountTreeController: {
+        getAccountsFromSelectedAccountGroup: jest.fn().mockReturnValue([]),
+      },
+      PermissionController: {
+        getCaveat: jest.fn(),
+      },
+    },
+  },
+}));
+
+jest.mock('../../../Permissions', () => ({
+  getPermittedCaipChainIds: jest.fn(),
+}));
+
+jest.mock('../router', () => {
+  const snapCallerMock = jest.fn();
+  return {
+    createSnapCaller: () => snapCallerMock,
+  };
+});
+
+jest.mock('../../../SDKConnect/utils/DevLogger', () => ({
+  log: jest.fn(),
+}));
+
+const mockedGetAccountsFromSelectedAccountGroup = Engine.context
+  .AccountTreeController.getAccountsFromSelectedAccountGroup as jest.Mock;
+const mockedGetCaveat = Engine.context.PermissionController
+  .getCaveat as jest.Mock;
+const mockedGetPermittedCaipChainIds = getPermittedCaipChainIds as jest.Mock;
+const mockedCallSolanaSnap = (createSnapCaller as unknown as () => jest.Mock)();
+const mockedGetCaipAccountIdsFromCaip25CaveatValue =
+  getCaipAccountIdsFromCaip25CaveatValue as jest.Mock;
+
+const MOCK_ORIGIN_METADATA = {
+  transport: 'WalletConnect',
+  selfReportedOrigin: 'https://jup.ag',
+};
+
+const SOLANA_MAINNET = SolScope.Mainnet as CaipChainId;
+const SOLANA_ACCOUNT = `${SOLANA_MAINNET}:AddrA` as CaipAccountId;
+
+describe('multichain/solana', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetAccountsFromSelectedAccountGroup.mockReturnValue([]);
+    mockedGetCaveat.mockReturnValue(undefined);
+    mockedGetPermittedCaipChainIds.mockResolvedValue([]);
+    mockedCallSolanaSnap.mockResolvedValue(undefined);
+    mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([]);
+  });
+
+  describe('normalizeCaipChainIdInbound', () => {
+    it('maps the legacy WalletConnect mainnet genesis hash to SolScope.Mainnet', () => {
+      expect(
+        normalizeCaipChainIdInbound(SOLANA_MAINNET_LEGACY_CAIP_CHAIN_ID),
+      ).toBe(SOLANA_MAINNET);
+    });
+
+    it('passes current Solana CAIP chain ids through unchanged', () => {
+      expect(normalizeCaipChainIdInbound(SOLANA_MAINNET)).toBe(SOLANA_MAINNET);
+    });
+
+    it('passes non-Solana CAIP chain ids through unchanged', () => {
+      expect(normalizeCaipChainIdInbound('eip155:1')).toBe('eip155:1');
+    });
+  });
+
+  describe('normalizeCaipChainIdOutbound', () => {
+    it('leaves Solana genesis-hash chain ids unchanged', () => {
+      expect(normalizeCaipChainIdOutbound(SOLANA_MAINNET)).toBe(SOLANA_MAINNET);
+    });
+  });
+
+  describe('enrichCaveatValue', () => {
+    it('adds the Solana optional scope when a proposal references Solana', () => {
+      const caveatValue = {
+        requiredScopes: {},
+        optionalScopes: {},
+        isMultichainOrigin: true,
+        sessionProperties: {},
+      } as Caip25CaveatValue;
+
+      expect(
+        enrichCaveatValue({
+          proposal: {
+            requiredNamespaces: {},
+            optionalNamespaces: {
+              solana: {
+                chains: [SOLANA_MAINNET],
+                methods: [],
+                events: [],
+              },
+            },
+          },
+          caveatValue,
+        }),
+      ).toStrictEqual({
+        ...caveatValue,
+        optionalScopes: {
+          [SOLANA_MAINNET]: { accounts: [] },
+        },
+      });
+    });
+
+    it('falls back to Mainnet for the legacy WalletConnect genesis hash', () => {
+      const caveatValue = {
+        requiredScopes: {},
+        optionalScopes: {},
+        isMultichainOrigin: true,
+        sessionProperties: {},
+      } as Caip25CaveatValue;
+
+      expect(
+        enrichCaveatValue({
+          proposal: {
+            requiredNamespaces: {
+              solana: {
+                chains: [SOLANA_MAINNET_LEGACY_CAIP_CHAIN_ID],
+                methods: [],
+                events: [],
+              },
+            },
+            optionalNamespaces: {},
+          },
+          caveatValue,
+        }),
+      ).toStrictEqual({
+        ...caveatValue,
+        optionalScopes: {
+          [SOLANA_MAINNET]: { accounts: [] },
+        },
+      });
+    });
+  });
+
+  describe('getSessionProperties', () => {
+    it('advertises solana account-changed notifications when the proposal references Solana', () => {
+      expect(
+        getSessionProperties({
+          proposal: {
+            requiredNamespaces: {},
+            optionalNamespaces: {
+              solana: {
+                chains: [SOLANA_MAINNET],
+                methods: [],
+                events: [],
+              },
+            },
+          },
+        }),
+      ).toStrictEqual({ solana_accountChanged_notifications: 'true' });
+    });
+
+    it('returns undefined when the proposal does not reference Solana', () => {
+      expect(
+        getSessionProperties({
+          proposal: {
+            requiredNamespaces: {
+              eip155: { chains: ['eip155:1'], methods: [], events: [] },
+            },
+            optionalNamespaces: {},
+          },
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('getScopedPermissions', () => {
+    it('returns scoped permissions for permitted Solana chains and accounts', async () => {
+      mockedGetPermittedCaipChainIds.mockResolvedValue([
+        'eip155:1',
+        SOLANA_MAINNET,
+      ]);
+      mockedGetCaveat.mockReturnValue({ value: {} });
+      mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([
+        'eip155:1:0xabc',
+        SOLANA_ACCOUNT,
+      ]);
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toStrictEqual({
+        chains: [SOLANA_MAINNET],
+        methods: [
+          'solana_getAccounts',
+          'solana_requestAccounts',
+          'solana_signMessage',
+          'solana_signTransaction',
+          'solana_signAllTransactions',
+          'solana_signAndSendTransaction',
+        ],
+        events: ['accountsChanged'],
+        accounts: [SOLANA_ACCOUNT],
+      });
+    });
+
+    it('returns undefined when there are no Solana chains or accounts', async () => {
+      mockedGetPermittedCaipChainIds.mockResolvedValue(['eip155:1']);
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toBeUndefined();
+
+      mockedGetPermittedCaipChainIds.mockResolvedValue([SOLANA_MAINNET]);
+      mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([]);
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('continues when getCaveat throws PermissionDoesNotExistError', async () => {
+      mockedGetPermittedCaipChainIds.mockResolvedValue([SOLANA_MAINNET]);
+      mockedGetCaveat.mockImplementation(() => {
+        throw new PermissionDoesNotExistError('wc-topic', 'endowment:caip25');
+      });
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('solanaAdapter', () => {
+    it('declares the Solana CAIP namespace and approved methods', () => {
+      expect(solanaAdapter.namespace).toBe('solana');
+      expect(solanaAdapter.redirectMethods).toStrictEqual([
+        'solana_signMessage',
+        'solana_signTransaction',
+        'solana_signAllTransactions',
+        'solana_signAndSendTransaction',
+      ]);
+      expect(solanaAdapter.approvedMethods).toStrictEqual([
+        'solana_getAccounts',
+        'solana_requestAccounts',
+        'solana_signMessage',
+        'solana_signTransaction',
+        'solana_signAllTransactions',
+        'solana_signAndSendTransaction',
+      ]);
+      expect(solanaAdapter.getSessionProperties).toBe(getSessionProperties);
+    });
+
+    it('handles solana_signMessage by mapping, routing, and normalizing the result', async () => {
+      mockedCallSolanaSnap.mockResolvedValue({
+        signature: 'sig',
+      });
+      const encoded = base58.encode(Buffer.from('hello', 'utf8'));
+
+      const result = await solanaAdapter.handleRequest({
+        origin: 'channelId',
+        originMetadata: MOCK_ORIGIN_METADATA,
+        connectedAddresses: [SOLANA_ACCOUNT],
+        scope: SOLANA_MAINNET,
+        requestId: 1,
+        method: 'solana_signMessage',
+        params: {
+          pubkey: 'AddrA',
+          message: encoded,
+        },
+      });
+
+      expect(mockedCallSolanaSnap).toHaveBeenCalledWith({
+        origin: 'channelId',
+        originMetadata: MOCK_ORIGIN_METADATA,
+        connectedAddresses: [SOLANA_ACCOUNT],
+        scope: SOLANA_MAINNET,
+        requestId: 1,
+        request: {
+          method: 'signMessage',
+          params: {
+            account: { address: 'AddrA' },
+            message: Buffer.from('hello', 'utf8').toString('base64'),
+          },
+        },
+      });
+      expect(result).toStrictEqual({ signature: 'sig' });
+    });
+
+    it('handles solana_signAndSendTransaction with confirmed preflight by default', async () => {
+      mockedCallSolanaSnap.mockResolvedValue({
+        signature: 'txid',
+      });
+
+      const result = await solanaAdapter.handleRequest({
+        origin: 'channelId',
+        originMetadata: MOCK_ORIGIN_METADATA,
+        connectedAddresses: [SOLANA_ACCOUNT],
+        scope: SOLANA_MAINNET,
+        requestId: 1,
+        method: 'solana_signAndSendTransaction',
+        params: {
+          pubkey: 'AddrA',
+          transaction: 'base64tx',
+        },
+      });
+
+      expect(mockedCallSolanaSnap).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request: {
+            method: 'signAndSendTransaction',
+            params: {
+              account: { address: 'AddrA' },
+              transaction: 'base64tx',
+              options: { preflightCommitment: 'confirmed' },
+            },
+          },
+        }),
+      );
+      expect(result).toStrictEqual({ signature: 'txid' });
+    });
+
+    it('handles solana_signAllTransactions by signing each transaction', async () => {
+      mockedCallSolanaSnap
+        .mockResolvedValueOnce({ transaction: 'signed-a' })
+        .mockResolvedValueOnce({ transaction: 'signed-b' });
+
+      const result = await solanaAdapter.handleRequest({
+        origin: 'channelId',
+        originMetadata: MOCK_ORIGIN_METADATA,
+        connectedAddresses: [SOLANA_ACCOUNT],
+        scope: SOLANA_MAINNET,
+        requestId: 10,
+        method: 'solana_signAllTransactions',
+        params: {
+          transactions: ['tx-a', 'tx-b'],
+        },
+      });
+
+      expect(mockedCallSolanaSnap).toHaveBeenCalledTimes(2);
+      expect(result).toStrictEqual({
+        transactions: ['signed-a', 'signed-b'],
+      });
+    });
+
+    it('returns session accounts for solana_getAccounts without calling the snap', async () => {
+      const result = await solanaAdapter.handleRequest({
+        origin: 'channelId',
+        originMetadata: MOCK_ORIGIN_METADATA,
+        connectedAddresses: [SOLANA_ACCOUNT],
+        scope: SOLANA_MAINNET,
+        requestId: 1,
+        method: 'solana_getAccounts',
+        params: {},
+      });
+
+      expect(mockedCallSolanaSnap).not.toHaveBeenCalled();
+      expect(result).toStrictEqual([{ pubkey: 'AddrA' }]);
+    });
+
+    it('rejects unsupported WalletConnect methods', async () => {
+      const args = {
+        origin: 'channelId',
+        originMetadata: MOCK_ORIGIN_METADATA,
+        connectedAddresses: [] as CaipAccountId[],
+        scope: SOLANA_MAINNET,
+        requestId: 1,
+        method: 'solana_unknownMethod',
+        params: {},
+      };
+
+      await expect(
+        // @ts-expect-error - misbehaving client sending an unapproved method
+        solanaAdapter.handleRequest(args),
+      ).rejects.toThrow(
+        'WalletConnect Solana method solana_unknownMethod is not supported',
+      );
+
+      expect(mockedCallSolanaSnap).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/core/WalletConnect/multichain/solana/adapter.test.ts
+++ b/app/core/WalletConnect/multichain/solana/adapter.test.ts
@@ -32,9 +32,7 @@ jest.mock('../../../Engine', () => ({
       AccountTreeController: {
         getAccountsFromSelectedAccountGroup: jest.fn().mockReturnValue([]),
       },
-      PermissionController: {
-        getCaveat: jest.fn(),
-      },
+      PermissionController: { getCaveat: jest.fn() },
     },
   },
 }));
@@ -45,14 +43,10 @@ jest.mock('../../../Permissions', () => ({
 
 jest.mock('../router', () => {
   const snapCallerMock = jest.fn();
-  return {
-    createSnapCaller: () => snapCallerMock,
-  };
+  return { createSnapCaller: () => snapCallerMock };
 });
 
-jest.mock('../../../SDKConnect/utils/DevLogger', () => ({
-  log: jest.fn(),
-}));
+jest.mock('../../../SDKConnect/utils/DevLogger', () => ({ log: jest.fn() }));
 
 const mockedGetAccountsFromSelectedAccountGroup = Engine.context
   .AccountTreeController.getAccountsFromSelectedAccountGroup as jest.Mock;
@@ -71,6 +65,37 @@ const MOCK_ORIGIN_METADATA = {
 const SOLANA_MAINNET = SolScope.Mainnet as CaipChainId;
 const SOLANA_ACCOUNT = `${SOLANA_MAINNET}:AddrA` as CaipAccountId;
 
+const REDIRECT_METHODS = [
+  'solana_signMessage',
+  'solana_signTransaction',
+  'solana_signAllTransactions',
+  'solana_signAndSendTransaction',
+];
+const APPROVED_METHODS = [
+  'solana_getAccounts',
+  'solana_requestAccounts',
+  ...REDIRECT_METHODS,
+];
+
+const EMPTY_CAVEAT_VALUE = {
+  requiredScopes: {},
+  optionalScopes: {},
+  isMultichainOrigin: true,
+  sessionProperties: {},
+} as Caip25CaveatValue;
+
+const solanaNamespace = (chains: CaipChainId[]) => ({
+  solana: { chains, methods: [], events: [] },
+});
+
+const BASE_REQUEST = {
+  origin: 'channelId',
+  originMetadata: MOCK_ORIGIN_METADATA,
+  connectedAddresses: [SOLANA_ACCOUNT],
+  scope: SOLANA_MAINNET,
+  requestId: 1,
+};
+
 describe('multichain/solana', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -81,103 +106,59 @@ describe('multichain/solana', () => {
     mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([]);
   });
 
-  describe('normalizeCaipChainIdInbound', () => {
-    it('maps the legacy WalletConnect mainnet genesis hash to SolScope.Mainnet', () => {
-      expect(
-        normalizeCaipChainIdInbound(SOLANA_MAINNET_LEGACY_CAIP_CHAIN_ID),
-      ).toBe(SOLANA_MAINNET);
+  describe('chain id normalization', () => {
+    it.each([
+      [
+        'the legacy mainnet genesis hash',
+        SOLANA_MAINNET_LEGACY_CAIP_CHAIN_ID,
+        SOLANA_MAINNET,
+      ],
+      ['a current Solana chain id', SOLANA_MAINNET, SOLANA_MAINNET],
+      ['a non-Solana chain id', 'eip155:1' as CaipChainId, 'eip155:1'],
+    ])('maps %s inbound', (_label, input, expected) => {
+      expect(normalizeCaipChainIdInbound(input)).toBe(expected);
     });
 
-    it('passes current Solana CAIP chain ids through unchanged', () => {
-      expect(normalizeCaipChainIdInbound(SOLANA_MAINNET)).toBe(SOLANA_MAINNET);
-    });
-
-    it('passes non-Solana CAIP chain ids through unchanged', () => {
-      expect(normalizeCaipChainIdInbound('eip155:1')).toBe('eip155:1');
-    });
-  });
-
-  describe('normalizeCaipChainIdOutbound', () => {
-    it('leaves Solana genesis-hash chain ids unchanged', () => {
+    it('leaves Solana genesis-hash chain ids unchanged outbound', () => {
       expect(normalizeCaipChainIdOutbound(SOLANA_MAINNET)).toBe(SOLANA_MAINNET);
     });
   });
 
   describe('enrichCaveatValue', () => {
-    it('adds the Solana optional scope when a proposal references Solana', () => {
-      const caveatValue = {
-        requiredScopes: {},
-        optionalScopes: {},
-        isMultichainOrigin: true,
-        sessionProperties: {},
-      } as Caip25CaveatValue;
-
-      expect(
-        enrichCaveatValue({
-          proposal: {
-            requiredNamespaces: {},
-            optionalNamespaces: {
-              solana: {
-                chains: [SOLANA_MAINNET],
-                methods: [],
-                events: [],
-              },
-            },
-          },
-          caveatValue,
-        }),
-      ).toStrictEqual({
-        ...caveatValue,
-        optionalScopes: {
-          [SOLANA_MAINNET]: { accounts: [] },
+    it.each([
+      [
+        'an optional Solana namespace',
+        {
+          requiredNamespaces: {},
+          optionalNamespaces: solanaNamespace([SOLANA_MAINNET]),
         },
-      });
-    });
-
-    it('falls back to Mainnet for the legacy WalletConnect genesis hash', () => {
-      const caveatValue = {
-        requiredScopes: {},
-        optionalScopes: {},
-        isMultichainOrigin: true,
-        sessionProperties: {},
-      } as Caip25CaveatValue;
-
-      expect(
-        enrichCaveatValue({
-          proposal: {
-            requiredNamespaces: {
-              solana: {
-                chains: [SOLANA_MAINNET_LEGACY_CAIP_CHAIN_ID],
-                methods: [],
-                events: [],
-              },
-            },
-            optionalNamespaces: {},
-          },
-          caveatValue,
-        }),
-      ).toStrictEqual({
-        ...caveatValue,
-        optionalScopes: {
-          [SOLANA_MAINNET]: { accounts: [] },
+      ],
+      [
+        'the legacy genesis hash in required namespaces',
+        {
+          requiredNamespaces: solanaNamespace([
+            SOLANA_MAINNET_LEGACY_CAIP_CHAIN_ID,
+          ]),
+          optionalNamespaces: {},
         },
+      ],
+    ])('seeds the Mainnet optional scope from %s', (_label, proposal) => {
+      expect(
+        enrichCaveatValue({ proposal, caveatValue: EMPTY_CAVEAT_VALUE }),
+      ).toStrictEqual({
+        ...EMPTY_CAVEAT_VALUE,
+        optionalScopes: { [SOLANA_MAINNET]: { accounts: [] } },
       });
     });
   });
 
   describe('getSessionProperties', () => {
-    it('advertises solana account-changed notifications when the proposal references Solana', () => {
+    it('advertises account-changed notifications for Solana proposals', () => {
       expect(
         getSessionProperties({
           proposal: {
             requiredNamespaces: {},
-            optionalNamespaces: {
-              solana: {
-                chains: [SOLANA_MAINNET],
-                methods: [],
-                events: [],
-              },
-            },
+            optionalNamespaces: solanaNamespace([SOLANA_MAINNET]),
           },
         }),
       ).toStrictEqual({ solana_accountChanged_notifications: 'true' });
@@ -213,14 +194,7 @@ describe('multichain/solana', () => {
         getScopedPermissions({ channelId: 'wc-topic' }),
       ).resolves.toStrictEqual({
         chains: [SOLANA_MAINNET],
-        methods: [
-          'solana_getAccounts',
-          'solana_requestAccounts',
-          'solana_signMessage',
-          'solana_signTransaction',
-          'solana_signAllTransactions',
-          'solana_signAndSendTransaction',
-        ],
+        methods: APPROVED_METHODS,
         events: ['accountsChanged'],
         accounts: [SOLANA_ACCOUNT],
       });
@@ -256,48 +230,25 @@ describe('multichain/solana', () => {
   describe('solanaAdapter', () => {
     it('declares the Solana CAIP namespace and approved methods', () => {
       expect(solanaAdapter.namespace).toBe('solana');
-      expect(solanaAdapter.redirectMethods).toStrictEqual([
-        'solana_signMessage',
-        'solana_signTransaction',
-        'solana_signAllTransactions',
-        'solana_signAndSendTransaction',
-      ]);
-      expect(solanaAdapter.approvedMethods).toStrictEqual([
-        'solana_getAccounts',
-        'solana_requestAccounts',
-        'solana_signMessage',
-        'solana_signTransaction',
-        'solana_signAllTransactions',
-        'solana_signAndSendTransaction',
-      ]);
+      expect(solanaAdapter.approvedMethods).toStrictEqual(APPROVED_METHODS);
+      expect(solanaAdapter.redirectMethods).toStrictEqual(REDIRECT_METHODS);
       expect(solanaAdapter.getSessionProperties).toBe(getSessionProperties);
     });
 
-    it('handles solana_signMessage by mapping, routing, and normalizing the result', async () => {
-      mockedCallSolanaSnap.mockResolvedValue({
-        signature: 'sig',
-      });
-      const encoded = base58.encode(Buffer.from('hello', 'utf8'));
+    it('handles solana_signMessage by mapping, routing, and normalizing', async () => {
+      mockedCallSolanaSnap.mockResolvedValue({ signature: 'sig' });
 
       const result = await solanaAdapter.handleRequest({
-        origin: 'channelId',
-        originMetadata: MOCK_ORIGIN_METADATA,
-        connectedAddresses: [SOLANA_ACCOUNT],
-        scope: SOLANA_MAINNET,
-        requestId: 1,
+        ...BASE_REQUEST,
         method: 'solana_signMessage',
         params: {
           pubkey: 'AddrA',
-          message: encoded,
+          message: base58.encode(Buffer.from('hello', 'utf8')),
         },
       });
 
       expect(mockedCallSolanaSnap).toHaveBeenCalledWith({
-        origin: 'channelId',
-        originMetadata: MOCK_ORIGIN_METADATA,
-        connectedAddresses: [SOLANA_ACCOUNT],
-        scope: SOLANA_MAINNET,
-        requestId: 1,
+        ...BASE_REQUEST,
         request: {
           method: 'signMessage',
           params: {
@@ -309,22 +260,13 @@ describe('multichain/solana', () => {
       expect(result).toStrictEqual({ signature: 'sig' });
     });
 
-    it('handles solana_signAndSendTransaction with confirmed preflight by default', async () => {
-      mockedCallSolanaSnap.mockResolvedValue({
-        signature: 'txid',
-      });
+    it('handles solana_signAndSendTransaction with confirmed preflight', async () => {
+      mockedCallSolanaSnap.mockResolvedValue({ signature: 'txid' });
 
       const result = await solanaAdapter.handleRequest({
-        origin: 'channelId',
-        originMetadata: MOCK_ORIGIN_METADATA,
-        connectedAddresses: [SOLANA_ACCOUNT],
-        scope: SOLANA_MAINNET,
-        requestId: 1,
+        ...BASE_REQUEST,
         method: 'solana_signAndSendTransaction',
-        params: {
-          pubkey: 'AddrA',
-          transaction: 'base64tx',
-        },
+        params: { pubkey: 'AddrA', transaction: 'base64tx' },
       });
 
       expect(mockedCallSolanaSnap).toHaveBeenCalledWith(
@@ -348,30 +290,22 @@ describe('multichain/solana', () => {
         .mockResolvedValueOnce({ transaction: 'signed-b' });
 
       const result = await solanaAdapter.handleRequest({
-        origin: 'channelId',
-        originMetadata: MOCK_ORIGIN_METADATA,
-        connectedAddresses: [SOLANA_ACCOUNT],
-        scope: SOLANA_MAINNET,
+        ...BASE_REQUEST,
         requestId: 10,
         method: 'solana_signAllTransactions',
-        params: {
-          transactions: ['tx-a', 'tx-b'],
-        },
+        params: { transactions: ['tx-a', 'tx-b'] },
       });
 
       expect(mockedCallSolanaSnap).toHaveBeenCalledTimes(2);
-      expect(result).toStrictEqual({
-        transactions: ['signed-a', 'signed-b'],
-      });
+      expect(mockedCallSolanaSnap).toHaveBeenLastCalledWith(
+        expect.objectContaining({ requestId: 11 }),
+      );
+      expect(result).toStrictEqual({ transactions: ['signed-a', 'signed-b'] });
     });
 
     it('returns session accounts for solana_getAccounts without calling the snap', async () => {
       const result = await solanaAdapter.handleRequest({
-        origin: 'channelId',
-        originMetadata: MOCK_ORIGIN_METADATA,
-        connectedAddresses: [SOLANA_ACCOUNT],
-        scope: SOLANA_MAINNET,
-        requestId: 1,
+        ...BASE_REQUEST,
         method: 'solana_getAccounts',
         params: {},
       });
@@ -381,19 +315,13 @@ describe('multichain/solana', () => {
     });
 
     it('rejects unsupported WalletConnect methods', async () => {
-      const args = {
-        origin: 'channelId',
-        originMetadata: MOCK_ORIGIN_METADATA,
-        connectedAddresses: [] as CaipAccountId[],
-        scope: SOLANA_MAINNET,
-        requestId: 1,
-        method: 'solana_unknownMethod',
-        params: {},
-      };
-
       await expect(
-        // @ts-expect-error - misbehaving client sending an unapproved method
-        solanaAdapter.handleRequest(args),
+        solanaAdapter.handleRequest({
+          ...BASE_REQUEST,
+          // @ts-expect-error - misbehaving client sending an unapproved method
+          method: 'solana_unknownMethod',
+          params: {},
+        }),
       ).rejects.toThrow(
         'WalletConnect Solana method solana_unknownMethod is not supported',
       );

--- a/app/core/WalletConnect/multichain/solana/adapter.ts
+++ b/app/core/WalletConnect/multichain/solana/adapter.ts
@@ -1,0 +1,273 @@
+import { SolScope } from '@metamask/keyring-api';
+import {
+  type CaipChainId,
+  KnownCaipNamespace,
+  parseCaipChainId,
+} from '@metamask/utils';
+import { type Caip25CaveatValue } from '@metamask/chain-agnostic-permission';
+
+import {
+  buildAdapterScopedPermissions,
+  doesProposalOrSessionIncludeNamespace,
+  enrichCaveatValueForNamespace,
+} from '../utils';
+import type {
+  AdapterHandleRequestArgs,
+  ChainAdapter,
+  NamespaceConfig,
+  ProposalParamsLight,
+  RpcMethod,
+  RpcResponse,
+} from '../types';
+import { createSnapCaller } from '../router';
+import {
+  extractSignedTransaction,
+  mapGetAccountsResponse,
+  mapSignAndSendTransactionRequest,
+  mapSignAndSendTransactionResponse,
+  mapSignMessageRequest,
+  mapSignMessageResponse,
+  mapSignTransactionRequest,
+  mapSignTransactionResponse,
+} from './mapper';
+import type { SolanaSnapSpec, SolanaWalletConnectSpec } from './types';
+
+/**
+ * Snap caller bound to the Solana Snap spec.
+ */
+const callSolanaSnap = createSnapCaller<SolanaSnapSpec>();
+
+/**
+ * WalletConnect methods the wallet exposes for the Solana namespace.
+ */
+const SOLANA_METHODS: readonly RpcMethod<SolanaWalletConnectSpec>[] = [
+  'solana_getAccounts',
+  'solana_requestAccounts',
+  'solana_signMessage',
+  'solana_signTransaction',
+  'solana_signAllTransactions',
+  'solana_signAndSendTransaction',
+];
+
+/**
+ * Signing methods that should return the user to the dapp after handling.
+ */
+const SOLANA_REDIRECT_METHODS: readonly RpcMethod<SolanaWalletConnectSpec>[] = [
+  'solana_signMessage',
+  'solana_signTransaction',
+  'solana_signAllTransactions',
+  'solana_signAndSendTransaction',
+];
+
+/**
+ * WalletConnect events the wallet may emit for the Solana namespace.
+ */
+const SOLANA_EVENTS: readonly string[] = ['accountsChanged'];
+
+/**
+ * Historical WalletConnect mainnet genesis hash. Normalize inbound to
+ * `SolScope.Mainnet` so permissions and the snap use the current CAIP-2 id.
+ */
+export const SOLANA_MAINNET_LEGACY_CAIP_CHAIN_ID =
+  'solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ' as CaipChainId;
+
+/**
+ * CAIP-2 chain IDs we seed into the CAIP-25 caveat.
+ *
+ * Devnet/testnet are gated in the permission UI
+ * (`NON_EVM_CAIP_CHAIN_IDS`). Injecting them here would be stripped on
+ * approve and leave an empty Solana namespace. Unsupported requested
+ * chains fall back to Mainnet via `enrichCaveatValue`.
+ */
+const SUPPORTED_SOLANA_SCOPES = new Set<CaipChainId>([SolScope.Mainnet]);
+
+/**
+ * Convert an inbound CAIP-2 chain id to the Snap form. Maps the legacy
+ * WalletConnect mainnet genesis hash onto `SolScope.Mainnet`.
+ */
+export function normalizeCaipChainIdInbound(
+  caipChainId: CaipChainId,
+): CaipChainId {
+  const { namespace } = parseCaipChainId(caipChainId);
+  if (namespace !== KnownCaipNamespace.Solana) {
+    return caipChainId;
+  }
+  if (caipChainId === SOLANA_MAINNET_LEGACY_CAIP_CHAIN_ID) {
+    return SolScope.Mainnet as CaipChainId;
+  }
+  return caipChainId;
+}
+
+/**
+ * Convert an outbound CAIP-2 chain id to the WC form. Solana genesis hashes
+ * are already the CAIP-2 reference, so this is identity.
+ */
+export function normalizeCaipChainIdOutbound(
+  caipChainId: CaipChainId,
+): CaipChainId {
+  return caipChainId;
+}
+
+/**
+ * Build the Solana namespace slice from the wallet's current state.
+ */
+export async function getScopedPermissions({
+  channelId,
+}: {
+  channelId: string;
+}): Promise<NamespaceConfig | undefined> {
+  return buildAdapterScopedPermissions({
+    channelId,
+    namespace: KnownCaipNamespace.Solana,
+    methods: SOLANA_METHODS,
+    events: SOLANA_EVENTS,
+    normalizeChainIdOutbound: normalizeCaipChainIdOutbound,
+  });
+}
+
+/**
+ * Solana sessionProperties advertised to the dapp at handshake. Requests
+ * `solana_accountChanged` notifications so Wallet Standard-style clients can
+ * stay in sync with the selected account.
+ */
+export function getSessionProperties({
+  proposal,
+}: {
+  proposal: ProposalParamsLight;
+}): Record<string, string> | undefined {
+  if (
+    !doesProposalOrSessionIncludeNamespace({
+      proposalOrSession: proposal,
+      namespace: KnownCaipNamespace.Solana,
+    })
+  ) {
+    return undefined;
+  }
+  return { solana_accountChanged_notifications: 'true' };
+}
+
+/**
+ * Seed Solana scopes into the CAIP-25 caveat. Unsupported requested chains
+ * fall back to Mainnet.
+ */
+export function enrichCaveatValue({
+  proposal,
+  caveatValue,
+}: {
+  proposal: ProposalParamsLight;
+  caveatValue: Caip25CaveatValue;
+}): Caip25CaveatValue {
+  return enrichCaveatValueForNamespace({
+    proposal,
+    caveatValue,
+    namespace: KnownCaipNamespace.Solana,
+    supportedScopes: SUPPORTED_SOLANA_SCOPES,
+    fallbackScope: SolScope.Mainnet as CaipChainId,
+    normalizeChainIdInbound: normalizeCaipChainIdInbound,
+  });
+}
+
+/**
+ * Handle a WalletConnect request for the Solana namespace by mapping it to the
+ * multichain routing service, then mapping the result back to the expected
+ * WalletConnect format for the dapp.
+ */
+export async function handleRequest({
+  origin,
+  originMetadata,
+  connectedAddresses,
+  scope,
+  requestId,
+  method,
+  params,
+}: AdapterHandleRequestArgs<SolanaWalletConnectSpec>): Promise<
+  RpcResponse<SolanaWalletConnectSpec>
+> {
+  if (method === 'solana_getAccounts' || method === 'solana_requestAccounts') {
+    return mapGetAccountsResponse(connectedAddresses);
+  }
+
+  if (method === 'solana_signMessage') {
+    const result = await callSolanaSnap({
+      origin,
+      originMetadata,
+      connectedAddresses,
+      scope,
+      requestId,
+      request: mapSignMessageRequest({ params, connectedAddresses }),
+    });
+
+    return mapSignMessageResponse(result);
+  }
+
+  if (method === 'solana_signTransaction') {
+    const result = await callSolanaSnap({
+      origin,
+      originMetadata,
+      connectedAddresses,
+      scope,
+      requestId,
+      request: mapSignTransactionRequest({ params, connectedAddresses }),
+    });
+
+    return mapSignTransactionResponse(result);
+  }
+
+  if (method === 'solana_signAndSendTransaction') {
+    const result = await callSolanaSnap({
+      origin,
+      originMetadata,
+      connectedAddresses,
+      scope,
+      requestId,
+      request: mapSignAndSendTransactionRequest({
+        params,
+        connectedAddresses,
+      }),
+    });
+
+    return mapSignAndSendTransactionResponse(result);
+  }
+
+  if (method === 'solana_signAllTransactions') {
+    const signedTransactions: string[] = [];
+
+    for (const [index, transaction] of params.transactions.entries()) {
+      const result = await callSolanaSnap({
+        origin,
+        originMetadata,
+        connectedAddresses,
+        scope,
+        requestId: requestId + index,
+        request: mapSignTransactionRequest({
+          params: { transaction },
+          connectedAddresses,
+        }),
+      });
+      signedTransactions.push(extractSignedTransaction(result));
+    }
+
+    return { transactions: signedTransactions };
+  }
+
+  throw new Error(`WalletConnect Solana method ${method} is not supported`);
+}
+
+/**
+ * `ChainAdapter` for Solana, registered in `multichain/registry.ts` behind
+ * the `solana` feature flag.
+ */
+export const solanaAdapter: ChainAdapter<
+  KnownCaipNamespace.Solana,
+  SolanaWalletConnectSpec
+> = {
+  namespace: KnownCaipNamespace.Solana,
+  redirectMethods: SOLANA_REDIRECT_METHODS,
+  approvedMethods: SOLANA_METHODS,
+  enrichCaveatValue,
+  getScopedPermissions,
+  getSessionProperties,
+  normalizeCaipChainIdInbound,
+  normalizeCaipChainIdOutbound,
+  handleRequest,
+};

--- a/app/core/WalletConnect/multichain/solana/adapter.ts
+++ b/app/core/WalletConnect/multichain/solana/adapter.ts
@@ -24,22 +24,16 @@ import {
   extractSignedTransaction,
   mapGetAccountsResponse,
   mapSignAndSendTransactionRequest,
-  mapSignAndSendTransactionResponse,
+  mapSignatureResponse,
   mapSignMessageRequest,
-  mapSignMessageResponse,
   mapSignTransactionRequest,
   mapSignTransactionResponse,
 } from './mapper';
 import type { SolanaSnapSpec, SolanaWalletConnectSpec } from './types';
 
-/**
- * Snap caller bound to the Solana Snap spec.
- */
 const callSolanaSnap = createSnapCaller<SolanaSnapSpec>();
 
-/**
- * WalletConnect methods the wallet exposes for the Solana namespace.
- */
+/** WalletConnect methods the wallet exposes for the Solana namespace. */
 const SOLANA_METHODS: readonly RpcMethod<SolanaWalletConnectSpec>[] = [
   'solana_getAccounts',
   'solana_requestAccounts',
@@ -49,9 +43,7 @@ const SOLANA_METHODS: readonly RpcMethod<SolanaWalletConnectSpec>[] = [
   'solana_signAndSendTransaction',
 ];
 
-/**
- * Signing methods that should return the user to the dapp after handling.
- */
+/** Signing methods that return the user to the dapp after handling. */
 const SOLANA_REDIRECT_METHODS: readonly RpcMethod<SolanaWalletConnectSpec>[] = [
   'solana_signMessage',
   'solana_signTransaction',
@@ -59,32 +51,20 @@ const SOLANA_REDIRECT_METHODS: readonly RpcMethod<SolanaWalletConnectSpec>[] = [
   'solana_signAndSendTransaction',
 ];
 
-/**
- * WalletConnect events the wallet may emit for the Solana namespace.
- */
 const SOLANA_EVENTS: readonly string[] = ['accountsChanged'];
 
-/**
- * Historical WalletConnect mainnet genesis hash. Normalize inbound to
- * `SolScope.Mainnet` so permissions and the snap use the current CAIP-2 id.
- */
+/** Historical WalletConnect mainnet genesis hash, normalized on the way in. */
 export const SOLANA_MAINNET_LEGACY_CAIP_CHAIN_ID =
   'solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ' as CaipChainId;
 
 /**
- * CAIP-2 chain IDs we seed into the CAIP-25 caveat.
- *
- * Devnet/testnet are gated in the permission UI
- * (`NON_EVM_CAIP_CHAIN_IDS`). Injecting them here would be stripped on
- * approve and leave an empty Solana namespace. Unsupported requested
- * chains fall back to Mainnet via `enrichCaveatValue`.
+ * Devnet/testnet are gated in the permission UI (`NON_EVM_CAIP_CHAIN_IDS`).
+ * Injecting them here would be stripped on approve and leave an empty Solana
+ * namespace. Unsupported requested chains fall back to Mainnet instead.
  */
 const SUPPORTED_SOLANA_SCOPES = new Set<CaipChainId>([SolScope.Mainnet]);
 
-/**
- * Convert an inbound CAIP-2 chain id to the Snap form. Maps the legacy
- * WalletConnect mainnet genesis hash onto `SolScope.Mainnet`.
- */
+/** Map the legacy mainnet genesis hash onto `SolScope.Mainnet`. */
 export function normalizeCaipChainIdInbound(
   caipChainId: CaipChainId,
 ): CaipChainId {
@@ -98,19 +78,14 @@ export function normalizeCaipChainIdInbound(
   return caipChainId;
 }
 
-/**
- * Convert an outbound CAIP-2 chain id to the WC form. Solana genesis hashes
- * are already the CAIP-2 reference, so this is identity.
- */
+/** Solana genesis hashes are already the CAIP-2 reference, so identity. */
 export function normalizeCaipChainIdOutbound(
   caipChainId: CaipChainId,
 ): CaipChainId {
   return caipChainId;
 }
 
-/**
- * Build the Solana namespace slice from the wallet's current state.
- */
+/** Build the Solana namespace slice from the wallet's current state. */
 export async function getScopedPermissions({
   channelId,
 }: {
@@ -126,9 +101,8 @@ export async function getScopedPermissions({
 }
 
 /**
- * Solana sessionProperties advertised to the dapp at handshake. Requests
- * `solana_accountChanged` notifications so Wallet Standard-style clients can
- * stay in sync with the selected account.
+ * Request `solana_accountChanged` notifications at handshake so Wallet
+ * Standard-style clients stay in sync with the selected account.
  */
 export function getSessionProperties({
   proposal,
@@ -146,10 +120,7 @@ export function getSessionProperties({
   return { solana_accountChanged_notifications: 'true' };
 }
 
-/**
- * Seed Solana scopes into the CAIP-25 caveat. Unsupported requested chains
- * fall back to Mainnet.
- */
+/** Seed Solana scopes into the CAIP-25 caveat, falling back to Mainnet. */
 export function enrichCaveatValue({
   proposal,
   caveatValue,
@@ -168,9 +139,8 @@ export function enrichCaveatValue({
 }
 
 /**
- * Handle a WalletConnect request for the Solana namespace by mapping it to the
- * multichain routing service, then mapping the result back to the expected
- * WalletConnect format for the dapp.
+ * Handle a WalletConnect Solana request by mapping it onto the multichain
+ * routing service, then mapping the result back into the WalletConnect shape.
  */
 export async function handleRequest({
   origin,
@@ -183,30 +153,30 @@ export async function handleRequest({
 }: AdapterHandleRequestArgs<SolanaWalletConnectSpec>): Promise<
   RpcResponse<SolanaWalletConnectSpec>
 > {
+  const envelope = {
+    origin,
+    originMetadata,
+    connectedAddresses,
+    scope,
+    requestId,
+  };
+
   if (method === 'solana_getAccounts' || method === 'solana_requestAccounts') {
     return mapGetAccountsResponse(connectedAddresses);
   }
 
   if (method === 'solana_signMessage') {
     const result = await callSolanaSnap({
-      origin,
-      originMetadata,
-      connectedAddresses,
-      scope,
-      requestId,
+      ...envelope,
       request: mapSignMessageRequest({ params, connectedAddresses }),
     });
 
-    return mapSignMessageResponse(result);
+    return mapSignatureResponse(result);
   }
 
   if (method === 'solana_signTransaction') {
     const result = await callSolanaSnap({
-      origin,
-      originMetadata,
-      connectedAddresses,
-      scope,
-      requestId,
+      ...envelope,
       request: mapSignTransactionRequest({ params, connectedAddresses }),
     });
 
@@ -215,18 +185,11 @@ export async function handleRequest({
 
   if (method === 'solana_signAndSendTransaction') {
     const result = await callSolanaSnap({
-      origin,
-      originMetadata,
-      connectedAddresses,
-      scope,
-      requestId,
-      request: mapSignAndSendTransactionRequest({
-        params,
-        connectedAddresses,
-      }),
+      ...envelope,
+      request: mapSignAndSendTransactionRequest({ params, connectedAddresses }),
     });
 
-    return mapSignAndSendTransactionResponse(result);
+    return mapSignatureResponse(result);
   }
 
   if (method === 'solana_signAllTransactions') {
@@ -234,10 +197,7 @@ export async function handleRequest({
 
     for (const [index, transaction] of params.transactions.entries()) {
       const result = await callSolanaSnap({
-        origin,
-        originMetadata,
-        connectedAddresses,
-        scope,
+        ...envelope,
         requestId: requestId + index,
         request: mapSignTransactionRequest({
           params: { transaction },

--- a/app/core/WalletConnect/multichain/solana/index.ts
+++ b/app/core/WalletConnect/multichain/solana/index.ts
@@ -1,0 +1,1 @@
+export { solanaAdapter } from './adapter';

--- a/app/core/WalletConnect/multichain/solana/mapper.test.ts
+++ b/app/core/WalletConnect/multichain/solana/mapper.test.ts
@@ -4,9 +4,8 @@ import {
   extractSignedTransaction,
   mapGetAccountsResponse,
   mapSignAndSendTransactionRequest,
-  mapSignAndSendTransactionResponse,
+  mapSignatureResponse,
   mapSignMessageRequest,
-  mapSignMessageResponse,
   mapSignTransactionRequest,
   mapSignTransactionResponse,
   resolveSignerAddress,
@@ -16,6 +15,9 @@ import {
 const CONNECTED_ADDRESSES = [
   'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:AddrA',
 ] as CaipAccountId[];
+
+const HELLO_BASE58 = base58.encode(Buffer.from('hello', 'utf8'));
+const HELLO_BASE64 = Buffer.from('hello', 'utf8').toString('base64');
 
 describe('multichain/solana - mapper', () => {
   describe('resolveSignerAddress', () => {
@@ -30,9 +32,7 @@ describe('multichain/solana - mapper', () => {
 
     it('falls back to the first connected account', () => {
       expect(
-        resolveSignerAddress({
-          connectedAddresses: CONNECTED_ADDRESSES,
-        }),
+        resolveSignerAddress({ connectedAddresses: CONNECTED_ADDRESSES }),
       ).toBe('AddrA');
     });
 
@@ -43,31 +43,20 @@ describe('multichain/solana - mapper', () => {
     });
   });
 
-  describe('walletConnectMessageToSnapBase64', () => {
-    it('converts a base58 WalletConnect message to base64', () => {
-      const encoded = base58.encode(Buffer.from('hello', 'utf8'));
-
-      expect(walletConnectMessageToSnapBase64(encoded)).toBe(
-        Buffer.from('hello', 'utf8').toString('base64'),
-      );
-    });
+  it('converts a base58 WalletConnect message to base64', () => {
+    expect(walletConnectMessageToSnapBase64(HELLO_BASE58)).toBe(HELLO_BASE64);
   });
 
   describe('inbound request mappers', () => {
-    it('maps solana_signMessage to snap signMessage with a base64 payload', () => {
-      const encoded = base58.encode(Buffer.from('hello', 'utf8'));
-
+    it('maps solana_signMessage to a base64 snap payload', () => {
       expect(
         mapSignMessageRequest({
-          params: { message: encoded, pubkey: 'AddrA' },
+          params: { message: HELLO_BASE58, pubkey: 'AddrA' },
           connectedAddresses: CONNECTED_ADDRESSES,
         }),
       ).toStrictEqual({
         method: 'signMessage',
-        params: {
-          account: { address: 'AddrA' },
-          message: Buffer.from('hello', 'utf8').toString('base64'),
-        },
+        params: { account: { address: 'AddrA' }, message: HELLO_BASE64 },
       });
     });
 
@@ -79,14 +68,11 @@ describe('multichain/solana - mapper', () => {
         }),
       ).toStrictEqual({
         method: 'signTransaction',
-        params: {
-          account: { address: 'AddrA' },
-          transaction: 'base64tx',
-        },
+        params: { account: { address: 'AddrA' }, transaction: 'base64tx' },
       });
     });
 
-    it('defaults signAndSendTransaction preflightCommitment to confirmed', () => {
+    it('defaults signAndSendTransaction preflight to confirmed', () => {
       expect(
         mapSignAndSendTransactionRequest({
           params: { transaction: 'base64tx', pubkey: 'AddrA' },
@@ -102,7 +88,7 @@ describe('multichain/solana - mapper', () => {
       });
     });
 
-    it('forwards WalletConnect sendOptions over the confirmed default', () => {
+    it('lets dapp sendOptions override the confirmed default', () => {
       expect(
         mapSignAndSendTransactionRequest({
           params: {
@@ -120,18 +106,17 @@ describe('multichain/solana - mapper', () => {
         params: {
           account: { address: 'AddrA' },
           transaction: 'base64tx',
-          options: {
-            preflightCommitment: 'processed',
-            skipPreflight: true,
-          },
+          options: { preflightCommitment: 'processed', skipPreflight: true },
         },
       });
     });
   });
 
   describe('outbound response mappers', () => {
-    it('forwards the snap message signature', () => {
-      expect(mapSignMessageResponse({ signature: 'sig' })).toStrictEqual({
+    it('rebuilds the signature response without snap-internal fields', () => {
+      const snapResult = { signature: 'sig', internalId: 'x' };
+
+      expect(mapSignatureResponse(snapResult)).toStrictEqual({
         signature: 'sig',
       });
     });
@@ -142,16 +127,7 @@ describe('multichain/solana - mapper', () => {
           transaction: 'signedTx',
           signature: 'sig',
         }),
-      ).toStrictEqual({
-        transaction: 'signedTx',
-        signature: 'sig',
-      });
-    });
-
-    it('forwards the send signature', () => {
-      expect(
-        mapSignAndSendTransactionResponse({ signature: 'txid' }),
-      ).toStrictEqual({ signature: 'txid' });
+      ).toStrictEqual({ transaction: 'signedTx', signature: 'sig' });
     });
 
     it('maps connected accounts to WalletConnect pubkey objects', () => {

--- a/app/core/WalletConnect/multichain/solana/mapper.test.ts
+++ b/app/core/WalletConnect/multichain/solana/mapper.test.ts
@@ -1,0 +1,175 @@
+import { base58 } from 'ethers/lib/utils';
+import type { CaipAccountId } from '@metamask/utils';
+import {
+  extractSignedTransaction,
+  mapGetAccountsResponse,
+  mapSignAndSendTransactionRequest,
+  mapSignAndSendTransactionResponse,
+  mapSignMessageRequest,
+  mapSignMessageResponse,
+  mapSignTransactionRequest,
+  mapSignTransactionResponse,
+  resolveSignerAddress,
+  walletConnectMessageToSnapBase64,
+} from './mapper';
+
+const CONNECTED_ADDRESSES = [
+  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:AddrA',
+] as CaipAccountId[];
+
+describe('multichain/solana - mapper', () => {
+  describe('resolveSignerAddress', () => {
+    it('prefers the pubkey from the request', () => {
+      expect(
+        resolveSignerAddress({
+          pubkey: 'ExplicitAddr',
+          connectedAddresses: CONNECTED_ADDRESSES,
+        }),
+      ).toBe('ExplicitAddr');
+    });
+
+    it('falls back to the first connected account', () => {
+      expect(
+        resolveSignerAddress({
+          connectedAddresses: CONNECTED_ADDRESSES,
+        }),
+      ).toBe('AddrA');
+    });
+
+    it('throws when no signer can be resolved', () => {
+      expect(() => resolveSignerAddress({ connectedAddresses: [] })).toThrow(
+        'No Solana account available to sign this request',
+      );
+    });
+  });
+
+  describe('walletConnectMessageToSnapBase64', () => {
+    it('converts a base58 WalletConnect message to base64', () => {
+      const encoded = base58.encode(Buffer.from('hello', 'utf8'));
+
+      expect(walletConnectMessageToSnapBase64(encoded)).toBe(
+        Buffer.from('hello', 'utf8').toString('base64'),
+      );
+    });
+  });
+
+  describe('inbound request mappers', () => {
+    it('maps solana_signMessage to snap signMessage with a base64 payload', () => {
+      const encoded = base58.encode(Buffer.from('hello', 'utf8'));
+
+      expect(
+        mapSignMessageRequest({
+          params: { message: encoded, pubkey: 'AddrA' },
+          connectedAddresses: CONNECTED_ADDRESSES,
+        }),
+      ).toStrictEqual({
+        method: 'signMessage',
+        params: {
+          account: { address: 'AddrA' },
+          message: Buffer.from('hello', 'utf8').toString('base64'),
+        },
+      });
+    });
+
+    it('maps solana_signTransaction to snap signTransaction', () => {
+      expect(
+        mapSignTransactionRequest({
+          params: { transaction: 'base64tx', pubkey: 'AddrA' },
+          connectedAddresses: CONNECTED_ADDRESSES,
+        }),
+      ).toStrictEqual({
+        method: 'signTransaction',
+        params: {
+          account: { address: 'AddrA' },
+          transaction: 'base64tx',
+        },
+      });
+    });
+
+    it('defaults signAndSendTransaction preflightCommitment to confirmed', () => {
+      expect(
+        mapSignAndSendTransactionRequest({
+          params: { transaction: 'base64tx', pubkey: 'AddrA' },
+          connectedAddresses: CONNECTED_ADDRESSES,
+        }),
+      ).toStrictEqual({
+        method: 'signAndSendTransaction',
+        params: {
+          account: { address: 'AddrA' },
+          transaction: 'base64tx',
+          options: { preflightCommitment: 'confirmed' },
+        },
+      });
+    });
+
+    it('forwards WalletConnect sendOptions over the confirmed default', () => {
+      expect(
+        mapSignAndSendTransactionRequest({
+          params: {
+            transaction: 'base64tx',
+            pubkey: 'AddrA',
+            sendOptions: {
+              skipPreflight: true,
+              preflightCommitment: 'processed',
+            },
+          },
+          connectedAddresses: CONNECTED_ADDRESSES,
+        }),
+      ).toStrictEqual({
+        method: 'signAndSendTransaction',
+        params: {
+          account: { address: 'AddrA' },
+          transaction: 'base64tx',
+          options: {
+            preflightCommitment: 'processed',
+            skipPreflight: true,
+          },
+        },
+      });
+    });
+  });
+
+  describe('outbound response mappers', () => {
+    it('forwards the snap message signature', () => {
+      expect(mapSignMessageResponse({ signature: 'sig' })).toStrictEqual({
+        signature: 'sig',
+      });
+    });
+
+    it('prefers the signed transaction when the snap returns both fields', () => {
+      expect(
+        mapSignTransactionResponse({
+          transaction: 'signedTx',
+          signature: 'sig',
+        }),
+      ).toStrictEqual({
+        transaction: 'signedTx',
+        signature: 'sig',
+      });
+    });
+
+    it('forwards the send signature', () => {
+      expect(
+        mapSignAndSendTransactionResponse({ signature: 'txid' }),
+      ).toStrictEqual({ signature: 'txid' });
+    });
+
+    it('maps connected accounts to WalletConnect pubkey objects', () => {
+      expect(mapGetAccountsResponse(CONNECTED_ADDRESSES)).toStrictEqual([
+        { pubkey: 'AddrA' },
+      ]);
+    });
+
+    it('extracts the signed transaction for signAllTransactions', () => {
+      expect(extractSignedTransaction({ transaction: 'signedTx' })).toBe(
+        'signedTx',
+      );
+    });
+
+    it('throws when the snap omits the signed transaction', () => {
+      expect(() => extractSignedTransaction({ signature: 'sig' })).toThrow(
+        'Solana snap did not return a signed transaction for solana_signAllTransactions',
+      );
+    });
+  });
+});

--- a/app/core/WalletConnect/multichain/solana/mapper.ts
+++ b/app/core/WalletConnect/multichain/solana/mapper.ts
@@ -3,9 +3,7 @@ import { base58 } from 'ethers/lib/utils';
 import type { RpcRequest } from '../types';
 import type { SolanaSnapSpec, SolanaWalletConnectSpec } from './types';
 
-/**
- * Resolve the signer address from WalletConnect params or the session accounts.
- */
+/** Signer from the request pubkey, else the first session account. */
 export function resolveSignerAddress({
   pubkey,
   connectedAddresses,
@@ -25,18 +23,12 @@ export function resolveSignerAddress({
   return parseCaipAccountId(firstAccount).address;
 }
 
-/**
- * WalletConnect `solana_signMessage` encodes the payload as base58. The Solana
- * snap / CAIP-25 `signMessage` method expects base64.
- */
+/** WalletConnect encodes message payloads as base58; the snap wants base64. */
 export function walletConnectMessageToSnapBase64(message: string): string {
   return Buffer.from(base58.decode(message)).toString('base64');
 }
 
-/**
- * Convert WalletConnect message signing params into the canonical Solana Snap
- * request.
- */
+/** Map `solana_signMessage` onto the snap `signMessage` method. */
 export function mapSignMessageRequest({
   params,
   connectedAddresses,
@@ -44,34 +36,21 @@ export function mapSignMessageRequest({
   params: SolanaWalletConnectSpec['solana_signMessage']['params'];
   connectedAddresses: CaipAccountId[];
 }): RpcRequest<SolanaSnapSpec, 'signMessage'> {
+  const { pubkey, message } = params;
+  const address = resolveSignerAddress({ pubkey, connectedAddresses });
+
   return {
     method: 'signMessage',
     params: {
-      account: {
-        address: resolveSignerAddress({
-          pubkey: params.pubkey,
-          connectedAddresses,
-        }),
-      },
-      message: walletConnectMessageToSnapBase64(params.message),
+      account: { address },
+      message: walletConnectMessageToSnapBase64(message),
     },
   };
 }
 
 /**
- * Forward the Solana Snap message signature in the WalletConnect
- * `solana_signMessage` response shape.
- */
-export function mapSignMessageResponse(
-  result: SolanaSnapSpec['signMessage']['response'],
-): SolanaWalletConnectSpec['solana_signMessage']['response'] {
-  return { signature: result.signature };
-}
-
-/**
- * Convert WalletConnect transaction signing params into the canonical Solana
- * Snap request. WalletConnect and the snap both use a base64-serialized
- * transaction.
+ * Map `solana_signTransaction` onto the snap `signTransaction` method. Both
+ * sides use a base64-serialized transaction.
  */
 export function mapSignTransactionRequest({
   params,
@@ -80,24 +59,18 @@ export function mapSignTransactionRequest({
   params: SolanaWalletConnectSpec['solana_signTransaction']['params'];
   connectedAddresses: CaipAccountId[];
 }): RpcRequest<SolanaSnapSpec, 'signTransaction'> {
+  const { pubkey, transaction } = params;
+  const address = resolveSignerAddress({ pubkey, connectedAddresses });
+
   return {
     method: 'signTransaction',
-    params: {
-      account: {
-        address: resolveSignerAddress({
-          pubkey: params.pubkey,
-          connectedAddresses,
-        }),
-      },
-      transaction: params.transaction,
-    },
+    params: { account: { address }, transaction },
   };
 }
 
 /**
- * Convert the Solana Snap transaction result into the WalletConnect
- * `solana_signTransaction` response. Prefer the signed transaction when the
- * snap returns it so versioned transactions stay intact.
+ * Prefer the signed transaction when the snap returns it so versioned
+ * transactions reach the dapp intact.
  */
 export function mapSignTransactionResponse(
   result: SolanaSnapSpec['signTransaction']['response'],
@@ -115,12 +88,7 @@ export function mapSignTransactionResponse(
   return response;
 }
 
-/**
- * Convert WalletConnect sign-and-send params into the canonical Solana Snap
- * request. `sendOptions` (including `preflightCommitment`) is forwarded so
- * dapps can avoid the Solana RPC default of `finalized`, which commonly
- * delays confirmation past 10 seconds.
- */
+/** Map `solana_signAndSendTransaction` onto the snap method of the same name. */
 export function mapSignAndSendTransactionRequest({
   params,
   connectedAddresses,
@@ -128,43 +96,33 @@ export function mapSignAndSendTransactionRequest({
   params: SolanaWalletConnectSpec['solana_signAndSendTransaction']['params'];
   connectedAddresses: CaipAccountId[];
 }): RpcRequest<SolanaSnapSpec, 'signAndSendTransaction'> {
-  const request: RpcRequest<SolanaSnapSpec, 'signAndSendTransaction'> = {
+  const { pubkey, transaction, sendOptions } = params;
+  const address = resolveSignerAddress({ pubkey, connectedAddresses });
+
+  return {
     method: 'signAndSendTransaction',
     params: {
-      account: {
-        address: resolveSignerAddress({
-          pubkey: params.pubkey,
-          connectedAddresses,
-        }),
-      },
-      transaction: params.transaction,
+      account: { address },
+      transaction,
       // Solana JSON-RPC sendTransaction defaults preflight to `finalized`,
-      // which commonly stalls dapps (e.g. Jupiter) past 10s. Prefer `confirmed`
-      // unless the dapp set sendOptions.
-      options: {
-        preflightCommitment: 'confirmed',
-        ...params.sendOptions,
-      },
+      // which commonly stalls dapps (e.g. Jupiter) past 10s. Prefer
+      // `confirmed` unless the dapp set sendOptions.
+      options: { preflightCommitment: 'confirmed', ...sendOptions },
     },
   };
-
-  return request;
 }
 
 /**
- * Forward the Solana Snap send result as a WalletConnect signature (base58 tx
- * id).
+ * `signMessage` and `signAndSendTransaction` share the `{ signature }` shape on
+ * both sides. Rebuild it so snap-internal fields never reach the dapp.
  */
-export function mapSignAndSendTransactionResponse(
-  result: SolanaSnapSpec['signAndSendTransaction']['response'],
-): SolanaWalletConnectSpec['solana_signAndSendTransaction']['response'] {
+export function mapSignatureResponse(result: { signature: string }): {
+  signature: string;
+} {
   return { signature: result.signature };
 }
 
-/**
- * Map session accounts to WalletConnect `solana_getAccounts` /
- * `solana_requestAccounts` results.
- */
+/** Map session accounts onto `solana_getAccounts` / `solana_requestAccounts`. */
 export function mapGetAccountsResponse(
   connectedAddresses: CaipAccountId[],
 ): SolanaWalletConnectSpec['solana_getAccounts']['response'] {
@@ -173,9 +131,7 @@ export function mapGetAccountsResponse(
   }));
 }
 
-/**
- * Extract the signed base64 transaction from a snap `signTransaction` result.
- */
+/** Pull the signed base64 transaction out of a snap `signTransaction` result. */
 export function extractSignedTransaction(
   result: SolanaSnapSpec['signTransaction']['response'],
 ): string {

--- a/app/core/WalletConnect/multichain/solana/mapper.ts
+++ b/app/core/WalletConnect/multichain/solana/mapper.ts
@@ -1,0 +1,189 @@
+import { parseCaipAccountId, type CaipAccountId } from '@metamask/utils';
+import { base58 } from 'ethers/lib/utils';
+import type { RpcRequest } from '../types';
+import type { SolanaSnapSpec, SolanaWalletConnectSpec } from './types';
+
+/**
+ * Resolve the signer address from WalletConnect params or the session accounts.
+ */
+export function resolveSignerAddress({
+  pubkey,
+  connectedAddresses,
+}: {
+  pubkey?: string;
+  connectedAddresses: CaipAccountId[];
+}): string {
+  if (typeof pubkey === 'string' && pubkey.length > 0) {
+    return pubkey;
+  }
+
+  const [firstAccount] = connectedAddresses;
+  if (!firstAccount) {
+    throw new Error('No Solana account available to sign this request');
+  }
+
+  return parseCaipAccountId(firstAccount).address;
+}
+
+/**
+ * WalletConnect `solana_signMessage` encodes the payload as base58. The Solana
+ * snap / CAIP-25 `signMessage` method expects base64.
+ */
+export function walletConnectMessageToSnapBase64(message: string): string {
+  return Buffer.from(base58.decode(message)).toString('base64');
+}
+
+/**
+ * Convert WalletConnect message signing params into the canonical Solana Snap
+ * request.
+ */
+export function mapSignMessageRequest({
+  params,
+  connectedAddresses,
+}: {
+  params: SolanaWalletConnectSpec['solana_signMessage']['params'];
+  connectedAddresses: CaipAccountId[];
+}): RpcRequest<SolanaSnapSpec, 'signMessage'> {
+  return {
+    method: 'signMessage',
+    params: {
+      account: {
+        address: resolveSignerAddress({
+          pubkey: params.pubkey,
+          connectedAddresses,
+        }),
+      },
+      message: walletConnectMessageToSnapBase64(params.message),
+    },
+  };
+}
+
+/**
+ * Forward the Solana Snap message signature in the WalletConnect
+ * `solana_signMessage` response shape.
+ */
+export function mapSignMessageResponse(
+  result: SolanaSnapSpec['signMessage']['response'],
+): SolanaWalletConnectSpec['solana_signMessage']['response'] {
+  return { signature: result.signature };
+}
+
+/**
+ * Convert WalletConnect transaction signing params into the canonical Solana
+ * Snap request. WalletConnect and the snap both use a base64-serialized
+ * transaction.
+ */
+export function mapSignTransactionRequest({
+  params,
+  connectedAddresses,
+}: {
+  params: SolanaWalletConnectSpec['solana_signTransaction']['params'];
+  connectedAddresses: CaipAccountId[];
+}): RpcRequest<SolanaSnapSpec, 'signTransaction'> {
+  return {
+    method: 'signTransaction',
+    params: {
+      account: {
+        address: resolveSignerAddress({
+          pubkey: params.pubkey,
+          connectedAddresses,
+        }),
+      },
+      transaction: params.transaction,
+    },
+  };
+}
+
+/**
+ * Convert the Solana Snap transaction result into the WalletConnect
+ * `solana_signTransaction` response. Prefer the signed transaction when the
+ * snap returns it so versioned transactions stay intact.
+ */
+export function mapSignTransactionResponse(
+  result: SolanaSnapSpec['signTransaction']['response'],
+): SolanaWalletConnectSpec['solana_signTransaction']['response'] {
+  const response: SolanaWalletConnectSpec['solana_signTransaction']['response'] =
+    {};
+
+  if (typeof result.transaction === 'string') {
+    response.transaction = result.transaction;
+  }
+  if (typeof result.signature === 'string') {
+    response.signature = result.signature;
+  }
+
+  return response;
+}
+
+/**
+ * Convert WalletConnect sign-and-send params into the canonical Solana Snap
+ * request. `sendOptions` (including `preflightCommitment`) is forwarded so
+ * dapps can avoid the Solana RPC default of `finalized`, which commonly
+ * delays confirmation past 10 seconds.
+ */
+export function mapSignAndSendTransactionRequest({
+  params,
+  connectedAddresses,
+}: {
+  params: SolanaWalletConnectSpec['solana_signAndSendTransaction']['params'];
+  connectedAddresses: CaipAccountId[];
+}): RpcRequest<SolanaSnapSpec, 'signAndSendTransaction'> {
+  const request: RpcRequest<SolanaSnapSpec, 'signAndSendTransaction'> = {
+    method: 'signAndSendTransaction',
+    params: {
+      account: {
+        address: resolveSignerAddress({
+          pubkey: params.pubkey,
+          connectedAddresses,
+        }),
+      },
+      transaction: params.transaction,
+      // Solana JSON-RPC sendTransaction defaults preflight to `finalized`,
+      // which commonly stalls dapps (e.g. Jupiter) past 10s. Prefer `confirmed`
+      // unless the dapp set sendOptions.
+      options: {
+        preflightCommitment: 'confirmed',
+        ...params.sendOptions,
+      },
+    },
+  };
+
+  return request;
+}
+
+/**
+ * Forward the Solana Snap send result as a WalletConnect signature (base58 tx
+ * id).
+ */
+export function mapSignAndSendTransactionResponse(
+  result: SolanaSnapSpec['signAndSendTransaction']['response'],
+): SolanaWalletConnectSpec['solana_signAndSendTransaction']['response'] {
+  return { signature: result.signature };
+}
+
+/**
+ * Map session accounts to WalletConnect `solana_getAccounts` /
+ * `solana_requestAccounts` results.
+ */
+export function mapGetAccountsResponse(
+  connectedAddresses: CaipAccountId[],
+): SolanaWalletConnectSpec['solana_getAccounts']['response'] {
+  return connectedAddresses.map((accountId) => ({
+    pubkey: parseCaipAccountId(accountId).address,
+  }));
+}
+
+/**
+ * Extract the signed base64 transaction from a snap `signTransaction` result.
+ */
+export function extractSignedTransaction(
+  result: SolanaSnapSpec['signTransaction']['response'],
+): string {
+  if (typeof result.transaction === 'string') {
+    return result.transaction;
+  }
+
+  throw new Error(
+    'Solana snap did not return a signed transaction for solana_signAllTransactions',
+  );
+}

--- a/app/core/WalletConnect/multichain/solana/types.ts
+++ b/app/core/WalletConnect/multichain/solana/types.ts
@@ -1,0 +1,108 @@
+import type { RpcMethod } from '../types';
+
+/**
+ * WalletConnect Solana RPC contract.
+ *
+ * @see https://docs.reown.com/advanced/multichain/rpc-reference/solana-rpc
+ */
+export interface SolanaWalletConnectSendOptions {
+  skipPreflight?: boolean;
+  preflightCommitment?:
+    | 'processed'
+    | 'confirmed'
+    | 'finalized'
+    | 'recent'
+    | 'single'
+    | 'singleGossip'
+    | 'root'
+    | 'max';
+  maxRetries?: number;
+  minContextSlot?: number;
+}
+
+export interface SolanaWalletConnectSpec {
+  solana_getAccounts: {
+    params: Record<string, never> | undefined;
+    response: { pubkey: string }[];
+  };
+  solana_requestAccounts: {
+    params: Record<string, never> | undefined;
+    response: { pubkey: string }[];
+  };
+  solana_signMessage: {
+    params: {
+      message: string;
+      pubkey: string;
+    };
+    response: {
+      signature: string;
+    };
+  };
+  solana_signTransaction: {
+    params: {
+      transaction: string;
+      pubkey?: string;
+    };
+    response: {
+      signature?: string;
+      transaction?: string;
+    };
+  };
+  solana_signAllTransactions: {
+    params: {
+      transactions: string[];
+    };
+    response: {
+      transactions: string[];
+    };
+  };
+  solana_signAndSendTransaction: {
+    params: {
+      transaction: string;
+      pubkey?: string;
+      sendOptions?: SolanaWalletConnectSendOptions;
+    };
+    response: {
+      signature: string;
+    };
+  };
+}
+
+/**
+ * Solana Snap / CAIP-25 RPC contract used by the mobile WalletConnect bridge.
+ *
+ * @see https://docs.metamask.io/metamask-connect/multichain/guides/send-transactions/
+ */
+export interface SolanaSnapSpec {
+  signMessage: {
+    params: {
+      account: { address: string };
+      message: string;
+    };
+    response: {
+      signature: string;
+    };
+  };
+  signTransaction: {
+    params: {
+      account: { address: string };
+      transaction: string;
+    };
+    response: {
+      signature?: string;
+      transaction?: string;
+    };
+  };
+  signAndSendTransaction: {
+    params: {
+      account: { address: string };
+      transaction: string;
+      options?: SolanaWalletConnectSendOptions;
+    };
+    response: {
+      signature: string;
+    };
+  };
+}
+
+export type SolanaWalletConnectMethod = RpcMethod<SolanaWalletConnectSpec>;

--- a/app/core/WalletConnect/multichain/solana/types.ts
+++ b/app/core/WalletConnect/multichain/solana/types.ts
@@ -1,5 +1,3 @@
-import type { RpcMethod } from '../types';
-
 /**
  * WalletConnect Solana RPC contract.
  *
@@ -20,41 +18,23 @@ export interface SolanaWalletConnectSendOptions {
   minContextSlot?: number;
 }
 
+type SolanaAccounts = { pubkey: string }[];
+type NoParams = Record<string, never> | undefined;
+
 export interface SolanaWalletConnectSpec {
-  solana_getAccounts: {
-    params: Record<string, never> | undefined;
-    response: { pubkey: string }[];
-  };
-  solana_requestAccounts: {
-    params: Record<string, never> | undefined;
-    response: { pubkey: string }[];
-  };
+  solana_getAccounts: { params: NoParams; response: SolanaAccounts };
+  solana_requestAccounts: { params: NoParams; response: SolanaAccounts };
   solana_signMessage: {
-    params: {
-      message: string;
-      pubkey: string;
-    };
-    response: {
-      signature: string;
-    };
+    params: { message: string; pubkey: string };
+    response: { signature: string };
   };
   solana_signTransaction: {
-    params: {
-      transaction: string;
-      pubkey?: string;
-    };
-    response: {
-      signature?: string;
-      transaction?: string;
-    };
+    params: { transaction: string; pubkey?: string };
+    response: { signature?: string; transaction?: string };
   };
   solana_signAllTransactions: {
-    params: {
-      transactions: string[];
-    };
-    response: {
-      transactions: string[];
-    };
+    params: { transactions: string[] };
+    response: { transactions: string[] };
   };
   solana_signAndSendTransaction: {
     params: {
@@ -62,9 +42,7 @@ export interface SolanaWalletConnectSpec {
       pubkey?: string;
       sendOptions?: SolanaWalletConnectSendOptions;
     };
-    response: {
-      signature: string;
-    };
+    response: { signature: string };
   };
 }
 
@@ -75,23 +53,12 @@ export interface SolanaWalletConnectSpec {
  */
 export interface SolanaSnapSpec {
   signMessage: {
-    params: {
-      account: { address: string };
-      message: string;
-    };
-    response: {
-      signature: string;
-    };
+    params: { account: { address: string }; message: string };
+    response: { signature: string };
   };
   signTransaction: {
-    params: {
-      account: { address: string };
-      transaction: string;
-    };
-    response: {
-      signature?: string;
-      transaction?: string;
-    };
+    params: { account: { address: string }; transaction: string };
+    response: { signature?: string; transaction?: string };
   };
   signAndSendTransaction: {
     params: {
@@ -99,10 +66,6 @@ export interface SolanaSnapSpec {
       transaction: string;
       options?: SolanaWalletConnectSendOptions;
     };
-    response: {
-      signature: string;
-    };
+    response: { signature: string };
   };
 }
-
-export type SolanaWalletConnectMethod = RpcMethod<SolanaWalletConnectSpec>;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Solana dapps opened in Safari or Chrome could not connect: WalletConnect only registered the Tron adapter, so every `solana:` request failed in `handleRequestByAdapter` with "No WalletConnect adapter registered". Only the in-app browser worked, via injected Wallet Standard.

This PR registers a Solana `ChainAdapter` behind the `solana` code fence, mapping the Reown Solana RPC methods onto the Solana snap through the existing MultichainRoutingService path. `signAndSendTransaction` defaults `preflightCommitment` to `confirmed` so dapps stop inheriting the RPC `finalized` default, which routinely pushed confirmation past 10s.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Added WalletConnect support for Solana so dapps in Safari and Chrome can connect Solana accounts

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: Solana dapp connect failures from Safari/Chrome (Raydium/Jupiter) and long Jupiter confirmation waits

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Solana dapp connect from an external mobile browser

  Scenario: user connects a Solana account from Safari or Chrome
    Given the user has a Solana account in MetaMask Mobile
    And Jupiter or Raydium is open in Safari or Chrome

    When the user selects MetaMask in the dapp wallet picker
    Then MetaMask opens, shows a Solana WalletConnect permission request
    And after approve the dapp shows the connected Solana address

  Scenario: user signs and sends a swap with confirmed preflight
    Given the user is connected to Jupiter over WalletConnect
    And the user has enough SOL for a small swap

    When the user submits the swap and confirms in MetaMask
    Then the snap send uses preflightCommitment confirmed unless the dapp set sendOptions
    And the dapp receives a signature without waiting on a finalized preflight
```

Unit coverage (run locally):

```bash
yarn jest app/core/WalletConnect/multichain/solana app/core/WalletConnect/multichain/registry.test.ts app/core/WalletConnect/multichain/helpers.test.ts --coverage=false
# Result: 4 suites, 49 tests passed
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — WalletConnect adapter wiring with no new UI. Evidence is unit tests for adapter, mapper, and registry registration.

### **Before**

N/A — WalletConnect `solana:` requests threw "No WalletConnect adapter registered".

### **After**

N/A — `solanaAdapter` is registered and maps Reown methods onto the Solana snap.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new WalletConnect path for Solana message and transaction signing, but it reuses the existing snap routing layer and is gated behind the `solana` feature flag with broad unit tests.
> 
> **Overview**
> **Adds WalletConnect support for the `solana` CAIP namespace** so Solana dapps in external browsers can connect and call signing RPCs instead of failing with no registered adapter.
> 
> A new `solanaAdapter` is registered in `multichain/registry.ts` behind the `solana` build flag. It wires Reown-style methods (`solana_getAccounts`, `solana_signMessage`, `solana_signTransaction`, `solana_signAllTransactions`, `solana_signAndSendTransaction`) through `createSnapCaller` into the Solana snap, with mappers for base58→base64 messages, signer resolution, and response shaping. Session handshake seeds CAIP-25 scopes (mainnet-only, legacy genesis hash normalized inbound), advertises `solana_accountChanged_notifications`, and marks signing methods as redirect methods.
> 
> **`signAndSendTransaction` defaults `preflightCommitment` to `confirmed`** (dapp `sendOptions` can override) to avoid slow `finalized` preflight timeouts on common dapps. Registry and helper tests are updated to expect both Solana and Tron adapters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9349d2d65f766407c472022bcd8636acad05a12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->