### PR TITLE
fix(content): replace "token allowance" with "spending cap" in mobile locale strings

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10148,7 +10148,7 @@
       "cancel": "Cancel",
       "done": "Done",
       "confirm": "Confirm",
-      "checking_allowance": "Checking token allowance...",
+      "checking_allowance": "Checking spending cap...",
       "token_not_enabled": "This token needs to be enabled for card spending",
       "token_enabled": "Token is enabled for card spending"
     },


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Replaces all instances of "token allowance" with "spending cap" in `locales/languages/en.json` per MetaMask content guidelines. This aligns the mobile locale strings with the standard terminology used across MetaMask products.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — locale string rename only, no logic changes.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — text-only change, no visual difference in layout.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.