### PR TITLE
feat: implement live token fiat rate hook through websockets

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -110,7 +110,9 @@ jest.mock('../../../../../core/Engine', () => {
   );
   return {
     controllerMessenger: {
-      call: jest.fn(),
+      // Messenger actions the tabs call are async, e.g. the limit tab's
+      // OHLCV subscribe, so this has to hand back a promise.
+      call: jest.fn().mockResolvedValue(undefined),
       subscribe: jest.fn(),
       unsubscribe: jest.fn(),
     },

--- a/app/components/UI/Bridge/hooks/useLiveTokenFiatRate/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useLiveTokenFiatRate/index.test.ts
@@ -1,0 +1,364 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import { formatAddressToAssetId } from '@metamask/bridge-controller';
+import { parseCaipAssetType, type CaipAssetType } from '@metamask/utils';
+import type { OHLCVBar } from '@metamask/core-backend';
+import Engine from '../../../../../core/Engine';
+import { createMockToken } from '../../testUtils/fixtures';
+import { normalizeTokenAddress } from '../../utils/tokenUtils';
+import { useTokenFiatRate } from '../useTokenFiatRate';
+import { useLiveTokenFiatRate } from './index';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../useTokenFiatRate', () => ({
+  useTokenFiatRate: jest.fn(),
+}));
+
+jest.mock('../../../../../core/Engine', () => ({
+  controllerMessenger: {
+    call: jest.fn(),
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
+  },
+}));
+
+const mockUseSelector = jest.mocked(useSelector);
+const mockUseTokenFiatRate = jest.mocked(useTokenFiatRate);
+const mockCall = jest.mocked(Engine.controllerMessenger.call);
+const mockSubscribe = jest.mocked(Engine.controllerMessenger.subscribe);
+const mockUnsubscribe = jest.mocked(Engine.controllerMessenger.unsubscribe);
+
+const FALLBACK_RATE = 100;
+const LIVE_CLOSE = 12.5;
+const SUBSCRIPTION_DEBOUNCE_MS = 10;
+const STALENESS_CHECK_INTERVAL_MS = 1_000;
+const STALENESS_THRESHOLD_MS = 4_000;
+
+const token = createMockToken({
+  address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  symbol: 'USDC',
+  decimals: 6,
+  chainId: '0x1',
+});
+
+const assetId = formatAddressToAssetId(
+  normalizeTokenAddress(token.address, token.chainId),
+  token.chainId,
+) as CaipAssetType;
+const chainId = parseCaipAssetType(assetId).chainId;
+const defaultChannel = `market-data.v1.${assetId}.1m.usd`;
+
+function createBar(overrides: Partial<OHLCVBar> = {}): OHLCVBar {
+  return {
+    timestamp: 1_704_067_200,
+    open: LIVE_CLOSE,
+    high: LIVE_CLOSE,
+    low: LIVE_CLOSE,
+    close: LIVE_CLOSE,
+    volume: 1,
+    ...overrides,
+  };
+}
+
+function getHandler<T>(eventName: string): (payload: T) => void {
+  const subscription = mockSubscribe.mock.calls.find(
+    ([event]: [string, (payload: T) => void]) => event === eventName,
+  );
+
+  if (!subscription) {
+    throw new Error(`No subscriber registered for ${eventName}`);
+  }
+
+  return subscription[1] as (payload: T) => void;
+}
+
+async function subscribeToLiveRate() {
+  const view = renderHook(() =>
+    useLiveTokenFiatRate(token, {
+      subscriptionDebounceMs: SUBSCRIPTION_DEBOUNCE_MS,
+      stalenessCheckIntervalMs: STALENESS_CHECK_INTERVAL_MS,
+      stalenessThresholdMs: STALENESS_THRESHOLD_MS,
+    }),
+  );
+
+  await act(async () => {
+    jest.advanceTimersByTime(SUBSCRIPTION_DEBOUNCE_MS);
+  });
+
+  return view;
+}
+
+async function emitLiveClose(close: number, channel = defaultChannel) {
+  const handleBarUpdated = getHandler<{ channel: string; bar: OHLCVBar }>(
+    'OHLCVService:barUpdated',
+  );
+
+  await act(async () => {
+    handleBarUpdated({
+      channel,
+      bar: createBar({ close }),
+    });
+  });
+}
+
+describe('useLiveTokenFiatRate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+    mockUseSelector.mockReturnValue('usd');
+    mockUseTokenFiatRate.mockReturnValue(FALLBACK_RATE);
+    mockCall.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('returns the Redux fallback rate when the token is missing', () => {
+    const { result } = renderHook(() => useLiveTokenFiatRate(undefined));
+
+    expect(result.current).toBe(FALLBACK_RATE);
+    expect(mockSubscribe).not.toHaveBeenCalled();
+  });
+
+  it('returns the Redux fallback rate when the token has no address', () => {
+    const { result } = renderHook(() =>
+      useLiveTokenFiatRate({ ...token, address: '' }),
+    );
+
+    expect(result.current).toBe(FALLBACK_RATE);
+    expect(mockSubscribe).not.toHaveBeenCalled();
+  });
+
+  it('returns the Redux fallback rate when the token has no chain id', () => {
+    const { result } = renderHook(() =>
+      useLiveTokenFiatRate({
+        ...token,
+        chainId: '' as typeof token.chainId,
+      }),
+    );
+
+    expect(result.current).toBe(FALLBACK_RATE);
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it('returns the Redux fallback rate when building the asset id throws', () => {
+    const { result } = renderHook(() =>
+      useLiveTokenFiatRate({
+        ...token,
+        chainId: 'not-a-chain-id' as typeof token.chainId,
+      }),
+    );
+
+    expect(result.current).toBe(FALLBACK_RATE);
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it('subscribes to the market-data channel after the debounce delay', async () => {
+    await subscribeToLiveRate();
+
+    expect(mockCall).toHaveBeenCalledWith('OHLCVService:subscribe', {
+      assetId,
+      interval: '1m',
+      currency: 'usd',
+    });
+  });
+
+  it('returns the live candle close after a bar update', async () => {
+    const { result } = await subscribeToLiveRate();
+
+    await emitLiveClose(LIVE_CLOSE);
+
+    expect(result.current).toBe(LIVE_CLOSE);
+  });
+
+  it('ignores bar updates for a different channel', async () => {
+    const { result } = await subscribeToLiveRate();
+
+    await emitLiveClose(LIVE_CLOSE, 'market-data.v1.other.1m.usd');
+
+    expect(result.current).toBe(FALLBACK_RATE);
+  });
+
+  it('returns the Redux fallback rate when the candle close is zero', async () => {
+    const { result } = await subscribeToLiveRate();
+
+    await emitLiveClose(0);
+
+    expect(result.current).toBe(FALLBACK_RATE);
+  });
+
+  it('returns the Redux fallback rate when subscribe fails', async () => {
+    const { result } = await subscribeToLiveRate();
+    const handleSubscriptionError = getHandler<{
+      channel: string;
+      error: string;
+      operation: string;
+    }>('OHLCVService:subscriptionError');
+
+    await emitLiveClose(LIVE_CLOSE);
+    await act(async () => {
+      handleSubscriptionError({
+        channel: defaultChannel,
+        error: 'subscribe failed',
+        operation: 'subscribe',
+      });
+    });
+
+    expect(result.current).toBe(FALLBACK_RATE);
+  });
+
+  it('keeps the live rate when a non-subscribe operation errors', async () => {
+    const { result } = await subscribeToLiveRate();
+    const handleSubscriptionError = getHandler<{
+      channel: string;
+      error: string;
+      operation: string;
+    }>('OHLCVService:subscriptionError');
+
+    await emitLiveClose(LIVE_CLOSE);
+    await act(async () => {
+      handleSubscriptionError({
+        channel: defaultChannel,
+        error: 'unsubscribe failed',
+        operation: 'unsubscribe',
+      });
+    });
+
+    expect(result.current).toBe(LIVE_CLOSE);
+  });
+
+  it('returns the Redux fallback rate when the asset chain is reported down', async () => {
+    const { result } = await subscribeToLiveRate();
+    const handleChainStatusChanged = getHandler<{
+      chainIds: string[];
+      status: 'up' | 'down';
+    }>('OHLCVService:chainStatusChanged');
+
+    await emitLiveClose(LIVE_CLOSE);
+    await act(async () => {
+      handleChainStatusChanged({
+        chainIds: [chainId],
+        status: 'down',
+      });
+    });
+
+    expect(result.current).toBe(FALLBACK_RATE);
+  });
+
+  it('keeps the live rate when a different chain is reported down', async () => {
+    const { result } = await subscribeToLiveRate();
+    const handleChainStatusChanged = getHandler<{
+      chainIds: string[];
+      status: 'up' | 'down';
+    }>('OHLCVService:chainStatusChanged');
+
+    await emitLiveClose(LIVE_CLOSE);
+    await act(async () => {
+      handleChainStatusChanged({
+        chainIds: ['eip155:137'],
+        status: 'down',
+      });
+    });
+
+    expect(result.current).toBe(LIVE_CLOSE);
+  });
+
+  it('returns the Redux fallback rate after the stream goes quiet past the staleness threshold', async () => {
+    const { result } = await subscribeToLiveRate();
+
+    await emitLiveClose(LIVE_CLOSE);
+
+    await act(async () => {
+      jest.advanceTimersByTime(
+        STALENESS_THRESHOLD_MS + STALENESS_CHECK_INTERVAL_MS,
+      );
+    });
+
+    expect(result.current).toBe(FALLBACK_RATE);
+  });
+
+  it('unsubscribes and removes listeners when the hook unmounts', async () => {
+    const { unmount } = await subscribeToLiveRate();
+
+    unmount();
+
+    expect(mockCall).toHaveBeenCalledWith('OHLCVService:unsubscribe', {
+      assetId,
+      interval: '1m',
+      currency: 'usd',
+    });
+    expect(mockUnsubscribe).toHaveBeenCalledWith(
+      'OHLCVService:barUpdated',
+      expect.any(Function),
+    );
+    expect(mockUnsubscribe).toHaveBeenCalledWith(
+      'OHLCVService:subscriptionError',
+      expect.any(Function),
+    );
+    expect(mockUnsubscribe).toHaveBeenCalledWith(
+      'OHLCVService:chainStatusChanged',
+      expect.any(Function),
+    );
+  });
+
+  it('unsubscribes when unmount happens after subscribe is requested', async () => {
+    let resolveSubscribe: (() => void) | undefined;
+    mockCall.mockImplementation((method: string) => {
+      if (method === 'OHLCVService:subscribe') {
+        return new Promise<void>((resolve) => {
+          resolveSubscribe = resolve;
+        });
+      }
+
+      return Promise.resolve();
+    });
+
+    const { unmount } = renderHook(() =>
+      useLiveTokenFiatRate(token, {
+        subscriptionDebounceMs: SUBSCRIPTION_DEBOUNCE_MS,
+      }),
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(SUBSCRIPTION_DEBOUNCE_MS);
+    });
+
+    unmount();
+
+    await act(async () => {
+      resolveSubscribe?.();
+    });
+
+    expect(mockCall).toHaveBeenCalledWith('OHLCVService:unsubscribe', {
+      assetId,
+      interval: '1m',
+      currency: 'usd',
+    });
+  });
+
+  it('uses usd when the selected currency is empty', async () => {
+    mockUseSelector.mockReturnValue('');
+
+    await subscribeToLiveRate();
+
+    expect(mockCall).toHaveBeenCalledWith('OHLCVService:subscribe', {
+      assetId,
+      interval: '1m',
+      currency: 'usd',
+    });
+  });
+
+  it('swallows subscribe rejections and keeps the Redux fallback rate', async () => {
+    mockCall.mockRejectedValue(new Error('network error'));
+
+    const { result } = await subscribeToLiveRate();
+
+    expect(result.current).toBe(FALLBACK_RATE);
+  });
+});

--- a/app/components/UI/Bridge/hooks/useLiveTokenFiatRate/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useLiveTokenFiatRate/index.test.ts
@@ -1,11 +1,10 @@
-import { act, renderHook } from '@testing-library/react-native';
+import { renderHook } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import { formatAddressToAssetId } from '@metamask/bridge-controller';
-import { parseCaipAssetType, type CaipAssetType } from '@metamask/utils';
 import type { OHLCVBar } from '@metamask/core-backend';
-import Engine from '../../../../../core/Engine';
 import { createMockToken } from '../../testUtils/fixtures';
 import { normalizeTokenAddress } from '../../utils/tokenUtils';
+import { useOHLCVRealtime } from '../../../Charts/AdvancedChart/useOHLCVRealtime';
 import { useTokenFiatRate } from '../useTokenFiatRate';
 import { useLiveTokenFiatRate } from './index';
 
@@ -17,25 +16,16 @@ jest.mock('../useTokenFiatRate', () => ({
   useTokenFiatRate: jest.fn(),
 }));
 
-jest.mock('../../../../../core/Engine', () => ({
-  controllerMessenger: {
-    call: jest.fn(),
-    subscribe: jest.fn(),
-    unsubscribe: jest.fn(),
-  },
+jest.mock('../../../Charts/AdvancedChart/useOHLCVRealtime', () => ({
+  useOHLCVRealtime: jest.fn(),
 }));
 
 const mockUseSelector = jest.mocked(useSelector);
 const mockUseTokenFiatRate = jest.mocked(useTokenFiatRate);
-const mockCall = jest.mocked(Engine.controllerMessenger.call);
-const mockSubscribe = jest.mocked(Engine.controllerMessenger.subscribe);
-const mockUnsubscribe = jest.mocked(Engine.controllerMessenger.unsubscribe);
+const mockUseOHLCVRealtime = jest.mocked(useOHLCVRealtime);
 
 const FALLBACK_RATE = 100;
 const LIVE_CLOSE = 12.5;
-const SUBSCRIPTION_DEBOUNCE_MS = 10;
-const STALENESS_CHECK_INTERVAL_MS = 1_000;
-const STALENESS_THRESHOLD_MS = 4_000;
 
 const token = createMockToken({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
@@ -47,107 +37,132 @@ const token = createMockToken({
 const assetId = formatAddressToAssetId(
   normalizeTokenAddress(token.address, token.chainId),
   token.chainId,
-) as CaipAssetType;
-const chainId = parseCaipAssetType(assetId).chainId;
-const defaultChannel = `market-data.v1.${assetId}.1m.usd`;
+) as string;
 
-function createBar(overrides: Partial<OHLCVBar> = {}): OHLCVBar {
+function createBar(close: number): OHLCVBar {
   return {
     timestamp: 1_704_067_200,
-    open: LIVE_CLOSE,
-    high: LIVE_CLOSE,
-    low: LIVE_CLOSE,
-    close: LIVE_CLOSE,
+    open: close,
+    high: close,
+    low: close,
+    close,
     volume: 1,
-    ...overrides,
   };
 }
 
-function getHandler<T>(eventName: string): (payload: T) => void {
-  const subscription = mockSubscribe.mock.calls.find(
-    ([event]: [string, (payload: T) => void]) => event === eventName,
-  );
-
-  if (!subscription) {
-    throw new Error(`No subscriber registered for ${eventName}`);
-  }
-
-  return subscription[1] as (payload: T) => void;
-}
-
-async function subscribeToLiveRate() {
-  const view = renderHook(() =>
-    useLiveTokenFiatRate(token, {
-      subscriptionDebounceMs: SUBSCRIPTION_DEBOUNCE_MS,
-      stalenessCheckIntervalMs: STALENESS_CHECK_INTERVAL_MS,
-      stalenessThresholdMs: STALENESS_THRESHOLD_MS,
-    }),
-  );
-
-  await act(async () => {
-    jest.advanceTimersByTime(SUBSCRIPTION_DEBOUNCE_MS);
-  });
-
-  return view;
-}
-
-async function emitLiveClose(close: number, channel = defaultChannel) {
-  const handleBarUpdated = getHandler<{ channel: string; bar: OHLCVBar }>(
-    'OHLCVService:barUpdated',
-  );
-
-  await act(async () => {
-    handleBarUpdated({
-      channel,
-      bar: createBar({ close }),
-    });
-  });
+function mockLatestBar(bar: OHLCVBar | null) {
+  mockUseOHLCVRealtime.mockReturnValue({ latestBar: bar });
 }
 
 describe('useLiveTokenFiatRate', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.useFakeTimers();
-    jest.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
     mockUseSelector.mockReturnValue('usd');
     mockUseTokenFiatRate.mockReturnValue(FALLBACK_RATE);
-    mockCall.mockResolvedValue(undefined);
+    mockLatestBar(null);
   });
 
-  afterEach(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
+  it('subscribes to the token asset in the display currency', () => {
+    renderHook(() => useLiveTokenFiatRate(token));
+
+    expect(mockUseOHLCVRealtime).toHaveBeenCalledWith({
+      assetId,
+      interval: '1m',
+      currency: 'usd',
+      timePeriod: '1d',
+      enabled: true,
+    });
   });
 
-  it('returns the Redux fallback rate when the token is missing', () => {
-    const { result } = renderHook(() => useLiveTokenFiatRate(undefined));
+  it('subscribes with the requested interval and REST time period', () => {
+    renderHook(() =>
+      useLiveTokenFiatRate(token, { interval: '5m', timePeriod: '1w' }),
+    );
+
+    expect(mockUseOHLCVRealtime).toHaveBeenCalledWith(
+      expect.objectContaining({ interval: '5m', timePeriod: '1w' }),
+    );
+  });
+
+  it('uses usd when no display currency is set', () => {
+    mockUseSelector.mockReturnValue('');
+
+    renderHook(() => useLiveTokenFiatRate(token));
+
+    expect(mockUseOHLCVRealtime).toHaveBeenCalledWith(
+      expect.objectContaining({ currency: 'usd' }),
+    );
+  });
+
+  it('returns the candle close as the rate', () => {
+    mockLatestBar(createBar(LIVE_CLOSE));
+
+    const { result } = renderHook(() => useLiveTokenFiatRate(token));
+
+    expect(result.current).toBe(LIVE_CLOSE);
+  });
+
+  it('returns the Redux fallback rate until a candle arrives', () => {
+    const { result } = renderHook(() => useLiveTokenFiatRate(token));
 
     expect(result.current).toBe(FALLBACK_RATE);
-    expect(mockSubscribe).not.toHaveBeenCalled();
   });
 
-  it('returns the Redux fallback rate when the token has no address', () => {
+  it('returns the Redux fallback rate when the candle close is zero', () => {
+    mockLatestBar(createBar(0));
+
+    const { result } = renderHook(() => useLiveTokenFiatRate(token));
+
+    expect(result.current).toBe(FALLBACK_RATE);
+  });
+
+  it('does not subscribe when disabled', () => {
+    // A bar handed back while disabled is one left over from an earlier
+    // subscription, so it says nothing about this token.
+    mockLatestBar(createBar(LIVE_CLOSE));
+
+    const { result } = renderHook(() =>
+      useLiveTokenFiatRate(token, { enabled: false }),
+    );
+
+    expect(mockUseOHLCVRealtime).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+    expect(result.current).toBe(FALLBACK_RATE);
+  });
+
+  it('does not subscribe when the token is missing', () => {
+    const { result } = renderHook(() => useLiveTokenFiatRate(undefined));
+
+    expect(mockUseOHLCVRealtime).toHaveBeenCalledWith(
+      expect.objectContaining({ assetId: '', enabled: false }),
+    );
+    expect(result.current).toBe(FALLBACK_RATE);
+  });
+
+  it('does not subscribe when the token has no address', () => {
     const { result } = renderHook(() =>
       useLiveTokenFiatRate({ ...token, address: '' }),
     );
 
+    expect(mockUseOHLCVRealtime).toHaveBeenCalledWith(
+      expect.objectContaining({ assetId: '', enabled: false }),
+    );
     expect(result.current).toBe(FALLBACK_RATE);
-    expect(mockSubscribe).not.toHaveBeenCalled();
   });
 
-  it('returns the Redux fallback rate when the token has no chain id', () => {
+  it('does not subscribe when the token has no chain id', () => {
     const { result } = renderHook(() =>
-      useLiveTokenFiatRate({
-        ...token,
-        chainId: '' as typeof token.chainId,
-      }),
+      useLiveTokenFiatRate({ ...token, chainId: '' as typeof token.chainId }),
     );
 
+    expect(mockUseOHLCVRealtime).toHaveBeenCalledWith(
+      expect.objectContaining({ assetId: '', enabled: false }),
+    );
     expect(result.current).toBe(FALLBACK_RATE);
-    expect(mockCall).not.toHaveBeenCalled();
   });
 
-  it('returns the Redux fallback rate when building the asset id throws', () => {
+  it('does not subscribe when building the asset id throws', () => {
     const { result } = renderHook(() =>
       useLiveTokenFiatRate({
         ...token,
@@ -155,209 +170,41 @@ describe('useLiveTokenFiatRate', () => {
       }),
     );
 
+    expect(mockUseOHLCVRealtime).toHaveBeenCalledWith(
+      expect.objectContaining({ assetId: '', enabled: false }),
+    );
     expect(result.current).toBe(FALLBACK_RATE);
-    expect(mockCall).not.toHaveBeenCalled();
   });
 
-  it('subscribes to the market-data channel after the debounce delay', async () => {
-    await subscribeToLiveRate();
+  it('returns the Redux fallback rate for a token the stream cannot price, whatever bar it holds', () => {
+    mockLatestBar(createBar(LIVE_CLOSE));
 
-    expect(mockCall).toHaveBeenCalledWith('OHLCVService:subscribe', {
-      assetId,
-      interval: '1m',
-      currency: 'usd',
-    });
+    const { result } = renderHook(() =>
+      useLiveTokenFiatRate({ ...token, address: '' }),
+    );
+
+    expect(result.current).toBe(FALLBACK_RATE);
   });
 
-  it('returns the live candle close after a bar update', async () => {
-    const { result } = await subscribeToLiveRate();
+  it('drops the live rate when switching to a token the stream cannot price', () => {
+    mockLatestBar(createBar(LIVE_CLOSE));
 
-    await emitLiveClose(LIVE_CLOSE);
+    const { result, rerender } = renderHook(
+      ({ activeToken }: { activeToken: typeof token }) =>
+        useLiveTokenFiatRate(activeToken),
+      { initialProps: { activeToken: token } },
+    );
 
     expect(result.current).toBe(LIVE_CLOSE);
-  });
 
-  it('ignores bar updates for a different channel', async () => {
-    const { result } = await subscribeToLiveRate();
-
-    await emitLiveClose(LIVE_CLOSE, 'market-data.v1.other.1m.usd');
-
-    expect(result.current).toBe(FALLBACK_RATE);
-  });
-
-  it('returns the Redux fallback rate when the candle close is zero', async () => {
-    const { result } = await subscribeToLiveRate();
-
-    await emitLiveClose(0);
-
-    expect(result.current).toBe(FALLBACK_RATE);
-  });
-
-  it('returns the Redux fallback rate when subscribe fails', async () => {
-    const { result } = await subscribeToLiveRate();
-    const handleSubscriptionError = getHandler<{
-      channel: string;
-      error: string;
-      operation: string;
-    }>('OHLCVService:subscriptionError');
-
-    await emitLiveClose(LIVE_CLOSE);
-    await act(async () => {
-      handleSubscriptionError({
-        channel: defaultChannel,
-        error: 'subscribe failed',
-        operation: 'subscribe',
-      });
+    // The shared hook holds on to the last bar once it stops subscribing, so
+    // the incoming token must not be priced by the outgoing token's candle.
+    rerender({
+      activeToken: {
+        ...token,
+        chainId: 'not-a-chain-id' as typeof token.chainId,
+      },
     });
-
-    expect(result.current).toBe(FALLBACK_RATE);
-  });
-
-  it('keeps the live rate when a non-subscribe operation errors', async () => {
-    const { result } = await subscribeToLiveRate();
-    const handleSubscriptionError = getHandler<{
-      channel: string;
-      error: string;
-      operation: string;
-    }>('OHLCVService:subscriptionError');
-
-    await emitLiveClose(LIVE_CLOSE);
-    await act(async () => {
-      handleSubscriptionError({
-        channel: defaultChannel,
-        error: 'unsubscribe failed',
-        operation: 'unsubscribe',
-      });
-    });
-
-    expect(result.current).toBe(LIVE_CLOSE);
-  });
-
-  it('returns the Redux fallback rate when the asset chain is reported down', async () => {
-    const { result } = await subscribeToLiveRate();
-    const handleChainStatusChanged = getHandler<{
-      chainIds: string[];
-      status: 'up' | 'down';
-    }>('OHLCVService:chainStatusChanged');
-
-    await emitLiveClose(LIVE_CLOSE);
-    await act(async () => {
-      handleChainStatusChanged({
-        chainIds: [chainId],
-        status: 'down',
-      });
-    });
-
-    expect(result.current).toBe(FALLBACK_RATE);
-  });
-
-  it('keeps the live rate when a different chain is reported down', async () => {
-    const { result } = await subscribeToLiveRate();
-    const handleChainStatusChanged = getHandler<{
-      chainIds: string[];
-      status: 'up' | 'down';
-    }>('OHLCVService:chainStatusChanged');
-
-    await emitLiveClose(LIVE_CLOSE);
-    await act(async () => {
-      handleChainStatusChanged({
-        chainIds: ['eip155:137'],
-        status: 'down',
-      });
-    });
-
-    expect(result.current).toBe(LIVE_CLOSE);
-  });
-
-  it('returns the Redux fallback rate after the stream goes quiet past the staleness threshold', async () => {
-    const { result } = await subscribeToLiveRate();
-
-    await emitLiveClose(LIVE_CLOSE);
-
-    await act(async () => {
-      jest.advanceTimersByTime(
-        STALENESS_THRESHOLD_MS + STALENESS_CHECK_INTERVAL_MS,
-      );
-    });
-
-    expect(result.current).toBe(FALLBACK_RATE);
-  });
-
-  it('unsubscribes and removes listeners when the hook unmounts', async () => {
-    const { unmount } = await subscribeToLiveRate();
-
-    unmount();
-
-    expect(mockCall).toHaveBeenCalledWith('OHLCVService:unsubscribe', {
-      assetId,
-      interval: '1m',
-      currency: 'usd',
-    });
-    expect(mockUnsubscribe).toHaveBeenCalledWith(
-      'OHLCVService:barUpdated',
-      expect.any(Function),
-    );
-    expect(mockUnsubscribe).toHaveBeenCalledWith(
-      'OHLCVService:subscriptionError',
-      expect.any(Function),
-    );
-    expect(mockUnsubscribe).toHaveBeenCalledWith(
-      'OHLCVService:chainStatusChanged',
-      expect.any(Function),
-    );
-  });
-
-  it('unsubscribes when unmount happens after subscribe is requested', async () => {
-    let resolveSubscribe: (() => void) | undefined;
-    mockCall.mockImplementation((method: string) => {
-      if (method === 'OHLCVService:subscribe') {
-        return new Promise<void>((resolve) => {
-          resolveSubscribe = resolve;
-        });
-      }
-
-      return Promise.resolve();
-    });
-
-    const { unmount } = renderHook(() =>
-      useLiveTokenFiatRate(token, {
-        subscriptionDebounceMs: SUBSCRIPTION_DEBOUNCE_MS,
-      }),
-    );
-
-    await act(async () => {
-      jest.advanceTimersByTime(SUBSCRIPTION_DEBOUNCE_MS);
-    });
-
-    unmount();
-
-    await act(async () => {
-      resolveSubscribe?.();
-    });
-
-    expect(mockCall).toHaveBeenCalledWith('OHLCVService:unsubscribe', {
-      assetId,
-      interval: '1m',
-      currency: 'usd',
-    });
-  });
-
-  it('uses usd when the selected currency is empty', async () => {
-    mockUseSelector.mockReturnValue('');
-
-    await subscribeToLiveRate();
-
-    expect(mockCall).toHaveBeenCalledWith('OHLCVService:subscribe', {
-      assetId,
-      interval: '1m',
-      currency: 'usd',
-    });
-  });
-
-  it('swallows subscribe rejections and keeps the Redux fallback rate', async () => {
-    mockCall.mockRejectedValue(new Error('network error'));
-
-    const { result } = await subscribeToLiveRate();
 
     expect(result.current).toBe(FALLBACK_RATE);
   });

--- a/app/components/UI/Bridge/hooks/useLiveTokenFiatRate/index.ts
+++ b/app/components/UI/Bridge/hooks/useLiveTokenFiatRate/index.ts
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { formatAddressToAssetId } from '@metamask/bridge-controller';
+import { parseCaipAssetType } from '@metamask/utils';
+import type { OHLCVBar } from '@metamask/core-backend';
+import Engine from '../../../../../core/Engine';
+import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
+import type { BridgeToken } from '../../types';
+import { normalizeTokenAddress } from '../../utils/tokenUtils';
+import { useTokenFiatRate } from '../useTokenFiatRate';
+import { UseLiveTokenFiatRateOptions } from './types';
+
+const DEFAULT_OPTIONS = {
+  interval: '1m',
+  subscriptionDebounceMs: 500,
+  stalenessCheckIntervalMs: 5_000,
+  stalenessThresholdMs: 4 * 5_000, // Four missed pushes.
+} as const satisfies Required<UseLiveTokenFiatRateOptions>;
+
+/**
+ * Fallback for a token the market-data channel can't serve.
+ */
+const NO_ASSET = { assetId: '', chainId: '' };
+
+/**
+ * Token fiat rate using the real-time OHLCV WebSocket price, falling
+ * back to the polled Redux rate from {@link useTokenFiatRate}.
+ *
+ * The live value is the close of the in-progress candle, i.e. the most recent
+ * traded price, refreshed every 5s. It is dropped in favour of the Redux rate
+ * whenever the socket can't serve the asset: unsupported asset ID, subscribe
+ * failure, the chain reporting down, or the stream going quiet.
+ */
+export const useLiveTokenFiatRate = (
+  token?: BridgeToken,
+  {
+    interval = DEFAULT_OPTIONS.interval,
+    subscriptionDebounceMs = DEFAULT_OPTIONS.subscriptionDebounceMs,
+    stalenessCheckIntervalMs = DEFAULT_OPTIONS.stalenessCheckIntervalMs,
+    stalenessThresholdMs = DEFAULT_OPTIONS.stalenessThresholdMs,
+  }: UseLiveTokenFiatRateOptions = {},
+) => {
+  const fallbackRate = useTokenFiatRate(token);
+  const currentCurrency = useSelector(selectCurrentCurrency);
+  const currency = (currentCurrency || 'usd').toLowerCase();
+
+  const { assetId, chainId } = useMemo(() => {
+    if (!token?.address || !token?.chainId) {
+      return NO_ASSET;
+    }
+
+    try {
+      const caipAssetId = formatAddressToAssetId(
+        normalizeTokenAddress(token.address, token.chainId),
+        token.chainId,
+      );
+
+      return caipAssetId
+        ? {
+            assetId: caipAssetId,
+            chainId: parseCaipAssetType(caipAssetId).chainId,
+          }
+        : NO_ASSET;
+    } catch {
+      // Throws for chains outside XChain Swaps/Bridge support, which have no
+      // market-data channel anyway.
+      return NO_ASSET;
+    }
+  }, [token?.address, token?.chainId]);
+
+  const [liveRate, setLiveRate] = useState<number | undefined>(undefined);
+  const channelRef = useRef('');
+  const cancelledRef = useRef(false);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const stalenessTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lastMessageTimeRef = useRef(0);
+
+  const handleBarUpdated = useCallback(
+    (payload: { channel: string; bar: OHLCVBar }) => {
+      if (payload.channel !== channelRef.current) {
+        return;
+      }
+
+      lastMessageTimeRef.current = Date.now();
+
+      // A candle with no trades in it re-sends the previous close, which React
+      // bails out on, so idle assets cost no re-renders.
+      setLiveRate(payload.bar.close > 0 ? payload.bar.close : undefined);
+    },
+    [],
+  );
+
+  const handleSubscriptionError = useCallback(
+    (payload: { channel: string; error: string; operation: string }) => {
+      if (
+        payload.operation === 'subscribe' &&
+        payload.channel === channelRef.current
+      ) {
+        setLiveRate(undefined);
+      }
+    },
+    [],
+  );
+
+  const handleChainStatusChanged = useCallback(
+    (payload: { chainIds: string[]; status: 'up' | 'down' }) => {
+      if (payload.status === 'down' && payload.chainIds.includes(chainId)) {
+        setLiveRate(undefined);
+      }
+    },
+    [chainId],
+  );
+
+  const clearSubscriptions = useCallback(() => {
+    cancelledRef.current = true;
+
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+
+    if (stalenessTimerRef.current) {
+      clearInterval(stalenessTimerRef.current);
+      stalenessTimerRef.current = null;
+    }
+
+    (Engine.controllerMessenger.unsubscribe as (...args: unknown[]) => void)(
+      'OHLCVService:barUpdated',
+      handleBarUpdated,
+    );
+    (Engine.controllerMessenger.unsubscribe as (...args: unknown[]) => void)(
+      'OHLCVService:subscriptionError',
+      handleSubscriptionError,
+    );
+    (Engine.controllerMessenger.unsubscribe as (...args: unknown[]) => void)(
+      'OHLCVService:chainStatusChanged',
+      handleChainStatusChanged,
+    );
+
+    Engine.controllerMessenger
+      .call('OHLCVService:unsubscribe', {
+        assetId,
+        interval,
+        currency,
+      })
+      .catch(() => {
+        // Non-fatal: the service's grace period handles cleanup.
+      });
+  }, [
+    assetId,
+    currency,
+    handleBarUpdated,
+    handleChainStatusChanged,
+    handleSubscriptionError,
+    interval,
+  ]);
+
+  useEffect(() => {
+    if (!assetId || !currency) {
+      return;
+    }
+
+    const channel = `market-data.v1.${assetId}.${interval}.${currency}`;
+    channelRef.current = channel;
+    cancelledRef.current = false;
+    lastMessageTimeRef.current = 0;
+    setLiveRate(undefined);
+
+    (Engine.controllerMessenger.subscribe as (...args: unknown[]) => void)(
+      'OHLCVService:barUpdated',
+      handleBarUpdated,
+    );
+    (Engine.controllerMessenger.subscribe as (...args: unknown[]) => void)(
+      'OHLCVService:subscriptionError',
+      handleSubscriptionError,
+    );
+    (Engine.controllerMessenger.subscribe as (...args: unknown[]) => void)(
+      'OHLCVService:chainStatusChanged',
+      handleChainStatusChanged,
+    );
+
+    stalenessTimerRef.current = setInterval(() => {
+      const elapsed = Date.now() - lastMessageTimeRef.current;
+      if (lastMessageTimeRef.current > 0 && elapsed >= stalenessThresholdMs) {
+        setLiveRate(undefined);
+      }
+    }, stalenessCheckIntervalMs);
+
+    debounceTimerRef.current = setTimeout(async () => {
+      try {
+        await Engine.controllerMessenger.call('OHLCVService:subscribe', {
+          assetId,
+          interval,
+          currency,
+        });
+
+        if (cancelledRef.current) {
+          await Engine.controllerMessenger.call('OHLCVService:unsubscribe', {
+            assetId,
+            interval,
+            currency,
+          });
+          return;
+        }
+
+        // Start the staleness clock only once the stream is live.
+        lastMessageTimeRef.current = Date.now();
+      } catch {
+        // Surfaced via subscriptionError, which falls back to the Redux rate.
+      }
+    }, subscriptionDebounceMs);
+
+    return clearSubscriptions;
+  }, [
+    assetId,
+    chainId,
+    clearSubscriptions,
+    currency,
+    handleBarUpdated,
+    handleChainStatusChanged,
+    handleSubscriptionError,
+    interval,
+    stalenessCheckIntervalMs,
+    stalenessThresholdMs,
+    subscriptionDebounceMs,
+  ]);
+
+  return liveRate ?? fallbackRate;
+};

--- a/app/components/UI/Bridge/hooks/useLiveTokenFiatRate/index.ts
+++ b/app/components/UI/Bridge/hooks/useLiveTokenFiatRate/index.ts
@@ -1,10 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { formatAddressToAssetId } from '@metamask/bridge-controller';
-import { parseCaipAssetType } from '@metamask/utils';
-import type { OHLCVBar } from '@metamask/core-backend';
-import Engine from '../../../../../core/Engine';
 import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
+import { useOHLCVRealtime } from '../../../Charts/AdvancedChart/useOHLCVRealtime';
 import type { BridgeToken } from '../../types';
 import { normalizeTokenAddress } from '../../utils/tokenUtils';
 import { useTokenFiatRate } from '../useTokenFiatRate';
@@ -12,218 +10,62 @@ import { UseLiveTokenFiatRateOptions } from './types';
 
 const DEFAULT_OPTIONS = {
   interval: '1m',
-  subscriptionDebounceMs: 500,
-  stalenessCheckIntervalMs: 5_000,
-  stalenessThresholdMs: 4 * 5_000, // Four missed pushes.
+  timePeriod: '1d',
+  enabled: true,
 } as const satisfies Required<UseLiveTokenFiatRateOptions>;
 
 /**
- * Fallback for a token the market-data channel can't serve.
- */
-const NO_ASSET = { assetId: '', chainId: '' };
-
-/**
- * Token fiat rate using the real-time OHLCV WebSocket price, falling
- * back to the polled Redux rate from {@link useTokenFiatRate}.
+ * Token fiat rate taken from the real-time OHLCV stream, falling back to the
+ * polled Redux rate from {@link useTokenFiatRate}.
  *
  * The live value is the close of the in-progress candle, i.e. the most recent
- * traded price, refreshed every 5s. It is dropped in favour of the Redux rate
- * whenever the socket can't serve the asset: unsupported asset ID, subscribe
- * failure, the chain reporting down, or the stream going quiet.
+ * traded price, refreshed every 5s. {@link useOHLCVRealtime} owns the socket:
+ * it subscribes to the `market-data.v1` channel, polls the `/latest` REST
+ * endpoint while the stream is stale or the chain is down, and ref-counts the
+ * subscription so pricing the same asset twice costs one channel. The Redux
+ * rate is only used when neither source can price the token, e.g. an asset the
+ * market-data channel does not serve.
  */
 export const useLiveTokenFiatRate = (
   token?: BridgeToken,
   {
     interval = DEFAULT_OPTIONS.interval,
-    subscriptionDebounceMs = DEFAULT_OPTIONS.subscriptionDebounceMs,
-    stalenessCheckIntervalMs = DEFAULT_OPTIONS.stalenessCheckIntervalMs,
-    stalenessThresholdMs = DEFAULT_OPTIONS.stalenessThresholdMs,
+    timePeriod = DEFAULT_OPTIONS.timePeriod,
+    enabled = DEFAULT_OPTIONS.enabled,
   }: UseLiveTokenFiatRateOptions = {},
 ) => {
   const fallbackRate = useTokenFiatRate(token);
   const currentCurrency = useSelector(selectCurrentCurrency);
   const currency = (currentCurrency || 'usd').toLowerCase();
 
-  const { assetId, chainId } = useMemo(() => {
+  const assetId = useMemo(() => {
     if (!token?.address || !token?.chainId) {
-      return NO_ASSET;
+      return '';
     }
 
     try {
-      const caipAssetId = formatAddressToAssetId(
-        normalizeTokenAddress(token.address, token.chainId),
-        token.chainId,
+      return (
+        formatAddressToAssetId(
+          normalizeTokenAddress(token.address, token.chainId),
+          token.chainId,
+        ) ?? ''
       );
-
-      return caipAssetId
-        ? {
-            assetId: caipAssetId,
-            chainId: parseCaipAssetType(caipAssetId).chainId,
-          }
-        : NO_ASSET;
     } catch {
       // Throws for chains outside XChain Swaps/Bridge support, which have no
       // market-data channel anyway.
-      return NO_ASSET;
+      return '';
     }
   }, [token?.address, token?.chainId]);
 
-  const [liveRate, setLiveRate] = useState<number | undefined>(undefined);
-  const channelRef = useRef('');
-  const cancelledRef = useRef(false);
-  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const stalenessTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const lastMessageTimeRef = useRef(0);
-
-  const handleBarUpdated = useCallback(
-    (payload: { channel: string; bar: OHLCVBar }) => {
-      if (payload.channel !== channelRef.current) {
-        return;
-      }
-
-      lastMessageTimeRef.current = Date.now();
-
-      // A candle with no trades in it re-sends the previous close, which React
-      // bails out on, so idle assets cost no re-renders.
-      setLiveRate(payload.bar.close > 0 ? payload.bar.close : undefined);
-    },
-    [],
-  );
-
-  const handleSubscriptionError = useCallback(
-    (payload: { channel: string; error: string; operation: string }) => {
-      if (
-        payload.operation === 'subscribe' &&
-        payload.channel === channelRef.current
-      ) {
-        setLiveRate(undefined);
-      }
-    },
-    [],
-  );
-
-  const handleChainStatusChanged = useCallback(
-    (payload: { chainIds: string[]; status: 'up' | 'down' }) => {
-      if (payload.status === 'down' && payload.chainIds.includes(chainId)) {
-        setLiveRate(undefined);
-      }
-    },
-    [chainId],
-  );
-
-  const clearSubscriptions = useCallback(() => {
-    cancelledRef.current = true;
-
-    if (debounceTimerRef.current) {
-      clearTimeout(debounceTimerRef.current);
-      debounceTimerRef.current = null;
-    }
-
-    if (stalenessTimerRef.current) {
-      clearInterval(stalenessTimerRef.current);
-      stalenessTimerRef.current = null;
-    }
-
-    (Engine.controllerMessenger.unsubscribe as (...args: unknown[]) => void)(
-      'OHLCVService:barUpdated',
-      handleBarUpdated,
-    );
-    (Engine.controllerMessenger.unsubscribe as (...args: unknown[]) => void)(
-      'OHLCVService:subscriptionError',
-      handleSubscriptionError,
-    );
-    (Engine.controllerMessenger.unsubscribe as (...args: unknown[]) => void)(
-      'OHLCVService:chainStatusChanged',
-      handleChainStatusChanged,
-    );
-
-    Engine.controllerMessenger
-      .call('OHLCVService:unsubscribe', {
-        assetId,
-        interval,
-        currency,
-      })
-      .catch(() => {
-        // Non-fatal: the service's grace period handles cleanup.
-      });
-  }, [
+  const { latestBar } = useOHLCVRealtime({
     assetId,
-    currency,
-    handleBarUpdated,
-    handleChainStatusChanged,
-    handleSubscriptionError,
     interval,
-  ]);
-
-  useEffect(() => {
-    if (!assetId || !currency) {
-      return;
-    }
-
-    const channel = `market-data.v1.${assetId}.${interval}.${currency}`;
-    channelRef.current = channel;
-    cancelledRef.current = false;
-    lastMessageTimeRef.current = 0;
-    setLiveRate(undefined);
-
-    (Engine.controllerMessenger.subscribe as (...args: unknown[]) => void)(
-      'OHLCVService:barUpdated',
-      handleBarUpdated,
-    );
-    (Engine.controllerMessenger.subscribe as (...args: unknown[]) => void)(
-      'OHLCVService:subscriptionError',
-      handleSubscriptionError,
-    );
-    (Engine.controllerMessenger.subscribe as (...args: unknown[]) => void)(
-      'OHLCVService:chainStatusChanged',
-      handleChainStatusChanged,
-    );
-
-    stalenessTimerRef.current = setInterval(() => {
-      const elapsed = Date.now() - lastMessageTimeRef.current;
-      if (lastMessageTimeRef.current > 0 && elapsed >= stalenessThresholdMs) {
-        setLiveRate(undefined);
-      }
-    }, stalenessCheckIntervalMs);
-
-    debounceTimerRef.current = setTimeout(async () => {
-      try {
-        await Engine.controllerMessenger.call('OHLCVService:subscribe', {
-          assetId,
-          interval,
-          currency,
-        });
-
-        if (cancelledRef.current) {
-          await Engine.controllerMessenger.call('OHLCVService:unsubscribe', {
-            assetId,
-            interval,
-            currency,
-          });
-          return;
-        }
-
-        // Start the staleness clock only once the stream is live.
-        lastMessageTimeRef.current = Date.now();
-      } catch {
-        // Surfaced via subscriptionError, which falls back to the Redux rate.
-      }
-    }, subscriptionDebounceMs);
-
-    return clearSubscriptions;
-  }, [
-    assetId,
-    chainId,
-    clearSubscriptions,
     currency,
-    handleBarUpdated,
-    handleChainStatusChanged,
-    handleSubscriptionError,
-    interval,
-    stalenessCheckIntervalMs,
-    stalenessThresholdMs,
-    subscriptionDebounceMs,
-  ]);
+    timePeriod,
+    enabled: enabled && Boolean(assetId),
+  });
 
-  return liveRate ?? fallbackRate;
+  const liveRate = enabled && assetId ? latestBar?.close : undefined;
+
+  return liveRate && liveRate > 0 ? liveRate : fallbackRate;
 };

--- a/app/components/UI/Bridge/hooks/useLiveTokenFiatRate/types.ts
+++ b/app/components/UI/Bridge/hooks/useLiveTokenFiatRate/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Candle aggregation buckets served by the `market-data.v1` channel. Bars are
+ * pushed every 5s whatever the interval, so this only sets the bucket size.
+ */
+export type LiveTokenFiatRateInterval =
+  | '1m'
+  | '5m'
+  | '15m'
+  | '1h'
+  | '4h'
+  | '1d'
+  | '1w';
+
+export interface UseLiveTokenFiatRateOptions {
+  /**
+   * Update interval.
+   */
+  interval?: LiveTokenFiatRateInterval;
+  /**
+   * Delay before subscribing.
+   */
+  subscriptionDebounceMs?: number;
+  /**
+   * Stalness check, to automatically discard channel connections.
+   */
+  stalenessCheckIntervalMs?: number;
+  /**
+   * Silence after which the live price is dropped in favour of the Redux rate.
+   */
+  stalenessThresholdMs?: number;
+}

--- a/app/components/UI/Bridge/hooks/useLiveTokenFiatRate/types.ts
+++ b/app/components/UI/Bridge/hooks/useLiveTokenFiatRate/types.ts
@@ -13,19 +13,17 @@ export type LiveTokenFiatRateInterval =
 
 export interface UseLiveTokenFiatRateOptions {
   /**
-   * Update interval.
+   * Candle bucket to subscribe to.
    */
   interval?: LiveTokenFiatRateInterval;
   /**
-   * Delay before subscribing.
+   * Time period sent to the `/latest` REST endpoint that backs the stream when
+   * the socket is down, stale, or missing the asset.
    */
-  subscriptionDebounceMs?: number;
+  timePeriod?: string;
   /**
-   * Stalness check, to automatically discard channel connections.
+   * When false no subscription is opened and the polled Redux rate is returned,
+   * so a screen can keep the socket to the window it actually prices in.
    */
-  stalenessCheckIntervalMs?: number;
-  /**
-   * Silence after which the live price is dropped in favour of the Redux rate.
-   */
-  stalenessThresholdMs?: number;
+  enabled?: boolean;
 }

--- a/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
-import { useTokenFiatRate } from '../useTokenFiatRate';
+import { useLiveTokenFiatRate } from '../useLiveTokenFiatRate';
 import { createMockToken } from '../../testUtils/fixtures';
 import { LimitOrderExecutionType } from '../../constants/limitOrders';
 import { getSwapsLimitOrderPriceMarketComparison } from '../../utils/limitOrders/getSwapsLimitOrderPriceMarketComparison';
@@ -10,14 +10,14 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
 
-jest.mock('../useTokenFiatRate', () => ({
-  useTokenFiatRate: jest.fn(),
+jest.mock('../useLiveTokenFiatRate', () => ({
+  useLiveTokenFiatRate: jest.fn(),
 }));
 
 jest.mock('../../utils/limitOrders/getSwapsLimitOrderPriceMarketComparison');
 
 const mockUseSelector = jest.mocked(useSelector);
-const mockUseTokenFiatRate = jest.mocked(useTokenFiatRate);
+const mockUseLiveTokenFiatRate = jest.mocked(useLiveTokenFiatRate);
 const mockGetSwapsLimitOrderPriceMarketComparison = jest.mocked(
   getSwapsLimitOrderPriceMarketComparison,
 );
@@ -46,7 +46,7 @@ function mockFiatRates({
   sourceRate?: number | undefined;
   destRate?: number | undefined;
 } = {}) {
-  mockUseTokenFiatRate.mockImplementation((token) => {
+  mockUseLiveTokenFiatRate.mockImplementation((token) => {
     if (token?.symbol === 'ETH') {
       return sourceRate;
     }
@@ -97,7 +97,7 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
       symbol: 'USDT',
       decimals: 6,
     });
-    mockUseTokenFiatRate.mockImplementation(() => 1);
+    mockUseLiveTokenFiatRate.mockImplementation(() => 1);
 
     const { result } = renderPriceAdjustHook({
       sourceToken: usdt,
@@ -300,7 +300,7 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
       symbol: 'DAI',
       decimals: 18,
     });
-    mockUseTokenFiatRate.mockImplementation((token) => {
+    mockUseLiveTokenFiatRate.mockImplementation((token) => {
       if (token?.symbol === 'ETH') {
         return 2000;
       }
@@ -317,7 +317,7 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
     expect(result.current.limitPrice).toBe('1');
 
     const usdc = destToken;
-    mockUseTokenFiatRate.mockImplementation((token) => {
+    mockUseLiveTokenFiatRate.mockImplementation((token) => {
       if (token?.symbol === 'ETH') {
         return 2000;
       }
@@ -354,7 +354,7 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
   });
 
   it('omits amount type toggle when a token fiat rate is unavailable', () => {
-    mockUseTokenFiatRate.mockReturnValue(undefined);
+    mockUseLiveTokenFiatRate.mockReturnValue(undefined);
     const { result } = renderPriceAdjustHook();
 
     expect(result.current.onAmountTypeTogglePress).toBeUndefined();
@@ -511,7 +511,7 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
       symbol: 'USDT',
       decimals: 6,
     });
-    mockUseTokenFiatRate.mockImplementation((token) =>
+    mockUseLiveTokenFiatRate.mockImplementation((token) =>
       token?.symbol === 'ETH' ? 2000 : 1,
     );
 

--- a/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useReducer } from 'react';
 import { useSelector } from 'react-redux';
 import { BigNumber } from 'bignumber.js';
 import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
-import { useTokenFiatRate } from '../useTokenFiatRate';
+import { useLiveTokenFiatRate } from '../useLiveTokenFiatRate';
 import type { BridgeToken } from '../../types';
 import { formatTokenInputAmountFromFiat } from '../../utils/sourceAmountInputMode';
 import { formatLimitOrderFiatPriceFromTokenAmount } from '../../utils/limitOrders/formatLimitOrderFiatPrice';
@@ -41,8 +41,8 @@ export const useSwapsLimitOrderPriceAdjust = ({
     executionType,
   } = state;
 
-  const destFiatRate = useTokenFiatRate(destToken);
-  const sourceFiatRate = useTokenFiatRate(sourceToken);
+  const destFiatRate = useLiveTokenFiatRate(destToken);
+  const sourceFiatRate = useLiveTokenFiatRate(sourceToken);
   const isSell = executionType === LimitOrderExecutionType.SELL;
   const quotedToken = isSell ? sourceToken : destToken;
   const counterToken = isSell ? destToken : sourceToken;


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Limit-order price adjustment was using the polled Redux token fiat rate, so the displayed market comparison could lag while the user set a limit price.

This PR adds `useLiveTokenFiatRate`, which subscribes to the OHLCV market-data WebSocket (`OHLCVService`) and uses the in-progress candle close as the live USD (or selected fiat) price. `useSwapsLimitOrderPriceAdjust` now reads that live rate instead of `useTokenFiatRate`. The hook still falls back to the existing Redux rate when the token cannot be mapped to an asset ID, subscribe fails, the chain is reported down, the candle close is invalid, or the stream goes quiet past a staleness threshold. Subscriptions are debounced and cleaned up on unmount so token switching does not leave dangling channels.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated swap limit orders to use live token fiat rates

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-5025

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Live token fiat rates on swap limit orders

  Background:
    Given I am logged into MetaMask Mobile
    And swaps/bridge limit orders are available for my account
    And I have a source token and a destination token with market-data coverage

  Scenario: limit order market comparison tracks live prices
    Given I am on the swap limit order screen
    And I have selected source and destination tokens
    And a limit price field is visible

    When user waits while live market data arrives
    Then the market comparison and derived fiat amounts should update from the live rate
    And the values should stay consistent with the selected execution type (buy or sell)

  Scenario: price adjust still works when live market data is unavailable
    Given I am on the swap limit order screen
    And I select a token or network that does not receive live market-data updates

    When user adjusts the limit price
    Then the screen should still show a usable market comparison from the fallback fiat rate
    And the amount type toggle should remain available when a fallback rate exists
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Limit-order UX now depends on OHLCV WebSocket/ref-count behavior and correct asset-id mapping; wrong live vs fallback pricing could mislead market comparison, though Redux fallback remains.
> 
> **Overview**
> Adds **`useLiveTokenFiatRate`**, which prices tokens from the OHLCV realtime stream (in-progress candle **close** in the user’s display currency) and falls back to the existing Redux **`useTokenFiatRate`** when subscription is off, the asset can’t be mapped, or the live close is missing or zero. Options cover candle interval, REST backup time period, and an **`enabled`** flag so callers can avoid stale bars from a prior subscription.
> 
> **`useSwapsLimitOrderPriceAdjust`** now uses this hook for source and destination fiat rates so limit-order market comparison and seeding track live prices instead of polled Redux only.
> 
> Tests cover the new hook (subscription args, fallbacks, token-switch safety) and update limit-order price-adjust tests to mock **`useLiveTokenFiatRate`**. **`BridgeView.test`** mocks **`Engine.controllerMessenger.call`** as **`mockResolvedValue(undefined)`** for async OHLCV subscribe on the limit tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93f0ccd39961a16ce4f2a3978303ae640ee772c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->