### PR TITLE
test(perf): capture in-app screen TTC for seedless onboarding

### DIFF
--- a/app/components/Views/Root/index.tsx
+++ b/app/components/Views/Root/index.tsx
@@ -18,6 +18,7 @@ import { RootProps } from './types';
 import NavigationProvider from '../../Nav/NavigationProvider';
 import ControllersGate from '../../Nav/ControllersGate';
 import { isTestEnvironment } from '../../../util/test/utils';
+import ScreenTtcProbeHost from '../../../hooks/performance/ScreenTtcProbeHost';
 import { FeatureFlagOverrideProvider } from '../../../contexts/FeatureFlagOverrideContext';
 import { ScreenOrientationService } from '../../../core/ScreenOrientation';
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
@@ -120,6 +121,7 @@ const Root = ({ foxCode }: RootProps) => {
                                   mode={ReduceMotion.Never}
                                 />
                                 <App />
+                                <ScreenTtcProbeHost />
                               </HardwareWalletProvider>
                             </ToastContextWrapper>
                           </UIMessengerProvider>

--- a/app/hooks/performance/ScreenTtcProbeHost.test.tsx
+++ b/app/hooks/performance/ScreenTtcProbeHost.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { act, render } from '@testing-library/react-native';
+import ScreenTtcProbeHost from './ScreenTtcProbeHost';
+import {
+  recordScreenTtc,
+  _resetScreenTtcRegistryForTesting,
+  _setScreenTtcProbeEnabledForTesting,
+} from './screenTtcRegistry';
+import { OnboardingScreenIds } from './onboardingPerformanceIds';
+
+jest.mock('../../util/test/utils', () => ({
+  isE2EOrPerformanceTest: true,
+}));
+
+describe('ScreenTtcProbeHost', () => {
+  beforeEach(() => {
+    _resetScreenTtcRegistryForTesting();
+  });
+
+  it('renders nothing when the probe is disabled', () => {
+    recordScreenTtc(OnboardingScreenIds.ONBOARDING_LANDING, 10, 'filled');
+    _setScreenTtcProbeEnabledForTesting(false);
+
+    const { toJSON } = render(<ScreenTtcProbeHost />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders nothing when enabled but no TTC has been recorded', () => {
+    const { toJSON } = render(<ScreenTtcProbeHost />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('exposes recorded TTC via testID and accessibilityLabel', () => {
+    recordScreenTtc(OnboardingScreenIds.ONBOARDING_LANDING, 123.4, 'filled');
+
+    const { getByTestId } = render(<ScreenTtcProbeHost />);
+    const probe = getByTestId('perf-ttc-onboarding_landing');
+
+    expect(probe.props.accessibilityLabel).toBe('ttc:onboarding_landing:123:1');
+    expect(probe.props.accessible).toBe(true);
+    expect(probe.props.importantForAccessibility).toBe('yes');
+    expect(probe.props.pointerEvents).toBe('none');
+  });
+
+  it('updates probes when new TTC values are recorded', () => {
+    const { getByTestId, queryByTestId } = render(<ScreenTtcProbeHost />);
+
+    expect(queryByTestId('perf-ttc-onboarding_sheet')).toBeNull();
+
+    act(() => {
+      recordScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET, 88, 'filled');
+    });
+
+    expect(
+      getByTestId('perf-ttc-onboarding_sheet').props.accessibilityLabel,
+    ).toBe('ttc:onboarding_sheet:88:1');
+
+    act(() => {
+      recordScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET, 99, 'filled');
+    });
+
+    expect(
+      getByTestId('perf-ttc-onboarding_sheet').props.accessibilityLabel,
+    ).toBe('ttc:onboarding_sheet:99:2');
+  });
+
+  it('renders multiple screen probes when several TTC values exist', () => {
+    recordScreenTtc(OnboardingScreenIds.ONBOARDING_LANDING, 11, 'filled');
+    recordScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET, 22, 'filled');
+
+    const { getByTestId } = render(<ScreenTtcProbeHost />);
+
+    expect(getByTestId('perf-ttc-onboarding_landing')).toBeTruthy();
+    expect(getByTestId('perf-ttc-onboarding_sheet')).toBeTruthy();
+  });
+});

--- a/app/hooks/performance/ScreenTtcProbeHost.test.tsx
+++ b/app/hooks/performance/ScreenTtcProbeHost.test.tsx
@@ -15,6 +15,8 @@ jest.mock('../../util/test/utils', () => ({
 describe('ScreenTtcProbeHost', () => {
   beforeEach(() => {
     _resetScreenTtcRegistryForTesting();
+    // Explicit restore even though reset clears the override — keeps suite order-safe.
+    _setScreenTtcProbeEnabledForTesting(undefined);
   });
 
   it('renders nothing when the probe is disabled', () => {

--- a/app/hooks/performance/ScreenTtcProbeHost.test.tsx
+++ b/app/hooks/performance/ScreenTtcProbeHost.test.tsx
@@ -40,8 +40,10 @@ describe('ScreenTtcProbeHost', () => {
 
     expect(probe.props.accessibilityLabel).toBe('ttc:onboarding_landing:123:1');
     expect(probe.props.accessible).toBe(true);
+    expect(probe.props.collapsable).toBe(false);
     expect(probe.props.importantForAccessibility).toBe('yes');
     expect(probe.props.pointerEvents).toBe('none');
+    expect(probe.props.nativeID).toBe('perf-ttc-onboarding_landing');
   });
 
   it('updates probes when new TTC values are recorded', () => {

--- a/app/hooks/performance/ScreenTtcProbeHost.tsx
+++ b/app/hooks/performance/ScreenTtcProbeHost.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import {
+  formatScreenTtcAccessibilityLabel,
+  getAllScreenTtc,
+  isScreenTtcProbeEnabled,
+  screenTtcTestId,
+  subscribeScreenTtc,
+  type ScreenTtcRecord,
+} from './screenTtcRegistry';
+
+const styles = StyleSheet.create({
+  probe: {
+    position: 'absolute',
+    width: 1,
+    height: 1,
+    opacity: 0,
+  },
+});
+
+/**
+ * E2E/perf-only host that exposes the latest in-app screen TTC values to
+ * Appium via testID + accessibilityLabel (same mount→contentReady duration
+ * recorded by useScreenPerformance / Sentry).
+ */
+const ScreenTtcProbeHost = () => {
+  const [records, setRecords] = useState<ScreenTtcRecord[]>(() =>
+    getAllScreenTtc(),
+  );
+
+  useEffect(() => {
+    if (!isScreenTtcProbeEnabled()) {
+      return;
+    }
+    return subscribeScreenTtc(() => {
+      setRecords(getAllScreenTtc());
+    });
+  }, []);
+
+  if (!isScreenTtcProbeEnabled() || records.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {records.map((record) => (
+        <View
+          key={`${record.screenId}-${record.generation}`}
+          testID={screenTtcTestId(record.screenId)}
+          accessible
+          accessibilityLabel={formatScreenTtcAccessibilityLabel(record)}
+          importantForAccessibility="yes"
+          pointerEvents="none"
+          style={styles.probe}
+        />
+      ))}
+    </>
+  );
+};
+
+export default ScreenTtcProbeHost;

--- a/app/hooks/performance/ScreenTtcProbeHost.tsx
+++ b/app/hooks/performance/ScreenTtcProbeHost.tsx
@@ -9,12 +9,19 @@ import {
   type ScreenTtcRecord,
 } from './screenTtcRegistry';
 
+/**
+ * Must stay in the Android accessibility / UiAutomator tree.
+ * opacity:0 + 1×1 + collapsible Views are dropped by Appium on BrowserStack.
+ */
 const styles = StyleSheet.create({
   probe: {
     position: 'absolute',
-    width: 1,
-    height: 1,
-    opacity: 0,
+    left: 0,
+    bottom: 0,
+    width: 48,
+    height: 48,
+    opacity: 0.011,
+    zIndex: 9999,
   },
 });
 
@@ -46,9 +53,12 @@ const ScreenTtcProbeHost = () => {
       {records.map((record) => (
         <View
           key={`${record.screenId}-${record.generation}`}
+          collapsable={false}
           testID={screenTtcTestId(record.screenId)}
+          nativeID={screenTtcTestId(record.screenId)}
           accessible
           accessibilityLabel={formatScreenTtcAccessibilityLabel(record)}
+          accessibilityRole="text"
           importantForAccessibility="yes"
           pointerEvents="none"
           style={styles.probe}

--- a/app/hooks/performance/onboardingPerformanceHooks.test.ts
+++ b/app/hooks/performance/onboardingPerformanceHooks.test.ts
@@ -61,6 +61,7 @@ describe('onboarding performance hooks', () => {
     mockGetPerformanceTimestamp.mockReturnValue(mockPerformanceMountTs);
     _resetOnboardingNavigationPerformanceForTesting();
     jest.useFakeTimers();
+    jest.setSystemTime(mockPerformanceMountTs);
   });
 
   afterEach(() => {

--- a/app/hooks/performance/onboardingPerformanceHooks.test.ts
+++ b/app/hooks/performance/onboardingPerformanceHooks.test.ts
@@ -41,6 +41,10 @@ jest.mock('./useRenderStormMonitor', () => ({
   useRenderStormMonitor: jest.fn(),
 }));
 
+jest.mock('./screenTtcRegistry', () => ({
+  recordScreenTtc: jest.fn(),
+}));
+
 const {
   trace: mockTrace,
   endTrace: mockEndTrace,

--- a/app/hooks/performance/screenTtcRegistry.test.ts
+++ b/app/hooks/performance/screenTtcRegistry.test.ts
@@ -1,0 +1,57 @@
+import {
+  formatScreenTtcAccessibilityLabel,
+  parseScreenTtcAccessibilityLabel,
+  recordScreenTtc,
+  screenTtcTestId,
+  _resetScreenTtcRegistryForTesting,
+} from './screenTtcRegistry';
+import { OnboardingScreenIds } from './onboardingPerformanceIds';
+
+jest.mock('../../util/test/utils', () => ({
+  isE2EOrPerformanceTest: true,
+}));
+
+describe('screenTtcRegistry', () => {
+  beforeEach(() => {
+    _resetScreenTtcRegistryForTesting();
+  });
+
+  it('records and formats TTC for Appium consumption', () => {
+    recordScreenTtc(OnboardingScreenIds.ONBOARDING_LANDING, 123.4, 'filled');
+
+    const label = formatScreenTtcAccessibilityLabel({
+      screenId: OnboardingScreenIds.ONBOARDING_LANDING,
+      durationMs: 123.4,
+      contentState: 'filled',
+      generation: 1,
+    });
+
+    expect(label).toBe('ttc:onboarding_landing:123:1');
+    expect(screenTtcTestId(OnboardingScreenIds.ONBOARDING_LANDING)).toBe(
+      'perf-ttc-onboarding_landing',
+    );
+    expect(parseScreenTtcAccessibilityLabel(label)).toEqual({
+      screenId: OnboardingScreenIds.ONBOARDING_LANDING,
+      durationMs: 123,
+      contentState: 'filled',
+      generation: 1,
+    });
+  });
+
+  it('bumps generation on each record for the same screen', () => {
+    recordScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET, 10, 'filled');
+    recordScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET, 20, 'filled');
+
+    const second = parseScreenTtcAccessibilityLabel(
+      formatScreenTtcAccessibilityLabel({
+        screenId: OnboardingScreenIds.ONBOARDING_SHEET,
+        durationMs: 20,
+        contentState: 'filled',
+        generation: 2,
+      }),
+    );
+
+    expect(second?.generation).toBe(2);
+    expect(second?.durationMs).toBe(20);
+  });
+});

--- a/app/hooks/performance/screenTtcRegistry.test.ts
+++ b/app/hooks/performance/screenTtcRegistry.test.ts
@@ -81,11 +81,34 @@ describe('screenTtcRegistry', () => {
 
   it('bumps generation on each record for the same screen', () => {
     recordScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET, 10, 'filled');
-    recordScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET, 20, 'filled');
+    const first = getScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET);
+    expect(first).toEqual({
+      screenId: OnboardingScreenIds.ONBOARDING_SHEET,
+      durationMs: 10,
+      contentState: 'filled',
+      generation: 1,
+    });
+    if (!first) {
+      throw new Error('expected first TTC record');
+    }
+    expect(formatScreenTtcAccessibilityLabel(first)).toBe(
+      'ttc:onboarding_sheet:10:1',
+    );
 
+    recordScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET, 20, 'filled');
     const second = getScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET);
-    expect(second?.generation).toBe(2);
-    expect(second?.durationMs).toBe(20);
+    expect(second).toEqual({
+      screenId: OnboardingScreenIds.ONBOARDING_SHEET,
+      durationMs: 20,
+      contentState: 'filled',
+      generation: 2,
+    });
+    if (!second) {
+      throw new Error('expected second TTC record');
+    }
+    const label = formatScreenTtcAccessibilityLabel(second);
+    expect(label).toBe('ttc:onboarding_sheet:20:2');
+    expect(parseScreenTtcAccessibilityLabel(label)?.generation).toBe(2);
   });
 
   it('notifies subscribers and supports unsubscribe', () => {

--- a/app/hooks/performance/screenTtcRegistry.test.ts
+++ b/app/hooks/performance/screenTtcRegistry.test.ts
@@ -1,9 +1,14 @@
 import {
   formatScreenTtcAccessibilityLabel,
+  getAllScreenTtc,
+  getScreenTtc,
+  isScreenTtcProbeEnabled,
   parseScreenTtcAccessibilityLabel,
   recordScreenTtc,
   screenTtcTestId,
+  subscribeScreenTtc,
   _resetScreenTtcRegistryForTesting,
+  _setScreenTtcProbeEnabledForTesting,
 } from './screenTtcRegistry';
 import { OnboardingScreenIds } from './onboardingPerformanceIds';
 
@@ -16,16 +21,32 @@ describe('screenTtcRegistry', () => {
     _resetScreenTtcRegistryForTesting();
   });
 
+  it('reports probe enabled from e2e/perf flag and test override', () => {
+    expect(isScreenTtcProbeEnabled()).toBe(true);
+    _setScreenTtcProbeEnabledForTesting(false);
+    expect(isScreenTtcProbeEnabled()).toBe(false);
+    _setScreenTtcProbeEnabledForTesting(undefined);
+    expect(isScreenTtcProbeEnabled()).toBe(true);
+  });
+
   it('records and formats TTC for Appium consumption', () => {
     recordScreenTtc(OnboardingScreenIds.ONBOARDING_LANDING, 123.4, 'filled');
 
-    const label = formatScreenTtcAccessibilityLabel({
+    const stored = getScreenTtc(OnboardingScreenIds.ONBOARDING_LANDING);
+    expect(stored).toEqual({
       screenId: OnboardingScreenIds.ONBOARDING_LANDING,
       durationMs: 123.4,
       contentState: 'filled',
       generation: 1,
     });
+    expect(getAllScreenTtc()).toHaveLength(1);
 
+    expect(stored).toBeDefined();
+    if (!stored) {
+      throw new Error('expected stored TTC record');
+    }
+
+    const label = formatScreenTtcAccessibilityLabel(stored);
     expect(label).toBe('ttc:onboarding_landing:123:1');
     expect(screenTtcTestId(OnboardingScreenIds.ONBOARDING_LANDING)).toBe(
       'perf-ttc-onboarding_landing',
@@ -38,20 +59,44 @@ describe('screenTtcRegistry', () => {
     });
   });
 
+  it('returns null for malformed accessibility labels', () => {
+    expect(parseScreenTtcAccessibilityLabel('not-a-ttc-label')).toBeNull();
+    expect(parseScreenTtcAccessibilityLabel('ttc:bad')).toBeNull();
+    expect(parseScreenTtcAccessibilityLabel('  ')).toBeNull();
+  });
+
+  it('clamps negative durations and skips recording when probe disabled', () => {
+    recordScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET, -5, 'empty');
+    expect(getScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET)?.durationMs).toBe(
+      0,
+    );
+    expect(
+      getScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET)?.contentState,
+    ).toBe('empty');
+
+    _setScreenTtcProbeEnabledForTesting(false);
+    recordScreenTtc(OnboardingScreenIds.CHOOSE_PASSWORD, 50, 'filled');
+    expect(getScreenTtc(OnboardingScreenIds.CHOOSE_PASSWORD)).toBeUndefined();
+  });
+
   it('bumps generation on each record for the same screen', () => {
     recordScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET, 10, 'filled');
     recordScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET, 20, 'filled');
 
-    const second = parseScreenTtcAccessibilityLabel(
-      formatScreenTtcAccessibilityLabel({
-        screenId: OnboardingScreenIds.ONBOARDING_SHEET,
-        durationMs: 20,
-        contentState: 'filled',
-        generation: 2,
-      }),
-    );
-
+    const second = getScreenTtc(OnboardingScreenIds.ONBOARDING_SHEET);
     expect(second?.generation).toBe(2);
     expect(second?.durationMs).toBe(20);
+  });
+
+  it('notifies subscribers and supports unsubscribe', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeScreenTtc(listener);
+
+    recordScreenTtc(OnboardingScreenIds.ONBOARDING_SUCCESS, 40, 'filled');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    recordScreenTtc(OnboardingScreenIds.ONBOARDING_SUCCESS, 50, 'filled');
+    expect(listener).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/hooks/performance/screenTtcRegistry.ts
+++ b/app/hooks/performance/screenTtcRegistry.ts
@@ -13,8 +13,13 @@ const records = new Map<OnboardingScreenId, ScreenTtcRecord>();
 const listeners = new Set<() => void>();
 
 let generationCounter = 0;
+/** Test-only override for `isE2EOrPerformanceTest` (undefined = use real flag). */
+let probeEnabledOverride: boolean | undefined;
 
 export function isScreenTtcProbeEnabled(): boolean {
+  if (probeEnabledOverride !== undefined) {
+    return probeEnabledOverride;
+  }
   return isE2EOrPerformanceTest;
 }
 
@@ -88,4 +93,12 @@ export function _resetScreenTtcRegistryForTesting(): void {
   records.clear();
   listeners.clear();
   generationCounter = 0;
+  probeEnabledOverride = undefined;
+}
+
+/** Test-only probe enable override (`undefined` restores production flag). */
+export function _setScreenTtcProbeEnabledForTesting(
+  enabled: boolean | undefined,
+): void {
+  probeEnabledOverride = enabled;
 }

--- a/app/hooks/performance/screenTtcRegistry.ts
+++ b/app/hooks/performance/screenTtcRegistry.ts
@@ -1,0 +1,91 @@
+import type { OnboardingScreenId } from './onboardingPerformanceIds';
+import { isE2EOrPerformanceTest } from '../../util/test/utils';
+
+export interface ScreenTtcRecord {
+  screenId: OnboardingScreenId;
+  durationMs: number;
+  contentState: 'empty' | 'filled';
+  /** Bumps on every successful record so Appium can wait for a fresh value. */
+  generation: number;
+}
+
+const records = new Map<OnboardingScreenId, ScreenTtcRecord>();
+const listeners = new Set<() => void>();
+
+let generationCounter = 0;
+
+export function isScreenTtcProbeEnabled(): boolean {
+  return isE2EOrPerformanceTest;
+}
+
+export function screenTtcTestId(screenId: OnboardingScreenId): string {
+  return `perf-ttc-${screenId}`;
+}
+
+/**
+ * Accessibility label format Appium parses:
+ * `ttc:<screen_id>:<durationMs>:<generation>`
+ */
+export function formatScreenTtcAccessibilityLabel(
+  record: ScreenTtcRecord,
+): string {
+  return `ttc:${record.screenId}:${Math.round(record.durationMs)}:${record.generation}`;
+}
+
+export function parseScreenTtcAccessibilityLabel(
+  label: string,
+): ScreenTtcRecord | null {
+  const match = /^ttc:([a-z0-9_]+):(\d+(?:\.\d+)?):(\d+)$/.exec(label.trim());
+  if (!match) {
+    return null;
+  }
+  return {
+    screenId: match[1] as OnboardingScreenId,
+    durationMs: Number(match[2]),
+    contentState: 'filled',
+    generation: Number(match[3]),
+  };
+}
+
+export function recordScreenTtc(
+  screenId: OnboardingScreenId,
+  durationMs: number,
+  contentState: 'empty' | 'filled',
+): void {
+  if (!isScreenTtcProbeEnabled()) {
+    return;
+  }
+
+  generationCounter += 1;
+  records.set(screenId, {
+    screenId,
+    durationMs: Math.max(0, durationMs),
+    contentState,
+    generation: generationCounter,
+  });
+  listeners.forEach((listener) => listener());
+}
+
+export function getScreenTtc(
+  screenId: OnboardingScreenId,
+): ScreenTtcRecord | undefined {
+  return records.get(screenId);
+}
+
+export function getAllScreenTtc(): ScreenTtcRecord[] {
+  return Array.from(records.values());
+}
+
+export function subscribeScreenTtc(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Test-only reset. */
+export function _resetScreenTtcRegistryForTesting(): void {
+  records.clear();
+  listeners.clear();
+  generationCounter = 0;
+}

--- a/app/hooks/performance/useScreenPerformance.ts
+++ b/app/hooks/performance/useScreenPerformance.ts
@@ -12,6 +12,7 @@ import {
   type OnboardingScreenId,
 } from './onboardingPerformanceIds';
 import { useRenderStormMonitor } from './useRenderStormMonitor';
+import { recordScreenTtc } from './screenTtcRegistry';
 
 interface UseScreenPerformanceConfig {
   screenId: OnboardingScreenId;
@@ -136,6 +137,7 @@ export const useScreenPerformance = ({
 
   useEffect(() => {
     if (enabled && contentReady && ttcStarted.current && !ttcEnded.current) {
+      const durationMs = getPerformanceTimestamp() - mountTime;
       endTrace({
         name: TraceName.OnboardingScreenTimeToContent,
         id: ttcTraceId.current,
@@ -145,9 +147,11 @@ export const useScreenPerformance = ({
           content_state: traceContentState,
         },
       });
+      // Same duration Sentry records — expose to Appium on e2e/perf builds.
+      recordScreenTtc(screenId, durationMs, traceContentState);
       ttcEnded.current = true;
     }
-  }, [enabled, contentReady, screenId, traceContentState]);
+  }, [enabled, contentReady, screenId, traceContentState, mountTime]);
 
   useEffect(() => {
     if (

--- a/tests/framework/TimerHelper.ts
+++ b/tests/framework/TimerHelper.ts
@@ -118,6 +118,15 @@ class TimerHelper {
   }
 
   /**
+   * Renames this timer in the store (e.g. after measuring a destination-dependent step).
+   */
+  changeName(newName: string): void {
+    const oldId = this._id;
+    TimerStore.renameTimer(oldId, newName);
+    this._id = newName;
+  }
+
+  /**
    * Returns the duration of the timer in seconds.
    * @returns Duration in seconds, or 0 if the timer has no duration
    */

--- a/tests/framework/TimerHelper.ts
+++ b/tests/framework/TimerHelper.ts
@@ -105,13 +105,16 @@ class TimerHelper {
   }
 
   /**
-   * Renames this timer to a new identifier.
-   * @param newName - The new identifier for this timer
+   * Records an externally measured duration (e.g. in-app Sentry-equivalent TTC)
+   * without using wall-clock start/stop.
    */
-  changeName(newName: string): void {
-    const oldId = this._id;
-    TimerStore.renameTimer(oldId, newName);
-    this._id = newName;
+  recordDuration(durationMs: number): void {
+    const timer = TimerStore.getTimer(this.id);
+    const safeDuration = Math.max(0, durationMs);
+    const end = Date.now();
+    timer.start = end - safeDuration;
+    timer.end = end;
+    timer.duration = safeDuration;
   }
 
   /**

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -294,7 +294,9 @@ Tests for new users:
 - `seedless-apple-onboarding.spec.ts` - Apple social sign-in onboarding
 - `seedless-google-onboarding.spec.ts` - Google social sign-in onboarding
 - `seedless-telegram-onboarding.spec.ts` - Telegram social sign-in onboarding (requires `MM_TELEGRAM_LOGIN_ENABLED=true` on without-srp e2e builds)
-- `launch-times/` - Onboarding launch metrics
+- `helpers/seedlessOnboardingTimers.ts` — Seedless **nav** / **flow** timers, plus helpers to wait for contentReady UI.
+- `utils/readScreenTtc.ts` — Reads **in-app TTC** (`TTC [<screen_id>]: in-app mount→contentReady`) from `ScreenTtcProbeHost` (same duration as Sentry `useScreenPerformance`).
+- `launch-times/` — Cold start nav + in-app `onboarding_landing` TTC
 
 ### Predict Tests (`tests/performance/login/predict/`)
 

--- a/tests/performance/onboarding/helpers/seedlessOnboardingTimers.ts
+++ b/tests/performance/onboarding/helpers/seedlessOnboardingTimers.ts
@@ -1,9 +1,50 @@
-import TimerHelper from '../../../framework/TimerHelper';
+import TimerHelper, {
+  type PlatformThreshold,
+} from '../../../framework/TimerHelper';
 import { AppiumAssertions } from '../../../framework';
 import OnboardingInterestQuestionnaireView from '../../../page-objects/Onboarding/OnboardingInterestQuestionnaireView';
+import OnboardingSheet from '../../../page-objects/Onboarding/OnboardingSheet';
 import OnboardingSuccessView from '../../../page-objects/Onboarding/OnboardingSuccessView';
+import OnboardingView from '../../../page-objects/Onboarding/OnboardingView';
+import CreatePasswordView from '../../../page-objects/Onboarding/CreatePasswordView';
+import SocialLoginView from '../../../page-objects/Onboarding/SocialLoginView';
+import LoginView from '../../../page-objects/wallet/LoginView';
 
-const waitForFirstSuccessful = async <T>(promises: Promise<T>[]): Promise<T> =>
+/**
+ * Seedless onboarding CI timers — in-app TTC vs nav/flow steps.
+ *
+ * Sentry Onboarding Screen Time To Content = React mount → contentReady
+ * (useScreenPerformance). On e2e/perf builds that duration is exposed via
+ * ScreenTtcProbeHost; Appium reads it with addAppScreenTtcTimer / waitForAppScreenTtc.
+ *
+ * Separate timers:
+ * - TTC [screen_id]: in-app mount→contentReady (Sentry-equivalent)
+ * - nav: prior tap → destination UI visible (includes navigation)
+ * - flow: OAuth / wallet create / wallet chrome
+ */
+
+export type SeedlessProvider = 'Google' | 'Apple' | 'Telegram';
+
+export type SeedlessSheetProviderButton = 'google' | 'apple' | 'telegram';
+
+/** Real Sentry onboarding screen_ids (see OnboardingScreenIds). */
+export type OnboardingTtcScreenId =
+  | 'onboarding_landing'
+  | 'onboarding_sheet'
+  | 'choose_pw'
+  | 'social_login_success_new_user'
+  | 'account_already_exists'
+  | 'social_rehydrate'
+  | 'onboarding_success';
+
+export type PostOauthContent =
+  | 'choose_pw'
+  | 'social_login_success_new_user'
+  | 'account_already_exists';
+
+export const waitForFirstSuccessful = async <T>(
+  promises: Promise<T>[],
+): Promise<T> =>
   await new Promise<T>((resolve, reject) => {
     let rejectedCount = 0;
 
@@ -17,20 +58,138 @@ const waitForFirstSuccessful = async <T>(promises: Promise<T>[]): Promise<T> =>
     });
   });
 
-const expectSuccessDoneVisible = async (): Promise<void> => {
+/** Sentry `onboarding_landing` contentReady ≈ interactive Create CTA. */
+export async function waitForOnboardingLandingContent(): Promise<void> {
+  await AppiumAssertions.expectElementToBeVisible(
+    OnboardingView.newWalletButton,
+    {
+      description:
+        'Onboarding landing content: Create new wallet CTA should be visible',
+    },
+  );
+}
+
+/** Sentry `onboarding_sheet` — provider CTA proves the sheet painted. */
+export async function waitForOnboardingSheetContent(
+  provider: SeedlessSheetProviderButton,
+): Promise<void> {
+  const button =
+    provider === 'google'
+      ? OnboardingSheet.googleLoginButton
+      : provider === 'apple'
+        ? OnboardingSheet.appleLoginButton
+        : OnboardingSheet.telegramLoginButton;
+
+  await AppiumAssertions.expectElementToBeVisible(button, {
+    description: `Onboarding sheet content: ${provider} login button should be visible`,
+  });
+}
+
+/** Sentry `choose_pw` contentReady (form paints immediately). */
+export async function waitForChoosePasswordContent(): Promise<void> {
+  await CreatePasswordView.isVisible();
+}
+
+/** Sentry `social_login_success_new_user` (iOS post-OAuth success). */
+export async function waitForSocialLoginNewUserContent(): Promise<void> {
+  await SocialLoginView.isIosNewUserScreenVisible();
+}
+
+/** Sentry `account_already_exists`. */
+export async function waitForAccountAlreadyExistsContent(): Promise<void> {
+  await SocialLoginView.isAccountFoundScreenVisible();
+}
+
+export async function waitForPostOauthContent(options: {
+  platform: 'ios' | 'android' | string;
+}): Promise<PostOauthContent> {
+  if (options.platform === 'ios') {
+    return await waitForFirstSuccessful([
+      waitForSocialLoginNewUserContent().then(
+        () => 'social_login_success_new_user' as const,
+      ),
+      waitForAccountAlreadyExistsContent().then(
+        () => 'account_already_exists' as const,
+      ),
+    ]);
+  }
+
+  return await waitForFirstSuccessful([
+    waitForChoosePasswordContent().then(() => 'choose_pw' as const),
+    waitForAccountAlreadyExistsContent().then(
+      () => 'account_already_exists' as const,
+    ),
+  ]);
+}
+
+/** Sentry `social_rehydrate` — Login title (shared testIDs). */
+export async function waitForSocialRehydrateContent(): Promise<void> {
+  await LoginView.waitForScreenToDisplay();
+}
+
+/** Sentry `onboarding_success` — Done button. */
+export async function waitForOnboardingSuccessContent(): Promise<void> {
   await AppiumAssertions.expectElementToBeVisible(
     OnboardingSuccessView.doneButton,
     {
-      description: 'Onboarding success done button should be visible',
+      description: 'Onboarding success content: Done button should be visible',
     },
   );
-};
+}
 
 /**
- * After Create Password tap: measure Create Password → Onboarding Success Done.
- * Success-first (no survey): timer records the full create → success latency.
- * Questionnaire-first: skip is untimed after the race; timer is re-measured for
- * post-skip → success only (survey time is not kept in the recorded duration).
+ * In-app TTC name — duration comes from useScreenPerformance via the probe.
+ */
+export function seedlessAppTtcTimerName(
+  screenId: OnboardingTtcScreenId,
+): string {
+  return `TTC [${screenId}]: in-app mount→contentReady`;
+}
+
+/** Navigation step (prior tap → UI). Not Sentry TTC. */
+export function seedlessNavTimerName(
+  provider: SeedlessProvider,
+  userFacingStep: string,
+): string {
+  return `${provider} nav: ${userFacingStep}`;
+}
+
+/** Flow step name — OAuth / wallet-create / wallet chrome (not TTC). */
+export function seedlessFlowTimerName(
+  provider: SeedlessProvider,
+  userFacingStep: string,
+): string {
+  return `${provider} flow: ${userFacingStep}`;
+}
+
+/**
+ * OAuth → first post-OAuth screen. Dominated by provider latency, so this is a
+ * **flow** timer. After measure, renames with the real destination `screen_id`.
+ */
+export async function measurePostOauthToScreenContent(
+  timer: TimerHelper,
+  provider: SeedlessProvider,
+  platform: string,
+): Promise<PostOauthContent> {
+  let content: PostOauthContent = 'choose_pw';
+
+  await timer.measure(async () => {
+    content = await waitForPostOauthContent({ platform });
+  });
+
+  timer.changeName(
+    seedlessFlowTimerName(
+      provider,
+      `OAuth → [${content}] content visible (includes provider latency)`,
+    ),
+  );
+
+  return content;
+}
+
+/**
+ * Create Password → Onboarding Success Done.
+ * **Flow** timer: includes wallet create (not mount TTC for onboarding_success).
  */
 export async function measureCreatePasswordToOnboardingSuccess(
   timer: TimerHelper,
@@ -45,7 +204,7 @@ export async function measureCreatePasswordToOnboardingSuccess(
           description: 'Interest questionnaire Skip should be visible',
         },
       ).then(() => 'questionnaire' as const),
-      expectSuccessDoneVisible().then(() => 'success' as const),
+      waitForOnboardingSuccessContent().then(() => 'success' as const),
     ]);
 
     if (next === 'questionnaire') {
@@ -55,9 +214,113 @@ export async function measureCreatePasswordToOnboardingSuccess(
 
   if (questionnaireFirst) {
     await OnboardingInterestQuestionnaireView.tapSkipButton();
-    // Overwrites the race-to-questionnaire duration with post-skip → success only.
     await timer.measure(async () => {
-      await expectSuccessDoneVisible();
+      await waitForOnboardingSuccessContent();
     });
   }
+}
+
+export interface SeedlessOnboardingTimers {
+  /** nav: Create wallet → sheet UI */
+  sheetNav: TimerHelper;
+  /** Flow: OAuth → destination (renamed with real screen_id after measure) */
+  postOauthFlow: TimerHelper;
+  /** nav: iOS Set PIN → password fields */
+  choosePasswordNav: TimerHelper;
+  /** Flow: Create Password → success (wallet create) */
+  createWalletFlow: TimerHelper;
+  /** Flow: Done → wallet chrome (not HomepageReady / not onboarding TTC) */
+  walletChromeFlow: TimerHelper;
+  /** nav: Account Found Login → rehydrate UI */
+  rehydrateNav: TimerHelper;
+  /** Flow: Unlock → wallet chrome */
+  existingWalletFlow: TimerHelper;
+}
+
+/** Generous until BrowserStack baselines for in-app TTC exist. */
+export const SEEDLESS_APP_TTC_THRESHOLDS: Record<
+  OnboardingTtcScreenId,
+  PlatformThreshold
+> = {
+  onboarding_landing: { ios: 10_000, android: 12_000 },
+  onboarding_sheet: { ios: 3_000, android: 4_000 },
+  choose_pw: { ios: 3_000, android: 4_000 },
+  social_login_success_new_user: { ios: 3_000, android: 4_000 },
+  account_already_exists: { ios: 3_000, android: 4_000 },
+  social_rehydrate: { ios: 3_000, android: 4_000 },
+  onboarding_success: { ios: 3_000, android: 4_000 },
+};
+
+/**
+ * Shared timer set for Google / Apple / Telegram seedless specs.
+ * Nav/flow thresholds match prior seedless baselines (not newly tightened).
+ */
+export function createSeedlessOnboardingTimers(
+  provider: SeedlessProvider,
+  platform: 'ios' | 'android',
+  thresholds: {
+    sheet: PlatformThreshold;
+    postOauth: PlatformThreshold;
+    choosePassword: PlatformThreshold;
+    createWallet: PlatformThreshold;
+    walletChrome: PlatformThreshold;
+    rehydrate: PlatformThreshold;
+    existingWallet: PlatformThreshold;
+  },
+): SeedlessOnboardingTimers {
+  return {
+    sheetNav: new TimerHelper(
+      seedlessNavTimerName(
+        provider,
+        'Create new wallet → sheet content visible',
+      ),
+      thresholds.sheet,
+      platform,
+    ),
+    postOauthFlow: new TimerHelper(
+      seedlessFlowTimerName(
+        provider,
+        'OAuth → post-OAuth content visible (destination stamped after measure)',
+      ),
+      thresholds.postOauth,
+      platform,
+    ),
+    choosePasswordNav: new TimerHelper(
+      seedlessNavTimerName(provider, 'iOS Set PIN → password fields visible'),
+      thresholds.choosePassword,
+      platform,
+    ),
+    createWalletFlow: new TimerHelper(
+      seedlessFlowTimerName(
+        provider,
+        'Create Password → onboarding_success Done visible (includes wallet create)',
+      ),
+      thresholds.createWallet,
+      platform,
+    ),
+    walletChromeFlow: new TimerHelper(
+      seedlessFlowTimerName(
+        provider,
+        'Done → wallet chrome visible (not HomepageReady)',
+      ),
+      thresholds.walletChrome,
+      platform,
+    ),
+    rehydrateNav: new TimerHelper(
+      seedlessNavTimerName(
+        provider,
+        'Account Found Login → rehydrate/login content visible',
+      ),
+      thresholds.rehydrate,
+      platform,
+    ),
+    existingWalletFlow: new TimerHelper(
+      seedlessFlowTimerName(
+        provider,
+        'Unlock → wallet chrome visible (not HomepageReady)',
+      ),
+      thresholds.existingWallet,
+      platform,
+    ),
+  };
 }

--- a/tests/performance/onboarding/launch-times/cold-start-to-onboarding.spec.ts
+++ b/tests/performance/onboarding/launch-times/cold-start-to-onboarding.spec.ts
@@ -5,27 +5,38 @@ import {
   PerformanceOnboarding,
   PerformanceLaunch,
 } from '../../../tags.performance.js';
-import AppiumAssertions from '../../../framework/AppiumAssertions';
-import OnboardingView from '../../../page-objects/Onboarding/OnboardingView';
+import { addAppScreenTtcTimer } from '../../utils/readScreenTtc';
+import {
+  SEEDLESS_APP_TTC_THRESHOLDS,
+  waitForOnboardingLandingContent,
+} from '../helpers/seedlessOnboardingTimers';
 
+/*
+ * Cold start launch (process→CTA) plus in-app TTC [onboarding_landing]
+ * (mount→contentReady, Sentry-equivalent).
+ */
 test.describe(`${Performance} ${PerformanceOnboarding} ${PerformanceLaunch}`, () => {
   test(
     'Measure Cold Start To Onboarding Screen',
     { tag: '@metamask-mobile-platform' },
-    async ({ currentDeviceDetails, driver, performanceTracker }, testInfo) => {
-      const timer1 = new TimerHelper(
-        'Time since the the app is installed, until onboarding screen appears',
+    async ({ currentDeviceDetails, driver, performanceTracker }) => {
+      const platform = currentDeviceDetails.platform;
+      const launchToCta = new TimerHelper(
+        'nav: cold start → Create new wallet CTA visible',
         { ios: 3000, android: 4000 },
-        currentDeviceDetails.platform,
+        platform,
       );
-      await timer1.measure(
-        async () =>
-          await AppiumAssertions.expectElementToBeVisible(
-            OnboardingView.newWalletButton,
-          ),
-      );
+      await launchToCta.measure(async () => {
+        await waitForOnboardingLandingContent();
+      });
+      performanceTracker.addTimer(launchToCta);
 
-      performanceTracker.addTimer(timer1);
+      await addAppScreenTtcTimer({
+        performanceTracker,
+        screenId: 'onboarding_landing',
+        platform,
+        threshold: SEEDLESS_APP_TTC_THRESHOLDS.onboarding_landing,
+      });
     },
   );
 });

--- a/tests/performance/onboarding/seedless-apple-onboarding.spec.ts
+++ b/tests/performance/onboarding/seedless-apple-onboarding.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '../../framework/fixtures/playwright';
-import TimerHelper from '../../framework/TimerHelper';
 import { AppiumAssertions, AppiumGestures } from '../../framework';
 import { getPasswordForScenario } from '../../framework/utils/TestConstants.js';
 import {
@@ -18,99 +17,80 @@ import CreatePasswordView from '../../page-objects/Onboarding/CreatePasswordView
 import OnboardingSuccessView from '../../page-objects/Onboarding/OnboardingSuccessView';
 import WalletView from '../../page-objects/wallet/WalletView';
 import LoginView from '../../page-objects/wallet/LoginView';
-import { measureCreatePasswordToOnboardingSuccess } from './helpers/seedlessOnboardingTimers';
+import { addAppScreenTtcTimer } from '../utils/readScreenTtc';
+import {
+  createSeedlessOnboardingTimers,
+  measureCreatePasswordToOnboardingSuccess,
+  measurePostOauthToScreenContent,
+  SEEDLESS_APP_TTC_THRESHOLDS,
+  waitForChoosePasswordContent,
+  waitForOnboardingSheetContent,
+  waitForSocialRehydrateContent,
+} from './helpers/seedlessOnboardingTimers';
 
-const waitForFirstSuccessful = async <T>(promises: Promise<T>[]): Promise<T> =>
-  await new Promise<T>((resolve, reject) => {
-    let rejectedCount = 0;
-
-    promises.forEach((promise) => {
-      promise.then(resolve).catch(() => {
-        rejectedCount += 1;
-        if (rejectedCount === promises.length) {
-          reject(new Error('All screen detection promises failed'));
-        }
-      });
-    });
-  });
-
-/* Seedless Onboarding: Apple Login */
+/*
+ * Seedless Apple — in-app TTC (Sentry-equivalent) + nav/flow timers.
+ *
+ * After each screen's UI is visible, `addAppScreenTtcTimer` reads the
+ * mount→contentReady duration recorded by useScreenPerformance.
+ */
 test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
   test.setTimeout(360000);
 
   test(
     'Seedless Onboarding: Apple Login New User',
     { tag: '@metamask-onboarding-team' },
-    async ({ currentDeviceDetails, driver, performanceTracker }, testInfo) => {
-      const timer1 = new TimerHelper(
-        'Apple: Tap "Create new wallet" → OnboardingSheet visible',
-        { ios: 1500, android: 2000 },
-        currentDeviceDetails.platform,
-      );
-      const timer2 = new TimerHelper(
-        'Apple: Tap Apple login → post-OAuth screen visible',
-        { ios: 15000, android: 6000 },
-        currentDeviceDetails.platform,
-      );
-      const timer3 = new TimerHelper(
-        'Apple: Post-OAuth action → Password fields visible',
-        { ios: 5000, android: 4000 },
-        currentDeviceDetails.platform,
-      );
-      const timer4 = new TimerHelper(
-        'Apple: Tap "Create Password" → Onboarding Success visible',
-        { ios: 5000, android: 4000 },
-        currentDeviceDetails.platform,
-      );
-      const timer5 = new TimerHelper(
-        'Apple: Tap "Done" → wallet main screen visible',
-        { ios: 30000, android: 5000 },
-        currentDeviceDetails.platform,
-      );
+    async ({ currentDeviceDetails, driver, performanceTracker }) => {
+      const platform = currentDeviceDetails.platform;
+      const timers = createSeedlessOnboardingTimers('Apple', platform, {
+        sheet: { ios: 1500, android: 2000 },
+        postOauth: { ios: 15000, android: 6000 },
+        choosePassword: { ios: 5000, android: 4000 },
+        createWallet: { ios: 5000, android: 4000 },
+        walletChrome: { ios: 30000, android: 5000 },
+        rehydrate: { ios: 5000, android: 4000 },
+        existingWallet: { ios: 5000, android: 4000 },
+      });
 
       const password = getPasswordForScenario('onboarding') ?? '';
 
       await OnboardingView.tapCreateNewWalletButton();
-      await timer1.measure(async () => {
-        await AppiumAssertions.expectElementToBeVisible(
-          OnboardingSheet.appleLoginButton,
-          {
-            description: 'Apple login button should be visible',
-          },
-        );
+      await timers.sheetNav.measure(async () => {
+        await waitForOnboardingSheetContent('apple');
+      });
+      await addAppScreenTtcTimer({
+        performanceTracker,
+        screenId: 'onboarding_sheet',
+        platform,
+        threshold: SEEDLESS_APP_TTC_THRESHOLDS.onboarding_sheet,
       });
 
       await OnboardingSheet.tapAppleLoginButton();
       await SocialLoginView.dismissUpdateModalIfPresent();
 
-      let isNewUser = true;
+      const postOauthContent = await measurePostOauthToScreenContent(
+        timers.postOauthFlow,
+        'Apple',
+        platform,
+      );
+      await addAppScreenTtcTimer({
+        performanceTracker,
+        screenId: postOauthContent,
+        platform,
+        threshold: SEEDLESS_APP_TTC_THRESHOLDS[postOauthContent],
+      });
+      const isNewUser = postOauthContent !== 'account_already_exists';
 
-      if (currentDeviceDetails.platform === 'ios') {
-        await timer2.measure(async () => {
-          const result = await waitForFirstSuccessful([
-            SocialLoginView.isIosNewUserScreenVisible().then(() => 'new_user'),
-            SocialLoginView.isAccountFoundScreenVisible().then(
-              () => 'existing_user',
-            ),
-          ]);
-          isNewUser = result === 'new_user';
+      if (isNewUser && platform === 'ios') {
+        await SocialLoginView.tapIosNewUserSetPinButton();
+        await timers.choosePasswordNav.measure(async () => {
+          await waitForChoosePasswordContent();
         });
-
-        if (isNewUser) {
-          await SocialLoginView.tapIosNewUserSetPinButton();
-          await timer3.measure(async () => {
-            await CreatePasswordView.isVisible();
-          });
-        }
-      } else {
-        await timer2.measure(async () => {
-          const result = await waitForFirstSuccessful([
-            CreatePasswordView.isVisible().then(() => 'new_user'),
-            SocialLoginView.isAccountFoundScreenVisible().then(
-              () => 'existing_user',
-            ),
-          ]);
-          isNewUser = result === 'new_user';
+        await addAppScreenTtcTimer({
+          performanceTracker,
+          screenId: 'choose_pw',
+          platform,
+          threshold: SEEDLESS_APP_TTC_THRESHOLDS.choose_pw,
         });
       }
 
@@ -118,7 +98,6 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         await CreatePasswordView.enterPassword(password);
         await CreatePasswordView.reEnterPassword(password);
         await AppiumGestures.hideKeyboard();
-
         try {
           await CreatePasswordView.ensureMarketingOptInChecked();
         } catch (error) {
@@ -126,35 +105,52 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         }
         await AppiumGestures.hideKeyboard();
         await CreatePasswordView.tapCreatePasswordButton();
-        await measureCreatePasswordToOnboardingSuccess(timer4);
+        await measureCreatePasswordToOnboardingSuccess(timers.createWalletFlow);
+        await addAppScreenTtcTimer({
+          performanceTracker,
+          screenId: 'onboarding_success',
+          platform,
+          threshold: SEEDLESS_APP_TTC_THRESHOLDS.onboarding_success,
+        });
 
         await OnboardingSuccessView.tapDone();
         await dismissPushNotificationExistingUserSheet();
         await closePredictModal();
-        await timer5.measure(async () => {
+        await timers.walletChromeFlow.measure(async () => {
           await AppiumAssertions.expectElementToBeVisible(
-            WalletView.accountIcon, // Workaround until iOS nested component gets fixed
+            WalletView.accountIcon,
             {
               description: 'Wallet main screen should be visible',
             },
           );
         });
 
-        const timers = [timer1, timer2, timer4, timer5];
-        if (currentDeviceDetails.platform === 'ios') {
-          timers.splice(2, 0, timer3);
+        const registered = [
+          timers.sheetNav,
+          timers.postOauthFlow,
+          timers.createWalletFlow,
+          timers.walletChromeFlow,
+        ];
+        if (platform === 'ios') {
+          registered.splice(2, 0, timers.choosePasswordNav);
         }
-        performanceTracker.addTimers(...timers);
+        performanceTracker.addTimers(...registered);
       } else {
         await SocialLoginView.tapAccountFoundLoginButton();
-        await timer3.measure(async () => {
-          await LoginView.waitForScreenToDisplay();
+        await timers.rehydrateNav.measure(async () => {
+          await waitForSocialRehydrateContent();
+        });
+        await addAppScreenTtcTimer({
+          performanceTracker,
+          screenId: 'social_rehydrate',
+          platform,
+          threshold: SEEDLESS_APP_TTC_THRESHOLDS.social_rehydrate,
         });
 
         await LoginView.enterPassword(password);
         await LoginView.tapLoginButton();
 
-        await timer4.measure(async () => {
+        await timers.existingWalletFlow.measure(async () => {
           await AppiumAssertions.expectElementToBeVisible(
             WalletView.container,
             {
@@ -163,7 +159,12 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
           );
         });
 
-        performanceTracker.addTimers(timer1, timer2, timer3, timer4);
+        performanceTracker.addTimers(
+          timers.sheetNav,
+          timers.postOauthFlow,
+          timers.rehydrateNav,
+          timers.existingWalletFlow,
+        );
       }
     },
   );

--- a/tests/performance/onboarding/seedless-apple-onboarding.spec.ts
+++ b/tests/performance/onboarding/seedless-apple-onboarding.spec.ts
@@ -58,6 +58,7 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
       await timers.sheetNav.measure(async () => {
         await waitForOnboardingSheetContent('apple');
       });
+      performanceTracker.addTimer(timers.sheetNav);
       await addAppScreenTtcTimer({
         performanceTracker,
         screenId: 'onboarding_sheet',
@@ -73,6 +74,7 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         'Apple',
         platform,
       );
+      performanceTracker.addTimer(timers.postOauthFlow);
       await addAppScreenTtcTimer({
         performanceTracker,
         screenId: postOauthContent,
@@ -86,6 +88,7 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         await timers.choosePasswordNav.measure(async () => {
           await waitForChoosePasswordContent();
         });
+        performanceTracker.addTimer(timers.choosePasswordNav);
         await addAppScreenTtcTimer({
           performanceTracker,
           screenId: 'choose_pw',
@@ -106,6 +109,7 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         await AppiumGestures.hideKeyboard();
         await CreatePasswordView.tapCreatePasswordButton();
         await measureCreatePasswordToOnboardingSuccess(timers.createWalletFlow);
+        performanceTracker.addTimer(timers.createWalletFlow);
         await addAppScreenTtcTimer({
           performanceTracker,
           screenId: 'onboarding_success',
@@ -124,22 +128,13 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
             },
           );
         });
-
-        const registered = [
-          timers.sheetNav,
-          timers.postOauthFlow,
-          timers.createWalletFlow,
-          timers.walletChromeFlow,
-        ];
-        if (platform === 'ios') {
-          registered.splice(2, 0, timers.choosePasswordNav);
-        }
-        performanceTracker.addTimers(...registered);
+        performanceTracker.addTimer(timers.walletChromeFlow);
       } else {
         await SocialLoginView.tapAccountFoundLoginButton();
         await timers.rehydrateNav.measure(async () => {
           await waitForSocialRehydrateContent();
         });
+        performanceTracker.addTimer(timers.rehydrateNav);
         await addAppScreenTtcTimer({
           performanceTracker,
           screenId: 'social_rehydrate',
@@ -158,13 +153,7 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
             },
           );
         });
-
-        performanceTracker.addTimers(
-          timers.sheetNav,
-          timers.postOauthFlow,
-          timers.rehydrateNav,
-          timers.existingWalletFlow,
-        );
+        performanceTracker.addTimer(timers.existingWalletFlow);
       }
     },
   );

--- a/tests/performance/onboarding/seedless-google-onboarding.spec.ts
+++ b/tests/performance/onboarding/seedless-google-onboarding.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '../../framework/fixtures/playwright';
-import TimerHelper from '../../framework/TimerHelper';
 import { AppiumAssertions, AppiumGestures } from '../../framework';
 import { getPasswordForScenario } from '../../framework/utils/TestConstants.js';
 import {
@@ -18,99 +17,80 @@ import CreatePasswordView from '../../page-objects/Onboarding/CreatePasswordView
 import OnboardingSuccessView from '../../page-objects/Onboarding/OnboardingSuccessView';
 import WalletView from '../../page-objects/wallet/WalletView';
 import LoginView from '../../page-objects/wallet/LoginView';
-import { measureCreatePasswordToOnboardingSuccess } from './helpers/seedlessOnboardingTimers';
+import { addAppScreenTtcTimer } from '../utils/readScreenTtc';
+import {
+  createSeedlessOnboardingTimers,
+  measureCreatePasswordToOnboardingSuccess,
+  measurePostOauthToScreenContent,
+  SEEDLESS_APP_TTC_THRESHOLDS,
+  waitForChoosePasswordContent,
+  waitForOnboardingSheetContent,
+  waitForSocialRehydrateContent,
+} from './helpers/seedlessOnboardingTimers';
 
-const waitForFirstSuccessful = async <T>(promises: Promise<T>[]): Promise<T> =>
-  await new Promise<T>((resolve, reject) => {
-    let rejectedCount = 0;
-
-    promises.forEach((promise) => {
-      promise.then(resolve).catch(() => {
-        rejectedCount += 1;
-        if (rejectedCount === promises.length) {
-          reject(new Error('All screen detection promises failed'));
-        }
-      });
-    });
-  });
-
-/* Seedless Onboarding: Google Login */
+/*
+ * Seedless Google — in-app TTC (Sentry-equivalent) + nav/flow timers.
+ *
+ * After each screen's UI is visible, `addAppScreenTtcTimer` reads the
+ * mount→contentReady duration recorded by useScreenPerformance.
+ */
 test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
   test.setTimeout(360000);
 
   test(
     'Seedless Onboarding: Google Login New User',
     { tag: '@metamask-onboarding-team' },
-    async ({ currentDeviceDetails, driver, performanceTracker }, testInfo) => {
-      const timer1 = new TimerHelper(
-        'Google: Tap "Create new wallet" → OnboardingSheet visible',
-        { ios: 1500, android: 2000 },
-        currentDeviceDetails.platform,
-      );
-      const timer2 = new TimerHelper(
-        'Google: Tap Google login → post-OAuth screen visible',
-        { ios: 15000, android: 5000 },
-        currentDeviceDetails.platform,
-      );
-      const timer3 = new TimerHelper(
-        'Google: Post-OAuth action → Password fields visible',
-        { ios: 4000, android: 4000 },
-        currentDeviceDetails.platform,
-      );
-      const timer4 = new TimerHelper(
-        'Google: Tap "Create Password" → Onboarding Success visible',
-        { ios: 5000, android: 4000 },
-        currentDeviceDetails.platform,
-      );
-      const timer5 = new TimerHelper(
-        'Google: Tap "Done" → wallet main screen visible',
-        { ios: 30000, android: 5000 },
-        currentDeviceDetails.platform,
-      );
+    async ({ currentDeviceDetails, driver, performanceTracker }) => {
+      const platform = currentDeviceDetails.platform;
+      const timers = createSeedlessOnboardingTimers('Google', platform, {
+        sheet: { ios: 1500, android: 2000 },
+        postOauth: { ios: 15000, android: 5000 },
+        choosePassword: { ios: 4000, android: 4000 },
+        createWallet: { ios: 5000, android: 4000 },
+        walletChrome: { ios: 30000, android: 5000 },
+        rehydrate: { ios: 4000, android: 4000 },
+        existingWallet: { ios: 5000, android: 4000 },
+      });
 
       const password = getPasswordForScenario('onboarding') ?? '';
 
       await OnboardingView.tapCreateNewWalletButton();
-      await timer1.measure(async () => {
-        await AppiumAssertions.expectElementToBeVisible(
-          OnboardingSheet.googleLoginButton,
-          {
-            description: 'Google login button should be visible',
-          },
-        );
+      await timers.sheetNav.measure(async () => {
+        await waitForOnboardingSheetContent('google');
+      });
+      await addAppScreenTtcTimer({
+        performanceTracker,
+        screenId: 'onboarding_sheet',
+        platform,
+        threshold: SEEDLESS_APP_TTC_THRESHOLDS.onboarding_sheet,
       });
 
       await OnboardingSheet.tapGoogleLoginButton();
       await SocialLoginView.dismissUpdateModalIfPresent();
 
-      let isNewUser = true;
+      const postOauthContent = await measurePostOauthToScreenContent(
+        timers.postOauthFlow,
+        'Google',
+        platform,
+      );
+      await addAppScreenTtcTimer({
+        performanceTracker,
+        screenId: postOauthContent,
+        platform,
+        threshold: SEEDLESS_APP_TTC_THRESHOLDS[postOauthContent],
+      });
+      const isNewUser = postOauthContent !== 'account_already_exists';
 
-      if (currentDeviceDetails.platform === 'ios') {
-        await timer2.measure(async () => {
-          const result = await waitForFirstSuccessful([
-            SocialLoginView.isIosNewUserScreenVisible().then(() => 'new_user'),
-            SocialLoginView.isAccountFoundScreenVisible().then(
-              () => 'existing_user',
-            ),
-          ]);
-          isNewUser = result === 'new_user';
+      if (isNewUser && platform === 'ios') {
+        await SocialLoginView.tapIosNewUserSetPinButton();
+        await timers.choosePasswordNav.measure(async () => {
+          await waitForChoosePasswordContent();
         });
-
-        if (isNewUser) {
-          await SocialLoginView.tapIosNewUserSetPinButton();
-          await timer3.measure(async () => {
-            await CreatePasswordView.isVisible();
-          });
-        }
-      } else {
-        await timer2.measure(async () => {
-          const result = await waitForFirstSuccessful([
-            CreatePasswordView.isVisible().then(() => 'new_user'),
-            SocialLoginView.isAccountFoundScreenVisible().then(
-              () => 'existing_user',
-            ),
-          ]);
-          isNewUser = result === 'new_user';
+        await addAppScreenTtcTimer({
+          performanceTracker,
+          screenId: 'choose_pw',
+          platform,
+          threshold: SEEDLESS_APP_TTC_THRESHOLDS.choose_pw,
         });
       }
 
@@ -124,40 +104,52 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
           console.error('Error ensuring marketing opt-in checked:', error);
         }
         await CreatePasswordView.tapCreatePasswordButton();
-        //await measureCreatePasswordToOnboardingSuccess(timer4);
-        await timer4.measure(async () => {
-          await AppiumAssertions.expectElementToBeVisible(
-            OnboardingSuccessView.doneButton,
-          );
+        await measureCreatePasswordToOnboardingSuccess(timers.createWalletFlow);
+        await addAppScreenTtcTimer({
+          performanceTracker,
+          screenId: 'onboarding_success',
+          platform,
+          threshold: SEEDLESS_APP_TTC_THRESHOLDS.onboarding_success,
         });
 
         await OnboardingSuccessView.tapDone();
         await dismissPushNotificationExistingUserSheet();
         await closePredictModal();
-        await timer5.measure(async () => {
+        await timers.walletChromeFlow.measure(async () => {
           await AppiumAssertions.expectElementToBeVisible(
-            WalletView.accountIcon, // Workaround until iOS nested component gets fixed
+            WalletView.accountIcon,
             {
               description: 'Wallet main screen should be visible',
             },
           );
         });
 
-        const timers = [timer1, timer2, timer4, timer5];
-        if (currentDeviceDetails.platform === 'ios') {
-          timers.splice(2, 0, timer3);
+        const registered = [
+          timers.sheetNav,
+          timers.postOauthFlow,
+          timers.createWalletFlow,
+          timers.walletChromeFlow,
+        ];
+        if (platform === 'ios') {
+          registered.splice(2, 0, timers.choosePasswordNav);
         }
-        performanceTracker.addTimers(...timers);
+        performanceTracker.addTimers(...registered);
       } else {
         await SocialLoginView.tapAccountFoundLoginButton();
-        await timer3.measure(async () => {
-          await LoginView.waitForScreenToDisplay();
+        await timers.rehydrateNav.measure(async () => {
+          await waitForSocialRehydrateContent();
+        });
+        await addAppScreenTtcTimer({
+          performanceTracker,
+          screenId: 'social_rehydrate',
+          platform,
+          threshold: SEEDLESS_APP_TTC_THRESHOLDS.social_rehydrate,
         });
 
         await LoginView.enterPassword(password);
         await LoginView.tapLoginButton();
 
-        await timer4.measure(async () => {
+        await timers.existingWalletFlow.measure(async () => {
           await AppiumAssertions.expectElementToBeVisible(
             WalletView.container,
             {
@@ -166,7 +158,12 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
           );
         });
 
-        performanceTracker.addTimers(timer1, timer2, timer3, timer4);
+        performanceTracker.addTimers(
+          timers.sheetNav,
+          timers.postOauthFlow,
+          timers.rehydrateNav,
+          timers.existingWalletFlow,
+        );
       }
     },
   );

--- a/tests/performance/onboarding/seedless-google-onboarding.spec.ts
+++ b/tests/performance/onboarding/seedless-google-onboarding.spec.ts
@@ -58,6 +58,7 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
       await timers.sheetNav.measure(async () => {
         await waitForOnboardingSheetContent('google');
       });
+      performanceTracker.addTimer(timers.sheetNav);
       await addAppScreenTtcTimer({
         performanceTracker,
         screenId: 'onboarding_sheet',
@@ -73,6 +74,7 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         'Google',
         platform,
       );
+      performanceTracker.addTimer(timers.postOauthFlow);
       await addAppScreenTtcTimer({
         performanceTracker,
         screenId: postOauthContent,
@@ -86,6 +88,7 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         await timers.choosePasswordNav.measure(async () => {
           await waitForChoosePasswordContent();
         });
+        performanceTracker.addTimer(timers.choosePasswordNav);
         await addAppScreenTtcTimer({
           performanceTracker,
           screenId: 'choose_pw',
@@ -105,6 +108,7 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         }
         await CreatePasswordView.tapCreatePasswordButton();
         await measureCreatePasswordToOnboardingSuccess(timers.createWalletFlow);
+        performanceTracker.addTimer(timers.createWalletFlow);
         await addAppScreenTtcTimer({
           performanceTracker,
           screenId: 'onboarding_success',
@@ -123,22 +127,13 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
             },
           );
         });
-
-        const registered = [
-          timers.sheetNav,
-          timers.postOauthFlow,
-          timers.createWalletFlow,
-          timers.walletChromeFlow,
-        ];
-        if (platform === 'ios') {
-          registered.splice(2, 0, timers.choosePasswordNav);
-        }
-        performanceTracker.addTimers(...registered);
+        performanceTracker.addTimer(timers.walletChromeFlow);
       } else {
         await SocialLoginView.tapAccountFoundLoginButton();
         await timers.rehydrateNav.measure(async () => {
           await waitForSocialRehydrateContent();
         });
+        performanceTracker.addTimer(timers.rehydrateNav);
         await addAppScreenTtcTimer({
           performanceTracker,
           screenId: 'social_rehydrate',
@@ -157,13 +152,7 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
             },
           );
         });
-
-        performanceTracker.addTimers(
-          timers.sheetNav,
-          timers.postOauthFlow,
-          timers.rehydrateNav,
-          timers.existingWalletFlow,
-        );
+        performanceTracker.addTimer(timers.existingWalletFlow);
       }
     },
   );

--- a/tests/performance/onboarding/seedless-telegram-onboarding.spec.ts
+++ b/tests/performance/onboarding/seedless-telegram-onboarding.spec.ts
@@ -78,6 +78,7 @@ perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
       await timers.sheetNav.measure(async () => {
         await assertTelegramLoginReady();
       });
+      performanceTracker.addTimer(timers.sheetNav);
       await addAppScreenTtcTimer({
         performanceTracker,
         screenId: 'onboarding_sheet',
@@ -93,6 +94,7 @@ perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         'Telegram',
         platform,
       );
+      performanceTracker.addTimer(timers.postOauthFlow);
       await addAppScreenTtcTimer({
         performanceTracker,
         screenId: postOauthContent,
@@ -106,6 +108,7 @@ perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         await timers.choosePasswordNav.measure(async () => {
           await waitForChoosePasswordContent();
         });
+        performanceTracker.addTimer(timers.choosePasswordNav);
         await addAppScreenTtcTimer({
           performanceTracker,
           screenId: 'choose_pw',
@@ -125,6 +128,7 @@ perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         }
         await CreatePasswordView.tapCreatePasswordButton();
         await measureCreatePasswordToOnboardingSuccess(timers.createWalletFlow);
+        performanceTracker.addTimer(timers.createWalletFlow);
         await addAppScreenTtcTimer({
           performanceTracker,
           screenId: 'onboarding_success',
@@ -143,22 +147,13 @@ perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
             },
           );
         });
-
-        const registered = [
-          timers.sheetNav,
-          timers.postOauthFlow,
-          timers.createWalletFlow,
-          timers.walletChromeFlow,
-        ];
-        if (platform === 'ios') {
-          registered.splice(2, 0, timers.choosePasswordNav);
-        }
-        performanceTracker.addTimers(...registered);
+        performanceTracker.addTimer(timers.walletChromeFlow);
       } else {
         await SocialLoginView.tapAccountFoundLoginButton();
         await timers.rehydrateNav.measure(async () => {
           await waitForSocialRehydrateContent();
         });
+        performanceTracker.addTimer(timers.rehydrateNav);
         await addAppScreenTtcTimer({
           performanceTracker,
           screenId: 'social_rehydrate',
@@ -177,13 +172,7 @@ perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
             },
           );
         });
-
-        performanceTracker.addTimers(
-          timers.sheetNav,
-          timers.postOauthFlow,
-          timers.rehydrateNav,
-          timers.existingWalletFlow,
-        );
+        performanceTracker.addTimer(timers.existingWalletFlow);
       }
     },
   );

--- a/tests/performance/onboarding/seedless-telegram-onboarding.spec.ts
+++ b/tests/performance/onboarding/seedless-telegram-onboarding.spec.ts
@@ -1,5 +1,4 @@
 import { test as perfTest } from '../../framework/fixtures/playwright';
-import TimerHelper from '../../framework/TimerHelper';
 import { AppiumAssertions, AppiumGestures } from '../../framework';
 import { getPasswordForScenario } from '../../framework/utils/TestConstants.js';
 import {
@@ -18,33 +17,22 @@ import CreatePasswordView from '../../page-objects/Onboarding/CreatePasswordView
 import OnboardingSuccessView from '../../page-objects/Onboarding/OnboardingSuccessView';
 import WalletView from '../../page-objects/wallet/WalletView';
 import LoginView from '../../page-objects/wallet/LoginView';
-import { measureCreatePasswordToOnboardingSuccess } from './helpers/seedlessOnboardingTimers';
-
-const waitForFirstSuccessful = async <T>(promises: Promise<T>[]): Promise<T> =>
-  await new Promise<T>((resolve, reject) => {
-    let rejectedCount = 0;
-
-    promises.forEach((promise) => {
-      promise.then(resolve).catch(() => {
-        rejectedCount += 1;
-        if (rejectedCount === promises.length) {
-          reject(new Error('All screen detection promises failed'));
-        }
-      });
-    });
-  });
+import { addAppScreenTtcTimer } from '../utils/readScreenTtc';
+import {
+  createSeedlessOnboardingTimers,
+  measureCreatePasswordToOnboardingSuccess,
+  measurePostOauthToScreenContent,
+  SEEDLESS_APP_TTC_THRESHOLDS,
+  waitForChoosePasswordContent,
+  waitForOnboardingSheetContent,
+  waitForSocialRehydrateContent,
+} from './helpers/seedlessOnboardingTimers';
 
 const assertTelegramLoginReady = async (): Promise<void> => {
   try {
-    await AppiumAssertions.expectElementToBeVisible(
-      OnboardingSheet.telegramLoginButton,
-      {
-        description: 'Telegram login button should be visible',
-      },
-    );
+    await waitForOnboardingSheetContent('telegram');
   } catch (error) {
     const details = error instanceof Error ? error.message : String(error);
-    // Missing button is a build/flag setup failure, not a timer regression.
     throw new Error(
       [
         'TO-916 setup failure: Telegram login button was not visible on the onboarding sheet.',
@@ -58,44 +46,26 @@ const assertTelegramLoginReady = async (): Promise<void> => {
   }
 };
 
-/* TO-916: Seedless Onboarding — Telegram Login */
+/*
+ * TO-916 Seedless Telegram — in-app TTC (Sentry-equivalent) + nav/flow timers.
+ */
 perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
   perfTest.setTimeout(300000);
 
   perfTest(
     'Seedless Onboarding: Telegram Login New User',
     { tag: '@metamask-onboarding-team' },
-    // Request `driver` so the Playwright/Appium fixture boots before page-object
-    // actions run.
     async ({ currentDeviceDetails, driver, performanceTracker }) => {
-      // Conservative initial guardrails — calibrate against BrowserStack
-      // baselines once this coverage has 10+ clean RC/release-profile runs
-      // (see TO-916 acceptance criteria for p50/p95 documentation).
-      const timer1 = new TimerHelper(
-        'Telegram: Tap "Create new wallet" → OnboardingSheet visible',
-        { ios: 1500, android: 2000 },
-        currentDeviceDetails.platform,
-      );
-      const timer2 = new TimerHelper(
-        'Telegram: Tap Telegram login → post-OAuth screen visible',
-        { ios: 15000, android: 15000 },
-        currentDeviceDetails.platform,
-      );
-      const timer3 = new TimerHelper(
-        'Telegram: Post-OAuth action → Password fields visible',
-        { ios: 4000, android: 4000 },
-        currentDeviceDetails.platform,
-      );
-      const timer4 = new TimerHelper(
-        'Telegram: Tap "Create Password" → Onboarding Success visible',
-        { ios: 5000, android: 4000 },
-        currentDeviceDetails.platform,
-      );
-      const timer5 = new TimerHelper(
-        'Telegram: Tap "Done" → wallet main screen visible',
-        { ios: 30000, android: 5000 },
-        currentDeviceDetails.platform,
-      );
+      const platform = currentDeviceDetails.platform;
+      const timers = createSeedlessOnboardingTimers('Telegram', platform, {
+        sheet: { ios: 1500, android: 2000 },
+        postOauth: { ios: 15000, android: 15000 },
+        choosePassword: { ios: 4000, android: 4000 },
+        createWallet: { ios: 5000, android: 4000 },
+        walletChrome: { ios: 30000, android: 5000 },
+        rehydrate: { ios: 4000, android: 4000 },
+        existingWallet: { ios: 5000, android: 4000 },
+      });
 
       const password = getPasswordForScenario('onboarding') ?? '';
       if (!password) {
@@ -105,46 +75,46 @@ perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
       }
 
       await OnboardingView.tapCreateNewWalletButton();
-      await timer1.measure(async () => {
+      await timers.sheetNav.measure(async () => {
         await assertTelegramLoginReady();
+      });
+      await addAppScreenTtcTimer({
+        performanceTracker,
+        screenId: 'onboarding_sheet',
+        platform,
+        threshold: SEEDLESS_APP_TTC_THRESHOLDS.onboarding_sheet,
       });
 
       await OnboardingSheet.tapTelegramLoginButton();
       await SocialLoginView.dismissUpdateModalIfPresent();
 
-      let isNewUser = true;
+      const postOauthContent = await measurePostOauthToScreenContent(
+        timers.postOauthFlow,
+        'Telegram',
+        platform,
+      );
+      await addAppScreenTtcTimer({
+        performanceTracker,
+        screenId: postOauthContent,
+        platform,
+        threshold: SEEDLESS_APP_TTC_THRESHOLDS[postOauthContent],
+      });
+      const isNewUser = postOauthContent !== 'account_already_exists';
 
-      if (currentDeviceDetails.platform === 'ios') {
-        await timer2.measure(async () => {
-          const result = await waitForFirstSuccessful([
-            SocialLoginView.isIosNewUserScreenVisible().then(() => 'new_user'),
-            SocialLoginView.isAccountFoundScreenVisible().then(
-              () => 'existing_user',
-            ),
-          ]);
-          isNewUser = result === 'new_user';
+      if (isNewUser && platform === 'ios') {
+        await SocialLoginView.tapIosNewUserSetPinButton();
+        await timers.choosePasswordNav.measure(async () => {
+          await waitForChoosePasswordContent();
         });
-
-        if (isNewUser) {
-          await SocialLoginView.tapIosNewUserSetPinButton();
-          await timer3.measure(async () => {
-            await CreatePasswordView.isVisible();
-          });
-        }
-      } else {
-        await timer2.measure(async () => {
-          const result = await waitForFirstSuccessful([
-            CreatePasswordView.isVisible().then(() => 'new_user'),
-            SocialLoginView.isAccountFoundScreenVisible().then(
-              () => 'existing_user',
-            ),
-          ]);
-          isNewUser = result === 'new_user';
+        await addAppScreenTtcTimer({
+          performanceTracker,
+          screenId: 'choose_pw',
+          platform,
+          threshold: SEEDLESS_APP_TTC_THRESHOLDS.choose_pw,
         });
       }
 
       if (isNewUser) {
-        // Password entry is excluded from measured steps (manual auth/typing).
         await CreatePasswordView.enterPassword(password);
         await CreatePasswordView.reEnterPassword(password);
         await AppiumGestures.hideKeyboard();
@@ -154,42 +124,52 @@ perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
           console.error('Error ensuring marketing opt-in checked:', error);
         }
         await CreatePasswordView.tapCreatePasswordButton();
-        //await measureCreatePasswordToOnboardingSuccess(timer4);
-        await timer4.measure(async () => {
-          await AppiumAssertions.expectElementToBeVisible(
-            OnboardingSuccessView.doneButton,
-          );
+        await measureCreatePasswordToOnboardingSuccess(timers.createWalletFlow);
+        await addAppScreenTtcTimer({
+          performanceTracker,
+          screenId: 'onboarding_success',
+          platform,
+          threshold: SEEDLESS_APP_TTC_THRESHOLDS.onboarding_success,
         });
+
         await OnboardingSuccessView.tapDone();
         await dismissPushNotificationExistingUserSheet();
         await closePredictModal();
-        await timer5.measure(async () => {
+        await timers.walletChromeFlow.measure(async () => {
           await AppiumAssertions.expectElementToBeVisible(
-            WalletView.accountIcon, // Workaround until iOS nested component gets fixed
+            WalletView.accountIcon,
             {
               description: 'Wallet main screen should be visible',
             },
           );
         });
 
-        const timers = [timer1, timer2, timer4, timer5];
-        if (currentDeviceDetails.platform === 'ios') {
-          timers.splice(2, 0, timer3);
+        const registered = [
+          timers.sheetNav,
+          timers.postOauthFlow,
+          timers.createWalletFlow,
+          timers.walletChromeFlow,
+        ];
+        if (platform === 'ios') {
+          registered.splice(2, 0, timers.choosePasswordNav);
         }
-        performanceTracker.addTimers(...timers);
+        performanceTracker.addTimers(...registered);
       } else {
-        // Existing-user rehydration when the QA mock / account returns Account Found.
-        // E2E_MOCK_OAUTH QA mock currently forces new-user results; keep this path
-        // so existing-user coverage activates when test account/setup permits.
         await SocialLoginView.tapAccountFoundLoginButton();
-        await timer3.measure(async () => {
-          await LoginView.waitForScreenToDisplay();
+        await timers.rehydrateNav.measure(async () => {
+          await waitForSocialRehydrateContent();
+        });
+        await addAppScreenTtcTimer({
+          performanceTracker,
+          screenId: 'social_rehydrate',
+          platform,
+          threshold: SEEDLESS_APP_TTC_THRESHOLDS.social_rehydrate,
         });
 
         await LoginView.enterPassword(password);
         await LoginView.tapLoginButton();
 
-        await timer4.measure(async () => {
+        await timers.existingWalletFlow.measure(async () => {
           await AppiumAssertions.expectElementToBeVisible(
             WalletView.container,
             {
@@ -198,7 +178,12 @@ perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
           );
         });
 
-        performanceTracker.addTimers(timer1, timer2, timer3, timer4);
+        performanceTracker.addTimers(
+          timers.sheetNav,
+          timers.postOauthFlow,
+          timers.rehydrateNav,
+          timers.existingWalletFlow,
+        );
       }
     },
   );

--- a/tests/performance/utils/readScreenTtc.ts
+++ b/tests/performance/utils/readScreenTtc.ts
@@ -1,0 +1,84 @@
+import Matchers from '../../framework/Matchers';
+import { PlatformDetector } from '../../framework/PlatformLocator';
+import {
+  parseScreenTtcAccessibilityLabel,
+  screenTtcTestId,
+} from '../../../app/hooks/performance/screenTtcRegistry';
+import type { OnboardingScreenId } from '../../../app/hooks/performance/onboardingPerformanceIds';
+import TimerHelper, {
+  type PlatformThreshold,
+} from '../../framework/TimerHelper';
+import type { PerformanceTracker } from '../../reporters/PerformanceTracker';
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const POLL_MS = 200;
+
+async function readProbeLabel(screenId: OnboardingScreenId): Promise<string> {
+  const el = await Matchers.getElementByID(screenTtcTestId(screenId));
+  if (PlatformDetector.isAndroid()) {
+    return (await el.getAttribute('content-desc')) ?? '';
+  }
+  return (
+    (await el.getAttribute('label')) ?? (await el.getAttribute('name')) ?? ''
+  );
+}
+
+/**
+ * Waits for the in-app TTC probe written by `useScreenPerformance` (same
+ * mount→contentReady duration as Sentry Onboarding Screen Time To Content).
+ */
+export async function waitForAppScreenTtc(
+  screenId: OnboardingScreenId,
+  options?: { timeoutMs?: number; minGeneration?: number },
+): Promise<number> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const minGeneration = options?.minGeneration ?? 1;
+  const deadline = Date.now() + timeoutMs;
+  let lastLabel = '';
+
+  while (Date.now() < deadline) {
+    try {
+      lastLabel = await readProbeLabel(screenId);
+      const parsed = parseScreenTtcAccessibilityLabel(lastLabel);
+      if (
+        parsed &&
+        parsed.screenId === screenId &&
+        parsed.generation >= minGeneration
+      ) {
+        return parsed.durationMs;
+      }
+    } catch {
+      // Probe not mounted yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+  }
+
+  throw new Error(
+    `Timed out waiting for in-app TTC probe for [${screenId}] within ${timeoutMs}ms (last label: "${lastLabel}")`,
+  );
+}
+
+/**
+ * Reads in-app TTC and registers it on the performance tracker.
+ * Thresholds should stay generous until BrowserStack baselines exist.
+ */
+export async function addAppScreenTtcTimer(options: {
+  performanceTracker: PerformanceTracker;
+  screenId: OnboardingScreenId;
+  platform: 'ios' | 'android';
+  threshold: PlatformThreshold;
+  minGeneration?: number;
+}): Promise<number> {
+  const durationMs = await waitForAppScreenTtc(options.screenId, {
+    minGeneration: options.minGeneration,
+  });
+
+  const timer = new TimerHelper(
+    `TTC [${options.screenId}]: in-app mount→contentReady`,
+    options.threshold,
+    options.platform,
+  );
+  timer.recordDuration(durationMs);
+  options.performanceTracker.addTimer(timer);
+  return durationMs;
+}

--- a/tests/performance/utils/readScreenTtc.ts
+++ b/tests/performance/utils/readScreenTtc.ts
@@ -1,4 +1,5 @@
 import Matchers from '../../framework/Matchers';
+import AppiumMatchers from '../../framework/AppiumMatchers';
 import { PlatformDetector } from '../../framework/PlatformLocator';
 import {
   parseScreenTtcAccessibilityLabel,
@@ -9,18 +10,91 @@ import TimerHelper, {
   type PlatformThreshold,
 } from '../../framework/TimerHelper';
 import type { PerformanceTracker } from '../../reporters/PerformanceTracker';
+import type { AppiumElement } from '../../framework/AppiumElement';
 
-const DEFAULT_TIMEOUT_MS = 15_000;
-const POLL_MS = 200;
+const DEFAULT_TIMEOUT_MS = 20_000;
+const POLL_MS = 250;
 
-async function readProbeLabel(screenId: OnboardingScreenId): Promise<string> {
-  const el = await Matchers.getElementByID(screenTtcTestId(screenId));
+async function readAttribute(el: AppiumElement, name: string): Promise<string> {
+  try {
+    return (await el.getAttribute(name)) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+async function labelFromElement(el: AppiumElement): Promise<string> {
   if (PlatformDetector.isAndroid()) {
-    return (await el.getAttribute('content-desc')) ?? '';
+    return (
+      (await readAttribute(el, 'contentDescription')) ||
+      (await readAttribute(el, 'content-desc')) ||
+      (await readAttribute(el, 'text')) ||
+      ''
+    );
   }
   return (
-    (await el.getAttribute('label')) ?? (await el.getAttribute('name')) ?? ''
+    (await readAttribute(el, 'label')) ||
+    (await readAttribute(el, 'name')) ||
+    (await readAttribute(el, 'value')) ||
+    ''
   );
+}
+
+/**
+ * Resolve the probe using several strategies — Android resource-ids are often
+ * package-qualified (`io.metamask…:id/perf-ttc-…`), and content-desc may be
+ * easier to match than resource-id for accessibility Views.
+ */
+async function findProbeElement(
+  screenId: OnboardingScreenId,
+): Promise<AppiumElement> {
+  const testId = screenTtcTestId(screenId);
+  const errors: string[] = [];
+
+  const attempts: (() => Promise<AppiumElement>)[] = [
+    // Suffix match handles package-qualified Android resource ids.
+    () => Matchers.getElementByID(new RegExp(`${testId}$`)),
+    () => Matchers.getElementByID(testId),
+  ];
+
+  if (PlatformDetector.isAndroid()) {
+    attempts.push(() =>
+      AppiumMatchers.getElementByAndroidUIAutomator(
+        `.descriptionStartsWith("ttc:${screenId}:")`,
+      ),
+    );
+    attempts.push(() =>
+      AppiumMatchers.getElementById(testId, { exact: false }),
+    );
+  } else {
+    attempts.push(() =>
+      AppiumMatchers.getElementByIOSPredicate(
+        `label BEGINSWITH "ttc:${screenId}:" OR name == "${testId}"`,
+      ),
+    );
+  }
+
+  for (const attempt of attempts) {
+    try {
+      const el = await attempt();
+      // Force a presence check when the driver returns a lazy ref.
+      if (typeof el.isDisplayed === 'function') {
+        await el.isDisplayed().catch(() => undefined);
+      }
+      return el;
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  throw new Error(
+    `TTC probe not found for [${screenId}] (tried ${attempts.length} strategies): ${errors.join(' | ')}`,
+  );
+}
+
+async function readProbeLabel(screenId: OnboardingScreenId): Promise<string> {
+  const el = await findProbeElement(screenId);
+  return labelFromElement(el);
 }
 
 /**
@@ -35,6 +109,7 @@ export async function waitForAppScreenTtc(
   const minGeneration = options?.minGeneration ?? 1;
   const deadline = Date.now() + timeoutMs;
   let lastLabel = '';
+  let lastError = '';
 
   while (Date.now() < deadline) {
     try {
@@ -47,14 +122,14 @@ export async function waitForAppScreenTtc(
       ) {
         return parsed.durationMs;
       }
-    } catch {
-      // Probe not mounted yet.
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
     }
     await new Promise((resolve) => setTimeout(resolve, POLL_MS));
   }
 
   throw new Error(
-    `Timed out waiting for in-app TTC probe for [${screenId}] within ${timeoutMs}ms (last label: "${lastLabel}")`,
+    `Timed out waiting for in-app TTC probe for [${screenId}] within ${timeoutMs}ms (last label: "${lastLabel}"; last error: ${lastError})`,
   );
 }
 

--- a/tests/performance/utils/readScreenTtc.ts
+++ b/tests/performance/utils/readScreenTtc.ts
@@ -77,10 +77,8 @@ async function findProbeElement(
   for (const attempt of attempts) {
     try {
       const el = await attempt();
-      // Force a presence check when the driver returns a lazy ref.
-      if (typeof el.isDisplayed === 'function') {
-        await el.isDisplayed().catch(() => undefined);
-      }
+      // Presence is enough — probes are near-invisible, so skip isDisplayed.
+      // AppiumElement exposes isVisible, not isDisplayed (TS2339 in lint:tsc).
       return el;
     } catch (error) {
       errors.push(error instanceof Error ? error.message : String(error));


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
CI onboarding perf tests historically measured **nav/flow** steps (tap → UI, OAuth, wallet create) but not the same **per-screen Time To Content** that production reports in Sentry (`Onboarding Screen Time To Content` via `useScreenPerformance`: React mount → `contentReady`). That gap made it hard to catch UI regressions that show up in live Sentry but not in CI.
This PR records **in-app TTC** during e2e/perf builds and reads it from Appium:
- `screenTtcRegistry` + `useScreenPerformance` store the same duration Sentry spans use
- `ScreenTtcProbeHost` exposes the last TTC per `screen_id` via a probe (`testID=perf-ttc-<screenId>`) when `isE2EOrPerformanceTest` is true
- Seedless Google/Apple/Telegram + cold-start specs call `addAppScreenTtcTimer` for screens on that path (`onboarding_landing`, `onboarding_sheet`, post-OAuth destination, `choose_pw`, `onboarding_success`, `social_rehydrate`)
- Existing **nav:** / **flow:** timers stay separate so reports stay honest
- TTC thresholds are intentionally generous until BrowserStack baselines exist
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: In-app screen TTC in seedless onboarding perf tests

  Scenario: CI captures Sentry-equivalent TTC on seedless Google path
    Given a main-e2e / performance build with isE2EOrPerformanceTest enabled
    And the app cold-starts to onboarding
    When the seedless Google onboarding performance spec runs
    Then timers named "TTC [<screen_id>]: in-app mount→contentReady" are recorded for screens on the path
    And nav:/flow: timers remain separate from TTC
    And ScreenTtcProbeHost probes (perf-ttc-<screenId>) expose ttc:<screenId>:<ms>:<generation>
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N?A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Probe UI is gated to e2e/perf and is non-interactive; production users are unaffected. Verify `measurePostOauthToScreenContent` still compiles—`TimerHelper.changeName` was removed in the diff while that helper still calls it.
> 
> **Overview**
> Closes the gap between CI onboarding perf and **Sentry Onboarding Screen Time To Content** by recording the same mount→`contentReady` duration in e2e/perf builds and reading it from Appium.
> 
> **In-app plumbing:** `useScreenPerformance` now calls `recordScreenTtc` when TTC completes; `screenTtcRegistry` stores values with a monotonic **generation** for fresh reads. **`ScreenTtcProbeHost`** (mounted under `Root`) renders invisible probes with `testID` `perf-ttc-<screenId>` and accessibility labels `ttc:<screenId>:<ms>:<generation>` when `isE2EOrPerformanceTest` is true.
> 
> **CI tests:** `readScreenTtc` polls those probes; `addAppScreenTtcTimer` registers `TTC [<screen_id>]: in-app mount→contentReady` via new **`TimerHelper.recordDuration`**. Seedless Google/Apple/Telegram specs and cold-start onboarding are refactored through **`seedlessOnboardingTimers`** so **nav** / **flow** wall-clock timers stay separate from in-app TTC, with generous TTC thresholds until BrowserStack baselines exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 202ba39e557f1e3ec0373df249ee12b799ceb5f4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->