### PR TITLE
fix: fatal "Requiring unknown module react-native-nitro-text-decoder" crash

### DIFF
--- a/.yarn/patches/react-native-nitro-fetch-npm-1.5.1-a04fdec326.patch
+++ b/.yarn/patches/react-native-nitro-fetch-npm-1.5.1-a04fdec326.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/module/fetch.js b/lib/module/fetch.js
-index 0d91c71368388fa1eed6c1b97993539657ac086c..9571df2b1a277327b1a07b491e2c218e99075fb3 100644
+index 0d91c71..a41b0b3 100644
 --- a/lib/module/fetch.js
 +++ b/lib/module/fetch.js
 @@ -38,7 +38,7 @@ function headersToPairs(headers) {
@@ -11,8 +11,42 @@ index 0d91c71368388fa1eed6c1b97993539657ac086c..9571df2b1a277327b1a07b491e2c218e
      headers.forEach((v, k) => pairs.push({
        key: k,
        value: v
+@@ -491,22 +491,20 @@ function base64ToBytes(b64) {
+   return out;
+   /* eslint-enable no-bitwise */
+ }
+-// Cached: our nitro-text-decoder if the app bundles it (aliased require keeps it optional, not a dep), else a global TextDecoder.
++// Cached: the global TextDecoder (installed by the app, e.g. via Expo's winter
++// runtime) or null when unavailable.
++//
++// PATCHED (MetaMask): upstream resolved an optional 'react-native-nitro-text-decoder'
++// module here through an aliased require ("dynamicRequire") before falling back to
++// globalThis.TextDecoder. That pattern is fatal under Metro production bundles:
++// the aliased require is invisible to Metro's dependency collector, so the module
++// is never bundled and the runtime string lookup throws "Requiring unknown module".
++// Worse, Metro's guardedLoadModule intercepts that throw and routes it to
++// ErrorUtils.reportFatalError instead of rethrowing, so the surrounding try/catch
++// never fires and the app crashes. Use the global TextDecoder directly.
+ let _decoder;
+ function resolveTextDecoder() {
+   if (_decoder !== undefined) return _decoder;
+-  try {
+-    const dynamicRequire = require;
+-    const mod = dynamicRequire('react-native-nitro-text-decoder');
+-    if (mod && typeof mod.TextDecoder === 'function') {
+-      _decoder = new mod.TextDecoder('utf-8', {
+-        fatal: true
+-      });
+-      return _decoder;
+-    }
+-  } catch {
+-    // optional, not bundled
+-  }
+   const GlobalTextDecoder = globalThis.TextDecoder;
+   if (typeof GlobalTextDecoder === 'function') {
+     _decoder = new GlobalTextDecoder('utf-8', {
 diff --git a/src/fetch.ts b/src/fetch.ts
-index e61e64b562f260be7f51cb7f90badf538ccbab2d..f259526fd8e6ed47a449fcca4376024b7dcadcac 100644
+index e61e64b..808cb67 100644
 --- a/src/fetch.ts
 +++ b/src/fetch.ts
 @@ -47,7 +47,7 @@ function headersToPairs(headers?: HeadersInit): NitroHeader[] | undefined {
@@ -24,3 +58,37 @@ index e61e64b562f260be7f51cb7f90badf538ccbab2d..f259526fd8e6ed47a449fcca4376024b
      headers.forEach((v, k) => pairs.push({ key: k, value: v }));
      return pairs;
    }
+@@ -532,22 +532,20 @@ type TextDecoderCtor = new (
+   options?: { fatal?: boolean }
+ ) => MinimalTextDecoder;
+ 
+-// Cached: our nitro-text-decoder if the app bundles it (aliased require keeps it optional, not a dep), else a global TextDecoder.
++// Cached: the global TextDecoder (installed by the app, e.g. via Expo's winter
++// runtime) or null when unavailable.
++//
++// PATCHED (MetaMask): upstream resolved an optional 'react-native-nitro-text-decoder'
++// module here through an aliased require ("dynamicRequire") before falling back to
++// globalThis.TextDecoder. That pattern is fatal under Metro production bundles:
++// the aliased require is invisible to Metro's dependency collector, so the module
++// is never bundled and the runtime string lookup throws "Requiring unknown module".
++// Worse, Metro's guardedLoadModule intercepts that throw and routes it to
++// ErrorUtils.reportFatalError instead of rethrowing, so the surrounding try/catch
++// never fires and the app crashes. Use the global TextDecoder directly.
+ let _decoder: MinimalTextDecoder | null | undefined;
+ function resolveTextDecoder(): MinimalTextDecoder | null {
+   if (_decoder !== undefined) return _decoder;
+-  try {
+-    const dynamicRequire = require;
+-    const mod = dynamicRequire('react-native-nitro-text-decoder') as {
+-      TextDecoder?: TextDecoderCtor;
+-    };
+-    if (mod && typeof mod.TextDecoder === 'function') {
+-      _decoder = new mod.TextDecoder('utf-8', { fatal: true });
+-      return _decoder;
+-    }
+-  } catch {
+-    // optional, not bundled
+-  }
+   const GlobalTextDecoder = (globalThis as { TextDecoder?: TextDecoderCtor })
+     .TextDecoder;
+   if (typeof GlobalTextDecoder === 'function') {

--- a/app/core/NitroFetchDependency.test.ts
+++ b/app/core/NitroFetchDependency.test.ts
@@ -24,6 +24,21 @@ jest.mock('react-native-nitro-modules', () => ({
   },
 }));
 
+// Guards the resolveTextDecoder patch hunk: nitro-fetch must never require the
+// optional 'react-native-nitro-text-decoder' module. Under Metro production
+// bundles that require is unresolvable (it is hidden from Metro's dependency
+// collector by an aliased require), and Metro's guardedLoadModule reports the
+// resulting "Requiring unknown module" error via ErrorUtils.reportFatalError
+// instead of rethrowing — a fatal crash the library's own try/catch cannot
+// intercept. See the patch in
+// .yarn/patches/react-native-nitro-fetch-npm-1.5.1-a04fdec326.patch
+const mockRequireNitroTextDecoder = jest.fn(() => {
+  throw new Error('Requiring unknown module "react-native-nitro-text-decoder"');
+});
+jest.mock('react-native-nitro-text-decoder', () =>
+  mockRequireNitroTextDecoder(),
+);
+
 describe('react-native-nitro-fetch dependency patch', () => {
   let headersDescriptor: PropertyDescriptor | undefined;
 
@@ -61,5 +76,27 @@ describe('react-native-nitro-fetch dependency patch', () => {
     expect(nativeRequest.headers).toEqual([
       { key: 'Authorization', value: 'Bearer test' },
     ]);
+  });
+
+  it('decodes data: URLs with the global TextDecoder without requiring react-native-nitro-text-decoder', async () => {
+    let dependencyFetch:
+      | typeof import('react-native-nitro-fetch').fetch
+      | undefined;
+
+    await jest.isolateModulesAsync(async () => {
+      dependencyFetch = (await import('react-native-nitro-fetch')).fetch;
+    });
+
+    // 'aGVsbG8gd29ybGQ=' is base64 for 'hello world' — forces the
+    // decodeDataUrl -> decodeUtf8 -> resolveTextDecoder path that crashed
+    // in production (Sentry: 'Requiring unknown module
+    // "react-native-nitro-text-decoder"').
+    const response = await dependencyFetch?.(
+      'data:text/plain;base64,aGVsbG8gd29ybGQ=',
+    );
+
+    expect(response?.status).toBe(200);
+    await expect(response?.text()).resolves.toBe('hello world');
+    expect(mockRequireNitroTextDecoder).not.toHaveBeenCalled();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -46197,7 +46197,7 @@ __metadata:
 
 "react-native-nitro-fetch@patch:react-native-nitro-fetch@npm%3A1.5.1#~/.yarn/patches/react-native-nitro-fetch-npm-1.5.1-a04fdec326.patch":
   version: 1.5.1
-  resolution: "react-native-nitro-fetch@patch:react-native-nitro-fetch@npm%3A1.5.1#~/.yarn/patches/react-native-nitro-fetch-npm-1.5.1-a04fdec326.patch::version=1.5.1&hash=5bfa17"
+  resolution: "react-native-nitro-fetch@patch:react-native-nitro-fetch@npm%3A1.5.1#~/.yarn/patches/react-native-nitro-fetch-npm-1.5.1-a04fdec326.patch::version=1.5.1&hash=26e5fa"
   dependencies:
     web-streams-polyfill: "npm:^4.2.0"
   peerDependencies:
@@ -46208,7 +46208,7 @@ __metadata:
   peerDependenciesMeta:
     react-native-worklets:
       optional: true
-  checksum: 10/00b0c140f413e7029b003ffc3c540d393cf83bb5e311505e41d1260b6820a731f3bc10ba2ed9902a4a432e02fb881e6af3d2d52c37c8a3c3e09eb937d4eb8879
+  checksum: 10/4a4672088d77951a686a2a4e46f5ec727a1edeeb3cc082ee341b64c3828474ac8f37f681ddb08753992881dacccc0ed57c9083d90771554d7e3107dca14b679b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Fixes a production fatal reported in Sentry:

```
Requiring unknown module "react-native-nitro-text-decoder".  (level: Fatal)
    at unknownModuleError (metro-runtime/src/polyfills/require.js:335)
    at resolveTextDecoder (react-native-nitro-fetch/lib/module/fetch.js:500)
    at decodeUtf8 -> decodeDataUrl -> fetchLocalResource
```

**What is the reason for the change?**

The crash fires whenever anything calls `fetch()` on a `data:` URL (global `fetch` is nitro-fetch via `app/core/NitroFetchSetup.ts`; `data:` URLs are decoded in JS via `fetchLocalResource → decodeDataUrl → decodeUtf8 → resolveTextDecoder`).

`resolveTextDecoder` in `react-native-nitro-fetch@1.5.1` tries to load an optional companion module before falling back to the global `TextDecoder`:

```js
try {
  const dynamicRequire = require;                                  // hides the require from Metro
  const mod = dynamicRequire('react-native-nitro-text-decoder');   // <- crash site (fetch.js:500)
  ...
} catch {
  // optional, not bundled  <- never reached in production, see below
}
const GlobalTextDecoder = globalThis.TextDecoder;                  // <- working fallback, never reached
```

Two things go wrong, both Metro-specific:

1. **The module is never in the bundle.** The `dynamicRequire` alias exists precisely so Metro's dependency collector cannot see the require — which also means Metro never bundles the module's JS. `react-native-nitro-text-decoder@^0.2.0` is in `package.json` (added in #32472) and its native pod is linked, but no JS file statically imports it, so it is absent from `main.jsbundle`. Additionally, production Metro bundles key modules by numeric ID, so a runtime string-name require can never resolve regardless.

2. **The library's `try/catch` cannot catch the error.** Metro's runtime routes top-level requires through `guardedLoadModule` (`metro-runtime/src/polyfills/require.js`), which catches the `unknownModuleError` itself and calls `global.ErrorUtils.reportFatalError(e)` instead of rethrowing. The library's own `catch` never fires, RN's release-mode handler treats it as fatal, and Sentry records the crash — even though the app already has a working global `TextDecoder` (installed by Expo's winter runtime via `import 'expo'` in `shim.js`), one line below the crash site.

**What is the improvement/solution?**

Extends our existing yarn patch for `react-native-nitro-fetch` (same file already patched for the `Headers` guard in #33224): `resolveTextDecoder` now uses `globalThis.TextDecoder` directly and the unreachable-by-design `dynamicRequire` block is removed. The patch stays flat (regenerated pristine→final, same locator in `package.json`; only patch content and the `yarn.lock` checksum change).

Net behavior change: instead of crashing, decoding `data:` URLs as text now works.

A regression test in `app/core/NitroFetchDependency.test.ts` fetches a base64 `data:` URL through the real (patched) dependency, asserts `.text()` resolves via the global `TextDecoder`, and mocks `react-native-nitro-text-decoder` with a throwing factory to assert it is never required — so a future dependency bump that drops the patch hunk fails CI.

Follow-ups (out of scope): upstream the fix to margelo/nitro-fetch; remove the now-dead `react-native-nitro-text-decoder` dependency in a separate cleanup.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed a fatal crash (Requiring unknown module "react-native-nitro-text-decoder") when fetching data: URLs

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: Sentry fatal `Requiring unknown module "react-native-nitro-text-decoder"` (metamask-mobile production)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: fetch() of data: URLs does not crash the app

  Scenario: app decodes a data: URL as text
    Given a release (production) build of the app is installed
    And the app is open with Sentry crash reporting available

    When any code path calls fetch('data:text/plain;base64,aGVsbG8gd29ybGQ=') and reads response.text()
    Then the promise resolves with "hello world" decoded via the global TextDecoder
    And no fatal "Requiring unknown module react-native-nitro-text-decoder" error is reported
```

Automated verification: `yarn jest app/core/NitroFetchDependency.test.ts app/core/NitroFetchSetup.test.ts` — 27/27 pass. The new regression test fails against the unpatched dependency and passes with the patch.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no UI change; this fixes a production crash in the networking layer (dependency patch + unit test only).

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
