### PR TITLE
fix: Ledger something went wrong error when recovering from eth app not open

### DIFF
--- a/app/components/UI/HardwareWallet/Swaps/hooks/useHwQrState.test.ts
+++ b/app/components/UI/HardwareWallet/Swaps/hooks/useHwQrState.test.ts
@@ -56,6 +56,7 @@ function mockQrWallet(
     setTargetWalletType: jest.fn(),
     setPendingOperationAddress: jest.fn(),
     showHardwareWalletError: jest.fn(),
+    cancelConnectionFlow: jest.fn(),
     showAwaitingConfirmation: jest.fn(),
     hideAwaitingConfirmation: jest.fn(),
     qr: {
@@ -83,6 +84,7 @@ function mockLedgerWallet(): HardwareWalletContextValue {
     setTargetWalletType: jest.fn(),
     setPendingOperationAddress: jest.fn(),
     showHardwareWalletError: jest.fn(),
+    cancelConnectionFlow: jest.fn(),
     showAwaitingConfirmation: jest.fn(),
     hideAwaitingConfirmation: jest.fn(),
     qr: {

--- a/app/components/UI/HardwareWallet/Swaps/useHwConnectionMonitoring.test.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHwConnectionMonitoring.test.ts
@@ -70,6 +70,8 @@ const stubContext: Omit<HardwareWalletContextValue, 'connectionState'> & {
     jest.fn() as HardwareWalletContextValue['setPendingOperationAddress'],
   showHardwareWalletError:
     jest.fn() as HardwareWalletContextValue['showHardwareWalletError'],
+  cancelConnectionFlow:
+    jest.fn() as HardwareWalletContextValue['cancelConnectionFlow'],
   showAwaitingConfirmation:
     jest.fn() as HardwareWalletContextValue['showAwaitingConfirmation'],
   hideAwaitingConfirmation:

--- a/app/components/Views/LedgerSelectAccount/index.test.tsx
+++ b/app/components/Views/LedgerSelectAccount/index.test.tsx
@@ -38,6 +38,7 @@ const mockCreateEventBuilder = jest.fn(() => ({
 const mockEnsureDeviceReady = jest.fn().mockResolvedValue(true);
 const mockSetTargetWalletType = jest.fn();
 const mockShowHardwareWalletError = jest.fn();
+const mockCancelConnectionFlow = jest.fn();
 
 const mockShowAwaitingConfirmation = jest.fn();
 const mockHideAwaitingConfirmation = jest.fn();
@@ -162,6 +163,7 @@ const defaultHardwareWalletValues = {
   setTargetWalletType: mockSetTargetWalletType,
   setPendingOperationAddress: jest.fn(),
   showHardwareWalletError: mockShowHardwareWalletError,
+  cancelConnectionFlow: mockCancelConnectionFlow,
   showAwaitingConfirmation: mockShowAwaitingConfirmation,
   hideAwaitingConfirmation: mockHideAwaitingConfirmation,
   qr: {
@@ -259,6 +261,20 @@ describe('LedgerSelectAccount', () => {
       await waitFor(() => {
         expect(mockedGoBack).toHaveBeenCalled();
       });
+    });
+
+    it('calls cancelConnectionFlow exactly once on unmount', async () => {
+      const { unmount } = renderWithProvider(<LedgerSelectAccount />);
+
+      await waitFor(() => {
+        expect(mockEnsureDeviceReady).toHaveBeenCalled();
+      });
+
+      expect(mockCancelConnectionFlow).not.toHaveBeenCalled();
+
+      unmount();
+
+      expect(mockCancelConnectionFlow).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/components/Views/LedgerSelectAccount/index.tsx
+++ b/app/components/Views/LedgerSelectAccount/index.tsx
@@ -73,8 +73,13 @@ const LedgerSelectAccount = () => {
     ledgerDeviceDarkImage,
   );
 
-  const { deviceId, deviceSelection, ensureDeviceReady, setTargetWalletType } =
-    useHardwareWallet();
+  const {
+    deviceId,
+    deviceSelection,
+    ensureDeviceReady,
+    setTargetWalletType,
+    cancelConnectionFlow,
+  } = useHardwareWallet();
 
   const ledgerModelName = useMemo(() => {
     if (deviceSelection?.selectedDevice) {
@@ -185,6 +190,19 @@ const LedgerSelectAccount = () => {
     },
 
     // This is ran once on mount, so we don't need to add any dependencies
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  // Unmount-only cleanup: when the flow screen exits (Android back/gesture or
+  // sheet dismissal), settle any pending readiness promise and reset the
+  // provider flow state, so late adapter errors cannot re-open a stranded
+  // error bottom sheet over Home.
+  useEffect(
+    () => () => {
+      cancelConnectionFlow();
+    },
+    // Intentionally mount/unmount only — cancelConnectionFlow is stable.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );

--- a/app/core/HardwareWallet/HardwareWalletProvider.test.tsx
+++ b/app/core/HardwareWallet/HardwareWalletProvider.test.tsx
@@ -133,14 +133,21 @@ describe('HardwareWalletProvider', () => {
   });
 
   const TestConsumer: React.FC = () => {
-    const { walletType, connectionState, ensureDeviceReady } =
-      useHardwareWallet();
+    const {
+      walletType,
+      connectionState,
+      ensureDeviceReady,
+      cancelConnectionFlow,
+    } = useHardwareWallet();
     return (
       <>
         <Text testID="walletType">{walletType ?? 'null'}</Text>
         <Text testID="connectionStatus">{connectionState.status}</Text>
         <Text testID="hasEnsureDeviceReady">
           {String(typeof ensureDeviceReady === 'function')}
+        </Text>
+        <Text testID="hasCancelConnectionFlow">
+          {String(typeof cancelConnectionFlow === 'function')}
         </Text>
       </>
     );
@@ -174,6 +181,12 @@ describe('HardwareWalletProvider', () => {
       const { getByTestId } = renderProvider();
 
       expect(getByTestId('hasEnsureDeviceReady').children[0]).toBe('true');
+    });
+
+    it('exposes cancelConnectionFlow as a callable on the context', () => {
+      const { getByTestId } = renderProvider();
+
+      expect(getByTestId('hasCancelConnectionFlow').children[0]).toBe('true');
     });
   });
 

--- a/app/core/HardwareWallet/HardwareWalletProvider.tsx
+++ b/app/core/HardwareWallet/HardwareWalletProvider.tsx
@@ -66,11 +66,20 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
 
   const [forceHideBottomSheet, setForceHideBottomSheet] = useState(false);
 
+  // Tracks whether a connection flow is active. Late adapter/device errors
+  // arriving after a flow has closed must not re-open the error bottom sheet
+  // over the app (e.g. a locked Ledger re-connecting after the flow screen
+  // exited). `showHardwareWalletError` intentionally bypasses this gate —
+  // signing flows rely on it surfacing errors unconditionally.
+  const flowActiveRef = useRef(false);
+  const isFlowActive = useCallback(() => flowActiveRef.current, []);
+
   const { handleDeviceEvent, handleError, updateConnectionState } =
     useDeviceEventHandlers({
       refs,
       setters,
       walletType: effectiveWalletType,
+      isFlowActive,
     });
 
   const {
@@ -84,6 +93,7 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
     handleDeviceEvent,
     handleError,
     updateConnectionState,
+    isFlowActive,
   });
 
   const { checkTransportEnabledOrShowError } = useTransportMonitoring({
@@ -143,6 +153,7 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
     initializeAdapter,
     checkTransportEnabledOrShowError,
     onFlowStart: handleFlowStart,
+    flowActiveRef,
   });
 
   const showHardwareWalletError = useCallback(
@@ -295,6 +306,7 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
       setTargetWalletType: setters.setTargetWalletType,
       setPendingOperationAddress,
       showHardwareWalletError,
+      cancelConnectionFlow: closeFlow,
       setQrScanRetryHandler,
       showAwaitingConfirmation,
       hideAwaitingConfirmation,
@@ -310,6 +322,7 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
       setters.setTargetWalletType,
       setPendingOperationAddress,
       showHardwareWalletError,
+      closeFlow,
       setQrScanRetryHandler,
       showAwaitingConfirmation,
       hideAwaitingConfirmation,

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
@@ -241,6 +241,63 @@ describe('LedgerBluetoothAdapter', () => {
       expect(adapter.isConnected()).toBe(false);
     });
 
+    it('waits for a pending transport teardown before reopening the connection', async () => {
+      await adapter.connect('device-123');
+
+      let resolveDisconnect!: () => void;
+      const disconnectPromise = new Promise<void>((resolve) => {
+        resolveDisconnect = resolve;
+      });
+      mockedTransportBLE.disconnectDevice.mockReturnValueOnce(
+        disconnectPromise,
+      );
+      mockedTransportBLE.open.mockClear();
+
+      // Fire-and-forget teardown (as retryEnsureDeviceReady does), then
+      // immediately reconnect without awaiting the close.
+      adapter.resetFlowState();
+      const connectPromise = adapter.connect('device-123');
+
+      // Flush microtasks so #doConnect reaches the pending-close await.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockedTransportBLE.open).not.toHaveBeenCalled();
+
+      resolveDisconnect();
+      await connectPromise;
+
+      expect(mockedTransportBLE.open).toHaveBeenCalledTimes(1);
+    });
+
+    it('times out and cleans up when TransportBLE.open stalls', async () => {
+      jest.useFakeTimers();
+      try {
+        mockedTransportBLE.open.mockImplementationOnce(
+          // eslint-disable-next-line no-empty-function
+          () => new Promise(() => {}),
+        );
+
+        const connectPromise = adapter.connect('device-123');
+        connectPromise.catch(() => undefined);
+        await jest.advanceTimersByTimeAsync(11000);
+
+        await expect(connectPromise).rejects.toMatchObject({
+          name: 'LedgerTimeoutError',
+          message: 'Device unresponsive while connecting',
+        });
+        expect(onDeviceEvent).toHaveBeenCalledWith(
+          expect.objectContaining({ event: DeviceEvent.ConnectionFailed }),
+        );
+        expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalledWith(
+          'device-123',
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('ignores transport error event when flow is complete', async () => {
       await adapter.connect('device-123');
       adapter.markFlowComplete();
@@ -677,31 +734,64 @@ describe('LedgerBluetoothAdapter', () => {
       );
     });
 
-    it('throws LedgerTimeoutError when device unresponsive during app check', async () => {
+    it('returns false and emits AppNotOpen when device unresponsive during app check', async () => {
       jest.useFakeTimers();
-      jest.mocked(connectLedgerHardware).mockImplementation(
-        // eslint-disable-next-line no-empty-function
-        () => new Promise(() => {}),
+      try {
+        jest.mocked(connectLedgerHardware).mockImplementation(
+          // eslint-disable-next-line no-empty-function
+          () => new Promise(() => {}),
+        );
+
+        const resultPromise = adapter.ensureDeviceReady('device-123');
+        await jest.advanceTimersByTimeAsync(11000);
+
+        await expect(resultPromise).resolves.toBe(false);
+        expect(onDeviceEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            event: DeviceEvent.AppNotOpen,
+            currentAppName: 'Ethereum',
+          }),
+        );
+        expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalledWith(
+          'device-123',
+        );
+        expect(adapter.isConnected()).toBe(false);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('returns false and emits AppNotOpen when the app check fails with a timeout error', async () => {
+      const timeoutError = new Error('Device unresponsive');
+      timeoutError.name = 'LedgerTimeoutError';
+      jest.mocked(connectLedgerHardware).mockRejectedValueOnce(timeoutError);
+
+      const result = await adapter.ensureDeviceReady('device-123');
+
+      expect(result).toBe(false);
+      expect(onDeviceEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: DeviceEvent.AppNotOpen,
+          currentAppName: 'Ethereum',
+        }),
       );
+    });
 
-      const resultPromise = adapter.ensureDeviceReady('device-123').then(
-        () => undefined,
-        (err: Error) => err,
+    it('returns false and emits AppNotOpen when verification fails with a timeout error', async () => {
+      jest.mocked(connectLedgerHardware).mockResolvedValue('Ethereum');
+      const timeoutError = new Error('Device unresponsive during verification');
+      timeoutError.name = 'LedgerTimeoutError';
+      mockGetAddress.mockRejectedValueOnce(timeoutError);
+
+      const result = await adapter.ensureDeviceReady('device-123');
+
+      expect(result).toBe(false);
+      expect(onDeviceEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: DeviceEvent.AppNotOpen,
+          currentAppName: 'Ethereum',
+        }),
       );
-
-      await jest.advanceTimersByTimeAsync(11000);
-      const result = await resultPromise;
-
-      expect(result).toMatchObject({
-        name: 'LedgerTimeoutError',
-        message: 'Device unresponsive',
-      });
-      expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalledWith(
-        'device-123',
-      );
-      expect(adapter.isConnected()).toBe(false);
-
-      jest.useRealTimers();
     });
 
     it('closes transport when device verification times out', async () => {

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
@@ -283,19 +283,73 @@ describe('LedgerBluetoothAdapter', () => {
         connectPromise.catch(() => undefined);
         await jest.advanceTimersByTimeAsync(11000);
 
+        // Rejection surfaces via ensureDeviceReady (routed to AppNotOpen);
+        // a bare connect() only rejects and cleans up.
         await expect(connectPromise).rejects.toMatchObject({
           name: 'LedgerTimeoutError',
           message: 'Device unresponsive while connecting',
         });
-        expect(onDeviceEvent).toHaveBeenCalledWith(
-          expect.objectContaining({ event: DeviceEvent.ConnectionFailed }),
-        );
         expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalledWith(
           'device-123',
         );
       } finally {
         jest.useRealTimers();
       }
+    });
+
+    it('serializes the connect-timeout cleanup disconnect before the next open', async () => {
+      jest.useFakeTimers();
+      try {
+        mockedTransportBLE.open.mockImplementationOnce(
+          // eslint-disable-next-line no-empty-function
+          () => new Promise(() => {}),
+        );
+
+        // The timeout cleanup's disconnect is deferred: the next connect
+        // must serialize behind it instead of racing it.
+        let resolveCleanupDisconnect!: () => void;
+        mockedTransportBLE.disconnectDevice.mockReturnValueOnce(
+          new Promise<void>((resolve) => {
+            resolveCleanupDisconnect = resolve;
+          }),
+        );
+
+        const firstConnect = adapter.connect('device-123');
+        firstConnect.catch(() => undefined);
+        await jest.advanceTimersByTimeAsync(11000);
+
+        // Timeout fired and queued the (still pending) cleanup disconnect.
+        mockedTransportBLE.open.mockClear();
+        const secondConnect = adapter.connect('device-123');
+
+        // Flush microtasks so #doConnect reaches the pending-close await.
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(mockedTransportBLE.open).not.toHaveBeenCalled();
+
+        resolveCleanupDisconnect();
+        await expect(firstConnect).rejects.toMatchObject({
+          name: 'LedgerTimeoutError',
+        });
+        await secondConnect;
+
+        expect(mockedTransportBLE.open).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('emits ConnectionFailed when connect fails with a non-timeout error', async () => {
+      const error = new Error('BLE connection failed');
+      mockedTransportBLE.open.mockRejectedValueOnce(error);
+
+      await expect(adapter.connect('device-123')).rejects.toThrow(error);
+
+      expect(onDeviceEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ event: DeviceEvent.ConnectionFailed }),
+      );
     });
 
     it('ignores transport error event when flow is complete', async () => {
@@ -732,6 +786,69 @@ describe('LedgerBluetoothAdapter', () => {
           event: DeviceEvent.DeviceLocked,
         }),
       );
+    });
+
+    it('returns false and emits AppNotOpen (not ConnectionFailed) when the connect phase times out', async () => {
+      jest.useFakeTimers();
+      try {
+        mockedTransportBLE.open.mockImplementation(
+          // eslint-disable-next-line no-empty-function
+          () => new Promise(() => {}),
+        );
+
+        const resultPromise = adapter.ensureDeviceReady('device-123');
+        await jest.advanceTimersByTimeAsync(11000);
+
+        await expect(resultPromise).resolves.toBe(false);
+        expect(onDeviceEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            event: DeviceEvent.AppNotOpen,
+            currentAppName: 'Ethereum',
+          }),
+        );
+        expect(onDeviceEvent).not.toHaveBeenCalledWith(
+          expect.objectContaining({ event: DeviceEvent.ConnectionFailed }),
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('recovers with a successful ensureDeviceReady after a connect timeout', async () => {
+      jest.useFakeTimers();
+      try {
+        // First attempt: open never resolves (device stuck on the open-app
+        // prompt) — connect times out and routes to AwaitingApp.
+        mockedTransportBLE.open.mockImplementationOnce(
+          // eslint-disable-next-line no-empty-function
+          () => new Promise(() => {}),
+        );
+
+        const firstAttempt = adapter.ensureDeviceReady('device-123');
+        await jest.advanceTimersByTimeAsync(11000);
+
+        await expect(firstAttempt).resolves.toBe(false);
+        expect(onDeviceEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            event: DeviceEvent.AppNotOpen,
+            currentAppName: 'Ethereum',
+          }),
+        );
+
+        // Second attempt (user opened the ETH app): full success.
+        onDeviceEvent.mockClear();
+        await expect(adapter.ensureDeviceReady('device-123')).resolves.toBe(
+          true,
+        );
+        expect(onDeviceEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            event: DeviceEvent.AppOpened,
+            currentAppName: 'Ethereum',
+          }),
+        );
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('returns false and emits AppNotOpen when device unresponsive during app check', async () => {

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
@@ -112,10 +112,10 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
         LEDGER_OPERATION_TIMEOUT_MS,
         'Device unresponsive while connecting',
         () => {
-          // Clear any half-open native connection so the next attempt
-          // starts clean.
-          void TransportBLE.disconnectDevice(deviceId).catch(
-            () => undefined,
+          // Clear any half-open native connection so the next attempt starts
+          // clean — queued so a subsequent open serializes behind it.
+          void this.#enqueueClose(() =>
+            TransportBLE.disconnectDevice(deviceId),
           );
         },
       );
@@ -168,10 +168,15 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
     } catch (error) {
       this.#clearTransportState();
 
-      this.#emitEvent({
-        event: DeviceEvent.ConnectionFailed,
-        error: toError(error),
-      });
+      // Timeout errors are re-routed by ensureDeviceReady to the
+      // "open the app" modal — emitting ConnectionFailed here would make
+      // the sheet flip Error → AwaitingApp.
+      if (!isLedgerTimeoutError(error)) {
+        this.#emitEvent({
+          event: DeviceEvent.ConnectionFailed,
+          error: toError(error),
+        });
+      }
 
       throw error;
     }
@@ -384,7 +389,21 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
   async #doEnsureDeviceReady(deviceId: string): Promise<boolean> {
     if (!this.isConnected() || this.#deviceId !== deviceId) {
       DevLogger.log('[LedgerBluetoothAdapter] Connecting first...');
-      await this.connect(deviceId);
+      try {
+        await this.connect(deviceId);
+      } catch (error) {
+        if (isLedgerTimeoutError(error)) {
+          // Connect-phase stall (device mid app-switch or showing the
+          // open-app prompt). Return to the "open the app" modal rather
+          // than a fatal error screen.
+          this.#emitEvent({
+            event: DeviceEvent.AppNotOpen,
+            currentAppName: REQUIRED_APP_NAME,
+          });
+          return false;
+        }
+        throw error;
+      }
     }
 
     if (!this.#transport) {
@@ -547,40 +566,46 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
     this.#options.onDeviceEvent(payload);
   }
 
+  /**
+   * Chain a close/disconnect operation onto the pending-close queue so
+   * subsequent connects serialize behind every in-flight teardown.
+   */
+  #enqueueClose(close: () => Promise<void>): Promise<void> {
+    const run = async (): Promise<void> => {
+      try {
+        await close();
+      } catch {
+        // Ignore close errors — device may already be disconnected
+      }
+    };
+    this.#pendingClose = this.#pendingClose
+      ? this.#pendingClose.then(run, run)
+      : run();
+    return this.#pendingClose;
+  }
+
   async #closeTransport(): Promise<void> {
     const transport = this.#transport;
     const deviceId = this.#deviceId;
     this.#transport = null;
 
-    const doClose = async (): Promise<void> => {
-      try {
-        if (transport) {
-          if (deviceId) {
-            // TransportBLE.close() queues a delayed disconnect (5s timeout).
-            // Force an immediate BLE disconnection so in-flight signing is
-            // aborted without delay.
-            await TransportBLE.disconnectDevice(deviceId);
-          } else {
-            await transport.close();
-          }
-        } else if (deviceId) {
-          // Transport already cleared (e.g. by #handleDisconnect) but device
-          // ID still set — force BLE cleanup so the OS stack doesn't keep a
-          // stale connection that blocks the next TransportBLE.open() call.
+    await this.#enqueueClose(async () => {
+      if (transport) {
+        if (deviceId) {
+          // TransportBLE.close() queues a delayed disconnect (5s timeout).
+          // Force an immediate BLE disconnection so in-flight signing is
+          // aborted without delay.
           await TransportBLE.disconnectDevice(deviceId);
+        } else {
+          await transport.close();
         }
-      } catch {
-        // Ignore close errors — device may already be disconnected
+      } else if (deviceId) {
+        // Transport already cleared (e.g. by #handleDisconnect) but device
+        // ID still set — force BLE cleanup so the OS stack doesn't keep a
+        // stale connection that blocks the next TransportBLE.open() call.
+        await TransportBLE.disconnectDevice(deviceId);
       }
-    };
-
-    // Serialize concurrent closes so a subsequent TransportBLE.open can never
-    // race a pending disconnectDevice for the same peripheral.
-    this.#pendingClose = this.#pendingClose
-      ? this.#pendingClose.then(doClose, doClose)
-      : doClose();
-
-    await this.#pendingClose;
+    });
   }
 
   #clearTransportState(): void {

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
@@ -29,6 +29,7 @@ import { ensureLedgerPermissions } from './shared/ledger-permissions';
 import {
   TRANSIENT_BLE_ERROR_NAMES,
   isDeviceLockedError,
+  isLedgerTimeoutError,
   hasTransientBleMessage,
   toError,
 } from './shared/ledger-errors';
@@ -54,6 +55,7 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
   readonly #bleMonitor: BluetoothStateMonitor;
   #scanSubscription: Subscription | null = null;
   #scanTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  #pendingClose: Promise<void> | null = null;
 
   constructor(options: HardwareWalletAdapterOptions) {
     this.#options = options;
@@ -97,7 +99,26 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
 
   async #doConnect(deviceId: string): Promise<void> {
     try {
-      const transport = await TransportBLE.open(deviceId);
+      // Serialize with any in-flight teardown so TransportBLE.open can never
+      // race a pending disconnectDevice for the same peripheral.
+      if (this.#pendingClose) {
+        await this.#pendingClose.catch(() => undefined);
+        // Destroy may have run while awaiting the teardown.
+        this.#assertAdapterReady();
+      }
+
+      const transport = await withLedgerTimeout(
+        TransportBLE.open(deviceId),
+        LEDGER_OPERATION_TIMEOUT_MS,
+        'Device unresponsive while connecting',
+        () => {
+          // Clear any half-open native connection so the next attempt
+          // starts clean.
+          void TransportBLE.disconnectDevice(deviceId).catch(
+            () => undefined,
+          );
+        },
+      );
 
       if (transport == null) {
         this.#clearTransportState();
@@ -408,6 +429,17 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
         });
       }
 
+      if (isLedgerTimeoutError(error)) {
+        // Device stalled during the app check (typically mid app-switch after
+        // the user tapped Continue). Return to the "open the app" modal
+        // instead of surfacing a fatal error screen.
+        this.#emitEvent({
+          event: DeviceEvent.AppNotOpen,
+          currentAppName: REQUIRED_APP_NAME,
+        });
+        return false;
+      }
+
       throw error;
     }
   }
@@ -454,6 +486,15 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
         this.#emitEvent({
           event: DeviceEvent.DeviceLocked,
           error: toError(verifyError),
+        });
+      }
+
+      if (isLedgerTimeoutError(verifyError)) {
+        // Device stalled mid verification (e.g. the user was switching apps).
+        // Return to the "open the app" modal instead of a silent spinner.
+        this.#emitEvent({
+          event: DeviceEvent.AppNotOpen,
+          currentAppName: REQUIRED_APP_NAME,
         });
       }
       return false;
@@ -511,25 +552,35 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
     const deviceId = this.#deviceId;
     this.#transport = null;
 
-    try {
-      if (transport) {
-        if (deviceId) {
-          // TransportBLE.close() queues a delayed disconnect (5s timeout).
-          // Force an immediate BLE disconnection so in-flight signing is
-          // aborted without delay.
+    const doClose = async (): Promise<void> => {
+      try {
+        if (transport) {
+          if (deviceId) {
+            // TransportBLE.close() queues a delayed disconnect (5s timeout).
+            // Force an immediate BLE disconnection so in-flight signing is
+            // aborted without delay.
+            await TransportBLE.disconnectDevice(deviceId);
+          } else {
+            await transport.close();
+          }
+        } else if (deviceId) {
+          // Transport already cleared (e.g. by #handleDisconnect) but device
+          // ID still set — force BLE cleanup so the OS stack doesn't keep a
+          // stale connection that blocks the next TransportBLE.open() call.
           await TransportBLE.disconnectDevice(deviceId);
-        } else {
-          await transport.close();
         }
-      } else if (deviceId) {
-        // Transport already cleared (e.g. by #handleDisconnect) but device
-        // ID still set — force BLE cleanup so the OS stack doesn't keep a
-        // stale connection that blocks the next TransportBLE.open() call.
-        await TransportBLE.disconnectDevice(deviceId);
+      } catch {
+        // Ignore close errors — device may already be disconnected
       }
-    } catch {
-      // Ignore close errors — device may already be disconnected
-    }
+    };
+
+    // Serialize concurrent closes so a subsequent TransportBLE.open can never
+    // race a pending disconnectDevice for the same peripheral.
+    this.#pendingClose = this.#pendingClose
+      ? this.#pendingClose.then(doClose, doClose)
+      : doClose();
+
+    await this.#pendingClose;
   }
 
   #clearTransportState(): void {

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothDMKAdapter.test.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothDMKAdapter.test.ts
@@ -770,6 +770,16 @@ describe('LedgerBluetoothDMKAdapter', () => {
         expectEmitted(DeviceEvent.AppNotOpen);
       });
 
+      it('returns false and emits AppNotOpen when the app check fails with a DMK unresponsive error', async () => {
+        const unresponsiveError = new Error(
+          'Device action ended without completion',
+        );
+        mockConnectLedgerHardware.mockRejectedValueOnce(unresponsiveError);
+
+        await expect(adapter.ensureDeviceReady(DEVICE_ID)).resolves.toBe(false);
+        expectEmitted(DeviceEvent.AppNotOpen);
+      });
+
       it('opens the Ethereum app from the BOLOS screen and returns false', async () => {
         mockConnectLedgerHardware.mockResolvedValueOnce('BOLOS');
         mockOpenEthereumAppOnLedger.mockResolvedValueOnce(undefined);

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothDMKAdapter.test.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothDMKAdapter.test.ts
@@ -740,7 +740,7 @@ describe('LedgerBluetoothDMKAdapter', () => {
         expectEmitted(DeviceEvent.DeviceLocked);
       });
 
-      it('times out and closes the session when address verification stalls', async () => {
+      it('returns false, emits AppNotOpen, and closes the session when address verification stalls', async () => {
         jest.useFakeTimers();
         try {
           mockConnectLedgerHardware.mockResolvedValueOnce('Ethereum');
@@ -752,14 +752,22 @@ describe('LedgerBluetoothDMKAdapter', () => {
           pending.catch(() => undefined);
           await jest.advanceTimersByTimeAsync(OPERATION_TIMEOUT_MS);
 
-          await expect(pending).rejects.toThrow(
-            'Device unresponsive during verification',
-          );
+          await expect(pending).resolves.toBe(false);
+          expectEmitted(DeviceEvent.AppNotOpen);
           expect(adapter.isConnected()).toBe(false);
           expect(mockDisconnectLedgerDmkSession).toHaveBeenCalled();
         } finally {
           jest.useRealTimers();
         }
+      });
+
+      it('returns false and emits AppNotOpen when the app check fails with a timeout error', async () => {
+        const timeoutError = new Error('Device unresponsive');
+        timeoutError.name = 'LedgerTimeoutError';
+        mockConnectLedgerHardware.mockRejectedValueOnce(timeoutError);
+
+        await expect(adapter.ensureDeviceReady(DEVICE_ID)).resolves.toBe(false);
+        expectEmitted(DeviceEvent.AppNotOpen);
       });
 
       it('opens the Ethereum app from the BOLOS screen and returns false', async () => {

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothDMKAdapter.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothDMKAdapter.ts
@@ -44,6 +44,7 @@ import {
   TRANSIENT_BLE_ERROR_NAMES,
   TRANSIENT_DMK_TAGS,
   isDeviceLockedError,
+  isDeviceUnresponsiveError,
   isLedgerTimeoutError,
   hasTransientBleMessage,
   toError,
@@ -610,9 +611,10 @@ export class LedgerBluetoothDMKAdapter implements HardwareWalletAdapter {
         });
       }
 
-      if (isLedgerTimeoutError(error)) {
+      if (isLedgerTimeoutError(error) || isDeviceUnresponsiveError(error)) {
         // Device stalled during the app check (typically mid app-switch after
-        // the user tapped Continue). Return to the "open the app" modal
+        // the user tapped Continue) — either our operation timeout or DMK's
+        // own unresponsiveness error. Return to the "open the app" modal
         // instead of surfacing a fatal error screen.
         this.#emitEvent({
           event: DeviceEvent.AppNotOpen,

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothDMKAdapter.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothDMKAdapter.ts
@@ -44,6 +44,7 @@ import {
   TRANSIENT_BLE_ERROR_NAMES,
   TRANSIENT_DMK_TAGS,
   isDeviceLockedError,
+  isLedgerTimeoutError,
   hasTransientBleMessage,
   toError,
 } from './shared/ledger-errors';
@@ -607,6 +608,17 @@ export class LedgerBluetoothDMKAdapter implements HardwareWalletAdapter {
           event: DeviceEvent.DeviceLocked,
           error: toError(error),
         });
+      }
+
+      if (isLedgerTimeoutError(error)) {
+        // Device stalled during the app check (typically mid app-switch after
+        // the user tapped Continue). Return to the "open the app" modal
+        // instead of surfacing a fatal error screen.
+        this.#emitEvent({
+          event: DeviceEvent.AppNotOpen,
+          currentAppName: REQUIRED_APP_NAME,
+        });
+        return false;
       }
 
       throw error;

--- a/app/core/HardwareWallet/adapters/shared/ledger-errors.ts
+++ b/app/core/HardwareWallet/adapters/shared/ledger-errors.ts
@@ -57,6 +57,27 @@ export function isLedgerTimeoutError(error: unknown): boolean {
 }
 
 /**
+ * Whether an error indicates the device stalled without completing an
+ * operation — DMK's own unresponsiveness errors (e.g. "Device action ended
+ * without completion") or any unresponsive-flavored message. These are not
+ * `LedgerTimeoutError`s (different error name), but during the app check
+ * they should behave the same: return to the awaiting-app modal instead of
+ * a fatal, unrecoverable error screen.
+ */
+export function isDeviceUnresponsiveError(error: unknown): boolean {
+  if (error === null || typeof error !== 'object' || !('message' in error)) {
+    return false;
+  }
+  const message = String(
+    (error as { message?: unknown }).message,
+  ).toLowerCase();
+  return (
+    message.includes('device action ended without completion') ||
+    message.includes('unresponsive')
+  );
+}
+
+/**
  * Normalize an unknown value to an `Error` for event/callback payloads.
  *
  * @param value - The value thrown or passed in.

--- a/app/core/HardwareWallet/adapters/shared/ledger-errors.ts
+++ b/app/core/HardwareWallet/adapters/shared/ledger-errors.ts
@@ -44,6 +44,19 @@ export function hasTransientBleMessage(message: string): boolean {
 }
 
 /**
+ * Whether an error is the timeout error thrown by `withLedgerTimeout`
+ * (name is set to `LedgerTimeoutError`).
+ */
+export function isLedgerTimeoutError(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === 'object' &&
+    'name' in error &&
+    (error as { name?: string }).name === 'LedgerTimeoutError'
+  );
+}
+
+/**
  * Normalize an unknown value to an `Error` for event/callback payloads.
  *
  * @param value - The value thrown or passed in.

--- a/app/core/HardwareWallet/components/HardwareWalletBottomSheet/contents/AwaitingConfirmationContent.test.tsx
+++ b/app/core/HardwareWallet/components/HardwareWalletBottomSheet/contents/AwaitingConfirmationContent.test.tsx
@@ -176,6 +176,7 @@ describe('AwaitingConfirmationContent', () => {
     setTargetWalletType: jest.fn(),
     setPendingOperationAddress: jest.fn(),
     showHardwareWalletError: jest.fn(),
+    cancelConnectionFlow: jest.fn(),
     showAwaitingConfirmation: jest.fn(),
     hideAwaitingConfirmation: jest.fn(),
     qr: {

--- a/app/core/HardwareWallet/contexts/HardwareWalletContext.test.tsx
+++ b/app/core/HardwareWallet/contexts/HardwareWalletContext.test.tsx
@@ -30,6 +30,7 @@ const createMockContextValue = (
   setTargetWalletType: noop,
   setPendingOperationAddress: noop,
   showHardwareWalletError: noop,
+  cancelConnectionFlow: noop,
   showAwaitingConfirmation: noop,
   hideAwaitingConfirmation: noop,
   qr: {

--- a/app/core/HardwareWallet/contexts/HardwareWalletContext.tsx
+++ b/app/core/HardwareWallet/contexts/HardwareWalletContext.tsx
@@ -41,6 +41,13 @@ export interface HardwareWalletContextValue {
   setPendingOperationAddress: (address: string | null) => void;
   /** Show a hardware wallet error in the bottom sheet. Use after ensureDeviceReady succeeds. */
   showHardwareWalletError: (error: unknown) => void;
+  /**
+   * Cancel any in-flight connection flow: settles the pending readiness
+   * promise with `false`, transitions to Disconnected (closing the bottom
+   * sheet) and clears the target wallet type. Flow screens should call this
+   * on unmount so a stranded error sheet cannot re-appear over the app.
+   */
+  cancelConnectionFlow: () => void;
   /** Register a retry handler for QR scan errors outside the provider-managed flows. */
   setQrScanRetryHandler?: (handler: (() => void) | null) => void;
   /** Show "awaiting confirmation" bottom sheet. */

--- a/app/core/HardwareWallet/errors/parser.test.ts
+++ b/app/core/HardwareWallet/errors/parser.test.ts
@@ -375,6 +375,22 @@ describe('parseErrorByType', () => {
       expect(result.code).toBe(ErrorCode.ConnectionTimeout);
     });
 
+    it('parses "Device unresponsive" timeout message', () => {
+      const error = new Error('Device unresponsive');
+
+      const result = parseErrorByType(error, walletType);
+
+      expect(result.code).toBe(ErrorCode.DeviceUnresponsive);
+    });
+
+    it('parses "Device unresponsive during verification" timeout message', () => {
+      const error = new Error('Device unresponsive during verification');
+
+      const result = parseErrorByType(error, walletType);
+
+      expect(result.code).toBe(ErrorCode.DeviceUnresponsive);
+    });
+
     it('parses scan timeout message containing "unlocked" as ConnectionTimeout, not AuthenticationDeviceLocked', () => {
       const error = new Error(
         'Scan timeout: No Ledger devices found. Make sure your Ledger is unlocked and Bluetooth is enabled on the device.',

--- a/app/core/HardwareWallet/errors/parser.ts
+++ b/app/core/HardwareWallet/errors/parser.ts
@@ -291,6 +291,7 @@ export const LOCAL_MESSAGE_PATTERNS: {
     code: ErrorCode.DeviceDisconnected,
   },
   { patterns: ['timeout', 'timed out'], code: ErrorCode.ConnectionTimeout },
+  { patterns: ['unresponsive'], code: ErrorCode.DeviceUnresponsive },
   {
     patterns: ['locked', 'unlock'],
     code: ErrorCode.AuthenticationDeviceLocked,

--- a/app/core/HardwareWallet/hooks/useAdapterLifecycle.test.ts
+++ b/app/core/HardwareWallet/hooks/useAdapterLifecycle.test.ts
@@ -1,0 +1,178 @@
+import { renderHook, act } from '@testing-library/react-native';
+import type { MutableRefObject } from 'react';
+import { useSelector } from 'react-redux';
+import { HardwareWalletType, ConnectionStatus } from '@metamask/hw-wallet-sdk';
+import { useAdapterLifecycle } from './useAdapterLifecycle';
+import { createAdapter } from '../adapters';
+import { HardwareWalletAdapter, HardwareWalletAdapterOptions } from '../types';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../SDKConnect/utils/DevLogger', () => ({
+  log: jest.fn(),
+}));
+
+jest.mock('../adapters', () => ({
+  createAdapter: jest.fn(),
+}));
+
+const mockUseSelector = useSelector as jest.Mock;
+const mockCreateAdapter = createAdapter as jest.MockedFunction<
+  typeof createAdapter
+>;
+
+const createMockAdapter = (): HardwareWalletAdapter =>
+  ({
+    walletType: HardwareWalletType.Ledger,
+    onTransportStateChange: jest.fn(() => jest.fn()),
+    destroy: jest.fn(),
+  }) as unknown as HardwareWalletAdapter;
+
+interface LifecycleOptionsOverrides {
+  handleError?: jest.Mock;
+  updateConnectionState?: jest.Mock;
+  isFlowActive?: () => boolean;
+}
+
+const createOptions = (
+  overrides: LifecycleOptionsOverrides = {},
+): Parameters<typeof useAdapterLifecycle>[0] => ({
+  walletType: HardwareWalletType.Ledger as HardwareWalletType | null,
+  adapterRef: {
+    current: null,
+  } as MutableRefObject<HardwareWalletAdapter | null>,
+  handleDeviceEvent: jest.fn(),
+  handleError: jest.fn(),
+  updateConnectionState: jest.fn(),
+  ...overrides,
+});
+
+/** Returns the callbacks the hook registered for the Ledger adapter. */
+const getAdapterCallbacks = (): HardwareWalletAdapterOptions => {
+  const call = mockCreateAdapter.mock.calls.find(
+    ([targetType]) => targetType === HardwareWalletType.Ledger,
+  );
+  if (!call) {
+    throw new Error('Expected createAdapter to be called with Ledger');
+  }
+  return call[1];
+};
+
+describe('useAdapterLifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelector.mockReturnValue({});
+    mockCreateAdapter.mockImplementation(() => createMockAdapter());
+  });
+
+  describe('onDisconnect error routing', () => {
+    it('routes the error through handleError while the flow is active', () => {
+      const handleError = jest.fn();
+      const updateConnectionState = jest.fn();
+
+      const { result } = renderHook(() =>
+        useAdapterLifecycle(
+          createOptions({
+            handleError,
+            updateConnectionState,
+            isFlowActive: () => true,
+          }),
+        ),
+      );
+
+      act(() => {
+        getAdapterCallbacks().onDisconnect(new Error('device dropped'));
+      });
+
+      expect(handleError).toHaveBeenCalledWith(expect.any(Error));
+      expect(updateConnectionState).not.toHaveBeenCalledWith({
+        status: ConnectionStatus.Disconnected,
+      });
+    });
+
+    it('does not route the error through handleError when the flow is inactive and sets Disconnected', () => {
+      const handleError = jest.fn();
+      const updateConnectionState = jest.fn();
+
+      const { result } = renderHook(() =>
+        useAdapterLifecycle(
+          createOptions({
+            handleError,
+            updateConnectionState,
+            isFlowActive: () => false,
+          }),
+        ),
+      );
+
+      act(() => {
+        getAdapterCallbacks().onDisconnect(new Error('device dropped'));
+      });
+
+      expect(handleError).not.toHaveBeenCalled();
+      expect(updateConnectionState).toHaveBeenCalledWith({
+        status: ConnectionStatus.Disconnected,
+      });
+    });
+
+    it('routes the error through handleError when isFlowActive is not provided (back-compat)', () => {
+      const handleError = jest.fn();
+      const updateConnectionState = jest.fn();
+
+      const { result } = renderHook(() =>
+        useAdapterLifecycle(
+          createOptions({ handleError, updateConnectionState }),
+        ),
+      );
+
+      act(() => {
+        getAdapterCallbacks().onDisconnect(new Error('device dropped'));
+      });
+
+      expect(handleError).toHaveBeenCalledWith(expect.any(Error));
+      expect(updateConnectionState).not.toHaveBeenCalledWith({
+        status: ConnectionStatus.Disconnected,
+      });
+    });
+
+    it('sets Disconnected without handleError when no error is provided', () => {
+      const handleError = jest.fn();
+      const updateConnectionState = jest.fn();
+
+      const { result } = renderHook(() =>
+        useAdapterLifecycle(
+          createOptions({
+            handleError,
+            updateConnectionState,
+            isFlowActive: () => false,
+          }),
+        ),
+      );
+
+      act(() => {
+        getAdapterCallbacks().onDisconnect();
+      });
+
+      expect(handleError).not.toHaveBeenCalled();
+      expect(updateConnectionState).toHaveBeenCalledWith({
+        status: ConnectionStatus.Disconnected,
+      });
+    });
+  });
+
+  describe('adapter creation', () => {
+    it('creates an adapter for the current wallet type on mount', () => {
+      renderHook(() => useAdapterLifecycle(createOptions()));
+
+      expect(mockCreateAdapter).toHaveBeenCalledWith(
+        HardwareWalletType.Ledger,
+        expect.objectContaining({
+          onDisconnect: expect.any(Function),
+          onDeviceEvent: expect.any(Function),
+        }),
+        expect.any(Boolean),
+      );
+    });
+  });
+});

--- a/app/core/HardwareWallet/hooks/useAdapterLifecycle.ts
+++ b/app/core/HardwareWallet/hooks/useAdapterLifecycle.ts
@@ -25,6 +25,14 @@ interface UseAdapterLifecycleOptions {
   handleDeviceEvent: (payload: DeviceEventPayload) => void;
   handleError: (error: unknown) => void;
   updateConnectionState: (state: HardwareWalletConnectionState) => void;
+  /**
+   * Returns whether a connection flow is currently active. When it returns
+   * `false`, a late `onDisconnect` error (device dropped after the flow
+   * closed) must not surface through `handleError` — that would re-open the
+   * error bottom sheet over the app. Optional for back-compat: when omitted,
+   * behavior is unchanged.
+   */
+  isFlowActive?: () => boolean;
 }
 
 interface UseAdapterLifecycleResult {
@@ -56,10 +64,16 @@ export const useAdapterLifecycle = ({
   handleDeviceEvent,
   handleError,
   updateConnectionState,
+  isFlowActive,
 }: UseAdapterLifecycleOptions): UseAdapterLifecycleResult => {
   const [isTransportAvailable, setIsTransportAvailable] = useState(false);
   const previousTransportAvailableRef = useRef<boolean | null>(null);
   const transportCleanupRef = useRef<(() => void) | null>(null);
+
+  // Held in a ref so the adapter callbacks stay identity-stable regardless of
+  // the caller-provided function's identity.
+  const isFlowActiveRef = useRef(isFlowActive);
+  isFlowActiveRef.current = isFlowActive;
 
   // DMK flag, read live from feature-flag state. Held in a ref so the adapter
   // callbacks stay stable (no spurious re-creation on flag change); the value
@@ -79,9 +93,12 @@ export const useAdapterLifecycle = ({
         targetType,
         {
           onDisconnect: (error) => {
-            if (error) {
+            const flowActive = isFlowActiveRef.current?.() !== false;
+            if (error && flowActive) {
               onError(error);
             } else {
+              // No error, or the flow already closed: a late device drop must
+              // not re-open the error bottom sheet over the app.
               onUpdateConnectionState({
                 status: ConnectionStatus.Disconnected,
               });

--- a/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.test.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.test.ts
@@ -1,5 +1,10 @@
 import { renderHook, act } from '@testing-library/react-native';
-import { HardwareWalletType, ConnectionStatus } from '@metamask/hw-wallet-sdk';
+import {
+  HardwareWalletType,
+  ConnectionStatus,
+  ErrorCode,
+  HardwareWalletError,
+} from '@metamask/hw-wallet-sdk';
 import { useDeviceConnectionFlow } from './useDeviceConnectionFlow';
 import {
   HardwareWalletRefs,
@@ -109,9 +114,15 @@ describe('useDeviceConnectionFlow', () => {
       const options = createDefaultOptions({ walletType: null });
       const { result } = renderHook(() => useDeviceConnectionFlow(options));
 
-      await expect(
-        act(() => result.current.ensureDeviceReady()),
-      ).rejects.toThrow('ensureDeviceReady called without a wallet type');
+      const rejection = await act(() =>
+        result.current.ensureDeviceReady().catch((error: unknown) => error),
+      );
+
+      expect(rejection).toBeInstanceOf(HardwareWalletError);
+      expect(rejection).toMatchObject({
+        code: ErrorCode.Unknown,
+        message: 'ensureDeviceReady called without a wallet type',
+      });
     });
 
     it('uses targetWalletTypeRef when walletType is null', async () => {
@@ -729,6 +740,7 @@ describe('useDeviceConnectionFlow', () => {
 
       expect(options.handleError).toHaveBeenCalledWith(
         expect.objectContaining({
+          code: ErrorCode.DeviceNotReady,
           message: 'No adapter available',
         }),
       );

--- a/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.test.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.test.ts
@@ -5,6 +5,7 @@ import {
   ErrorCode,
   HardwareWalletError,
 } from '@metamask/hw-wallet-sdk';
+import { flushPromises as flushAllPromises } from '../../../util/test/utils';
 import { useDeviceConnectionFlow } from './useDeviceConnectionFlow';
 import {
   HardwareWalletRefs,
@@ -69,8 +70,7 @@ const createDefaultOptions = (overrides = {}) => ({
 
 const flushPromises = async () => {
   await act(async () => {
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAllPromises();
   });
 };
 

--- a/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.test.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.test.ts
@@ -58,6 +58,7 @@ const createDefaultOptions = (overrides = {}) => ({
   createAdapterWithCallbacks: jest.fn(),
   initializeAdapter: jest.fn(),
   checkTransportEnabledOrShowError: jest.fn().mockResolvedValue(false),
+  flowActiveRef: { current: false },
   ...overrides,
 });
 
@@ -703,10 +704,24 @@ describe('useDeviceConnectionFlow', () => {
 
     it('throws when no adapter available', async () => {
       const refs = createMockRefs();
-      refs.adapterRef.current = null;
-      const options = createDefaultOptions({ refs });
+      const options = createDefaultOptions({
+        refs,
+        createAdapterWithCallbacks: jest
+          .fn()
+          .mockReturnValue(createMockAdapter()),
+      });
 
       const { result } = renderHook(() => useDeviceConnectionFlow(options));
+
+      // Arm the flow first — connect is only invoked from the bottom sheet
+      // while a connection flow is active.
+      const { readyPromise } = await capturePendingReadiness(() =>
+        result.current.ensureDeviceReady(),
+      );
+      expect(options.flowActiveRef.current).toBe(true);
+      // The mocked initializeAdapter never assigns the adapter, so connect
+      // runs with no adapter available.
+      expect(refs.adapterRef.current).toBeNull();
 
       await act(async () => {
         await result.current.connect('device-123');
@@ -717,6 +732,11 @@ describe('useDeviceConnectionFlow', () => {
           message: 'No adapter available',
         }),
       );
+
+      await act(async () => {
+        result.current.closeFlow();
+        await readyPromise;
+      });
     });
 
     it('connects and runs readiness check', async () => {
@@ -934,11 +954,25 @@ describe('useDeviceConnectionFlow', () => {
 
       const { result } = renderHook(() => useDeviceConnectionFlow(options));
 
+      // Arm the flow first — the retry button only exists while the flow is
+      // active (bottom sheet mounted).
+      const { readyPromise } = await capturePendingReadiness(() =>
+        result.current.ensureDeviceReady('device-123'),
+      );
+      await flushPromises();
+      expect(options.flowActiveRef.current).toBe(true);
+      (options.handleError as jest.Mock).mockClear();
+
       await act(async () => {
         await result.current.retryEnsureDeviceReady();
       });
 
       expect(options.handleError).toHaveBeenCalledWith(expect.any(Error));
+
+      await act(async () => {
+        result.current.closeFlow();
+        await readyPromise;
+      });
     });
   });
 
@@ -1011,6 +1045,67 @@ describe('useDeviceConnectionFlow', () => {
         const resolved = await readyPromise;
         expect(resolved).toBe(true);
       });
+    });
+  });
+
+  describe('flowActiveRef gating', () => {
+    it('arms flowActiveRef when a flow starts and clears it when closeFlow resolves the pending promise false', async () => {
+      const mockAdapter = createMockAdapter();
+      const options = createDefaultOptions({
+        createAdapterWithCallbacks: jest.fn().mockReturnValue(mockAdapter),
+        checkTransportEnabledOrShowError: jest.fn().mockResolvedValue(true),
+      });
+
+      const { result } = renderHook(() => useDeviceConnectionFlow(options));
+
+      const { readyPromise } = await capturePendingReadiness(() =>
+        result.current.ensureDeviceReady(),
+      );
+
+      expect(options.flowActiveRef.current).toBe(true);
+
+      await act(async () => {
+        result.current.closeFlow();
+        const resolved = await readyPromise;
+        expect(resolved).toBe(false);
+      });
+
+      expect(options.flowActiveRef.current).toBe(false);
+    });
+
+    it('does not route a late failure through handleError once the flow is closed', async () => {
+      const mockAdapter = createMockAdapter({
+        ensureDeviceReady: jest.fn().mockRejectedValue(new Error('late fail')),
+      });
+      const refs = createMockRefs();
+      refs.adapterRef.current = mockAdapter;
+      const options = createDefaultOptions({ refs, deviceId: 'device-123' });
+
+      const { result } = renderHook(() => useDeviceConnectionFlow(options));
+
+      // While the flow is active, the readiness failure surfaces normally.
+      const { readyPromise } = await capturePendingReadiness(() =>
+        result.current.ensureDeviceReady('device-123'),
+      );
+      await flushPromises();
+      expect(options.handleError).toHaveBeenCalledTimes(1);
+      expect(options.flowActiveRef.current).toBe(true);
+
+      // Closing the flow arms the guard.
+      await act(async () => {
+        result.current.closeFlow();
+        await readyPromise;
+      });
+      expect(options.flowActiveRef.current).toBe(false);
+      (options.handleError as jest.Mock).mockClear();
+
+      // A failure routed through the internal handleError after closeFlow
+      // must not surface an error state (guard active).
+      await act(async () => {
+        await result.current.retryEnsureDeviceReady();
+      });
+
+      expect(options.handleError).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
@@ -11,7 +11,6 @@ import {
   HardwareWalletRefs,
   HardwareWalletStateSetters,
 } from './useHardwareWalletStateManager';
-import Logger from '../../../util/Logger';
 
 interface UseDeviceConnectionFlowOptions {
   refs: HardwareWalletRefs;
@@ -139,12 +138,6 @@ export const useDeviceConnectionFlow = ({
       targetDeviceId: string,
     ): Promise<boolean> => {
       const isReady = await adapter.ensureDeviceReady(targetDeviceId);
-      Logger.log('[HW-SendBundle] adapter.ensureDeviceReady returned', {
-        isReady,
-        walletType: adapter.walletType,
-        hasResolve: Boolean(pendingReadyResolveRef?.current),
-        hasCallback: Boolean(connectionSuccessCallbackRef.current),
-      });
       if (isReady) {
         adapter.markFlowComplete();
         // Resolve the blocking promise immediately when the adapter reports

--- a/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
@@ -4,9 +4,11 @@ import {
   HardwareWalletType,
   HardwareWalletConnectionState,
   ConnectionStatus,
+  ErrorCode,
 } from '@metamask/hw-wallet-sdk';
 
 import { HardwareWalletAdapter } from '../types';
+import { createHardwareWalletError } from '../errors';
 import {
   HardwareWalletRefs,
   HardwareWalletStateSetters,
@@ -178,7 +180,11 @@ export const useDeviceConnectionFlow = ({
       try {
         const adapter = refs.adapterRef.current;
         if (!adapter) {
-          throw new Error('No adapter available');
+          throw createHardwareWalletError(
+            ErrorCode.DeviceNotReady,
+            walletType,
+            'No adapter available',
+          );
         }
 
         await adapter.connect(targetDeviceId);
@@ -217,6 +223,7 @@ export const useDeviceConnectionFlow = ({
       refs,
       setters,
       handleError,
+      walletType,
       updateConnectionState,
       tryEnsureReady,
       flowActiveRef,
@@ -252,7 +259,11 @@ export const useDeviceConnectionFlow = ({
         walletType;
 
       if (!targetType) {
-        throw new Error('ensureDeviceReady called without a wallet type');
+        throw createHardwareWalletError(
+          ErrorCode.Unknown,
+          walletType,
+          'ensureDeviceReady called without a wallet type',
+        );
       }
 
       if (!targetDeviceId) {

--- a/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
@@ -29,6 +29,14 @@ interface UseDeviceConnectionFlowOptions {
   ) => Promise<boolean>;
   /** Called at the start of each new ensureDeviceReady flow. */
   onFlowStart?: () => void;
+  /**
+   * Provider-owned flag tracking whether a connection flow is active.
+   * Set while a readiness flow is armed/pending; cleared whenever the
+   * pending promise is resolved (success, cancel, or closeFlow). Used to
+   * gate internal error surfacing: late errors after the flow closed must
+   * not re-open the error bottom sheet over the app.
+   */
+  flowActiveRef: React.MutableRefObject<boolean>;
 }
 
 interface UseDeviceConnectionFlowResult {
@@ -56,6 +64,7 @@ export const useDeviceConnectionFlow = ({
   initializeAdapter,
   checkTransportEnabledOrShowError,
   onFlowStart,
+  flowActiveRef,
 }: UseDeviceConnectionFlowOptions): UseDeviceConnectionFlowResult => {
   const pendingReadyResolveRef = useRef<((ready: boolean) => void) | null>(
     null,
@@ -102,6 +111,7 @@ export const useDeviceConnectionFlow = ({
     (afterSetup?: () => void): Promise<boolean> =>
       new Promise<boolean>((resolve) => {
         pendingReadyResolveRef.current = resolve;
+        flowActiveRef.current = true;
 
         connectionSuccessCallbackRef.current = () => {
           DevLogger.log(
@@ -109,13 +119,14 @@ export const useDeviceConnectionFlow = ({
           );
           if (pendingReadyResolveRef.current === resolve) {
             pendingReadyResolveRef.current = null;
+            flowActiveRef.current = false;
             resolve(true);
           }
         };
 
         afterSetup?.();
       }),
-    [],
+    [flowActiveRef],
   );
 
   const tryEnsureReady = useCallback(
@@ -149,6 +160,7 @@ export const useDeviceConnectionFlow = ({
         if (resolvePending) {
           pendingReadyResolveRef.current = null;
           connectionSuccessCallbackRef.current = null;
+          flowActiveRef.current = false;
           resolvePending(true);
         }
       } else {
@@ -158,7 +170,7 @@ export const useDeviceConnectionFlow = ({
       }
       return isReady;
     },
-    [updateConnectionState],
+    [updateConnectionState, flowActiveRef],
   );
 
   const connect = useCallback(
@@ -196,15 +208,26 @@ export const useDeviceConnectionFlow = ({
           await tryEnsureReady(adapter, targetDeviceId);
         } catch (error) {
           DevLogger.log('[HardwareWallet] Readiness check failed:', error);
-          handleError(error);
+          if (flowActiveRef.current) {
+            handleError(error);
+          }
         }
       } catch (error) {
-        handleError(error);
+        if (flowActiveRef.current) {
+          handleError(error);
+        }
       } finally {
         refs.isConnectingRef.current = false;
       }
     },
-    [refs, setters, handleError, updateConnectionState, tryEnsureReady],
+    [
+      refs,
+      setters,
+      handleError,
+      updateConnectionState,
+      tryEnsureReady,
+      flowActiveRef,
+    ],
   );
 
   const ensureDeviceReady = useCallback(
@@ -215,6 +238,7 @@ export const useDeviceConnectionFlow = ({
       );
 
       onFlowStart?.();
+      flowActiveRef.current = true;
 
       if (pendingReadyResolveRef.current) {
         DevLogger.log(
@@ -224,6 +248,7 @@ export const useDeviceConnectionFlow = ({
         if (resolvePending) {
           pendingReadyResolveRef.current = null;
           connectionSuccessCallbackRef.current = null;
+          flowActiveRef.current = false;
           resolvePending(false);
         }
       }
@@ -326,7 +351,9 @@ export const useDeviceConnectionFlow = ({
                   '[HardwareWallet] ensureDeviceReady error:',
                   error,
                 );
-                handleError(error);
+                if (flowActiveRef.current) {
+                  handleError(error);
+                }
               } finally {
                 refs.abortControllerRef.current = null;
               }
@@ -351,7 +378,9 @@ export const useDeviceConnectionFlow = ({
             await tryEnsureReady(adapter, targetDeviceId);
           } catch (error) {
             DevLogger.log('[HardwareWallet] ensureDeviceReady error:', error);
-            handleError(error);
+            if (flowActiveRef.current) {
+              handleError(error);
+            }
           } finally {
             refs.abortControllerRef.current = null;
           }
@@ -369,6 +398,7 @@ export const useDeviceConnectionFlow = ({
       checkTransportEnabledOrShowError,
       createBlockingPromise,
       onFlowStart,
+      flowActiveRef,
     ],
   );
 
@@ -393,7 +423,9 @@ export const useDeviceConnectionFlow = ({
       try {
         await tryEnsureReady(adapter, effectiveDeviceId);
       } catch (error) {
-        handleError(error);
+        if (flowActiveRef.current) {
+          handleError(error);
+        }
       }
     } else {
       updateConnectionState({ status: ConnectionStatus.Scanning });
@@ -404,6 +436,7 @@ export const useDeviceConnectionFlow = ({
     refs,
     checkTransportEnabledOrShowError,
     tryEnsureReady,
+    flowActiveRef,
   ]);
 
   const closeFlow = useCallback(() => {
@@ -411,11 +444,12 @@ export const useDeviceConnectionFlow = ({
     if (resolvePending) {
       pendingReadyResolveRef.current = null;
       connectionSuccessCallbackRef.current = null;
+      flowActiveRef.current = false;
       resolvePending(false);
     }
     setters.setTargetWalletType(null);
     updateConnectionState({ status: ConnectionStatus.Disconnected });
-  }, [setters, updateConnectionState]);
+  }, [setters, updateConnectionState, flowActiveRef]);
 
   const handleConnectionSuccess = useCallback(() => {
     const callback = connectionSuccessCallbackRef.current;

--- a/app/core/HardwareWallet/hooks/useDeviceEventHandlers.test.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceEventHandlers.test.ts
@@ -83,12 +83,14 @@ describe('useDeviceEventHandlers', () => {
 
   const createHook = (
     walletType: HardwareWalletType | null = HardwareWalletType.Ledger,
+    isFlowActive?: () => boolean,
   ) =>
     renderHook(() =>
       useDeviceEventHandlers({
         refs: mockRefs,
         setters: mockSetters,
         walletType,
+        isFlowActive,
       }),
     );
 
@@ -559,6 +561,132 @@ describe('useDeviceEventHandlers', () => {
       });
 
       expect(lastConnectionState.status).toBe(ConnectionStatus.Disconnected);
+      expect(mockRefs.isConnectingRef.current).toBe(false);
+    });
+  });
+
+  describe('with inactive connection flow (isFlowActive returns false)', () => {
+    const isFlowActive = () => false;
+
+    beforeEach(() => {
+      mockRefs.isConnectingRef.current = true;
+      lastConnectionState = { status: ConnectionStatus.Connecting };
+    });
+
+    it('handleError is not gated and still transitions to ErrorState (ungated for signing flows)', () => {
+      const { result } = createHook(HardwareWalletType.Ledger, isFlowActive);
+
+      act(() => {
+        result.current.handleError(new Error('Direct error'));
+      });
+
+      expect(lastConnectionState.status).toBe(ConnectionStatus.ErrorState);
+      expect(mockRefs.isConnectingRef.current).toBe(false);
+    });
+
+    it('DeviceLocked with error does not transition to ErrorState', () => {
+      const { result } = createHook(HardwareWalletType.Ledger, isFlowActive);
+
+      act(() => {
+        result.current.handleDeviceEvent({
+          event: DeviceEvent.DeviceLocked,
+          error: new Error('Device locked'),
+        });
+      });
+
+      expect(lastConnectionState.status).toBe(ConnectionStatus.Connecting);
+      expect(mockRefs.isConnectingRef.current).toBe(false);
+    });
+
+    it('DeviceLocked without error does not transition to ErrorState', () => {
+      const { result } = createHook(HardwareWalletType.Ledger, isFlowActive);
+
+      act(() => {
+        result.current.handleDeviceEvent({
+          event: DeviceEvent.DeviceLocked,
+        });
+      });
+
+      expect(lastConnectionState.status).toBe(ConnectionStatus.Connecting);
+      expect(mockRefs.isConnectingRef.current).toBe(false);
+    });
+
+    it('ConnectionFailed with error does not transition to ErrorState', () => {
+      const { result } = createHook(HardwareWalletType.Ledger, isFlowActive);
+
+      act(() => {
+        result.current.handleDeviceEvent({
+          event: DeviceEvent.ConnectionFailed,
+          error: new Error('Connection failed'),
+        });
+      });
+
+      expect(lastConnectionState.status).toBe(ConnectionStatus.Connecting);
+      expect(mockRefs.isConnectingRef.current).toBe(false);
+    });
+
+    it('OperationTimeout with error does not transition to ErrorState', () => {
+      const { result } = createHook(HardwareWalletType.Ledger, isFlowActive);
+
+      act(() => {
+        result.current.handleDeviceEvent({
+          event: DeviceEvent.OperationTimeout,
+          error: new Error('Operation timed out'),
+        });
+      });
+
+      expect(lastConnectionState.status).toBe(ConnectionStatus.Connecting);
+      expect(mockRefs.isConnectingRef.current).toBe(false);
+    });
+
+    it('Disconnected events still transition when the flow is inactive', () => {
+      const { result } = createHook(HardwareWalletType.Ledger, isFlowActive);
+
+      act(() => {
+        result.current.handleDeviceEvent({
+          event: DeviceEvent.Disconnected,
+        });
+      });
+
+      expect(lastConnectionState.status).toBe(ConnectionStatus.Disconnected);
+      expect(mockRefs.isConnectingRef.current).toBe(false);
+    });
+
+    it('ConnectionFailed without error still transitions to Disconnected', () => {
+      const { result } = createHook(HardwareWalletType.Ledger, isFlowActive);
+
+      act(() => {
+        result.current.handleDeviceEvent({
+          event: DeviceEvent.ConnectionFailed,
+        });
+      });
+
+      expect(lastConnectionState.status).toBe(ConnectionStatus.Disconnected);
+      expect(mockRefs.isConnectingRef.current).toBe(false);
+    });
+  });
+
+  describe('without isFlowActive option (back-compat)', () => {
+    it('handleError still transitions to ErrorState when isFlowActive is undefined', () => {
+      const { result } = createHook();
+
+      act(() => {
+        result.current.handleError(new Error('Test'));
+      });
+
+      expect(lastConnectionState.status).toBe(ConnectionStatus.ErrorState);
+    });
+
+    it('DeviceLocked still transitions to ErrorState when isFlowActive is undefined', () => {
+      const { result } = createHook();
+
+      act(() => {
+        result.current.handleDeviceEvent({
+          event: DeviceEvent.DeviceLocked,
+        });
+      });
+
+      expect(lastConnectionState.status).toBe(ConnectionStatus.ErrorState);
       expect(mockRefs.isConnectingRef.current).toBe(false);
     });
   });

--- a/app/core/HardwareWallet/hooks/useDeviceEventHandlers.test.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceEventHandlers.test.ts
@@ -639,6 +639,46 @@ describe('useDeviceEventHandlers', () => {
       expect(mockRefs.isConnectingRef.current).toBe(false);
     });
 
+    it('Connected events do not transition when the flow is inactive', () => {
+      const { result } = createHook(HardwareWalletType.Ledger, isFlowActive);
+
+      act(() => {
+        result.current.handleDeviceEvent({
+          event: DeviceEvent.Connected,
+          deviceId: 'device-456',
+        });
+      });
+
+      expect(lastConnectionState.status).toBe(ConnectionStatus.Connecting);
+      expect(mockSetters.setDeviceId).not.toHaveBeenCalled();
+      expect(mockRefs.isConnectingRef.current).toBe(false);
+    });
+
+    it('AppOpened events do not transition when the flow is inactive', () => {
+      const { result } = createHook(HardwareWalletType.Ledger, isFlowActive);
+
+      act(() => {
+        result.current.handleDeviceEvent({
+          event: DeviceEvent.AppOpened,
+        });
+      });
+
+      expect(lastConnectionState.status).toBe(ConnectionStatus.Connecting);
+    });
+
+    it('AppNotOpen events do not transition when the flow is inactive', () => {
+      const { result } = createHook(HardwareWalletType.Ledger, isFlowActive);
+
+      act(() => {
+        result.current.handleDeviceEvent({
+          event: DeviceEvent.AppNotOpen,
+          currentAppName: 'BOLOS',
+        });
+      });
+
+      expect(lastConnectionState.status).toBe(ConnectionStatus.Connecting);
+    });
+
     it('Disconnected events still transition when the flow is inactive', () => {
       const { result } = createHook(HardwareWalletType.Ledger, isFlowActive);
 

--- a/app/core/HardwareWallet/hooks/useDeviceEventHandlers.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceEventHandlers.ts
@@ -90,6 +90,13 @@ export const useDeviceEventHandlers = ({
     (payload: DeviceEventPayload) => {
       switch (payload.event) {
         case DeviceEvent.Connected: {
+          // When no flow is active, late connect events (e.g. in-flight
+          // adapter retry loops completing after the flow closed) must not
+          // re-open the bottom sheet over the app.
+          if (isFlowActive?.() === false) {
+            refs.isConnectingRef.current = false;
+            break;
+          }
           const connectedDeviceId =
             payload.deviceId ??
             refs.adapterRef.current?.getConnectedDeviceId() ??
@@ -111,6 +118,11 @@ export const useDeviceEventHandlers = ({
           break;
 
         case DeviceEvent.AppOpened:
+          // When no flow is active, a late app-opened event must not
+          // re-open the bottom sheet over the app.
+          if (isFlowActive?.() === false) {
+            break;
+          }
           updateConnectionState({
             status: ConnectionStatus.Connected,
             deviceId: refs.adapterRef.current?.getConnectedDeviceId() ?? '',
@@ -118,6 +130,12 @@ export const useDeviceEventHandlers = ({
           break;
 
         case DeviceEvent.AppNotOpen:
+          // When no flow is active, a late app-not-open event (e.g. from
+          // in-flight wrong-app recovery after the flow closed) must not
+          // re-open the bottom sheet over the app.
+          if (isFlowActive?.() === false) {
+            break;
+          }
           updateConnectionState({
             status: ConnectionStatus.AwaitingApp,
             deviceId: refs.adapterRef.current?.getConnectedDeviceId() ?? '',

--- a/app/core/HardwareWallet/hooks/useDeviceEventHandlers.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceEventHandlers.ts
@@ -23,6 +23,15 @@ interface UseDeviceEventHandlersOptions {
   setters: HardwareWalletStateSetters;
   /** Current wallet type, used for error parsing context. */
   walletType: HardwareWalletType | null;
+  /**
+   * Returns whether a connection flow is currently active. When it returns
+   * `false`, late *device event* errors (events arriving after the flow
+   * closed) must not transition the state to ErrorState — that would re-open
+   * the error bottom sheet over the app. Direct `handleError` callers (e.g.
+   * `showHardwareWalletError` for signing flows) remain ungated. Optional for
+   * back-compat: when omitted, behavior is unchanged.
+   */
+  isFlowActive?: () => boolean;
 }
 
 /** Return value of the {@link useDeviceEventHandlers} hook. */
@@ -45,6 +54,7 @@ export const useDeviceEventHandlers = ({
   refs,
   setters,
   walletType,
+  isFlowActive,
 }: UseDeviceEventHandlersOptions): DeviceEventHandlersResult => {
   const updateConnectionState = useCallback(
     (newState: HardwareWalletConnectionState) => {
@@ -116,21 +126,26 @@ export const useDeviceEventHandlers = ({
           });
           break;
 
-        case DeviceEvent.DeviceLocked:
-          if (payload.error) {
-            handleError(payload.error);
-          } else {
-            const lockedError = createHardwareWalletError(
-              ErrorCode.AuthenticationDeviceLocked,
-              walletType ?? refs.adapterRef.current?.walletType,
-            );
-            updateConnectionState({
-              status: ConnectionStatus.ErrorState,
-              error: lockedError,
-            });
+        case DeviceEvent.DeviceLocked: {
+          // When no flow is active, a late lock event must not re-open the
+          // error bottom sheet over the app — only clear the connecting flag.
+          if (isFlowActive?.() !== false) {
+            if (payload.error) {
+              handleError(payload.error);
+            } else {
+              const lockedError = createHardwareWalletError(
+                ErrorCode.AuthenticationDeviceLocked,
+                walletType ?? refs.adapterRef.current?.walletType,
+              );
+              updateConnectionState({
+                status: ConnectionStatus.ErrorState,
+                error: lockedError,
+              });
+            }
           }
           refs.isConnectingRef.current = false;
           break;
+        }
 
         case DeviceEvent.ConfirmationRequired:
           updateConnectionState({
@@ -158,16 +173,20 @@ export const useDeviceEventHandlers = ({
           break;
 
         case DeviceEvent.ConnectionFailed:
-          if (payload.error) {
+          // When no flow is active, a late failure must not re-open the
+          // error bottom sheet over the app.
+          if (payload.error && isFlowActive?.() !== false) {
             handleError(payload.error);
-          } else {
+          } else if (!payload.error) {
             updateConnectionState({ status: ConnectionStatus.Disconnected });
           }
           refs.isConnectingRef.current = false;
           break;
 
         case DeviceEvent.OperationTimeout:
-          if (payload.error) {
+          // When no flow is active, a late timeout must not re-open the
+          // error bottom sheet over the app.
+          if (payload.error && isFlowActive?.() !== false) {
             handleError(payload.error);
           }
           refs.isConnectingRef.current = false;
@@ -185,7 +204,14 @@ export const useDeviceEventHandlers = ({
           }
       }
     },
-    [setters, refs, updateConnectionState, handleError, walletType],
+    [
+      setters,
+      refs,
+      updateConnectionState,
+      handleError,
+      walletType,
+      isFlowActive,
+    ],
   );
 
   return {

--- a/tests/component-view/renderers/perpsViewRenderer.tsx
+++ b/tests/component-view/renderers/perpsViewRenderer.tsx
@@ -125,6 +125,7 @@ const testHardwareWalletValue: HardwareWalletContextValue = {
   setTargetWalletType: (): void => undefined,
   setPendingOperationAddress: (): void => undefined,
   showHardwareWalletError: (): void => undefined,
+  cancelConnectionFlow: (): void => undefined,
   showAwaitingConfirmation: (): void => undefined,
   hideAwaitingConfirmation: (): void => undefined,
   qr: {

--- a/tests/integration/harnesses/perps/perps-component.tsx
+++ b/tests/integration/harnesses/perps/perps-component.tsx
@@ -217,6 +217,7 @@ const testHardwareWalletValue: HardwareWalletContextValue = {
   setTargetWalletType: (): void => undefined,
   setPendingOperationAddress: (): void => undefined,
   showHardwareWalletError: (): void => undefined,
+  cancelConnectionFlow: (): void => undefined,
   showAwaitingConfirmation: (): void => undefined,
   hideAwaitingConfirmation: (): void => undefined,
   qr: {


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Fixes an unknown error triggered when opening the ETH app after recovering from the "ETH app not open" condition.


<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix unknown error being shown when recovering from eth app not open. 

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-2223?atlOrigin=eyJpIjoiN2FkNzkyYjRhYzY0NDdmZjhkMDkxNjZhODk0N2Q1ZWIiLCJwIjoiaiJ9

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Ledger eth app not open error handling

  Scenario: device auto-locks while the open-Ethereum-app prompt is showing
    Given the device is connected with the Ethereum app not open
    And the bottom sheet prompts to open the Ethereum app
   
    When user taps Continue to retry
    Then the sheet shows the "device unresponsive" error with its recovery action
    And the sheet does NOT show the generic "Something went wrong" error

```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Ledger BLE/DMK connection, readiness, and bottom-sheet state machines; incorrect gating could hide real errors during signing or leave flows stuck, though signing paths intentionally keep `showHardwareWalletError` ungated.
> 
> **Overview**
> Fixes the generic **"Something went wrong"** sheet when recovering from **ETH app not open**, and stops **stranded hardware-wallet bottom sheets** after the user leaves a flow screen.
> 
> **Ledger readiness timeouts** (connect stall, app check, verification) now return **`false`** and emit **`AppNotOpen`** instead of **`ConnectionFailed`** or thrown fatal errors, in both BLE and DMK adapters. Connect uses **`withLedgerTimeout`** on `TransportBLE.open`, and teardown is **serialized** via a pending-close queue so reconnect does not race `disconnectDevice`. Error parsing treats **"unresponsive"** messages as **`DeviceUnresponsive`**.
> 
> **Connection flow lifecycle**: the provider tracks **`flowActiveRef`** and exposes **`cancelConnectionFlow`** (wired to **`closeFlow`**). Late adapter disconnects, device events, and internal **`handleError`** paths are **gated** when no flow is active so errors cannot reopen the sheet over Home. **`LedgerSelectAccount`** calls **`cancelConnectionFlow` on unmount** with a **`cancelled`** guard so a settled **`ensureDeviceReady(false)`** does not **`goBack`** twice.
> 
> **`useDeviceConnectionFlow`** refactors readiness into **`resolveReadinessTarget`** / **`runReadinessCheck`**: live sessions skip **`Connecting`** so they do not overwrite **`AwaitingApp`**, and **`closeFlow`** aborts in-flight work and clears flow state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d173aeeeab8ee8db5f83c0b656ed46f17854d57c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->