### PR TITLE
fix(predict): block PWAT CTAs until pay state passes the publish guard

### DIFF
--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.test.ts
@@ -27,6 +27,8 @@ let mockAvailableTokens: {
 
 let mockPredictBalance = 0;
 let mockQuotes: unknown[] = [];
+let mockIsPaySubmitReady = false;
+let mockTransactionMeta: { id: string } | undefined;
 const mockResetSelectedPaymentToken = jest.fn();
 const mockNavigationListeners: Record<string, Set<() => void>> = {};
 const mockAddListener = jest.fn((eventName: string, callback: () => void) => {
@@ -92,8 +94,16 @@ jest.mock(
     useTransactionPayTotals: () => mockPayTotals,
     useIsTransactionPayLoading: () => mockIsPayTotalsLoading,
     useIsTransactionPayQuoteLoading: () => mockIsPayQuoteLoading,
+    useIsTransactionPaySubmitReady: () => mockIsPaySubmitReady,
     useTransactionPayRequiredTokens: () => mockRequiredTokens,
     useTransactionPayQuotes: () => mockQuotes,
+  }),
+);
+
+jest.mock(
+  '../../../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest',
+  () => ({
+    useTransactionMetadataRequest: () => mockTransactionMeta,
   }),
 );
 
@@ -141,6 +151,8 @@ describe('usePredictBuyConditions', () => {
     mockAvailableTokens = [];
     mockPredictBalance = 0;
     mockQuotes = [];
+    mockIsPaySubmitReady = false;
+    mockTransactionMeta = undefined;
   });
 
   afterEach(() => {
@@ -430,6 +442,54 @@ describe('usePredictBuyConditions', () => {
       );
 
       expect(result.current.canPlaceBet).toBe(false);
+    });
+
+    it('returns false when the pay deposit transaction is not submit-ready', () => {
+      mockIsPredictBalanceSelected = false;
+      mockTransactionMeta = { id: 'tx-1' };
+      mockIsPaySubmitReady = false;
+
+      const { result } = renderHook(() =>
+        usePredictBuyConditions(defaultParams),
+      );
+
+      expect(result.current.canPlaceBet).toBe(false);
+    });
+
+    it('returns true when the pay deposit transaction is submit-ready', () => {
+      mockIsPredictBalanceSelected = false;
+      mockTransactionMeta = { id: 'tx-1' };
+      mockIsPaySubmitReady = true;
+
+      const { result } = renderHook(() =>
+        usePredictBuyConditions(defaultParams),
+      );
+
+      expect(result.current.canPlaceBet).toBe(true);
+    });
+
+    it('does not block when paying from Predict balance, even if not submit-ready', () => {
+      mockIsPredictBalanceSelected = true;
+      mockTransactionMeta = { id: 'tx-1' };
+      mockIsPaySubmitReady = false;
+
+      const { result } = renderHook(() =>
+        usePredictBuyConditions(defaultParams),
+      );
+
+      expect(result.current.canPlaceBet).toBe(true);
+    });
+
+    it('does not block when no pay deposit transaction exists', () => {
+      mockIsPredictBalanceSelected = false;
+      mockTransactionMeta = undefined;
+      mockIsPaySubmitReady = false;
+
+      const { result } = renderHook(() =>
+        usePredictBuyConditions(defaultParams),
+      );
+
+      expect(result.current.canPlaceBet).toBe(true);
     });
   });
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
@@ -5,8 +5,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   useIsTransactionPayLoading,
   useIsTransactionPayQuoteLoading,
+  useIsTransactionPaySubmitReady,
   useTransactionPayQuotes,
 } from '../../../../../Views/confirmations/hooks/pay/useTransactionPayData';
+import { useTransactionMetadataRequest } from '../../../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest';
 import { useTransactionPayAvailableTokens } from '../../../../../Views/confirmations/hooks/pay/useTransactionPayAvailableTokens';
 import {
   MINIMUM_BET,
@@ -43,6 +45,8 @@ export const usePredictBuyConditions = ({
     usePredictBuyAvailableBalance();
   const isPayTotalsLoading = useIsTransactionPayLoading();
   const isPayQuoteLoading = useIsTransactionPayQuoteLoading();
+  const isPaySubmitReady = useIsTransactionPaySubmitReady();
+  const transactionMeta = useTransactionMetadataRequest();
   const quotes = useTransactionPayQuotes();
   const { isDepositPending } = usePredictDeposit();
   const { isPredictBalanceSelected, selectedPaymentToken } =
@@ -201,6 +205,21 @@ export const usePredictBuyConditions = ({
 
   const isRateLimited = useMemo(() => preview?.rateLimited ?? false, [preview]);
 
+  // Mirror the publish guard: while the pay deposit transaction exists and the
+  // user is paying with a wallet token, a tap must not reach publish in a state
+  // the guard rejects with "MetaMask Pay: Cannot submit without quote". The
+  // loading and alert checks miss states where the quote fetch failed, never
+  // started, or the payment token is still unset. Predict-balance payments
+  // create a deposit transaction but never engage MetaMask Pay, so they are
+  // scoped out; direct pUSD routes pass the predicate without quotes.
+  const isPaySubmitBlocked = useMemo(
+    () =>
+      Boolean(transactionMeta) &&
+      !isPredictBalanceSelected &&
+      !isPaySubmitReady,
+    [transactionMeta, isPredictBalanceSelected, isPaySubmitReady],
+  );
+
   // Active loading: quotes are being fetched for the current ERC20 token.
   const isPayFeesLoading = useMemo(
     () => shouldWaitForPayFees && (isPayTotalsLoading || isPayQuoteLoading),
@@ -318,6 +337,7 @@ export const usePredictBuyConditions = ({
       !isRateLimited &&
       !isBalanceLoading &&
       !isPayFeesLoading &&
+      !isPaySubmitBlocked &&
       !hasBlockingPayAlerts &&
       !isPaymentSelectorNavigationLocked,
     [
@@ -329,6 +349,7 @@ export const usePredictBuyConditions = ({
       isRateLimited,
       isBalanceLoading,
       isPayFeesLoading,
+      isPaySubmitBlocked,
       hasBlockingPayAlerts,
       isPaymentSelectorNavigationLocked,
     ],

--- a/app/components/Views/confirmations/components/footer/footer.test.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.test.tsx
@@ -28,7 +28,10 @@ import { merge } from 'lodash';
 import { simpleSendTransactionControllerMock } from '../../__mocks__/controllers/transaction-controller-mock';
 import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
 import { emptySignatureControllerMock } from '../../__mocks__/controllers/signature-controller-mock';
-import { useIsTransactionPayLoading } from '../../hooks/pay/useTransactionPayData';
+import {
+  useIsTransactionPayLoading,
+  useIsTransactionPaySubmitReady,
+} from '../../hooks/pay/useTransactionPayData';
 import { useIsTransactionPayAmountStale } from '../../hooks/pay/useIsTransactionPayAmountStale';
 import { useIsGaslessLoading } from '../../hooks/gas/useIsGaslessLoading';
 import { SCAM_QUESTIONNAIRE_FLAG_KEY } from '../../../../product-safety/scam-questionnaire/scam-questionnaire.constants';
@@ -113,6 +116,9 @@ describe('Footer', () => {
   const useIsTransactionPayLoadingMock = jest.mocked(
     useIsTransactionPayLoading,
   );
+  const useIsTransactionPaySubmitReadyMock = jest.mocked(
+    useIsTransactionPaySubmitReady,
+  );
   const useIsTransactionPayAmountStaleMock = jest.mocked(
     useIsTransactionPayAmountStale,
   );
@@ -149,6 +155,7 @@ describe('Footer', () => {
     });
 
     useIsTransactionPayLoadingMock.mockReturnValue(false);
+    useIsTransactionPaySubmitReadyMock.mockReturnValue(true);
     useIsTransactionPayAmountStaleMock.mockReturnValue(false);
     useIsGaslessLoadingMock.mockReturnValue({ isGaslessLoading: false });
   });
@@ -339,6 +346,69 @@ describe('Footer', () => {
 
   it('keeps confirm button enabled when pay amount is stale for a non-MM Pay transaction', () => {
     useIsTransactionPayAmountStaleMock.mockReturnValue(true);
+
+    const { getByTestId } = renderWithProvider(<Footer />, {
+      state: personalSignatureConfirmationState,
+    });
+
+    expect(
+      getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
+    ).not.toBeDisabled();
+  });
+
+  it('disables confirm button when a predict deposit is not submit-ready', () => {
+    useIsTransactionPaySubmitReadyMock.mockReturnValue(false);
+
+    const predictDepositConfirmation = {
+      chainId: '0x89',
+      id: 'predict-deposit-id',
+      networkClientId: 'polygon',
+      origin: 'metamask',
+      txParams: {
+        from: '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477',
+        to: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+        value: '0x0',
+      },
+      type: TransactionType.predictDeposit,
+    } as unknown as TransactionMeta;
+
+    const { getByTestId } = renderWithProvider(<Footer />, {
+      state: getAppStateForConfirmation(predictDepositConfirmation),
+    });
+
+    expect(
+      getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON).props
+        .accessibilityState?.disabled,
+    ).toBe(true);
+  });
+
+  it('keeps confirm button enabled when a predict deposit is submit-ready', () => {
+    useIsTransactionPaySubmitReadyMock.mockReturnValue(true);
+
+    const predictDepositConfirmation = {
+      chainId: '0x89',
+      id: 'predict-deposit-id',
+      networkClientId: 'polygon',
+      origin: 'metamask',
+      txParams: {
+        from: '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477',
+        to: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+        value: '0x0',
+      },
+      type: TransactionType.predictDeposit,
+    } as unknown as TransactionMeta;
+
+    const { getByTestId } = renderWithProvider(<Footer />, {
+      state: getAppStateForConfirmation(predictDepositConfirmation),
+    });
+
+    expect(
+      getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
+    ).not.toBeDisabled();
+  });
+
+  it('does not gate confirm on pay submit readiness for non-pay-token transactions', () => {
+    useIsTransactionPaySubmitReadyMock.mockReturnValue(false);
 
     const { getByTestId } = renderWithProvider(<Footer />, {
       state: personalSignatureConfirmationState,

--- a/app/components/Views/confirmations/components/footer/footer.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.tsx
@@ -38,10 +38,14 @@ import {
 import {
   MMM_ORIGIN,
   MM_PAY_TRANSACTION_TYPES,
+  PAY_TOKEN_REQUIRED_TRANSACTION_TYPES,
   TRANSFER_TRANSACTION_TYPES,
 } from '../../constants/confirmations';
 import { PredictClaimFooter } from '../predict-confirmations/predict-claim-footer/predict-claim-footer';
-import { useIsTransactionPayLoading } from '../../hooks/pay/useTransactionPayData';
+import {
+  useIsTransactionPayLoading,
+  useIsTransactionPaySubmitReady,
+} from '../../hooks/pay/useTransactionPayData';
 import { useIsTransactionPayAmountStale } from '../../hooks/pay/useIsTransactionPayAmountStale';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { useQRHardwareContext } from '../../context/qr-hardware-context';
@@ -78,9 +82,14 @@ export const Footer = () => {
     TRANSFER_TRANSACTION_TYPES.includes(transactionType) &&
     transactionMetadata?.origin === MMM_ORIGIN;
   const isPayLoading = useIsTransactionPayLoading();
+  const isPaySubmitReady = useIsTransactionPaySubmitReady();
   const isMMPayTransaction = hasTransactionType(
     transactionMetadata,
     MM_PAY_TRANSACTION_TYPES,
+  );
+  const isPayTokenRequiredTransaction = hasTransactionType(
+    transactionMetadata,
+    PAY_TOKEN_REQUIRED_TRANSACTION_TYPES,
   );
   const isPayAmountStale = useIsTransactionPayAmountStale();
   const { isGaslessLoading } = useIsGaslessLoading();
@@ -189,6 +198,11 @@ export const Footer = () => {
     isTransactionValueUpdating ||
     isPayLoading ||
     (isMMPayTransaction && isPayAmountStale) ||
+    // Mirror the publish guard: pay-token-required transactions (predict and
+    // perps deposits) throw "MetaMask Pay: Cannot submit without quote" at
+    // publish when no executable quote or validated direct/fiat route exists.
+    // Block confirm in exactly those states instead of letting the tap fail.
+    (isPayTokenRequiredTransaction && !isPaySubmitReady) ||
     isGaslessLoading;
 
   const isFooterVisible =


### PR DESCRIPTION
## **Description**

Ports the Perps UX gate (CONF-1731, #34471) to the Predict flows so users cannot submit a PWAT-funded Predict deposit or buy in a state the MetaMask Pay publish guard rejects with `"MetaMask Pay: Cannot submit without quote"`.

**Problem:** Predict deposits and wallet-token bets could reach publish while the pay state was not submit-ready — the existing loading checks and alerts miss states where the quote fetch failed, never started, or the payment token is unset. Users saw amounts/fees that looked ready, tapped confirm/place bet, and the attempt failed hard (~80–150 failures/day per PRED-1282 telemetry).

**Solution (mirrors the publish guard, does not weaken it):**
- `usePredictBuyConditions`: `canPlaceBet` is forced `false` while a pay deposit transaction exists and the user pays with a wallet token but `isPayTokenSubmitReady` is `false`. Predict-balance payments are scoped out — they create a deposit transaction but never engage MetaMask Pay. Direct pUSD routes pass the predicate without quotes.
- Confirmation footer: Confirm is disabled for `PAY_TOKEN_REQUIRED_TRANSACTION_TYPES` (`predictDeposit`, `predictDepositAndOrder`, `perpsDeposit`, `perpsDepositAndOrder`) while `!isPayTokenSubmitReady`.

`isPayTokenSubmitReady` is the exact predicate `validateRequiredQuote` enforces at publish, so the CTA now mirrors the guard instead of letting taps fail.

## **Changelog**

CHANGELOG entry: Fixed a bug that allowed Predict deposits and wallet-token bets to be submitted before MetaMask Pay was ready, causing failed deposits with the error "MetaMask Pay: Cannot submit without quote".

## **Related issues**

Fixes: [PRED-1282](https://consensyssoftware.atlassian.net/browse/PRED-1282)

## **Manual testing steps**

Tested on iOS Simulator (`mm-green`, dev build attached to Metro, prod context) against a wallet with USDC, pUSD and Predict balance on Polygon. The quote-failure state was forced deterministically by monkey-patching `fetch` in the running Hermes runtime (via `mm cdp`) to return HTTP 500 for all `intents.dev-api.cx.metamask.io/relay/quote` and `intents.api.cx.metamask.io/relay/quote` requests; mock hit-logs confirmed the app's requests were served by the mocks.

```gherkin
Feature: Predict PWAT CTAs respect the MetaMask Pay publish guard

  Scenario: quote fetch fails → buy CTA is blocked with guidance
    Given the buy-with-any-token view with USDC selected as payment token
    And all Relay quote requests are failing with HTTP 500

    When the user types a $1 amount
    Then the action button never becomes a tappable "Place bet"
    And an inline error is shown with "change payment" guidance
    And no "Cannot submit without quote" error appears anywhere

  Scenario: quote fetch fails → changing payment keeps the CTA blocked
    Given the blocked state above

    When the user switches the payment token to another wallet token (POL)
    Then the CTA remains blocked (quotes are still failing)
    And no submit is possible

  Scenario: Predict balance bypasses the pay gate entirely
    Given all Relay quote requests are failing with HTTP 500

    When the user selects Predict balance as the payment source and types a $1 amount
    Then the "Place bet" button is active
    And the bet is placed successfully end-to-end

  Scenario: direct-route payment (pUSD) is not blocked without quotes
    Given all Relay quote requests are failing with HTTP 500

    When the user starts a Predict deposit and selects pUSD as payment token
    Then the error state clears and the action button becomes active
    And the deposit confirmation's Confirm button is active
    And the deposit completes successfully

  Scenario: healthy flow is not over-blocked
    Given quotes are available and the pay state is submit-ready

    When the user places a bet or completes a deposit (tested via pUSD and Predict balance)
    Then fees resolve normally and the action button enables after loading
    And the flow completes without errors
```

Additional observations from the same session:
- With quotes failing, the Add Funds (deposit) entry screen also disables its action button and shows "This payment route isn't available right now" guidance — consistent gating on a second surface.
- While reproducing, an organic `"Quote simulation failed"` error (`QuoteError`, reason `simulation-failed` from `@metamask/transaction-pay-controller`) was observed for $1 USDC bets even though `/relay/quote` returned 201. The app correctly falls back to the change-payment UX for it (pre-existing alert gate, not affected by this PR), but it currently blocks USDC happy-path testing on dev — worth a follow-up investigation.

## **Screenshots/Recordings**

N/A — the change is CTA gating state (disabled/enabled button and inline guidance text), captured interactively during the manual testing session above; before/after visual diff would not show additional information beyond the described button states.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-1282]: https://consensyssoftware.atlassian.net/browse/PRED-1282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing CTA gating on Predict buy and pay-token deposit confirmations; logic is scoped to MetaMask Pay submit readiness but incorrect blocking could frustrate users or miss edge cases.
> 
> **Overview**
> Predict **wallet-token** buys and deposits were still tappable while MetaMask Pay was not submit-ready, so users could hit **"MetaMask Pay: Cannot submit without quote"** after tapping Place bet or Confirm.
> 
> **`usePredictBuyConditions`** now adds **`isPaySubmitBlocked`** (deposit transaction present, paying with a wallet token, and **`!isPaySubmitReady`**) into **`canPlaceBet`**. Predict-balance funding and flows with no deposit transaction are excluded.
> 
> **Confirmation `Footer`** disables Confirm for **`PAY_TOKEN_REQUIRED_TRANSACTION_TYPES`** (predict/perps deposit variants) when **`!isPaySubmitReady`**, matching the same publish predicate without weakening it.
> 
> Unit tests cover the new **`canPlaceBet`** rules and footer confirm enable/disable for predict deposits vs other confirmation types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eb58877df2841beaae09a0e42893e800c2af7fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->