### PR TITLE
fix: checksum token address before bridge market data lookup

### DIFF
--- a/app/components/UI/Bridge/utils/exchange-rates.ts
+++ b/app/components/UI/Bridge/utils/exchange-rates.ts
@@ -149,7 +149,13 @@ export const calcTokenFiatRate = ({
 
   const evmChainId = token.chainId as Hex;
   const evmMultiChainExchangeRates = evmMultiChainMarketData?.[evmChainId];
-  const evmTokenMarketData = evmMultiChainExchangeRates?.[token.address as Hex];
+  // Market data is keyed by checksummed address; normalize the lookup key
+  // since token.address may come from sources (e.g. default token configs)
+  // that store addresses in lowercase.
+  const evmTokenMarketData =
+    evmMultiChainExchangeRates?.[
+      (safeToChecksumAddress(token.address) ?? token.address) as Hex
+    ];
 
   const nativeCurrency =
     networkConfigurationsByChainId[evmChainId]?.nativeCurrency;
@@ -201,7 +207,13 @@ export const calcTokenFiatValue = ({
   // EVM
   const evmChainId = token.chainId as Hex;
   const evmMultiChainExchangeRates = evmMultiChainMarketData?.[evmChainId];
-  const evmTokenMarketData = evmMultiChainExchangeRates?.[token.address as Hex];
+  // Market data is keyed by checksummed address; normalize the lookup key
+  // since token.address may come from sources (e.g. default token configs)
+  // that store addresses in lowercase.
+  const evmTokenMarketData =
+    evmMultiChainExchangeRates?.[
+      (safeToChecksumAddress(token.address) ?? token.address) as Hex
+    ];
 
   const nativeCurrency =
     networkConfigurationsByChainId[evmChainId]?.nativeCurrency;


### PR DESCRIPTION
## **Description**

`calcTokenFiatRate` and `calcTokenFiatValue` looked up EVM market data using the token's address as-is, but the market data map is keyed by checksummed address. Tokens sourced from default token configs (which store lowercase addresses) were missing a fiat rate as a result.

This normalizes the lookup key to a checksummed address before reading from market data. Found while working on the asset controller cleanup, unrelated to it, so shipping it separately.

## **Changelog**

CHANGELOG entry: Fixed a bug that could cause some tokens to be missing a fiat price

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/ASSETS-3957

## **Manual testing steps**

```gherkin
Feature: Token fiat value display

  Scenario: user views a token whose address is stored in lowercase
    Given a default token config stores the token's address in lowercase
    When user views that token's balance
    Then a fiat value is shown instead of being blank
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
