### PR TITLE
fix(predict): remove dead status spacing above the market details chart

### DIFF
--- a/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsStatus/PredictMarketDetailsStatus.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsStatus/PredictMarketDetailsStatus.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import PredictMarketDetailsStatus, {
+  type PredictMarketDetailsStatusProps,
+} from './PredictMarketDetailsStatus';
+import {
+  PredictMarketStatus,
+  type PredictOutcomeToken,
+} from '../../../../types';
+
+const winningOutcomeToken: PredictOutcomeToken = {
+  id: 'outcome-token-1',
+  title: 'Yes',
+  price: 0.98,
+};
+
+const renderStatus = (
+  overrides: Partial<PredictMarketDetailsStatusProps> = {},
+) =>
+  render(
+    <PredictMarketDetailsStatus
+      winningOutcomeToken={undefined}
+      multipleOpenOutcomesPartiallyResolved={false}
+      resolutionStatus={undefined}
+      marketStatus={PredictMarketStatus.OPEN}
+      {...overrides}
+    />,
+  );
+
+describe('PredictMarketDetailsStatus', () => {
+  it('renders nothing for an open market with no status to report', () => {
+    const { toJSON } = renderStatus();
+
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders nothing when the winning outcome is withheld by a partial resolution', () => {
+    const { toJSON } = renderStatus({
+      winningOutcomeToken,
+      multipleOpenOutcomesPartiallyResolved: true,
+    });
+
+    expect(toJSON()).toBeNull();
+  });
+
+  it('reports the winning outcome once the market is resolved', () => {
+    const { getByText } = renderStatus({
+      winningOutcomeToken,
+      resolutionStatus: 'resolved',
+      marketStatus: PredictMarketStatus.RESOLVED,
+    });
+
+    expect(getByText('Market resulted to Yes')).toBeOnTheScreen();
+  });
+
+  it('reports that the market ended while resolution is still pending', () => {
+    const { getByText } = renderStatus({
+      winningOutcomeToken,
+      marketStatus: PredictMarketStatus.CLOSED,
+    });
+
+    expect(getByText('Market ended on Yes')).toBeOnTheScreen();
+  });
+
+  it('reports that a closed market is awaiting final resolution', () => {
+    const { getByText } = renderStatus({
+      marketStatus: PredictMarketStatus.CLOSED,
+    });
+
+    expect(getByText('Waiting for final resolution')).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsStatus/PredictMarketDetailsStatus.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsStatus/PredictMarketDetailsStatus.tsx
@@ -31,6 +31,18 @@ const PredictMarketDetailsStatus = memo(
   }: PredictMarketDetailsStatusProps) => {
     const { colors } = useTheme();
 
+    const showResult =
+      Boolean(winningOutcomeToken) && !multipleOpenOutcomesPartiallyResolved;
+    const showAwaitingResolution =
+      marketStatus === PredictMarketStatus.CLOSED &&
+      resolutionStatus !== 'resolved';
+
+    // Rendering an empty Box would still consume the parent's gap, leaving dead
+    // space above the chart on markets that have no status to report.
+    if (!showResult && !showAwaitingResolution) {
+      return null;
+    }
+
     return (
       <Box twClassName="gap-2">
         {winningOutcomeToken && !multipleOpenOutcomesPartiallyResolved && (


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

On a market's details screen the chart legend (for example `Barcelona 18.5%`, `Arsenal 14.5%`) sat far below the header, with 45pt between the title's glyphs and the legend.

The legend itself has no top spacing. The space came from two 16pt gaps stacking: the header's own `pb-4`, plus a second one because `PredictMarketDetailsStatus` always returned a `Box`, even for a market with no status to report. An empty `Box` has no height, but the parent's `gap-4` still reserves the gap beside it, so open markets paid 32pt of structural spacing for a component that drew nothing.

The component now returns `null` when there is neither a result nor a pending resolution to show, leaving the header's 16pt as the only spacing above the legend. Measured on the rendered screen, the title-to-legend distance goes from 45pt to 29pt — the 16pt of dead space removed, with the remainder being the normal line-height slack under the title and above the legend text.

This is fixed at the source rather than by trimming the header padding or the container gap, since both of those would also shrink the spacing on resolved and closed markets, where the status genuinely renders and the 16pt gap belongs.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Tightened the spacing above the chart on Predict market details

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A. Visual polish on the Predict market details screen from design review; no tracking issue.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict market details chart spacing

  Background:
    Given I am logged into MetaMask Mobile

  Scenario: user opens an open multi-outcome market
    Given I am on the Wallet home screen

    When user opens Predictions
    And user opens a multi-outcome market such as "UEFA Champions League: 2027 Champion"
    Then the chart legend sits 16pt below the header, with no empty band above it

  Scenario: user opens a market that reports a status
    Given I am on the Wallet home screen

    When user opens Predictions
    And user opens a resolved or closed market
    Then the status line is shown above the chart as before
    And it keeps a 16pt gap from the header
```

Verified on the iOS simulator by measuring the title-to-legend distance on the same market before and after the change.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- Both captures are from the same market at the same scroll position. -->

### **Before**

45pt between the title and the legend, 16pt of it reserved for a status component that renders nothing:

<img src="https://github.com/user-attachments/assets/b1bcb304-7b4f-4fe7-b5a4-1ad6caded1a9" alt="Before: wide empty band between the header and the chart legend" width="520" />

Full screen:

<img src="https://github.com/user-attachments/assets/44892710-9608-4815-84e1-5c9a24af4c20" alt="Before: market details screen with a wide gap above the chart" width="390" />

### **After**

29pt, i.e. the header's 16pt plus normal text slack:

<img src="https://github.com/user-attachments/assets/23d5c4c1-ad2b-4a11-acdb-aea7d05c9b91" alt="After: legend sits directly below the header" width="520" />

Full screen:

<img src="https://github.com/user-attachments/assets/5da77b07-cddb-4dbd-be5a-c5bf624beff8" alt="After: market details screen with the chart pulled up" width="390" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
  - Added `PredictMarketDetailsStatus.test.tsx`, which the component previously lacked, covering both render-nothing paths and the three status messages
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

Considered and not applicable: this removes a render rather than adding work, so it is marginally cheaper than before. Visual verification was done on the iOS simulator; the layout tokens are platform-independent.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Predict market-details UI only; no auth, data, or payment behavior changes.
> 
> **Overview**
> **Predict market details** no longer leaves a blank band above the chart on open markets where there is nothing to report.
> 
> `PredictMarketDetailsStatus` now returns **`null`** when there is neither a winning-outcome line to show nor a closed-market “awaiting resolution” message, instead of always mounting an empty `Box`. That stops the parent `gap-4` from reserving space for a zero-height status row. Resolved, closed, and pending-resolution cases still render the same status copy as before.
> 
> New **`PredictMarketDetailsStatus.test.tsx`** covers the two render-nothing paths and the three status messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03f595dd725b24bc3386287f3b0d150bbdbcb97f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->