### PR TITLE
fix(onboarding): fill Android gesture inset without pushing fox under nav

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -55,6 +55,8 @@ expo.useLegacyPackaging=false
 # Use this property to enable edge-to-edge display support.
 # This allows your app to draw behind system bars for an immersive UI.
 # Note: Only works with ReactActivity and should not be used with custom Activity.
-edgeToEdgeEnabled=false
+# Required for onboarding cream canvas / fox to reach the Android gesture area
+# (targetSdk 36 treats the nav bar as transparent over the window background).
+edgeToEdgeEnabled=true
 reactNativeDir=../node_modules/react-native
 REACT_NATIVE_DIR=../node_modules/react-native

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -306,7 +306,7 @@ const OnboardingSuccessFlow = () => {
  * Create Wallet and Import from Secret Recovery Phrase
  */
 const OnboardingNav = () => {
-  const { colors, themeAppearance } = useTheme();
+  const { themeAppearance } = useTheme();
   const onboardingCanvasColor =
     themeAppearance === 'dark'
       ? importedColors.gettingStartedTextColor
@@ -316,7 +316,7 @@ const OnboardingNav = () => {
     <NativeStack.Navigator
       initialRouteName={'Onboarding'}
       screenOptions={{
-        contentStyle: { backgroundColor: colors.background.default },
+        contentStyle: { backgroundColor: onboardingCanvasColor },
       }}
     >
       <NativeStack.Screen
@@ -464,29 +464,42 @@ const SimpleWebviewScreen = () => (
   </NativeStack.Navigator>
 );
 
-const OnboardingRootNav = () => (
-  <NativeStack.Navigator
-    initialRouteName={Routes.ONBOARDING.NAV}
-    screenOptions={{ headerShown: false }}
-  >
-    <NativeStack.Screen name="OnboardingNav" component={OnboardingNav} />
-    <NativeStack.Screen
-      name={Routes.QR_TAB_SWITCHER}
-      component={QRTabSwitcherWithMessenger}
-      options={{ presentation: 'modal' }}
-    />
-    <NativeStack.Screen
-      name={Routes.SHEET.ADD_DEVICE_VERIFICATION_CODE}
-      component={VerificationCodeBottomSheet}
-      options={addDeviceVerificationCodeScreenOptions}
-    />
-    <NativeStack.Screen
-      name={Routes.WEBVIEW.MAIN}
-      component={SimpleWebviewScreen}
-      options={{ presentation: 'modal' }}
-    />
-  </NativeStack.Navigator>
-);
+const OnboardingRootNav = () => {
+  const { themeAppearance } = useTheme();
+  const onboardingCanvasColor =
+    themeAppearance === 'dark'
+      ? importedColors.gettingStartedTextColor
+      : importedColors.gettingStartedPageBackgroundColorLightMode;
+
+  return (
+    <NativeStack.Navigator
+      initialRouteName={Routes.ONBOARDING.NAV}
+      screenOptions={{
+        headerShown: false,
+        // Keep stack chrome cream/purple so Android gesture inset never flashes
+        // the default white window background behind Onboarding.
+        contentStyle: { backgroundColor: onboardingCanvasColor },
+      }}
+    >
+      <NativeStack.Screen name="OnboardingNav" component={OnboardingNav} />
+      <NativeStack.Screen
+        name={Routes.QR_TAB_SWITCHER}
+        component={QRTabSwitcherWithMessenger}
+        options={{ presentation: 'modal' }}
+      />
+      <NativeStack.Screen
+        name={Routes.SHEET.ADD_DEVICE_VERIFICATION_CODE}
+        component={VerificationCodeBottomSheet}
+        options={addDeviceVerificationCodeScreenOptions}
+      />
+      <NativeStack.Screen
+        name={Routes.WEBVIEW.MAIN}
+        component={SimpleWebviewScreen}
+        options={{ presentation: 'modal' }}
+      />
+    </NativeStack.Navigator>
+  );
+};
 
 const VaultRecoveryFlow = () => {
   const { colors } = useTheme();
@@ -1151,7 +1164,11 @@ const ModalSwitchAccountType = () => (
 );
 
 const AppFlow = () => {
-  const { colors } = useTheme();
+  const { colors, themeAppearance } = useTheme();
+  const onboardingCanvasColor =
+    themeAppearance === 'dark'
+      ? importedColors.gettingStartedTextColor
+      : importedColors.gettingStartedPageBackgroundColorLightMode;
 
   return (
     <NativeStack.Navigator
@@ -1183,6 +1200,13 @@ const AppFlow = () => {
       <NativeStack.Screen
         name="OnboardingRootNav"
         component={OnboardingRootNav}
+        options={{
+          // Opaque card: AppFlow defaults to transparentModal, which lets the
+          // activity window's white theme color show in the Android gesture
+          // inset under the fox ("paper cut").
+          presentation: 'card',
+          contentStyle: { backgroundColor: onboardingCanvasColor },
+        }}
       />
       <NativeStack.Screen
         name={Routes.ONBOARDING.SUCCESS_FLOW}

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -306,7 +306,11 @@ const OnboardingSuccessFlow = () => {
  * Create Wallet and Import from Secret Recovery Phrase
  */
 const OnboardingNav = () => {
-  const { colors } = useTheme();
+  const { colors, themeAppearance } = useTheme();
+  const onboardingCanvasColor =
+    themeAppearance === 'dark'
+      ? importedColors.gettingStartedTextColor
+      : importedColors.gettingStartedPageBackgroundColorLightMode;
 
   return (
     <NativeStack.Navigator
@@ -315,7 +319,14 @@ const OnboardingNav = () => {
         contentStyle: { backgroundColor: colors.background.default },
       }}
     >
-      <NativeStack.Screen name="Onboarding" component={Onboarding} />
+      <NativeStack.Screen
+        name="Onboarding"
+        component={Onboarding}
+        options={{
+          headerShown: false,
+          contentStyle: { backgroundColor: onboardingCanvasColor },
+        }}
+      />
       <NativeStack.Screen
         name={Routes.ONBOARDING.SOCIAL_LOGIN_SUCCESS_NEW_USER}
         component={SocialLoginSuccessNewUser}

--- a/app/components/UI/FoxAnimation/FoxAnimation.test.tsx
+++ b/app/components/UI/FoxAnimation/FoxAnimation.test.tsx
@@ -89,16 +89,26 @@ describe('getSafeBottomPosition', () => {
     expect(getSafeBottomPosition(false, insets(0))).toBe(-20);
   });
 
-  it('returns Android bottom inset so fox sits above system nav', () => {
+  it('tucks Android full-bleed fox into the gesture inset like iOS', () => {
     setPlatformOS('android');
 
-    expect(getSafeBottomPosition(false, insets(48))).toBe(48);
+    expect(
+      getSafeBottomPosition(false, insets(48), { fullBleedBottom: true }),
+    ).toBe(-38);
   });
 
-  it('returns 0 for Android when bottom inset is missing', () => {
+  it('uses a small negative Android full-bleed offset when inset is missing', () => {
     setPlatformOS('android');
 
-    expect(getSafeBottomPosition(false)).toBe(0);
+    expect(
+      getSafeBottomPosition(false, undefined, { fullBleedBottom: true }),
+    ).toBe(-20);
+  });
+
+  it('returns 0 for Android when parent already applied bottom safe area', () => {
+    setPlatformOS('android');
+
+    expect(getSafeBottomPosition(false, insets(48))).toBe(0);
   });
 
   it('returns -20 for no-footer on non-iOS non-Android platforms', () => {

--- a/app/components/UI/FoxAnimation/FoxAnimation.test.tsx
+++ b/app/components/UI/FoxAnimation/FoxAnimation.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { Platform } from 'react-native';
 import { render, act } from '@testing-library/react-native';
-import FoxAnimation from './FoxAnimation';
+import FoxAnimation, { getSafeBottomPosition } from './FoxAnimation';
 import Logger from '../../../util/Logger';
 import Device from '../../../util/device';
 import {
@@ -15,6 +16,97 @@ jest.mock('../../../util/device');
 
 const mockedLogger = Logger as jest.Mocked<typeof Logger>;
 const mockedDevice = Device as jest.Mocked<typeof Device>;
+
+const insets = (bottom: number) => ({
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom,
+});
+
+describe('getSafeBottomPosition', () => {
+  const originalOS = Platform.OS;
+
+  afterEach(() => {
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      get: () => originalOS,
+    });
+  });
+
+  const setPlatformOS = (os: typeof Platform.OS) => {
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      get: () => os,
+    });
+  };
+
+  it('returns iOS footer offset using bottom inset plus 60', () => {
+    setPlatformOS('ios');
+
+    expect(getSafeBottomPosition(true, insets(50))).toBe(110);
+  });
+
+  it('returns minimum 100 for iOS footer when inset is small', () => {
+    setPlatformOS('ios');
+
+    expect(getSafeBottomPosition(true, insets(0))).toBe(100);
+  });
+
+  it('returns Android footer offset with large inset', () => {
+    setPlatformOS('android');
+
+    expect(getSafeBottomPosition(true, insets(48))).toBe(108);
+  });
+
+  it('returns Android footer offset with small inset', () => {
+    setPlatformOS('android');
+
+    expect(getSafeBottomPosition(true, insets(10))).toBe(100);
+  });
+
+  it('returns 100 for footer on non-iOS non-Android platforms', () => {
+    setPlatformOS('web');
+
+    expect(getSafeBottomPosition(true, insets(0))).toBe(100);
+  });
+
+  it('returns negative iOS offset when home indicator inset is present', () => {
+    setPlatformOS('ios');
+
+    expect(getSafeBottomPosition(false, insets(34))).toBe(-24);
+  });
+
+  it('clamps iOS no-footer offset to -40 for large home indicator', () => {
+    setPlatformOS('ios');
+
+    expect(getSafeBottomPosition(false, insets(80))).toBe(-40);
+  });
+
+  it('returns -20 for iOS with no bottom inset', () => {
+    setPlatformOS('ios');
+
+    expect(getSafeBottomPosition(false, insets(0))).toBe(-20);
+  });
+
+  it('returns Android bottom inset so fox sits above system nav', () => {
+    setPlatformOS('android');
+
+    expect(getSafeBottomPosition(false, insets(48))).toBe(48);
+  });
+
+  it('returns 0 for Android when bottom inset is missing', () => {
+    setPlatformOS('android');
+
+    expect(getSafeBottomPosition(false)).toBe(0);
+  });
+
+  it('returns -20 for no-footer on non-iOS non-Android platforms', () => {
+    setPlatformOS('web');
+
+    expect(getSafeBottomPosition(false, insets(0))).toBe(-20);
+  });
+});
 
 describe('FoxAnimation', () => {
   beforeEach(() => {

--- a/app/components/UI/FoxAnimation/FoxAnimation.tsx
+++ b/app/components/UI/FoxAnimation/FoxAnimation.tsx
@@ -22,9 +22,20 @@ const getFoxAnimationHeight = (hasFooter: boolean) => {
   return Device.isMediumDevice() ? 300 : 350;
 };
 
+export interface FoxSafeBottomOptions {
+  /**
+   * Parent paints under the Android system nav / gesture area (e.g. Onboarding
+   * root canvas with top-only SafeArea). When true, Android uses a negative
+   * bottom like iOS so the fox sits flush (no cream strip under the art).
+   * Login must leave this false — its SafeAreaView already applied the inset.
+   */
+  fullBleedBottom?: boolean;
+}
+
 export const getSafeBottomPosition = (
   hasFooter: boolean,
   insets?: EdgeInsets,
+  options?: FoxSafeBottomOptions,
 ) => {
   const basePadding = insets?.bottom || 0;
 
@@ -46,39 +57,49 @@ export const getSafeBottomPosition = (
   }
 
   if (Platform.OS === 'android') {
-    return Math.max(0, basePadding);
+    // Positive insets.bottom lifts the fox and leaves a cream/white strip under
+    // the graphic on full-bleed onboarding. Tuck like iOS instead.
+    if (options?.fullBleedBottom) {
+      if (basePadding > 0) {
+        return Math.max(-40, -(basePadding - 10));
+      }
+      // Edge-to-edge often reports 0 inset; still pull slightly into the gesture area.
+      return -20;
+    }
+    // Login (and other bottom-safe parents): do not double-count the inset.
+    return 0;
   }
 
   return -20;
 };
 
-const createStyles = (hasFooter: boolean, insets?: EdgeInsets) =>
-  StyleSheet.create({
-    foxAnimationWrapper: {
-      position: 'absolute',
-      bottom: getSafeBottomPosition(hasFooter, insets),
-      left: 0,
-      right: 0,
-      height: getFoxAnimationHeight(hasFooter),
-      alignItems: 'center',
-      justifyContent: 'center',
-      pointerEvents: 'none',
-    },
-    foxAnimation: {
-      width: '100%',
-      height: '100%',
-    },
-  });
+const styles = StyleSheet.create({
+  foxAnimationWrapper: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    pointerEvents: 'none',
+  },
+  foxAnimation: {
+    width: '100%',
+    height: '100%',
+  },
+});
 
 const FoxAnimation = ({
   hasFooter,
   trigger,
+  fullBleedBottom = false,
 }: {
   hasFooter: boolean;
   trigger?: 'Loader' | 'Start';
+  fullBleedBottom?: boolean;
 }) => {
   const insets = useSafeAreaInsets();
-  const styles = createStyles(hasFooter, insets);
+  const bottom = getSafeBottomPosition(hasFooter, insets, { fullBleedBottom });
+  const height = getFoxAnimationHeight(hasFooter);
 
   const { riveFile } = useRiveFile(FoxAnimationRive);
   const { riveViewRef, setHybridRef } = useRive();
@@ -98,7 +119,7 @@ const FoxAnimation = ({
   }, [riveViewRef, riveHandlers, trigger]);
 
   return (
-    <View style={[styles.foxAnimationWrapper]}>
+    <View style={[styles.foxAnimationWrapper, { bottom, height }]}>
       {riveFile && (
         <RiveView
           hybridRef={setHybridRef}
@@ -106,7 +127,7 @@ const FoxAnimation = ({
           file={riveFile}
           autoPlay
           fit={Fit.Contain}
-          alignment={Alignment.Center}
+          alignment={hasFooter ? Alignment.Center : Alignment.BottomCenter}
           stateMachineName="FoxRaiseUp"
           testID="fox-animation"
           onError={(riveError) => {

--- a/app/components/UI/FoxAnimation/FoxAnimation.tsx
+++ b/app/components/UI/FoxAnimation/FoxAnimation.tsx
@@ -22,7 +22,10 @@ const getFoxAnimationHeight = (hasFooter: boolean) => {
   return Device.isMediumDevice() ? 300 : 350;
 };
 
-const getSafeBottomPosition = (hasFooter: boolean, insets?: EdgeInsets) => {
+export const getSafeBottomPosition = (
+  hasFooter: boolean,
+  insets?: EdgeInsets,
+) => {
   const basePadding = insets?.bottom || 0;
 
   if (hasFooter) {

--- a/app/components/UI/FoxAnimation/FoxAnimation.tsx
+++ b/app/components/UI/FoxAnimation/FoxAnimation.tsx
@@ -25,36 +25,28 @@ const getFoxAnimationHeight = (hasFooter: boolean) => {
 const getSafeBottomPosition = (hasFooter: boolean, insets?: EdgeInsets) => {
   const basePadding = insets?.bottom || 0;
 
-  // iOS specific
-  if (Platform.OS === 'ios') {
-    if (hasFooter) {
-      // Footer case: position above footer + safe area
+  if (hasFooter) {
+    if (Platform.OS === 'ios') {
       return Math.max(100, basePadding + 60);
     }
+    if (Platform.OS === 'android') {
+      return Math.max(100, basePadding + (basePadding > 20 ? 60 : 40));
+    }
+    return 100;
+  }
+
+  if (Platform.OS === 'ios') {
     if (basePadding > 0) {
-      // iPhone X+ with home indicator
       return Math.max(-40, -(basePadding - 10));
     }
     return -20;
   }
 
-  // Android specific
   if (Platform.OS === 'android') {
-    // Samsung and other Android devices with gesture navigation
-    if (basePadding > 20) {
-      return hasFooter
-        ? Math.max(100, basePadding + 60)
-        : Math.max(-20, basePadding);
-    }
-
-    // Standard Android devices
-    return hasFooter
-      ? Math.max(100, basePadding + 40)
-      : Math.max(-20, basePadding - 20);
+    return Math.max(0, basePadding);
   }
 
-  // Fallback for other platforms
-  return hasFooter ? 100 : -20;
+  return -20;
 };
 
 const createStyles = (hasFooter: boolean, insets?: EdgeInsets) =>

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -1656,9 +1656,13 @@ const Onboarding = () => {
           {handleSimpleNotification()}
         </SafeAreaView>
 
-        {/* Fox sits on the root canvas and extends into the bottom inset. */}
+        {/* Fox on the full-bleed root canvas */}
         {!hasTestOverrides && (
-          <FoxAnimation hasFooter={false} trigger={startFoxAnimation} />
+          <FoxAnimation
+            hasFooter={false}
+            trigger={startFoxAnimation}
+            fullBleedBottom
+          />
         )}
       </View>
     </ErrorBoundary>

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -1588,6 +1588,11 @@ const Onboarding = () => {
 
   const { errorToThrow, startFoxAnimation } = state;
 
+  const onboardingCanvasColor =
+    themeContext.themeAppearance === 'dark'
+      ? importedColors.gettingStartedTextColor
+      : importedColors.gettingStartedPageBackgroundColorLightMode;
+
   const ThrowErrorIfNeeded = () => {
     if (errorToThrow) {
       throw errorToThrow;
@@ -1602,62 +1607,60 @@ const Onboarding = () => {
       useOnboardingErrorHandling={!!errorToThrow && !metrics.isEnabled()}
     >
       <ThrowErrorIfNeeded />
-      <SafeAreaView
-        style={tw.style('flex-1', {
-          backgroundColor:
-            themeContext.themeAppearance === 'dark'
-              ? importedColors.gettingStartedTextColor
-              : importedColors.gettingStartedPageBackgroundColorLightMode,
-        })}
+      {/*
+        Root canvas owns the background so it extends into the Android bottom
+        gesture inset. SafeAreaView only protects top content — do not put the
+        background color on a bottom-padded safe area.
+      */}
+      <View
+        style={tw.style('flex-1', { backgroundColor: onboardingCanvasColor })}
         testID={OnboardingSelectorIDs.CONTAINER_ID}
       >
-        <ScrollView
-          style={tw.style('flex-1')}
-          contentContainerStyle={tw.style('flex-1')}
-        >
-          <Box
-            alignItems={BoxAlignItems.Center}
-            justifyContent={BoxJustifyContent.Center}
-            twClassName="flex-1 py-4"
+        <SafeAreaView edges={['top']} style={tw.style('flex-1')}>
+          <ScrollView
+            style={tw.style('flex-1')}
+            contentContainerStyle={tw.style('flex-1')}
           >
-            {renderContent()}
+            <Box
+              alignItems={BoxAlignItems.Center}
+              justifyContent={BoxJustifyContent.Center}
+              twClassName="flex-1 py-4"
+            >
+              {renderContent()}
 
-            {loading && (
-              <Box
-                alignItems={BoxAlignItems.Center}
-                justifyContent={BoxJustifyContent.Center}
-                twClassName="absolute top-0 left-0 right-0 bottom-0"
-                style={tw.style(
-                  { zIndex: 1000 },
-                  {
-                    backgroundColor:
-                      themeContext.themeAppearance === 'dark'
-                        ? importedColors.gettingStartedTextColor
-                        : importedColors.gettingStartedPageBackgroundColorLightMode,
-                  },
-                )}
-              >
-                {renderLoader()}
-              </Box>
-            )}
-          </Box>
-        </ScrollView>
+              {loading && (
+                <Box
+                  alignItems={BoxAlignItems.Center}
+                  justifyContent={BoxJustifyContent.Center}
+                  twClassName="absolute top-0 left-0 right-0 bottom-0"
+                  style={tw.style(
+                    { zIndex: 1000 },
+                    { backgroundColor: onboardingCanvasColor },
+                  )}
+                >
+                  {renderLoader()}
+                </Box>
+              )}
+            </Box>
+          </ScrollView>
 
-        <FadeOutOverlay />
+          <FadeOutOverlay />
 
+          <FastOnboarding
+            onPressContinueWithGoogle={onPressContinueWithGoogle}
+            onPressContinueWithApple={onPressContinueWithApple}
+            onPressImport={onPressImport}
+            onPressCreate={onPressCreate}
+          />
+
+          {handleSimpleNotification()}
+        </SafeAreaView>
+
+        {/* Fox sits on the root canvas and extends into the bottom inset. */}
         {!hasTestOverrides && (
           <FoxAnimation hasFooter={false} trigger={startFoxAnimation} />
         )}
-
-        <FastOnboarding
-          onPressContinueWithGoogle={onPressContinueWithGoogle}
-          onPressContinueWithApple={onPressContinueWithApple}
-          onPressImport={onPressImport}
-          onPressCreate={onPressCreate}
-        />
-
-        {handleSimpleNotification()}
-      </SafeAreaView>
+      </View>
     </ErrorBoundary>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
On Android (especially gesture navigation / Pixel), the onboarding cream/purple canvas stopped short of the system navigation / gesture area, leaving a white “paper cut” strip under the fox. With targetSdk 36 the nav bar is transparent over the window background, so SafeArea-bottom padding on a background-colored container made the gap more visible.
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:  Fixed Android onboarding background not filling the gesture/navigation area under the fox

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TO-1033

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Onboarding Android bottom safe area / fox position

  Background:
    Given the app is freshly installed or reset to the welcome/onboarding screen
    And I am testing on Android

  Scenario: gesture navigation device shows continuous canvas under the fox
    Given the device uses gesture navigation (e.g. Pixel)
    And the app theme is light mode
    When user lands on the Onboarding welcome screen
    Then the cream onboarding background extends into the bottom gesture area
    And there is no white strip under the fox
    And the fox animation is fully visible above the gesture bar

```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="263" height="565" alt="Screenshot 2026-09-08 at 2 47 10 PM" src="https://github.com/user-attachments/assets/25c92837-b483-4b06-b0fd-d9cd5fd828e6" />

<!-- [screenshots/recordings] -->

### **After**
<img width="266" height="566" alt="Screenshot 2026-09-08 at 2 32 47 PM" src="https://github.com/user-attachments/assets/302c3432-66b4-4b2f-8808-7e2f9a173d1a" />
<img width="275" height="637" alt="Screenshot 2026-09-08 at 2 32 59 PM" src="https://github.com/user-attachments/assets/e05feca3-35a5-43ea-9b8b-30996da81c15" />

<img width="267" height="582" alt="Screenshot 2026-09-08 at 5 57 50 PM" src="https://github.com/user-attachments/assets/ba72e5c5-56b5-4ec9-97f4-0ccc6ca14978" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Android edge-to-edge and onboarding welcome layout/fox positioning; no auth, payments, or data-path changes, though edge-to-edge may have minor visual side effects elsewhere on Android.
> 
> **Overview**
> Fixes a visible white strip under the onboarding fox on Android (gesture nav / targetSdk 36) by letting the cream/purple canvas draw into the bottom system inset while keeping the fox above the gesture bar.
> 
> **Android** turns on `edgeToEdgeEnabled` in `gradle.properties` so the window background can extend behind the transparent navigation area.
> 
> **Onboarding layout** moves the themed background to a full-screen root `View`, uses `SafeAreaView` with only the top edge for scroll/CTAs, and places `FoxAnimation` as a sibling on that root canvas so it is not clipped by bottom safe-area padding. The onboarding stack screen gets matching `contentStyle` background and `headerShown: false`.
> 
> **Fox positioning** simplifies `getSafeBottomPosition` in `FoxAnimation` (notably Android without footer uses `max(0, bottom inset)` instead of negative offsets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01fd236314deb6c18f668c9624aed1e69e3bcc2c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->