### PR TITLE
chore: upgrade React Native design system to 0.43.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -304,7 +304,7 @@
     "@metamask/core-backend": "^9.0.0",
     "@metamask/delegation-controller": "^3.0.2",
     "@metamask/delegation-deployments": "^2.0.0",
-    "@metamask/design-system-react-native": "^0.42.1",
+    "@metamask/design-system-react-native": "^0.43.0",
     "@metamask/design-system-twrnc-preset": "^0.10.0",
     "@metamask/design-tokens": "^10.0.0",
     "@metamask/earn-controller": "^12.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10084,16 +10084,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react-native@npm:^0.42.1":
-  version: 0.42.1
-  resolution: "@metamask/design-system-react-native@npm:0.42.1"
+"@metamask/design-system-react-native@npm:^0.43.0":
+  version: 0.43.0
+  resolution: "@metamask/design-system-react-native@npm:0.43.0"
   dependencies:
-    "@metamask/design-system-shared": "npm:^0.34.0"
+    "@metamask/design-system-shared": "npm:^0.35.0"
     react-native-jazzicon: "npm:^0.1.2"
   peerDependencies:
     "@metamask/design-system-twrnc-preset": ^0.10.0
     "@metamask/design-tokens": ^10.0.0
-    "@metamask/utils": ^11.11.0
+    "@metamask/utils": ^11.12.0
     expo-image: ">=3.0.0"
     lodash: ^4.17.21
     react: ">=18.2.0"
@@ -10102,18 +10102,18 @@ __metadata:
     react-native-reanimated: ">=4.2.0"
     react-native-safe-area-context: ">=5.0.0"
     react-native-worklets: ">=0.7.4"
-  checksum: 10/ce8977d955a3bd4c7f65f714f69ed3a4ffe4acfee57fcad30ce352399005661cd5a5d157a0866b544509348dc42ca7d50ea2d796ac42ca879267842d38bed70a
+  checksum: 10/620f8424b684f11f86a7c137d4b84f998f108c3ca4dfcdf67201b9cfc1592176407cb6476572954703b5780c7e0ef6772ff7c1d672130dfd156f10f71dde830e
   languageName: node
   linkType: hard
 
-"@metamask/design-system-shared@npm:^0.34.0":
-  version: 0.34.0
-  resolution: "@metamask/design-system-shared@npm:0.34.0"
+"@metamask/design-system-shared@npm:^0.35.0":
+  version: 0.35.0
+  resolution: "@metamask/design-system-shared@npm:0.35.0"
   dependencies:
-    "@metamask/utils": "npm:^11.11.0"
+    "@metamask/utils": "npm:^11.12.0"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/6082a4541ef2cb35de6d8167da99fe3180048bf831759f5ea2b367839e9d1e5670e51d4fbeffa7a76f62d6ca855af8a088d701f2b553511729fad9630cec5f23
+  checksum: 10/7fc70d8f175b4b9b1fe5b2b59661200137a818332603b67c37140bedc000009cab7dac9a9d000bb813790bc7de94c4f825c999c8d5e05244b4e75d97a5f49eb4
   languageName: node
   linkType: hard
 
@@ -39725,7 +39725,7 @@ __metadata:
     "@metamask/core-backend": "npm:^9.0.0"
     "@metamask/delegation-controller": "npm:^3.0.2"
     "@metamask/delegation-deployments": "npm:^2.0.0"
-    "@metamask/design-system-react-native": "npm:^0.42.1"
+    "@metamask/design-system-react-native": "npm:^0.43.0"
     "@metamask/design-system-twrnc-preset": "npm:^0.10.0"
     "@metamask/design-tokens": "npm:^10.0.0"
     "@metamask/device-mcp": "npm:^0.3.3"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Upgrades `@metamask/design-system-react-native` from 0.42.1 to 0.43.0 and transitively upgrades `@metamask/design-system-shared` from 0.34.0 to 0.35.0. The Tailwind preset and design tokens were already on their latest versions (0.10.0 and 10.0.0).

Release notes: [MetaMask Design System v64.0.0](https://github.com/MetaMask/metamask-design-system/releases/tag/v64.0.0)

The release removes 111 unused icons. TypeScript validation found no references to removed `IconName` members, so no icon migrations are required.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: Design system dependency maintenance

## **Manual testing steps**

1. Run `yarn install --immutable`.
2. Run `yarn lint:tsc`.
3. Confirm there are no removed-icon type errors. The full command currently reports only two pre-existing missing generated-module errors for `app/util/termsOfUse/termsOfUseContent`.

## **Screenshots/Recordings**

### **Before**

N/A — no intended visual changes.

### **After**

N/A — no intended visual changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A — dependency metadata update only.
- [x] I've tested with a power user scenario
  - N/A — dependency metadata update only.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — no production operation changed.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87dfc599-75c5-44de-a883-07d02ee103a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87dfc599-75c5-44de-a883-07d02ee103a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

