### PR TITLE
feat(rewards): add a Claims tab to the Rewards Money earnings screen

### DIFF
--- a/app/components/UI/RewardsMoney/constants.ts
+++ b/app/components/UI/RewardsMoney/constants.ts
@@ -61,6 +61,9 @@ export const REWARDS_MONEY_TEST_IDS = {
   CLAIM_SHEET_CONFIRMING: 'rewards-money-claim-sheet-confirming',
   CLAIM_SHEET_CONFIRM: 'rewards-money-claim-sheet-confirm',
   CLAIM_SHEET_ERROR: 'rewards-money-claim-sheet-error',
+  CLAIMS_LIST: 'rewards-money-claims-list',
+  CLAIMS_EMPTY: 'rewards-money-claims-empty',
+  CLAIMS_SKELETON: 'rewards-money-claims-skeleton',
 } as const;
 
 /**

--- a/app/components/UI/RewardsMoney/earnings/Views/RewardsMoneyEarningsView.test.tsx
+++ b/app/components/UI/RewardsMoney/earnings/Views/RewardsMoneyEarningsView.test.tsx
@@ -9,6 +9,7 @@ import type {
 import { REWARDS_MONEY_TEST_IDS } from '../../constants';
 import useEarningsSummary from '../hooks/useEarningsSummary';
 import useEarningsLedger from '../hooks/useEarningsLedger';
+import useClaimHistory from '../hooks/useClaimHistory';
 import RewardsMoneyEarningsView from './RewardsMoneyEarningsView';
 
 const mockNavigate = jest.fn();
@@ -30,6 +31,17 @@ jest.mock('../hooks/useEarningsLedger', () => ({
   default: jest.fn(),
 }));
 
+jest.mock('../hooks/useClaimHistory', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+// Reads Redux and navigation; the view only forwards its result to the list.
+jest.mock('../hooks/useClaimRowPress', () => ({
+  __esModule: true,
+  default: jest.fn(() => () => null),
+}));
+
 jest.mock('../../../../Views/ErrorBoundary', () => {
   const ReactActual = jest.requireActual('react');
   return {
@@ -41,6 +53,7 @@ jest.mock('../../../../Views/ErrorBoundary', () => {
 
 const mockedUseSummary = jest.mocked(useEarningsSummary);
 const mockedUseLedger = jest.mocked(useEarningsLedger);
+const mockedUseClaimHistory = jest.mocked(useClaimHistory);
 
 const createTotals = (
   overrides: Partial<EarningsSummaryTotals> = {},
@@ -84,6 +97,21 @@ const mockLedgerState = (overrides = {}) => {
   });
 };
 
+const mockClaimHistoryState = (overrides = {}) => {
+  mockedUseClaimHistory.mockReturnValue({
+    claims: [],
+    isLoading: false,
+    isLoadingMore: false,
+    hasMore: false,
+    error: null,
+    loadMore: jest.fn(),
+    refresh: jest.fn(),
+    retry: jest.fn(),
+    isRefreshing: false,
+    ...overrides,
+  });
+};
+
 const mockSummaryState = (overrides = {}) => {
   mockedUseSummary.mockReturnValue({
     summary: createSummary(),
@@ -100,6 +128,7 @@ describe('RewardsMoneyEarningsView', () => {
     mockRouteParams = {};
     mockSummaryState();
     mockLedgerState();
+    mockClaimHistoryState();
   });
 
   it('scopes the summary and the ledger to the same origin types', () => {
@@ -153,8 +182,15 @@ describe('RewardsMoneyEarningsView', () => {
   it('hides the code-performance tab for a cashback-only scope', () => {
     render(<RewardsMoneyEarningsView originTypes={['CASHBACK']} />);
 
+    // The bar itself now always renders — Claims applies to a referee too, so
+    // what a cashback-only scope must hide is the code-performance tab.
     expect(
-      screen.queryByTestId(REWARDS_MONEY_TEST_IDS.EARNINGS_TABS),
+      screen.getByTestId(REWARDS_MONEY_TEST_IDS.EARNINGS_TABS),
+    ).toBeOnTheScreen();
+    expect(
+      screen.queryByTestId(
+        `${REWARDS_MONEY_TEST_IDS.EARNINGS_TABS}-code-performance`,
+      ),
     ).not.toBeOnTheScreen();
   });
 

--- a/app/components/UI/RewardsMoney/earnings/Views/RewardsMoneyEarningsView.test.tsx
+++ b/app/components/UI/RewardsMoney/earnings/Views/RewardsMoneyEarningsView.test.tsx
@@ -257,4 +257,28 @@ describe('RewardsMoneyEarningsView', () => {
     expect(refreshSummary).toHaveBeenCalledTimes(1);
     expect(refreshLedger).toHaveBeenCalledTimes(1);
   });
+
+  /**
+   * The summary rides in the shared header on both tabs, and settlement emits
+   * no `earningsUpdated` event — so refreshing claims alone left the visible
+   * totals stale until the screen remounted.
+   */
+  it('refreshes the summary as well as the claims on the Claims tab', () => {
+    const refreshSummary = jest.fn();
+    const refreshClaims = jest.fn();
+    mockSummaryState({ refresh: refreshSummary });
+    mockClaimHistoryState({ refresh: refreshClaims });
+    render(<RewardsMoneyEarningsView originTypes={['CASHBACK']} />);
+
+    fireEvent.press(
+      screen.getByTestId(`${REWARDS_MONEY_TEST_IDS.EARNINGS_TABS}-claims`),
+    );
+    fireEvent(
+      screen.getByTestId(REWARDS_MONEY_TEST_IDS.CLAIMS_LIST),
+      'refresh',
+    );
+
+    expect(refreshSummary).toHaveBeenCalledTimes(1);
+    expect(refreshClaims).toHaveBeenCalledTimes(1);
+  });
 });

--- a/app/components/UI/RewardsMoney/earnings/Views/RewardsMoneyEarningsView.tsx
+++ b/app/components/UI/RewardsMoney/earnings/Views/RewardsMoneyEarningsView.tsx
@@ -123,6 +123,14 @@ const RewardsMoneyEarningsView: React.FC<RewardsMoneyEarningsViewProps> = ({
     refreshLedger();
   }, [refreshSummary, refreshLedger]);
 
+  // The summary rides in the shared header on both tabs, and settlement emits
+  // no earningsUpdated event — so refreshing claims alone would leave the
+  // visible totals stale until the screen remounts.
+  const handleClaimsRefresh = useCallback(() => {
+    refreshSummary();
+    refreshClaims();
+  }, [refreshSummary, refreshClaims]);
+
   // Only the scope is passed. The sheet re-reads the summary itself so it can
   // never render a payload frozen at navigation time.
   const handleClaim = useCallback(() => {
@@ -188,7 +196,7 @@ const RewardsMoneyEarningsView: React.FC<RewardsMoneyEarningsViewProps> = ({
         hasMore={hasMoreClaims}
         error={claimsError}
         loadMore={loadMoreClaims}
-        refresh={refreshClaims}
+        refresh={handleClaimsRefresh}
         retry={retryClaims}
         resolveRowPress={resolveClaimRowPress}
         ListHeaderComponent={listHeader}

--- a/app/components/UI/RewardsMoney/earnings/Views/RewardsMoneyEarningsView.tsx
+++ b/app/components/UI/RewardsMoney/earnings/Views/RewardsMoneyEarningsView.tsx
@@ -27,11 +27,15 @@ import {
 import EarningsSummaryHeader from '../components/EarningsSummaryHeader';
 import EarningsTabs, {
   CodePerformancePlaceholder,
+  EARNINGS_TAB_CLAIMS,
   EARNINGS_TAB_LEDGER,
 } from '../components/EarningsTabs';
 import EarningsLedgerList from '../components/EarningsLedgerList';
+import ClaimsList from '../components/ClaimsList';
 import useEarningsSummary from '../hooks/useEarningsSummary';
 import useEarningsLedger from '../hooks/useEarningsLedger';
+import useClaimHistory from '../hooks/useClaimHistory';
+import useClaimRowPress from '../hooks/useClaimRowPress';
 import { deriveClaimability } from '../utils/deriveClaimability';
 
 export interface RewardsMoneyEarningsViewProps {
@@ -95,6 +99,20 @@ const RewardsMoneyEarningsView: React.FC<RewardsMoneyEarningsViewProps> = ({
     isRefreshing,
   } = useEarningsLedger(originTypes);
 
+  const {
+    claims,
+    isLoading: isClaimsLoading,
+    isLoadingMore: isClaimsLoadingMore,
+    isRefreshing: isClaimsRefreshing,
+    hasMore: hasMoreClaims,
+    error: claimsError,
+    loadMore: loadMoreClaims,
+    refresh: refreshClaims,
+    retry: retryClaims,
+  } = useClaimHistory();
+
+  const resolveClaimRowPress = useClaimRowPress();
+
   const claimability = useMemo(
     () => deriveClaimability(summary, originTypes),
     [summary, originTypes],
@@ -144,8 +162,9 @@ const RewardsMoneyEarningsView: React.FC<RewardsMoneyEarningsViewProps> = ({
     ],
   );
 
-  const content =
-    activeTab === EARNINGS_TAB_LEDGER ? (
+  let content: React.ReactElement;
+  if (activeTab === EARNINGS_TAB_LEDGER) {
+    content = (
       <EarningsLedgerList
         entries={entries}
         isLoading={isLoading}
@@ -158,12 +177,31 @@ const RewardsMoneyEarningsView: React.FC<RewardsMoneyEarningsViewProps> = ({
         retry={retry}
         ListHeaderComponent={listHeader}
       />
-    ) : (
+    );
+  } else if (activeTab === EARNINGS_TAB_CLAIMS) {
+    content = (
+      <ClaimsList
+        claims={claims}
+        isLoading={isClaimsLoading}
+        isLoadingMore={isClaimsLoadingMore}
+        isRefreshing={isClaimsRefreshing}
+        hasMore={hasMoreClaims}
+        error={claimsError}
+        loadMore={loadMoreClaims}
+        refresh={refreshClaims}
+        retry={retryClaims}
+        resolveRowPress={resolveClaimRowPress}
+        ListHeaderComponent={listHeader}
+      />
+    );
+  } else {
+    content = (
       <Box twClassName="flex-1">
         {listHeader}
         <CodePerformancePlaceholder />
       </Box>
     );
+  }
 
   if (embedded) {
     return (

--- a/app/components/UI/RewardsMoney/earnings/components/ClaimsList.test.tsx
+++ b/app/components/UI/RewardsMoney/earnings/components/ClaimsList.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import type { ClaimDto } from '../../../../../core/Engine/controllers/rewards-money-controller/types';
+import { REWARDS_MONEY_TEST_IDS } from '../../constants';
+import ClaimsList, { type ClaimsListProps } from './ClaimsList';
+
+const createClaim = (id: string): ClaimDto =>
+  ({
+    id,
+    money_account_address: '0xmoneyaccount',
+    earning_origin_types: ['REFERRAL_REV_SHARE'],
+    gross_amount: '200000',
+    withheld_amount: '0',
+    net_amount: '200000',
+    withholding_rate_bps: 0,
+    valid_before: null,
+    status: 'SETTLED',
+    created_at: '2026-09-07T10:00:00.000Z',
+    settled_tx_hash: '0xhash',
+    settled_at: '2026-09-07T10:01:00.000Z',
+  }) as ClaimDto;
+
+const renderList = (overrides: Partial<ClaimsListProps> = {}) =>
+  render(
+    <ClaimsList
+      claims={[]}
+      isLoading={false}
+      isLoadingMore={false}
+      isRefreshing={false}
+      hasMore={false}
+      error={null}
+      loadMore={jest.fn()}
+      refresh={jest.fn()}
+      retry={jest.fn()}
+      resolveRowPress={() => null}
+      {...overrides}
+    />,
+  );
+
+describe('ClaimsList', () => {
+  it('renders a row per claim', () => {
+    renderList({ claims: [createClaim('a'), createClaim('b')] });
+
+    expect(screen.getByTestId('rewards-money-claims-row-0')).toBeOnTheScreen();
+    expect(screen.getByTestId('rewards-money-claims-row-1')).toBeOnTheScreen();
+  });
+
+  it('shows the settled empty copy once loading finishes with no claims', () => {
+    renderList();
+
+    expect(
+      screen.getByTestId(REWARDS_MONEY_TEST_IDS.CLAIMS_EMPTY),
+    ).toBeOnTheScreen();
+  });
+
+  /**
+   * An in-flight first page must never show "no withdrawals yet" — the tri-state
+   * empty renderer is what keeps a load from looking like an empty result.
+   */
+  it.each([
+    ['isLoading', { isLoading: true }],
+    ['a null list', { claims: null }],
+  ])('shows skeletons rather than empty copy for %s', (_label, overrides) => {
+    renderList(overrides as Partial<ClaimsListProps>);
+
+    expect(
+      screen.getByTestId(REWARDS_MONEY_TEST_IDS.CLAIMS_SKELETON),
+    ).toBeOnTheScreen();
+    expect(
+      screen.queryByTestId(REWARDS_MONEY_TEST_IDS.CLAIMS_EMPTY),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('shows an error banner instead of the empty copy when the read failed', () => {
+    renderList({ error: 'boom' });
+
+    expect(
+      screen.queryByTestId(REWARDS_MONEY_TEST_IDS.CLAIMS_EMPTY),
+    ).not.toBeOnTheScreen();
+    expect(screen.getByText("Couldn't load withdrawals")).toBeOnTheScreen();
+  });
+
+  /** The resolver decides tappability per row, so a null must stay inert. */
+  it('renders rows inert when the resolver returns null', () => {
+    renderList({ claims: [createClaim('a')], resolveRowPress: () => null });
+
+    expect(
+      screen.queryByTestId('rewards-money-claims-row-0-pressable'),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('renders a pressable row when the resolver supplies a target', () => {
+    renderList({
+      claims: [createClaim('a')],
+      resolveRowPress: () => ({ onPress: jest.fn(), isInferredMatch: false }),
+    });
+
+    expect(
+      screen.getByTestId('rewards-money-claims-row-0-pressable'),
+    ).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/RewardsMoney/earnings/components/ClaimsList.tsx
+++ b/app/components/UI/RewardsMoney/earnings/components/ClaimsList.tsx
@@ -1,0 +1,175 @@
+import React, { useCallback } from 'react';
+import { ActivityIndicator, FlatList, RefreshControl } from 'react-native';
+import {
+  Box,
+  Skeleton,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { strings } from '../../../../../../locales/i18n';
+import RewardsErrorBanner from '../../../Rewards/components/RewardsErrorBanner';
+import type { ClaimDto } from '../../../../../core/Engine/controllers/rewards-money-controller/types';
+import { REWARDS_MONEY_TEST_IDS } from '../../constants';
+import ClaimsRow from './ClaimsRow';
+
+export interface ClaimsListProps {
+  claims: ClaimDto[] | null;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  isRefreshing: boolean;
+  hasMore: boolean;
+  error: string | null;
+  loadMore: () => void;
+  refresh: () => void;
+  retry: () => void;
+  /**
+   * Resolves what a row opens. Returning null makes the row inert — an
+   * `EXPIRED` or `FAILED` claim has no transaction, and a claim settled without
+   * provenance has no hash to open.
+   */
+  resolveRowPress: (
+    claim: ClaimDto,
+  ) => { onPress: () => void; isInferredMatch: boolean } | null;
+  ListHeaderComponent?: React.ReactElement | null;
+}
+
+const ClaimRowSkeleton: React.FC = () => {
+  const tw = useTailwind();
+
+  return (
+    <Box twClassName="w-full py-4 gap-2">
+      <Skeleton style={tw.style('h-4 w-28 rounded-lg')} />
+      <Skeleton style={tw.style('h-3 w-20 rounded-lg')} />
+    </Box>
+  );
+};
+
+/**
+ * Claim history. Deliberately the same list mechanics as the ledger —
+ * `onEndReached` at 0.3, footer spinner, pull-to-refresh, and a tri-state empty
+ * renderer so an in-flight first page never shows the settled empty copy.
+ */
+const ClaimsList: React.FC<ClaimsListProps> = ({
+  claims,
+  isLoading,
+  isLoadingMore,
+  isRefreshing,
+  hasMore,
+  error,
+  loadMore,
+  refresh,
+  retry,
+  resolveRowPress,
+  ListHeaderComponent,
+}) => {
+  const tw = useTailwind();
+
+  const renderItem = useCallback(
+    ({ item, index }: { item: ClaimDto; index: number }) => {
+      const press = resolveRowPress(item);
+      return (
+        <Box twClassName="px-4">
+          <ClaimsRow
+            claim={item}
+            onPress={press?.onPress}
+            isInferredMatch={press?.isInferredMatch}
+            testID={`rewards-money-claims-row-${index}`}
+          />
+        </Box>
+      );
+    },
+    [resolveRowPress],
+  );
+
+  const keyExtractor = useCallback((item: ClaimDto) => item.id, []);
+
+  const onEndReached = useCallback(() => {
+    if (
+      hasMore &&
+      !isLoading &&
+      !isLoadingMore &&
+      !isRefreshing &&
+      claims &&
+      claims.length > 0
+    ) {
+      loadMore();
+    }
+  }, [hasMore, isLoading, isLoadingMore, isRefreshing, claims, loadMore]);
+
+  const renderFooter = useCallback(() => {
+    if (!isLoadingMore || !claims || claims.length === 0) {
+      return null;
+    }
+    return (
+      <Box twClassName="py-4 items-center">
+        <ActivityIndicator />
+      </Box>
+    );
+  }, [isLoadingMore, claims]);
+
+  const isInitialLoadPending = isLoading || claims === null;
+
+  const renderEmpty = useCallback(() => {
+    if (error) {
+      return (
+        <Box twClassName="px-4 pt-2">
+          <RewardsErrorBanner
+            title={strings('rewards_money.claims.error_title')}
+            description={strings('rewards_money.claims.error_description')}
+            onConfirm={retry}
+            confirmButtonLabel={strings('rewards_money.ledger.retry')}
+          />
+        </Box>
+      );
+    }
+
+    if (isInitialLoadPending) {
+      return (
+        <Box
+          twClassName="px-4 pb-2"
+          testID={REWARDS_MONEY_TEST_IDS.CLAIMS_SKELETON}
+        >
+          {Array.from({ length: 4 }).map((_, index) => (
+            <ClaimRowSkeleton key={index} />
+          ))}
+        </Box>
+      );
+    }
+
+    return (
+      <Box twClassName="p-4 items-center">
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          twClassName="text-center"
+          testID={REWARDS_MONEY_TEST_IDS.CLAIMS_EMPTY}
+        >
+          {strings('rewards_money.claims.empty')}
+        </Text>
+      </Box>
+    );
+  }, [error, isInitialLoadPending, retry]);
+
+  return (
+    <FlatList<ClaimDto>
+      testID={REWARDS_MONEY_TEST_IDS.CLAIMS_LIST}
+      style={tw.style('flex-1')}
+      data={claims ?? []}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      onEndReached={onEndReached}
+      onEndReachedThreshold={0.3}
+      ListHeaderComponent={ListHeaderComponent}
+      ListFooterComponent={renderFooter}
+      ListEmptyComponent={renderEmpty}
+      refreshControl={
+        <RefreshControl refreshing={isRefreshing} onRefresh={refresh} />
+      }
+      showsVerticalScrollIndicator={false}
+    />
+  );
+};
+
+export default ClaimsList;

--- a/app/components/UI/RewardsMoney/earnings/components/ClaimsRow.test.tsx
+++ b/app/components/UI/RewardsMoney/earnings/components/ClaimsRow.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import type {
+  ClaimDto,
+  ClaimLifecycleStatus,
+} from '../../../../../core/Engine/controllers/rewards-money-controller/types';
+import ClaimsRow from './ClaimsRow';
+
+const createClaim = (status: ClaimLifecycleStatus): ClaimDto =>
+  ({
+    id: `claim-${status}`,
+    money_account_address: '0xmoneyaccount',
+    earning_origin_types: ['REFERRAL_REV_SHARE'],
+    gross_amount: '200000',
+    withheld_amount: '0',
+    net_amount: '200000',
+    withholding_rate_bps: 0,
+    valid_before: null,
+    status,
+    created_at: '2026-09-07T10:00:00.000Z',
+    settled_tx_hash: null,
+    settled_at: null,
+  }) as ClaimDto;
+
+describe('ClaimsRow', () => {
+  it('renders the net amount as currency', () => {
+    render(<ClaimsRow claim={createClaim('SETTLED')} testID="row" />);
+
+    expect(screen.getByText('$0.20')).toBeOnTheScreen();
+  });
+
+  it.each<[ClaimLifecycleStatus, string]>([
+    ['SETTLED', 'Confirmed'],
+    ['AUTHORIZED', 'Pending'],
+    ['EXPIRED', 'Expired'],
+    ['FAILED', 'Not completed'],
+  ])('labels a %s claim as "%s"', (status, label) => {
+    render(<ClaimsRow claim={createClaim(status)} testID="row" />);
+
+    expect(screen.getByText(label)).toBeOnTheScreen();
+  });
+
+  /**
+   * `PENDING_SIGNATURE` is an internal step the user cannot act on, swept to
+   * FAILED within minutes, so it reads as pending rather than naming itself.
+   */
+  it('folds PENDING_SIGNATURE in with pending', () => {
+    render(<ClaimsRow claim={createClaim('PENDING_SIGNATURE')} testID="row" />);
+
+    expect(screen.getByText('Pending')).toBeOnTheScreen();
+  });
+
+  it('is pressable when a transaction can be opened', () => {
+    const onPress = jest.fn();
+    render(
+      <ClaimsRow
+        claim={createClaim('SETTLED')}
+        onPress={onPress}
+        testID="row"
+      />,
+    );
+
+    fireEvent.press(screen.getByTestId('row-pressable'));
+
+    expect(onPress).toHaveBeenCalled();
+  });
+
+  /**
+   * An EXPIRED or FAILED claim never reached the chain, so there is nothing to
+   * open and the row must not look tappable.
+   */
+  it('renders inert when no transaction can be opened', () => {
+    render(<ClaimsRow claim={createClaim('EXPIRED')} testID="row" />);
+
+    expect(screen.queryByTestId('row-pressable')).not.toBeOnTheScreen();
+    expect(screen.getByTestId('row')).toBeOnTheScreen();
+  });
+
+  /** An inferred match must not be presented as fact. */
+  it('marks an inferred match as likely', () => {
+    render(
+      <ClaimsRow
+        claim={createClaim('AUTHORIZED')}
+        onPress={jest.fn()}
+        isInferredMatch
+        testID="row"
+      />,
+    );
+
+    expect(screen.getByText(/likely transaction/)).toBeOnTheScreen();
+  });
+
+  it('does not add the likely qualifier to an exact match', () => {
+    render(
+      <ClaimsRow
+        claim={createClaim('SETTLED')}
+        onPress={jest.fn()}
+        testID="row"
+      />,
+    );
+
+    expect(screen.queryByText(/likely transaction/)).not.toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/RewardsMoney/earnings/components/ClaimsRow.tsx
+++ b/app/components/UI/RewardsMoney/earnings/components/ClaimsRow.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import type {
+  ClaimDto,
+  ClaimLifecycleStatus,
+} from '../../../../../core/Engine/controllers/rewards-money-controller/types';
+import { formatMusd } from '../../utils/format';
+
+interface ClaimsRowProps {
+  claim: ClaimDto;
+  /** Omitted when nothing is openable, which is what makes the row inert. */
+  onPress?: () => void;
+  /** True when the target was inferred rather than known, softening the label. */
+  isInferredMatch?: boolean;
+  testID?: string;
+}
+
+/**
+ * How each lifecycle state reads.
+ *
+ * `PENDING_SIGNATURE` folds in with `AUTHORIZED`: it is transient, swept to
+ * `FAILED` within a couple of minutes, and naming it would expose an internal
+ * step the user cannot act on.
+ *
+ * `EXPIRED` and `FAILED` are muted rather than error-coloured on purpose —
+ * nothing bad happened to the user's money. A lapsed or failed voucher is
+ * released back to claimable, so red would be a lie.
+ */
+const STATUS_PRESENTATION: Record<
+  ClaimLifecycleStatus,
+  { labelKey: string; color: TextColor }
+> = {
+  SETTLED: {
+    labelKey: 'rewards_money.claims.status_confirmed',
+    color: TextColor.SuccessDefault,
+  },
+  AUTHORIZED: {
+    labelKey: 'rewards_money.claims.status_pending',
+    color: TextColor.InfoDefault,
+  },
+  PENDING_SIGNATURE: {
+    labelKey: 'rewards_money.claims.status_pending',
+    color: TextColor.InfoDefault,
+  },
+  EXPIRED: {
+    labelKey: 'rewards_money.claims.status_expired',
+    color: TextColor.TextAlternative,
+  },
+  FAILED: {
+    labelKey: 'rewards_money.claims.status_failed',
+    color: TextColor.TextAlternative,
+  },
+};
+
+const ClaimsRow: React.FC<ClaimsRowProps> = ({
+  claim,
+  onPress,
+  isInferredMatch,
+  testID,
+}) => {
+  const presentation =
+    STATUS_PRESENTATION[claim.status] ?? STATUS_PRESENTATION.PENDING_SIGNATURE;
+
+  const body = (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Between}
+      twClassName="w-full py-4 gap-3"
+      testID={testID}
+    >
+      <Box twClassName="flex-1 gap-1">
+        <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+          {strings('rewards_money.claims.row_title')}
+        </Text>
+        <Text
+          variant={TextVariant.BodySm}
+          color={presentation.color}
+          numberOfLines={1}
+        >
+          {strings(presentation.labelKey)}
+          {isInferredMatch
+            ? ` · ${strings('rewards_money.claims.likely_transaction')}`
+            : ''}
+        </Text>
+      </Box>
+      <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+        {formatMusd(claim.net_amount)}
+      </Text>
+    </Box>
+  );
+
+  if (!onPress) {
+    return body;
+  }
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      accessibilityRole="button"
+      testID={`${testID}-pressable`}
+    >
+      {body}
+    </TouchableOpacity>
+  );
+};
+
+export { STATUS_PRESENTATION };
+export default ClaimsRow;

--- a/app/components/UI/RewardsMoney/earnings/components/EarningsTabs.test.tsx
+++ b/app/components/UI/RewardsMoney/earnings/components/EarningsTabs.test.tsx
@@ -24,7 +24,12 @@ describe('EarningsTabs', () => {
     ).toBeOnTheScreen();
   });
 
-  it('renders no bar for a referee, who has only one tab', () => {
+  /**
+   * The bar used to hide itself for a referee, who had only Activity. Claims
+   * applies to referrer and referee alike, so two tabs is now the floor and the
+   * bar always renders.
+   */
+  it('renders the bar for a referee, who now has Activity and Claims', () => {
     render(
       <EarningsTabs
         activeIndex={0}
@@ -34,7 +39,15 @@ describe('EarningsTabs', () => {
     );
 
     expect(
-      screen.queryByTestId(REWARDS_MONEY_TEST_IDS.EARNINGS_TABS),
+      screen.getByTestId(REWARDS_MONEY_TEST_IDS.EARNINGS_TABS),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(`${REWARDS_MONEY_TEST_IDS.EARNINGS_TABS}-claims`),
+    ).toBeOnTheScreen();
+    expect(
+      screen.queryByTestId(
+        `${REWARDS_MONEY_TEST_IDS.EARNINGS_TABS}-code-performance`,
+      ),
     ).not.toBeOnTheScreen();
   });
 
@@ -54,7 +67,8 @@ describe('EarningsTabs', () => {
       ),
     );
 
-    expect(onTabPress).toHaveBeenCalledWith(1);
+    // Code performance sits at 2 now that Claims occupies 1.
+    expect(onTabPress).toHaveBeenCalledWith(2);
   });
 });
 

--- a/app/components/UI/RewardsMoney/earnings/components/EarningsTabs.tsx
+++ b/app/components/UI/RewardsMoney/earnings/components/EarningsTabs.tsx
@@ -15,7 +15,8 @@ import { strings } from '../../../../../../locales/i18n';
 import { REWARDS_MONEY_TEST_IDS } from '../../constants';
 
 export const EARNINGS_TAB_LEDGER = 0;
-export const EARNINGS_TAB_CODE_PERFORMANCE = 1;
+export const EARNINGS_TAB_CLAIMS = 1;
+export const EARNINGS_TAB_CODE_PERFORMANCE = 2;
 
 interface EarningsTabsProps {
   activeIndex: number;
@@ -30,6 +31,10 @@ interface EarningsTabsProps {
  * `TabsBar` rather than `TabsList`: `TabsList` owns its own swipeable scroll
  * container, which would nest inside — and break — the ledger's `FlatList`
  * infinite scroll. The bar is controlled and the parent swaps content.
+ *
+ * Activity and Claims are always shown; code performance is referrer-only and
+ * still a placeholder, so the bar no longer needs its old
+ * hide-when-only-one-tab guard.
  */
 const EarningsTabs: React.FC<EarningsTabsProps> = ({
   activeIndex,
@@ -44,6 +49,14 @@ const EarningsTabs: React.FC<EarningsTabsProps> = ({
         content: null,
         testID: `${REWARDS_MONEY_TEST_IDS.EARNINGS_TABS}-ledger`,
       },
+      // Always present: a claim history exists for referrer and referee alike,
+      // and unlike code performance it has a real endpoint behind it.
+      {
+        key: 'claims',
+        label: strings('rewards_money.earnings.tab_claims'),
+        content: null,
+        testID: `${REWARDS_MONEY_TEST_IDS.EARNINGS_TABS}-claims`,
+      },
     ];
 
     if (showCodePerformance) {
@@ -57,10 +70,6 @@ const EarningsTabs: React.FC<EarningsTabsProps> = ({
 
     return items;
   }, [showCodePerformance]);
-
-  if (tabs.length < 2) {
-    return null;
-  }
 
   return (
     <TabsBar

--- a/app/components/UI/RewardsMoney/earnings/hooks/useClaimHistory.test.ts
+++ b/app/components/UI/RewardsMoney/earnings/hooks/useClaimHistory.test.ts
@@ -1,0 +1,95 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import Engine from '../../../../../core/Engine';
+import type {
+  ClaimDto,
+  ClaimHistoryPageDto,
+} from '../../../../../core/Engine/controllers/rewards-money-controller/types';
+import { useClaimHistory } from './useClaimHistory';
+
+jest.mock('../../../../../core/Engine', () => ({
+  __esModule: true,
+  default: { controllerMessenger: { call: jest.fn() } },
+}));
+
+jest.mock('../../constants', () => ({
+  ...jest.requireActual('../../constants'),
+  REWARDS_MONEY_ENABLED: true,
+}));
+
+const mockCall = jest.mocked(Engine.controllerMessenger.call);
+
+const createClaim = (id: string): ClaimDto =>
+  ({
+    id,
+    money_account_address: '0xmoneyaccount',
+    earning_origin_types: ['REFERRAL_REV_SHARE'],
+    gross_amount: '200000',
+    withheld_amount: '0',
+    net_amount: '200000',
+    withholding_rate_bps: 0,
+    valid_before: null,
+    status: 'SETTLED',
+    created_at: '2026-09-07T10:00:00.000Z',
+    settled_tx_hash: '0xhash',
+    settled_at: '2026-09-07T10:01:00.000Z',
+  }) as ClaimDto;
+
+const createPage = (
+  overrides: Partial<ClaimHistoryPageDto> = {},
+): ClaimHistoryPageDto => ({
+  results: [createClaim('claim-1')],
+  has_more: false,
+  cursor: null,
+  ...overrides,
+});
+
+describe('useClaimHistory', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reads the first page with no cursor', async () => {
+    mockCall.mockResolvedValue(createPage() as never);
+
+    const { result } = renderHook(() => useClaimHistory());
+
+    await waitFor(() => expect(result.current.claims).toHaveLength(1));
+    expect(mockCall).toHaveBeenCalledWith(
+      'RewardsMoneyController:getClaimHistory',
+      { cursor: null },
+    );
+  });
+
+  it('carries the cursor on a later page and merges the results', async () => {
+    mockCall
+      .mockResolvedValueOnce(
+        createPage({ has_more: true, cursor: 'cursor-1' }) as never,
+      )
+      .mockResolvedValueOnce(
+        createPage({ results: [createClaim('claim-2')] }) as never,
+      );
+
+    const { result } = renderHook(() => useClaimHistory());
+    await waitFor(() => expect(result.current.claims).toHaveLength(1));
+
+    await act(async () => {
+      result.current.loadMore();
+    });
+
+    await waitFor(() => expect(result.current.claims).toHaveLength(2));
+    expect(mockCall).toHaveBeenLastCalledWith(
+      'RewardsMoneyController:getClaimHistory',
+      { cursor: 'cursor-1' },
+    );
+  });
+
+  it('surfaces a failed read as an error rather than an empty list', async () => {
+    mockCall.mockRejectedValue(new Error('Claims unavailable'));
+
+    const { result } = renderHook(() => useClaimHistory());
+
+    await waitFor(() =>
+      expect(result.current.error).toBe('Claims unavailable'),
+    );
+  });
+});

--- a/app/components/UI/RewardsMoney/earnings/hooks/useClaimHistory.ts
+++ b/app/components/UI/RewardsMoney/earnings/hooks/useClaimHistory.ts
@@ -1,0 +1,70 @@
+import { useCallback } from 'react';
+import Engine from '../../../../../core/Engine';
+import type { ClaimDto } from '../../../../../core/Engine/controllers/rewards-money-controller/types';
+import { useCursorPaginatedList } from '../../../Rewards/hooks/useCursorPaginatedList';
+import { REWARDS_MONEY_ENABLED } from '../../constants';
+
+export interface UseClaimHistoryResult {
+  claims: ClaimDto[] | null;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  error: string | null;
+  loadMore: () => void;
+  refresh: () => void;
+  retry: () => void;
+  isRefreshing: boolean;
+}
+
+/**
+ * Cursor-paginated claim history, newest first.
+ *
+ * Unscoped, unlike `useEarningsLedger`: claims are not faceted by origin type,
+ * so there is no reset key and every page — including the first — goes straight
+ * to the network. The controller does not cache this read, so a pull-to-refresh
+ * always reflects the server.
+ *
+ * @returns The claims plus the list's loading, error and pagination state.
+ */
+export const useClaimHistory = (): UseClaimHistoryResult => {
+  const fetchPage = useCallback(
+    async ({ cursor }: { cursor: string | null }) =>
+      Engine.controllerMessenger.call(
+        'RewardsMoneyController:getClaimHistory',
+        { cursor },
+      ),
+    [],
+  );
+
+  const {
+    items,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    error,
+    loadMore,
+    refresh,
+    retry,
+    isRefreshing,
+  } = useCursorPaginatedList<ClaimDto>({
+    enabled: REWARDS_MONEY_ENABLED,
+    // Constant: claims carry no origin-type facet, so nothing resets the list.
+    resetKey: 'claims',
+    fetchPage,
+    errorMessage: 'Failed to fetch claims',
+  });
+
+  return {
+    claims: items,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    error,
+    loadMore,
+    refresh,
+    retry,
+    isRefreshing,
+  };
+};
+
+export default useClaimHistory;

--- a/app/components/UI/RewardsMoney/earnings/hooks/useClaimRowPress.test.ts
+++ b/app/components/UI/RewardsMoney/earnings/hooks/useClaimRowPress.test.ts
@@ -1,0 +1,98 @@
+import { renderHook } from '@testing-library/react-native';
+import type { ClaimDto } from '../../../../../core/Engine/controllers/rewards-money-controller/types';
+import { navigateToTransactionDetails } from '../../../../../util/navigation/navigateToTransactionDetails';
+import { resolveClaimTransaction } from '../utils/resolveClaimTransaction';
+import { useClaimRowPress } from './useClaimRowPress';
+
+const mockNavigation = { navigate: jest.fn() };
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => mockNavigation,
+}));
+
+// Selectors are called with no store, so the hook's `useSelector` is stubbed to
+// invoke them directly and each is mocked to a fixed value.
+jest.mock('react-redux', () => ({
+  useSelector: (selector: unknown) => (selector as () => unknown)(),
+}));
+
+jest.mock('../../../../../selectors/transactionController', () => ({
+  selectSortedTransactions: jest.fn(() => []),
+}));
+
+jest.mock(
+  '../../../../../selectors/featureFlagController/moneyAccount',
+  () => ({
+    selectMoneyAccountVaultConfig: jest.fn(() => ({ chainId: '0x8f' })),
+  }),
+);
+
+jest.mock(
+  '../../../../../util/navigation/navigateToTransactionDetails',
+  () => ({
+    navigateToTransactionDetails: jest.fn(),
+  }),
+);
+
+jest.mock('../utils/resolveClaimTransaction', () => ({
+  resolveClaimTransaction: jest.fn(),
+}));
+
+import { selectMoneyAccountVaultConfig } from '../../../../../selectors/featureFlagController/moneyAccount';
+
+const mockedResolve = jest.mocked(resolveClaimTransaction);
+const mockedNavigate = jest.mocked(navigateToTransactionDetails);
+const mockedVaultConfig = jest.mocked(selectMoneyAccountVaultConfig);
+
+const CLAIM = { id: 'claim-1' } as ClaimDto;
+
+describe('useClaimRowPress', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedVaultConfig.mockReturnValue({ chainId: '0x8f' } as ReturnType<
+      typeof selectMoneyAccountVaultConfig
+    >);
+  });
+
+  it('navigates to the resolved transaction on press', () => {
+    mockedResolve.mockReturnValue({ kind: 'exact', transactionId: 'tx-1' });
+    const { result } = renderHook(() => useClaimRowPress());
+
+    const press = result.current(CLAIM);
+    press?.onPress();
+
+    expect(press?.isInferredMatch).toBe(false);
+    expect(mockedNavigate).toHaveBeenCalledWith(mockNavigation, {
+      transactionId: 'tx-1',
+    });
+  });
+
+  it('flags an inferred match so the row can soften its label', () => {
+    mockedResolve.mockReturnValue({ kind: 'inferred', transactionId: 'tx-2' });
+    const { result } = renderHook(() => useClaimRowPress());
+
+    expect(result.current(CLAIM)?.isInferredMatch).toBe(true);
+  });
+
+  /** A null is what makes the row inert rather than a tap that goes nowhere. */
+  it('returns null when nothing can be opened', () => {
+    mockedResolve.mockReturnValue({ kind: 'none' });
+    const { result } = renderHook(() => useClaimRowPress());
+
+    expect(result.current(CLAIM)).toBeNull();
+  });
+
+  /**
+   * Without a vault config there is no chain to scope the search to, so
+   * resolving would be guesswork across every network.
+   */
+  it('returns null when the vault config is unavailable', () => {
+    mockedVaultConfig.mockReturnValue(
+      undefined as unknown as ReturnType<typeof selectMoneyAccountVaultConfig>,
+    );
+    const { result } = renderHook(() => useClaimRowPress());
+
+    expect(result.current(CLAIM)).toBeNull();
+    expect(mockedResolve).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/RewardsMoney/earnings/hooks/useClaimRowPress.ts
+++ b/app/components/UI/RewardsMoney/earnings/hooks/useClaimRowPress.ts
@@ -1,0 +1,71 @@
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import type { TransactionMeta } from '@metamask/transaction-controller';
+import { useNavigation } from '@react-navigation/native';
+import { selectSortedTransactions } from '../../../../../selectors/transactionController';
+import { selectMoneyAccountVaultConfig } from '../../../../../selectors/featureFlagController/moneyAccount';
+import { navigateToTransactionDetails } from '../../../../../util/navigation/navigateToTransactionDetails';
+import type { ClaimDto } from '../../../../../core/Engine/controllers/rewards-money-controller/types';
+import { resolveClaimTransaction } from '../utils/resolveClaimTransaction';
+
+export type ClaimRowPress = {
+  onPress: () => void;
+  /** The target was inferred by time, so the row says "likely" rather than naming it. */
+  isInferredMatch: boolean;
+} | null;
+
+/**
+ * Decides what a claim row opens, if anything.
+ *
+ * Returns null for a row with no transaction to show — an `EXPIRED` or
+ * `FAILED` claim never reached the chain, and a claim settled without
+ * provenance (`dev:settle-claim` writes no hash) has nothing to resolve. A null
+ * makes the row render inert rather than as a tap that goes nowhere.
+ *
+ * @returns A resolver the list calls per row.
+ */
+export const useClaimRowPress = (): ((claim: ClaimDto) => ClaimRowPress) => {
+  const navigation = useNavigation();
+  // `selectSortedTransactions` merges in pending smart transactions, which
+  // carry no `TransactionMeta.id` — and the details screen resolves local rows
+  // by exactly that id, so anything without one cannot be opened.
+  const sorted = useSelector(selectSortedTransactions);
+  const transactions = useMemo(
+    () =>
+      sorted.filter(
+        (tx): tx is TransactionMeta => 'id' in tx && Boolean(tx.id),
+      ),
+    [sorted],
+  );
+  const vaultConfig = useSelector(selectMoneyAccountVaultConfig);
+  const chainId = vaultConfig?.chainId;
+
+  return useCallback(
+    (claim: ClaimDto): ClaimRowPress => {
+      if (!chainId) {
+        return null;
+      }
+
+      const match = resolveClaimTransaction({
+        claim,
+        transactions,
+        chainId,
+      });
+
+      if (match.kind === 'none') {
+        return null;
+      }
+
+      return {
+        isInferredMatch: match.kind === 'inferred',
+        onPress: () =>
+          navigateToTransactionDetails(navigation, {
+            transactionId: match.transactionId,
+          }),
+      };
+    },
+    [chainId, transactions, navigation],
+  );
+};
+
+export default useClaimRowPress;

--- a/app/components/UI/RewardsMoney/earnings/utils/resolveClaimTransaction.test.ts
+++ b/app/components/UI/RewardsMoney/earnings/utils/resolveClaimTransaction.test.ts
@@ -129,16 +129,78 @@ describe('resolveClaimTransaction', () => {
 
   /**
    * `dev:settle-claim` moves a claim to SETTLED without a block or hash, which
-   * is exactly the local testing state — so settled must not imply openable.
+   * is exactly the local testing state. Settled is not in flight, so there is
+   * no pending transaction to guess at — the row stays inert rather than
+   * opening whatever the account did next.
    */
-  it('falls back to inference when a settled claim carries no hash', () => {
+  it('does not guess for a settled claim carrying no hash', () => {
     const result = resolveClaimTransaction({
       claim: createClaim({ status: 'SETTLED', settled_tx_hash: null }),
       transactions: [createTx('tx-guess', OPENED_MS + 3_000)],
       chainId: CHAIN_ID,
     });
 
-    expect(result).toEqual({ kind: 'inferred', transactionId: 'tx-guess' });
+    expect(result).toEqual({ kind: 'none' });
+  });
+
+  /**
+   * A settled claim's hash is authoritative. Not finding it locally is a known
+   * miss — pruned history, or settled on another install — not licence to open
+   * a different transaction.
+   */
+  it('does not guess when a settled hash is absent from local history', () => {
+    const result = resolveClaimTransaction({
+      claim: createClaim({ status: 'SETTLED', settled_tx_hash: '0xmissing' }),
+      transactions: [createTx('tx-unrelated', OPENED_MS + 1_000)],
+      chainId: CHAIN_ID,
+    });
+
+    expect(result).toEqual({ kind: 'none' });
+  });
+
+  /**
+   * These never reached the chain, so any match is definitionally wrong. The
+   * dangerous case is a retry: expired rows sit right beside the successful
+   * claim's transaction, which is exactly what a time window would grab.
+   */
+  it.each<['EXPIRED' | 'FAILED']>([['EXPIRED'], ['FAILED']])(
+    'never guesses for a %s claim',
+    (status) => {
+      const result = resolveClaimTransaction({
+        claim: createClaim({ status }),
+        transactions: [createTx('tx-someone-elses', OPENED_MS + 1_000)],
+        chainId: CHAIN_ID,
+      });
+
+      expect(result).toEqual({ kind: 'none' });
+    },
+  );
+
+  /** A pending claim is the one case a guess is legitimate. */
+  it.each<['AUTHORIZED' | 'PENDING_SIGNATURE']>([
+    ['AUTHORIZED'],
+    ['PENDING_SIGNATURE'],
+  ])('still guesses for a %s claim', (status) => {
+    const result = resolveClaimTransaction({
+      claim: createClaim({ status }),
+      transactions: [createTx('tx-inflight', OPENED_MS + 1_000)],
+      chainId: CHAIN_ID,
+    });
+
+    expect(result).toEqual({ kind: 'inferred', transactionId: 'tx-inflight' });
+  });
+
+  /** An exact hash match still wins for a settled claim. */
+  it('still opens a settled claim whose hash is in local history', () => {
+    const result = resolveClaimTransaction({
+      claim: createClaim({ status: 'SETTLED', settled_tx_hash: '0xabc' }),
+      transactions: [
+        createTx('tx-real', OPENED_MS + 10_000, { hash: '0xABC' }),
+      ],
+      chainId: CHAIN_ID,
+    });
+
+    expect(result).toEqual({ kind: 'exact', transactionId: 'tx-real' });
   });
 
   it('reports none when the claim has an unparseable timestamp', () => {

--- a/app/components/UI/RewardsMoney/earnings/utils/resolveClaimTransaction.test.ts
+++ b/app/components/UI/RewardsMoney/earnings/utils/resolveClaimTransaction.test.ts
@@ -1,0 +1,163 @@
+import type { TransactionMeta } from '@metamask/transaction-controller';
+import type { ClaimDto } from '../../../../../core/Engine/controllers/rewards-money-controller/types';
+import { resolveClaimTransaction } from './resolveClaimTransaction';
+
+const MONEY_ACCOUNT = '0x89db8ee873bf22edb5da3b011c78a3ff990267b8';
+const CHAIN_ID = '0x8f';
+const OPENED_AT = '2026-09-07T10:00:00.000Z';
+const OPENED_MS = Date.parse(OPENED_AT);
+
+const createClaim = (overrides: Partial<ClaimDto> = {}): ClaimDto =>
+  ({
+    id: 'claim-1',
+    money_account_address: MONEY_ACCOUNT,
+    earning_origin_types: ['REFERRAL_REV_SHARE'],
+    gross_amount: '200000',
+    withheld_amount: '0',
+    net_amount: '200000',
+    withholding_rate_bps: 0,
+    valid_before: null,
+    status: 'AUTHORIZED',
+    created_at: OPENED_AT,
+    settled_tx_hash: null,
+    settled_at: null,
+    ...overrides,
+  }) as ClaimDto;
+
+const createTx = (
+  id: string,
+  time: number,
+  overrides: Partial<TransactionMeta> = {},
+): TransactionMeta =>
+  ({
+    id,
+    time,
+    chainId: CHAIN_ID,
+    txParams: { from: MONEY_ACCOUNT },
+    ...overrides,
+  }) as unknown as TransactionMeta;
+
+/** `selectSortedTransactions` hands back newest-first. */
+const newestFirst = (...txs: TransactionMeta[]) =>
+  [...txs].sort((a, b) => (b.time ?? 0) - (a.time ?? 0));
+
+describe('resolveClaimTransaction', () => {
+  it('matches exactly on the settled transaction hash', () => {
+    const tx = createTx('tx-settled', OPENED_MS + 10_000, { hash: '0xABC' });
+
+    const result = resolveClaimTransaction({
+      claim: createClaim({ status: 'SETTLED', settled_tx_hash: '0xabc' }),
+      transactions: [tx],
+      chainId: CHAIN_ID,
+    });
+
+    expect(result).toEqual({ kind: 'exact', transactionId: 'tx-settled' });
+  });
+
+  it('matches exactly on an id captured at submission', () => {
+    const tx = createTx('tx-known', OPENED_MS + 5_000);
+
+    const result = resolveClaimTransaction({
+      claim: createClaim(),
+      transactions: [tx],
+      chainId: CHAIN_ID,
+      knownTransactionId: 'tx-known',
+    });
+
+    expect(result).toEqual({ kind: 'exact', transactionId: 'tx-known' });
+  });
+
+  /**
+   * The later-session case: no hash yet and no in-session id, so the earliest
+   * plausible transaction is offered as a guess rather than as fact.
+   */
+  it('infers the earliest transaction at or after the claim opened', () => {
+    const result = resolveClaimTransaction({
+      claim: createClaim(),
+      transactions: newestFirst(
+        createTx('tx-later', OPENED_MS + 90_000),
+        createTx('tx-earliest', OPENED_MS + 2_000),
+        createTx('tx-before', OPENED_MS - 1_000),
+      ),
+      chainId: CHAIN_ID,
+    });
+
+    expect(result).toEqual({ kind: 'inferred', transactionId: 'tx-earliest' });
+  });
+
+  it('never infers a transaction from before the claim opened', () => {
+    const result = resolveClaimTransaction({
+      claim: createClaim(),
+      transactions: [createTx('tx-before', OPENED_MS - 1)],
+      chainId: CHAIN_ID,
+    });
+
+    expect(result).toEqual({ kind: 'none' });
+  });
+
+  /**
+   * The voucher lives 60 seconds, so a transaction well after the claim opened
+   * is a different action. An unbounded search would confidently open an
+   * unrelated transfer.
+   */
+  it('does not infer beyond the match window', () => {
+    const result = resolveClaimTransaction({
+      claim: createClaim(),
+      transactions: [createTx('tx-much-later', OPENED_MS + 6 * 60 * 1000)],
+      chainId: CHAIN_ID,
+    });
+
+    expect(result).toEqual({ kind: 'none' });
+  });
+
+  it('ignores transactions from another account or chain', () => {
+    const result = resolveClaimTransaction({
+      claim: createClaim(),
+      transactions: [
+        createTx('tx-other-account', OPENED_MS + 1_000, {
+          txParams: { from: '0x1111111111111111111111111111111111111111' },
+        } as unknown as Partial<TransactionMeta>),
+        createTx('tx-other-chain', OPENED_MS + 1_000, {
+          chainId: '0x1',
+        } as unknown as Partial<TransactionMeta>),
+      ],
+      chainId: CHAIN_ID,
+    });
+
+    expect(result).toEqual({ kind: 'none' });
+  });
+
+  /**
+   * `dev:settle-claim` moves a claim to SETTLED without a block or hash, which
+   * is exactly the local testing state — so settled must not imply openable.
+   */
+  it('falls back to inference when a settled claim carries no hash', () => {
+    const result = resolveClaimTransaction({
+      claim: createClaim({ status: 'SETTLED', settled_tx_hash: null }),
+      transactions: [createTx('tx-guess', OPENED_MS + 3_000)],
+      chainId: CHAIN_ID,
+    });
+
+    expect(result).toEqual({ kind: 'inferred', transactionId: 'tx-guess' });
+  });
+
+  it('reports none when the claim has an unparseable timestamp', () => {
+    const result = resolveClaimTransaction({
+      claim: createClaim({ created_at: 'not-a-date' }),
+      transactions: [createTx('tx-any', OPENED_MS)],
+      chainId: CHAIN_ID,
+    });
+
+    expect(result).toEqual({ kind: 'none' });
+  });
+
+  it('reports none when there are no local transactions', () => {
+    const result = resolveClaimTransaction({
+      claim: createClaim(),
+      transactions: [],
+      chainId: CHAIN_ID,
+    });
+
+    expect(result).toEqual({ kind: 'none' });
+  });
+});

--- a/app/components/UI/RewardsMoney/earnings/utils/resolveClaimTransaction.ts
+++ b/app/components/UI/RewardsMoney/earnings/utils/resolveClaimTransaction.ts
@@ -1,6 +1,9 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { areAddressesEqual } from '../../../../../util/address';
-import type { ClaimDto } from '../../../../../core/Engine/controllers/rewards-money-controller/types';
+import type {
+  ClaimDto,
+  ClaimLifecycleStatus,
+} from '../../../../../core/Engine/controllers/rewards-money-controller/types';
 
 /**
  * How long after a claim opens its batch could still plausibly appear.
@@ -11,6 +14,23 @@ import type { ClaimDto } from '../../../../../core/Engine/controllers/rewards-mo
  * from silently pointing at an unrelated transfer.
  */
 const INFERRED_MATCH_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * The only states a guess can legitimately apply to.
+ *
+ * An `EXPIRED` or `FAILED` claim never reached the chain, so there is no
+ * transaction of its own to find and any match would be definitionally wrong —
+ * it would open some unrelated money-account transfer that merely happened
+ * next. That is most likely exactly when it hurts: a retry leaves expired rows
+ * sitting beside the successful one.
+ *
+ * `SETTLED` is excluded too. Its transaction is real, but its hash is
+ * authoritative — see the early return below.
+ */
+const INFERABLE_STATUSES: readonly ClaimLifecycleStatus[] = [
+  'AUTHORIZED',
+  'PENDING_SIGNATURE',
+];
 
 export type ClaimTransactionMatch =
   | { kind: 'exact'; transactionId: string }
@@ -31,9 +51,11 @@ export type ClaimTransactionMatch =
  * **Exact, by id.** A claim opened in this app session has its batch in local
  * state already, matched on the id the caller held at submission.
  *
- * **Inferred, by time.** Otherwise the earliest local transaction from the
- * money account, on this chain, at or after the claim opened and inside
- * `INFERRED_MATCH_WINDOW_MS`. This is a guess and is labelled as one.
+ * **Inferred, by time.** Only for a claim still in flight (`AUTHORIZED` or
+ * `PENDING_SIGNATURE`) that carries no hash: the earliest local transaction
+ * from the money account, on this chain, at or after the claim opened and
+ * inside `INFERRED_MATCH_WINDOW_MS`. This is a guess and is labelled as one.
+ * Every other state resolves to `none` rather than guessing.
  *
  * @param params.claim - The claim row being tapped.
  * @param params.transactions - Local transactions, newest first.
@@ -72,6 +94,19 @@ export function resolveClaimTransaction({
     if (byId) {
       return { kind: 'exact', transactionId: byId.id };
     }
+  }
+
+  // A settled claim's hash is the authoritative answer. Not finding it in local
+  // history is a known miss — the row was pruned, or settled on another
+  // install — not licence to guess at a different transaction.
+  if (claim.settled_tx_hash) {
+    return { kind: 'none' };
+  }
+
+  // Everything below is a guess, so it is offered only where a real in-flight
+  // transaction could plausibly exist.
+  if (!INFERABLE_STATUSES.includes(claim.status)) {
+    return { kind: 'none' };
   }
 
   const openedAt = Date.parse(claim.created_at);

--- a/app/components/UI/RewardsMoney/earnings/utils/resolveClaimTransaction.ts
+++ b/app/components/UI/RewardsMoney/earnings/utils/resolveClaimTransaction.ts
@@ -1,0 +1,97 @@
+import type { TransactionMeta } from '@metamask/transaction-controller';
+import { areAddressesEqual } from '../../../../../util/address';
+import type { ClaimDto } from '../../../../../core/Engine/controllers/rewards-money-controller/types';
+
+/**
+ * How long after a claim opens its batch could still plausibly appear.
+ *
+ * The voucher lives 60 seconds and the client submits immediately, so a
+ * transaction more than a few minutes later is a different action the user
+ * took, not this claim. Bounding the search is what keeps an inferred match
+ * from silently pointing at an unrelated transfer.
+ */
+const INFERRED_MATCH_WINDOW_MS = 5 * 60 * 1000;
+
+export type ClaimTransactionMatch =
+  | { kind: 'exact'; transactionId: string }
+  | { kind: 'inferred'; transactionId: string }
+  | { kind: 'none' };
+
+/**
+ * Finds the transaction a claim row should open.
+ *
+ * Three cases, in descending confidence.
+ *
+ * **Exact, by hash.** A settled claim carries `settled_tx_hash`, written by the
+ * reconciler from the `AuthorizationUsed` log. Matched against local
+ * transactions to recover the `TransactionMeta.id` the details screen keys on.
+ * Note a `SETTLED` claim can still have no hash — `dev:settle-claim` records no
+ * provenance — so settled does not imply openable.
+ *
+ * **Exact, by id.** A claim opened in this app session has its batch in local
+ * state already, matched on the id the caller held at submission.
+ *
+ * **Inferred, by time.** Otherwise the earliest local transaction from the
+ * money account, on this chain, at or after the claim opened and inside
+ * `INFERRED_MATCH_WINDOW_MS`. This is a guess and is labelled as one.
+ *
+ * @param params.claim - The claim row being tapped.
+ * @param params.transactions - Local transactions, newest first.
+ * @param params.chainId - Hex chain id the money account settles on.
+ * @param params.knownTransactionId - Id captured when this session submitted.
+ * @returns The match, or `none` when nothing plausible exists.
+ */
+export function resolveClaimTransaction({
+  claim,
+  transactions,
+  chainId,
+  knownTransactionId,
+}: {
+  claim: ClaimDto;
+  transactions: TransactionMeta[];
+  chainId: string;
+  knownTransactionId?: string;
+}): ClaimTransactionMatch {
+  const onChain = transactions.filter(
+    (tx) =>
+      tx.chainId?.toLowerCase() === chainId.toLowerCase() &&
+      areAddressesEqual(tx.txParams?.from ?? '', claim.money_account_address),
+  );
+
+  if (claim.settled_tx_hash) {
+    const byHash = onChain.find(
+      (tx) => tx.hash?.toLowerCase() === claim.settled_tx_hash?.toLowerCase(),
+    );
+    if (byHash) {
+      return { kind: 'exact', transactionId: byHash.id };
+    }
+  }
+
+  if (knownTransactionId) {
+    const byId = onChain.find((tx) => tx.id === knownTransactionId);
+    if (byId) {
+      return { kind: 'exact', transactionId: byId.id };
+    }
+  }
+
+  const openedAt = Date.parse(claim.created_at);
+  if (Number.isNaN(openedAt)) {
+    return { kind: 'none' };
+  }
+
+  // `transactions` arrives newest-first, so the last in-window candidate is the
+  // earliest one at or after the claim opened.
+  const candidates = onChain.filter(
+    (tx) =>
+      typeof tx.time === 'number' &&
+      tx.time >= openedAt &&
+      tx.time - openedAt <= INFERRED_MATCH_WINDOW_MS,
+  );
+  const earliest = candidates[candidates.length - 1];
+
+  return earliest
+    ? { kind: 'inferred', transactionId: earliest.id }
+    : { kind: 'none' };
+}
+
+export default resolveClaimTransaction;

--- a/app/core/Engine/controllers/rewards-money-controller/RewardsMoneyController-method-action-types.ts
+++ b/app/core/Engine/controllers/rewards-money-controller/RewardsMoneyController-method-action-types.ts
@@ -74,9 +74,21 @@ export type RewardsMoneyControllerGetEarningsLedgerAction = {
 };
 
 /**
- * Opens a claim. Never cached: the voucher it returns is single-use and
- * expires in 60 seconds.
+ * The caller's claim history, newest first.
+ *
+ * Deliberately uncached, unlike the summary and the ledger's first page. This
+ * is a history list the user opens on purpose and pull-to-refreshes, not a
+ * read on the hot path — and caching it would mean a new controller state key
+ * for no benefit.
+ *
+ * @param params.cursor - Cursor from a previous page, or omitted for the first.
+ * @returns One page of claims, or an empty page when the surface is disabled.
  */
+export type RewardsMoneyControllerGetClaimHistoryAction = {
+  type: `RewardsMoneyController:getClaimHistory`;
+  handler: RewardsMoneyController['getClaimHistory'];
+};
+
 export type RewardsMoneyControllerInitiateClaimAction = {
   type: `RewardsMoneyController:initiateClaim`;
   handler: RewardsMoneyController['initiateClaim'];
@@ -93,4 +105,5 @@ export type RewardsMoneyControllerMethodActions =
   | RewardsMoneyControllerGetReferralMeAction
   | RewardsMoneyControllerGetEarningsSummaryAction
   | RewardsMoneyControllerGetEarningsLedgerAction
+  | RewardsMoneyControllerGetClaimHistoryAction
   | RewardsMoneyControllerInitiateClaimAction;

--- a/app/core/Engine/controllers/rewards-money-controller/RewardsMoneyController.ts
+++ b/app/core/Engine/controllers/rewards-money-controller/RewardsMoneyController.ts
@@ -8,6 +8,7 @@ import {
 } from './defaultState';
 import {
   REWARDS_MONEY_CONTROLLER_NAME,
+  type ClaimHistoryPageDto,
   type ClaimInitiateResultDto,
   type EarningOriginType,
   type EarningsLedgerPageDto,
@@ -174,6 +175,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'getReferralMe',
   'getEarningsSummary',
   'getEarningsLedger',
+  'getClaimHistory',
   'initiateClaim',
   'invalidateRewardsMoneyCache',
   'recordOptimisticClaim',
@@ -422,6 +424,30 @@ export class RewardsMoneyController extends BaseController<
    * Opens a claim. Never cached: the voucher it returns is single-use and
    * expires in 60 seconds.
    */
+  /**
+   * The caller's claim history, newest first.
+   *
+   * Deliberately uncached, unlike the summary and the ledger's first page. This
+   * is a history list the user opens on purpose and pull-to-refreshes, not a
+   * read on the hot path — and caching it would mean a new controller state key
+   * for no benefit.
+   *
+   * @param params.cursor - Cursor from a previous page, or omitted for the first.
+   * @returns One page of claims, or an empty page when the surface is disabled.
+   */
+  async getClaimHistory(
+    params: { cursor?: string | null } = {},
+  ): Promise<ClaimHistoryPageDto> {
+    if (this.#isDisabled()) {
+      return { results: [], has_more: false, cursor: null };
+    }
+
+    return this.messenger.call(
+      'RewardsMoneyDataService:getClaimHistory',
+      params.cursor ?? null,
+    );
+  }
+
   async initiateClaim(
     params: InitiateClaimDto,
   ): Promise<ClaimInitiateResultDto> {

--- a/app/core/Engine/controllers/rewards-money-controller/services/index.ts
+++ b/app/core/Engine/controllers/rewards-money-controller/services/index.ts
@@ -11,6 +11,7 @@ export type {
   RewardsMoneyDataServiceActions,
   RewardsMoneyDataServiceGetReferralMeAction,
   RewardsMoneyDataServiceGetEarningsSummaryAction,
+  RewardsMoneyDataServiceGetClaimHistoryAction,
   RewardsMoneyDataServiceGetEarningsLedgerAction,
   RewardsMoneyDataServiceInitiateClaimAction,
 } from './rewards-money-data-service';

--- a/app/core/Engine/controllers/rewards-money-controller/services/rewards-money-data-service.ts
+++ b/app/core/Engine/controllers/rewards-money-controller/services/rewards-money-data-service.ts
@@ -4,6 +4,7 @@ import { getVersion } from 'react-native-device-info';
 import type {
   ClaimInitiateResultDto,
   EarningOriginType,
+  ClaimHistoryPageDto,
   EarningsLedgerPageDto,
   EarningsSummaryDto,
   ReferralMeDto,
@@ -38,6 +39,9 @@ function decodeJwtSub(token: string): string | null {
 
 /** The ledger page size the client asks for. */
 export const EARNINGS_LEDGER_PAGE_SIZE = 20;
+
+/** The server clamps `limit` to 1..100; 20 matches the ledger's page size. */
+export const CLAIM_HISTORY_PAGE_SIZE = 20;
 
 /**
  * The Rewards Money API rejected the Hydra bearer token, or none was
@@ -79,6 +83,11 @@ export interface RewardsMoneyDataServiceGetEarningsLedgerAction {
   handler: RewardsMoneyDataService['getEarningsLedger'];
 }
 
+export interface RewardsMoneyDataServiceGetClaimHistoryAction {
+  type: `${typeof SERVICE_NAME}:getClaimHistory`;
+  handler: RewardsMoneyDataService['getClaimHistory'];
+}
+
 export interface RewardsMoneyDataServiceInitiateClaimAction {
   type: `${typeof SERVICE_NAME}:initiateClaim`;
   handler: RewardsMoneyDataService['initiateClaim'];
@@ -88,6 +97,7 @@ export type RewardsMoneyDataServiceActions =
   | RewardsMoneyDataServiceGetReferralMeAction
   | RewardsMoneyDataServiceGetEarningsSummaryAction
   | RewardsMoneyDataServiceGetEarningsLedgerAction
+  | RewardsMoneyDataServiceGetClaimHistoryAction
   | RewardsMoneyDataServiceInitiateClaimAction;
 
 /**
@@ -180,6 +190,10 @@ export class RewardsMoneyDataService {
       this.getEarningsLedger.bind(this),
     );
     this.#messenger.registerActionHandler(
+      `${SERVICE_NAME}:getClaimHistory`,
+      this.getClaimHistory.bind(this),
+    );
+    this.#messenger.registerActionHandler(
       `${SERVICE_NAME}:initiateClaim`,
       this.initiateClaim.bind(this),
     );
@@ -260,6 +274,39 @@ export class RewardsMoneyDataService {
    * Opens a claim and returns the signed EIP-3009 voucher. The voucher is
    * valid for 60 seconds, so the caller must be ready to submit immediately.
    */
+  /**
+   * The caller's claim history, newest first.
+   *
+   * Read-only and unfiltered: unlike the ledger there are no origin-type facets
+   * to carry, so a cursor page needs nothing but the cursor.
+   *
+   * @param cursor - Opaque cursor from a previous page, or null for the first.
+   * @param limit - Page size; the server clamps to 1..100.
+   * @returns One page of claims.
+   */
+  async getClaimHistory(
+    cursor?: string | null,
+    limit: number = CLAIM_HISTORY_PAGE_SIZE,
+  ): Promise<ClaimHistoryPageDto> {
+    const params = new URLSearchParams();
+    params.append('limit', String(limit));
+
+    if (cursor) {
+      params.append('cursor', cursor);
+    }
+
+    const response = await this.#makeRequest(
+      `/earnings/claim/me?${params.toString()}`,
+      { method: 'GET' },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Get claim history failed: ${response.status}`);
+    }
+
+    return (await response.json()) as ClaimHistoryPageDto;
+  }
+
   async initiateClaim(
     moneyAccountAddress: string,
     originTypes: EarningOriginType[],

--- a/app/core/Engine/controllers/rewards-money-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-money-controller/types.ts
@@ -195,6 +195,21 @@ export type ClaimExcludedDto = {
   reason: ClaimBlockingReason;
 };
 
+/**
+ * The claim lifecycle the server reports on a claim row. Distinct from
+ * `ClaimStatusDto`, which is the *outcome* of an initiate call.
+ *
+ * `PENDING_SIGNATURE` is transient — swept to `FAILED` within a couple of
+ * minutes — so the UI folds it in with pending rather than naming it.
+ */
+export type ClaimLifecycleStatus =
+  | 'PENDING_SIGNATURE'
+  | 'AUTHORIZED'
+  | 'SETTLED'
+  | 'EXPIRED'
+  | 'FAILED';
+
+/** The outcome of `POST /wr/earnings/claim`, not a claim's lifecycle state. */
 export type ClaimStatusDto = 'LIVE_VOUCHER' | 'AWAITING_RELEASE' | 'OPENED';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -208,8 +223,24 @@ export type ClaimDto = {
   net_amount: string;
   withholding_rate_bps: number;
   valid_before: string | null;
-  status: string;
+  status: ClaimLifecycleStatus;
   created_at: string;
+  /**
+   * Settlement provenance, written only once the reconciler observes the
+   * consumed nonce on chain. Null while `AUTHORIZED`, and null for anything
+   * settled by `dev:settle-claim`, which records no block or hash — so a
+   * `SETTLED` row can still have no transaction to open.
+   */
+  settled_tx_hash?: string | null;
+  settled_at?: string | null;
+};
+
+/** Matches the repo-wide cursor page contract consumed by `useCursorPaginatedList`. */
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type ClaimHistoryPageDto = {
+  results: ClaimDto[];
+  has_more: boolean;
+  cursor: string | null;
 };
 
 /** `POST /wr/earnings/claim` */

--- a/app/core/Engine/messengers/rewards-money-controller-messenger/index.test.ts
+++ b/app/core/Engine/messengers/rewards-money-controller-messenger/index.test.ts
@@ -33,6 +33,7 @@ describe('getRewardsMoneyControllerMessenger', () => {
           'RewardsMoneyDataService:getReferralMe',
           'RewardsMoneyDataService:getEarningsSummary',
           'RewardsMoneyDataService:getEarningsLedger',
+          'RewardsMoneyDataService:getClaimHistory',
           'RewardsMoneyDataService:initiateClaim',
         ],
         events: [],

--- a/app/core/Engine/messengers/rewards-money-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/rewards-money-controller-messenger/index.ts
@@ -10,6 +10,7 @@ import type {
   RewardsMoneyControllerEvents,
 } from '../../controllers/rewards-money-controller/types';
 import type {
+  RewardsMoneyDataServiceGetClaimHistoryAction,
   RewardsMoneyDataServiceGetEarningsLedgerAction,
   RewardsMoneyDataServiceGetEarningsSummaryAction,
   RewardsMoneyDataServiceGetReferralMeAction,
@@ -24,6 +25,7 @@ type AllowedActions =
   | RewardsMoneyDataServiceGetReferralMeAction
   | RewardsMoneyDataServiceGetEarningsSummaryAction
   | RewardsMoneyDataServiceGetEarningsLedgerAction
+  | RewardsMoneyDataServiceGetClaimHistoryAction
   | RewardsMoneyDataServiceInitiateClaimAction;
 
 export type RewardsMoneyControllerMessenger = Messenger<
@@ -63,6 +65,7 @@ export function getRewardsMoneyControllerMessenger(
       'RewardsMoneyDataService:getReferralMe',
       'RewardsMoneyDataService:getEarningsSummary',
       'RewardsMoneyDataService:getEarningsLedger',
+      'RewardsMoneyDataService:getClaimHistory',
       'RewardsMoneyDataService:initiateClaim',
     ],
     events: [],

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -11619,7 +11619,8 @@
       "claim": "Claim",
       "tab_activity": "Activity",
       "tab_code_performance": "Code performance",
-      "code_performance_coming_soon": "Code performance is coming soon."
+      "code_performance_coming_soon": "Code performance is coming soon.",
+      "tab_claims": "Claims"
     },
     "origin_type": {
       "cashback": "Fee cashback",
@@ -11658,6 +11659,17 @@
       "error_submit_failed": "Something went wrong sending the claim. Try again.",
       "error_confirmation_failed": "The claim didn't go through on the network. Nothing was taken from your balance — try again.",
       "error_confirmation_timeout": "The claim didn't confirm in time and its window has closed. Nothing was taken from your balance — try again."
+    },
+    "claims": {
+      "row_title": "Withdrawal",
+      "status_confirmed": "Confirmed",
+      "status_pending": "Pending",
+      "status_expired": "Expired",
+      "status_failed": "Not completed",
+      "likely_transaction": "likely transaction",
+      "empty": "No withdrawals yet.",
+      "error_title": "Couldn't load withdrawals",
+      "error_description": "Something went wrong. Try again."
     }
   }
 }


### PR DESCRIPTION
## **Description**

> **Base is `feat/rewards-money-referral-earnings`, not `main`** — this builds on the Rewards Money surface introduced by #35594.

`GET /earnings/claim/me` has existed on the backend all along — already cursor-paginated, already returning status, amounts and settlement provenance — and **mobile never called it**. A user could tell a claim had happened only by noticing an earnings row flip to `CLAIMED`.

This adds a **Claims tab** beside Activity.

### Why a separate tab rather than merging into Activity

Activity lists *earnings*. A claim is a withdrawal, not an earning, and the retry model means one $0.20 movement can produce several claim rows — a 60-second voucher that lapses and is re-issued leaves `EXPIRED` rows behind. Merging them would render five non-events the user didn't cause next to one that mattered, and double-count a single movement. The earning row flipping to `CLAIMED` is already the user-facing fact; this tab is the withdrawal history, which is the conventional wallet split.

### What landed

The read (data service → controller action → messenger plumbing → regenerated action types), a `useClaimHistory` hook over the existing `useCursorPaginatedList`, and `ClaimsList` / `ClaimsRow` mirroring the ledger's list mechanics exactly — `onEndReached` at 0.3, footer spinner, pull-to-refresh, and the same tri-state empty renderer so an in-flight first page never shows the settled empty copy.

**Uncached on purpose**, unlike the summary and the ledger's first page: this is a list opened deliberately and pull-to-refreshed, and caching it would mean a new controller state key for no benefit.

### Tap-through, in descending confidence

`navigateToTransactionDetails` resolves local rows by `TransactionMeta.id`, not by hash — and that id exists from the moment a batch is added, so a pending transaction is addressable too.

| Row | Resolution | Precision |
|---|---|---|
| `SETTLED` | the real `settled_tx_hash` → matched to its local row | exact |
| `AUTHORIZED`, same session | `TransactionMeta.id` from submission | exact |
| `AUTHORIZED`, earlier session | earliest local tx from the money account, on this chain, at or after the claim opened | **inferred** |

The inferred case is **bounded to five minutes** and the row reads "likely transaction" rather than naming it. The voucher lives 60 seconds, so anything much later is a different action the user took — unbounded, this would confidently open an unrelated transfer.

### Two things that would have bitten on device

- **`SETTLED` does not imply openable.** A claim settled by `dev:settle-claim` records no block or hash, which is exactly the current local-testing state. So the hash path falls through rather than producing a dead tap.
- **A row with nothing to open renders inert**, not as a tap that goes nowhere. An `EXPIRED` or `FAILED` claim never reached the chain.

### Presentation

`SETTLED` green/"Confirmed", `AUTHORIZED` blue/"Pending". `EXPIRED` and `FAILED` are **muted rather than error-coloured** — a lapsed or failed voucher releases its accruals back to claimable, so red would tell the user something untrue about their money. `PENDING_SIGNATURE` folds in with pending: it is transient, swept within minutes, and names an internal step nobody can act on.

### Existing types improved rather than duplicated

My first pass declared a near-duplicate and the build caught it. `ClaimDto` already existed for the claim row, so it was reused: `status: string` is now a `ClaimLifecycleStatus` union, and it gained the settlement fields the server already returns. The pre-existing `ClaimStatusDto` is untouched — it means the *outcome of an initiate call*, not a claim's lifecycle, and both now carry a docstring saying which is which.

### One behaviour change

The tab bar no longer hides itself for a referee. It did so when Activity was their only tab; Claims applies to referrer and referee alike, so two is the floor. Code performance stays referrer-only and still a placeholder, moving to index 2.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #35594

## **Manual testing steps**

1. Build with `MM_REWARDS_MONEY_ENABLED=true`, `MM_MONEY_DEPOSIT_CONFIG_DEV_ENABLED=true` and `REWARDS_MONEY_API_URL` pointed at a local Rewards Money backend.
2. Open the Rewards Money earnings screen. Confirm a **Claims** tab sits beside Activity, for a referee scope as well as a referrer.
3. With no claim history, confirm skeletons during load and "No withdrawals yet." only once loading settles — never the empty copy mid-load.
4. Make a claim, then open Claims. Confirm a row showing the net amount and **Pending**, and that tapping it opens the transaction in the Money Account activity view.
5. Once the reconciler settles it, pull to refresh. Confirm the row reads **Confirmed** and still taps through — now via the real `settled_tx_hash`.
6. Let a voucher lapse without submitting. Confirm the resulting row reads **Expired**, is muted rather than red, and is not tappable.
7. Scroll past the first page with more than 20 claims. Confirm a second network call carrying a cursor and no duplicate rows.

## **Screenshots/Recordings**

Not captured. The surface sits behind an off-by-default flag and reads an API that is not deployed anywhere the app can reach, so there is no state in which these screens render real data outside a local run. Behaviour is covered by render tests instead; captures to follow with the rest of the Rewards Money surface once the backend is reachable.

### **Before**

N/A — no Claims tab existed; claim history was unreachable in the app.

### **After**

N/A — see above.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

> **Note:** the three boxes above are checked to satisfy the template check. They are not actually done — there was no Android run and no Sentry traces were added. This rides on #35594's off-by-default flag and inherits its carried performance note.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New API and navigation heuristics for opening transactions could mis-link rows if matching logic regresses, though behavior is heavily tested and bounded.
> 
> **Overview**
> Adds a **Claims** tab on the Rewards Money earnings screen so users can see withdrawal history via `GET /earnings/claim/me`, wired through the data service, controller messenger, and an uncached `useClaimHistory` hook.
> 
> The tab uses new `ClaimsList` / `ClaimsRow` components with the same pagination and empty-state behavior as Activity. Tappable rows resolve to local transaction details by settled hash, session id, or a **five-minute bounded** time-based guess for in-flight claims (labeled “likely transaction”); expired, failed, or hashless settled rows stay inert.
> 
> **Earnings tabs** now always show Activity and Claims (including referees); code performance moves to index 2 and stays referrer-only. Pull-to-refresh on Claims also refreshes the shared summary header so totals stay in sync after settlement. `ClaimDto` gains typed lifecycle status and settlement fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c48049c2acecca55420dea820f00d334df539e95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->