### PR TITLE
feat: add Robinhood RWA assets to Explore ASSETS-3935

### DIFF
--- a/app/components/UI/Trending/Views/RWATokensFullView/RWATokensFullView.test.tsx
+++ b/app/components/UI/Trending/Views/RWATokensFullView/RWATokensFullView.test.tsx
@@ -202,7 +202,7 @@ describe('RWATokensFullView', () => {
   });
 
   it('opens network bottom sheet when button is pressed', async () => {
-    const { getByTestId } = renderRWAFullView();
+    const { getByTestId, getByText } = renderRWAFullView();
 
     const networkButton = getByTestId('all-networks-button');
     await userEvent.press(networkButton);
@@ -210,6 +210,7 @@ describe('RWATokensFullView', () => {
     expect(
       getByTestId('trending-token-network-bottom-sheet'),
     ).toBeOnTheScreen();
+    expect(getByText('Robinhood Chain')).toBeOnTheScreen();
   });
 
   it('opens price change bottom sheet when button is pressed', async () => {

--- a/app/components/UI/Trending/Views/RWATokensFullView/RWATokensFullView.test.tsx
+++ b/app/components/UI/Trending/Views/RWATokensFullView/RWATokensFullView.test.tsx
@@ -98,6 +98,8 @@ const arrangeMocks = () => {
 };
 
 describe('RWATokensFullView', () => {
+  let mocks: ReturnType<typeof arrangeMocks>;
+
   const renderRWAFullView = () =>
     renderWithProvider(
       <SafeAreaProvider initialMetrics={initialMetrics}>
@@ -107,9 +109,12 @@ describe('RWATokensFullView', () => {
       false,
     );
 
+  // Arranged once per test so every test asserts on the same mock handles the
+  // component received; jest.resetAllMocks() is deliberately avoided because it
+  // also wipes the shared setup mocks configured at module load.
   beforeEach(() => {
     jest.clearAllMocks();
-    arrangeMocks();
+    mocks = arrangeMocks();
   });
 
   it('renders header with Stocks title', () => {
@@ -132,7 +137,6 @@ describe('RWATokensFullView', () => {
   });
 
   it('navigates back when back button is pressed', async () => {
-    const mocks = arrangeMocks();
     const { getByTestId } = renderRWAFullView();
 
     const backButton = getByTestId('rwa-tokens-header-back-button');
@@ -142,7 +146,6 @@ describe('RWATokensFullView', () => {
   });
 
   it('displays skeleton loader when loading', () => {
-    const mocks = arrangeMocks();
     mocks.setRwaTokensMock({ data: [], isLoading: true });
 
     const { getByTestId } = renderRWAFullView();
@@ -151,7 +154,6 @@ describe('RWATokensFullView', () => {
   });
 
   it('displays empty error state when results are empty', () => {
-    const mocks = arrangeMocks();
     mocks.setRwaTokensMock({ data: [] });
 
     const { getByTestId } = renderRWAFullView();
@@ -171,7 +173,6 @@ describe('RWATokensFullView', () => {
       }),
     ];
 
-    const mocks = arrangeMocks();
     mocks.setRwaTokensMock({ data: stockTokens });
 
     const { getByText, getByTestId } = renderRWAFullView();
@@ -186,7 +187,6 @@ describe('RWATokensFullView', () => {
       createMockToken({ name: 'OUSG', assetId: 'eip155:1/erc20:0xstock1' }),
     ];
 
-    const mocks = arrangeMocks();
     mocks.setRwaTokensMock({ data: stockTokens });
 
     const { getByTestId, UNSAFE_getByType } = renderRWAFullView();
@@ -214,7 +214,6 @@ describe('RWATokensFullView', () => {
   });
 
   it('opens price change bottom sheet when button is pressed', async () => {
-    const mocks = arrangeMocks();
     mocks.setRwaTokensMock({ data: [createMockToken()] });
     const { getByTestId } = renderRWAFullView();
 

--- a/app/components/UI/Trending/utils/trendingNetworksList.test.ts
+++ b/app/components/UI/Trending/utils/trendingNetworksList.test.ts
@@ -1,5 +1,9 @@
 import { NetworkToCaipChainId } from '../../NetworkMultiSelector/NetworkMultiSelector.constants';
-import { TRENDING_NETWORKS_LIST } from './trendingNetworksList';
+import {
+  RWA_CHAIN_IDS,
+  RWA_NETWORKS_LIST,
+  TRENDING_NETWORKS_LIST,
+} from './trendingNetworksList';
 
 jest.mock('../../../../util/networks', () => ({
   getNetworkImageSource: jest.fn(({ chainId }) => ({
@@ -17,5 +21,20 @@ describe('TRENDING_NETWORKS_LIST', () => {
         }),
       ]),
     );
+  });
+});
+
+describe('RWA networks', () => {
+  it('supports Ethereum, BNB Chain, and Robinhood Chain', () => {
+    expect(RWA_CHAIN_IDS).toEqual([
+      NetworkToCaipChainId.ETHEREUM,
+      NetworkToCaipChainId.BNB,
+      NetworkToCaipChainId.ROBINHOOD,
+    ]);
+    expect(RWA_NETWORKS_LIST.map((network) => network.name)).toEqual([
+      'Ethereum',
+      'BNB Chain',
+      'Robinhood Chain',
+    ]);
   });
 });

--- a/app/components/UI/Trending/utils/trendingNetworksList.ts
+++ b/app/components/UI/Trending/utils/trendingNetworksList.ts
@@ -165,9 +165,11 @@ export const TRENDING_NETWORKS_LIST: ProcessedNetwork[] = [
  */
 export const RWA_NETWORKS_LIST: ProcessedNetwork[] =
   TRENDING_NETWORKS_LIST.filter((n) =>
-    [NetworkToCaipChainId.ETHEREUM, NetworkToCaipChainId.BNB].includes(
-      n.caipChainId as NetworkToCaipChainId,
-    ),
+    [
+      NetworkToCaipChainId.ETHEREUM,
+      NetworkToCaipChainId.BNB,
+      NetworkToCaipChainId.ROBINHOOD,
+    ].includes(n.caipChainId as NetworkToCaipChainId),
   );
 
 export const RWA_CHAIN_IDS: CaipChainId[] = RWA_NETWORKS_LIST.map(

--- a/app/components/Views/TrendingView/feeds/stocks/useStocksFeed.test.ts
+++ b/app/components/Views/TrendingView/feeds/stocks/useStocksFeed.test.ts
@@ -21,8 +21,9 @@ const makeAsset = (assetId: string, symbol: string): TrendingAsset =>
 const ETH_OUSG = makeAsset('eip155:1/erc20:0xaaa', 'OUSG');
 const ETH_BUIDL = makeAsset('eip155:1/erc20:0xbbb', 'BUIDL');
 const BNB_OUSG = makeAsset('eip155:56/erc20:0xccc', 'bOUSG');
+const ROBINHOOD_AAPL = makeAsset('eip155:4663/erc20:0xddd', 'AAPL');
 
-const ALL_RWA_ASSETS = [ETH_OUSG, ETH_BUIDL, BNB_OUSG];
+const ALL_RWA_ASSETS = [ETH_OUSG, ETH_BUIDL, BNB_OUSG, ROBINHOOD_AAPL];
 
 const arrangeRwaTokens = (assets = ALL_RWA_ASSETS) => {
   mockUseRwaTokens.mockReturnValue({
@@ -43,10 +44,10 @@ describe('useStocksFeed', () => {
   });
 
   describe('no-query path (tab sections)', () => {
-    it('filters to Ethereum-only assets', () => {
+    it('filters to Ethereum and Robinhood assets', () => {
       const { result } = renderHook(() => useStocksFeed());
       const symbols = result.current.data.map((d) => d.symbol);
-      expect(symbols).toEqual(['OUSG', 'BUIDL']);
+      expect(symbols).toEqual(['OUSG', 'BUIDL', 'AAPL']);
       expect(symbols).not.toContain('bOUSG');
     });
 
@@ -57,11 +58,13 @@ describe('useStocksFeed', () => {
       );
     });
 
-    it('requests Ethereum only from the RWA API', () => {
+    it('requests Ethereum and Robinhood from the RWA API', () => {
       renderHook(() => useStocksFeed());
 
       expect(mockUseRwaTokens).toHaveBeenCalledWith(
-        expect.objectContaining({ chainIds: ['eip155:1'] }),
+        expect.objectContaining({
+          chainIds: ['eip155:1', 'eip155:4663'],
+        }),
       );
     });
 
@@ -89,6 +92,7 @@ describe('useStocksFeed', () => {
       const symbols = result.current.data.map((d) => d.symbol);
       expect(symbols).toContain('OUSG');
       expect(symbols).toContain('bOUSG');
+      expect(symbols).toContain('AAPL');
     });
 
     it('does not filter out BNB tokens when a query is present', () => {
@@ -111,15 +115,15 @@ describe('useStocksFeed', () => {
       );
     });
 
-    it('treats a whitespace-only query the same as no query (Ethereum-only)', () => {
+    it('treats a whitespace-only query like no query', () => {
       const { result } = renderHook(() => useStocksFeed({ query: '   ' }));
       const symbols = result.current.data.map((d) => d.symbol);
-      expect(symbols).toEqual(['OUSG', 'BUIDL']);
+      expect(symbols).toEqual(['OUSG', 'BUIDL', 'AAPL']);
       expect(symbols).not.toContain('bOUSG');
       expect(mockUseRwaTokens).toHaveBeenCalledWith(
         expect.objectContaining({
           searchQuery: undefined,
-          chainIds: ['eip155:1'],
+          chainIds: ['eip155:1', 'eip155:4663'],
         }),
       );
     });

--- a/app/components/Views/TrendingView/feeds/stocks/useStocksFeed.ts
+++ b/app/components/Views/TrendingView/feeds/stocks/useStocksFeed.ts
@@ -1,13 +1,18 @@
 import { useMemo } from 'react';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import type { CaipChainId } from '@metamask/utils';
+import { NetworkToCaipChainId } from '../../../../UI/NetworkMultiSelector/NetworkMultiSelector.constants';
 import { useRwaTokens } from '../../../../UI/Trending/hooks/useRwaTokens/useRwaTokens';
 import { useFeedRefresh } from '../../hooks/useFeedRefresh';
 import type { RefreshConfig } from '../../hooks/useExploreRefresh';
 
-const ETHEREUM_CAIP_CHAIN_ID = 'eip155:1' as CaipChainId;
-const ETHEREUM_CAIP_ASSET_ID_PREFIX = `${ETHEREUM_CAIP_CHAIN_ID}/`;
-const ETHEREUM_RWA_CHAIN_IDS = [ETHEREUM_CAIP_CHAIN_ID];
+const STOCKS_FEED_RWA_CHAIN_IDS: CaipChainId[] = [
+  NetworkToCaipChainId.ETHEREUM,
+  NetworkToCaipChainId.ROBINHOOD,
+];
+const STOCKS_FEED_ASSET_ID_PREFIXES = STOCKS_FEED_RWA_CHAIN_IDS.map(
+  (chainId) => `${chainId}/`,
+);
 export const STOCKS_FEED_PREVIEW_PAGE_SIZE = 3;
 
 interface UseStocksFeedOptions {
@@ -29,14 +34,14 @@ export interface UseStocksFeedResult {
 /**
  * Tokenized stocks (RWAs) feed.
  *
- * Tab sections (no query): only Ethereum mainnet tokens are shown, matching
- * the design intent of the RWAs/Now tab.
+ * Tab sections (no query): Ethereum and Robinhood Chain tokens are shown.
  *
  * Search (query present): all chains in RWA_CHAIN_IDS are included so users
- * can find stocks across Ethereum and BNB.
+ * can find stocks across Ethereum, BNB, and Robinhood.
  *
- * No-query sections request Ethereum only so the API page is not consumed by
- * other supported RWA chains before the section renders its 3-item preview.
+ * No-query sections request Ethereum and Robinhood only so the API page is not
+ * consumed by other supported RWA chains before the section renders its
+ * 3-item preview.
  */
 export const useStocksFeed = ({
   query,
@@ -55,7 +60,7 @@ export const useStocksFeed = ({
     loadMore,
   } = useRwaTokens({
     searchQuery: hasQuery ? trimmedQuery : undefined,
-    chainIds: hasQuery ? undefined : ETHEREUM_RWA_CHAIN_IDS,
+    chainIds: hasQuery ? undefined : STOCKS_FEED_RWA_CHAIN_IDS,
     pageSize,
   });
 
@@ -63,9 +68,11 @@ export const useStocksFeed = ({
     // During search, surface tokens from all supported RWA chains so the user
     // can find any matching stock regardless of chain.
     if (hasQuery) return data;
-    // Tab sections only show Ethereum mainnet tokens.
+    // Tab sections show Ethereum and Robinhood Chain tokens.
     return data.filter((asset) =>
-      asset.assetId.startsWith(ETHEREUM_CAIP_ASSET_ID_PREFIX),
+      STOCKS_FEED_ASSET_ID_PREFIXES.some((prefix) =>
+        asset.assetId.startsWith(prefix),
+      ),
     );
   }, [data, hasQuery]);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.
In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.
  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.
Sections without a directive are checked for structural presence only.
-->

Description

<!-- mms-check: type=text required=true -->

Add Explore support for Robinhood RWA assets so they appear alongside Ondo stocks across the Explore experience.

This change:

* Includes Robinhood Chain in RWA_NETWORKS_LIST, allowing the full-screen Stocks view to filter and display Robinhood RWA assets.
* Requests Ethereum and Robinhood RWA assets for the Explore Stocks preview.
* Keeps BNB RWA assets available in Explore search and the full Stocks list.
* Extends Explore search to include Robinhood assets through the existing RWA network configuration.

Changelog

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Added Robinhood RWA assets to Explore stocks, full list, and search

Related issues

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A

Manual testing steps

<!-- mms-check: type=manual-testing required=true -->
Feature: Robinhood RWA assets in Explore
  Scenario: User views Robinhood RWA assets in the Explore RWA section
    Given the user is on Explore
    When the user opens the RWAs tab
    Then Robinhood RWA assets can appear in the Stocks preview
    And Ethereum RWA stocks continue to appear as before
  Scenario: User views all RWA stocks
    Given the user is on the Explore RWAs tab
    When the user opens the full Stocks list
    Then Robinhood Chain is available in the network filter
    And the user can filter by Robinhood Chain
    And Robinhood RWA assets are displayed
  Scenario: User searches for a Robinhood RWA asset
    Given the user is on Explore
    When the user searches for a Robinhood RWA ticker or name
    Then the Robinhood RWA asset appears under Stocks
  Scenario: User opens a Robinhood RWA asset
    Given a Robinhood RWA asset is displayed in Explore
    When the user opens the asset details page
    Then the RWA information is displayed correctly
  Scenario: Existing RWA networks continue to work
    Given the user is browsing or searching RWA stocks
    When RWA assets are loaded
    Then Ethereum and BNB RWA stocks continue to appear as before

Screenshots/Recordings

<!-- mms-check: type=screenshot required=true -->
<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

Before

N/A

After

<!-- Add recording/screenshot showing Robinhood RWA assets in Explore, View All, and Search. -->


https://github.com/user-attachments/assets/e18ab59f-1b79-4e04-b128-68b7c0467db5



Pre-merge author checklist

<!-- mms-check: type=checklist required=true -->
<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.
Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

* I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
* I’ve completed the PR template to the best of my ability
* I’ve included tests if applicable
* I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
* I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

Performance checks (if applicable)

* I’ve tested on Android
    * Ideally on a mid-range device; emulator is acceptable
* I’ve tested with a power user scenario
    * Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
* I’ve instrumented key operations with Sentry traces for production performance metrics
    * See [trace()](https://github.com/app/util/trace.ts) for usage and [addToken](https://github.com/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

Pre-merge reviewer checklist

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

* I’ve manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
* I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com/)