### PR TITLE
fix(content): remove "please" from mobile locale strings (batch 1 of 11)

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -129,7 +129,7 @@
     },
     "headless_buy_error": {
       "title": "Fiat purchase failed",
-      "message": "Something went wrong with your fiat purchase. Please try again."
+      "message": "Something went wrong with your fiat purchase. Try again."
     },
     "mmpay_hardware_account": {
       "title": "Wallet not supported",
@@ -219,7 +219,7 @@
     "setting_up_alerts_description": "We are going as fast as we can to set up security alerts. Hang in there, we are almost done.",
     "setup_complete": "Set up complete",
     "setup_failed": "We could not finish setting up the security alerts. Check your internet connection and try again.",
-    "setup_multiple_failures": "Your internet connection isn’t stable right now, so we couldn’t set up security alerts. Please try again when your connection is restored.",
+    "setup_multiple_failures": "Your internet connection isn't stable right now, so we couldn't set up security alerts. Try again when your connection is restored.",
     "setup_complete_description": "Security alerts are ready to go. You can close this page and start exploring your wallet",
     "continue": "Continue",
     "cancel": "Cancel",
@@ -314,7 +314,7 @@
     "new_to_metamask": "New to MetaMask?",
     "already_have_wallet": "Already have a wallet?",
     "optin_back_title": "Heads up!",
-    "optin_back_desc": "Please agree or disagree to the usage of data analytics. You can also update this option in settings.",
+    "optin_back_desc": "Agree or disagree to the usage of data analytics. You can also update this option in settings.",
     "warning_title": "Warning",
     "warning_text_1": "Your current wallet and accounts will be",
     "warning_text_2": "removed",
@@ -516,7 +516,7 @@
     "wrong_password_error": "Error: Decrypt failed",
     "wrong_password_error_android": "Error: error:1e000065:Cipher functions:OPENSSL_internal:BAD_DECRYPT",
     "vault_error": "Error: Cannot unlock without a previous vault.",
-    "clean_vault_error": "MetaMask encountered an error due to reaching a storage limit. The local data has been corrupted. Please reinstall MetaMask and restore with your Secret Recovery Phrase.",
+    "clean_vault_error": "MetaMask encountered an error due to reaching a storage limit. The local data has been corrupted. Reinstall MetaMask and restore with your Secret Recovery Phrase.",
     "seedless_password_outdated": "Your password was changed recently.",
     "seedless_password_outdated_modal_title": "Your password was changed",
     "seedless_password_outdated_modal_content": "Your password was recently changed, so you need to enter your new password to stay logged into MetaMask.",
@@ -527,8 +527,8 @@
     "seedless_controller_error_prompt_primary_button_label": "Log in",
     "security_alert_title": "Security alert",
     "security_alert_desc": "In order to proceed, you need to turn Passcode on or any biometrics authentication method supported in your device (FaceID, TouchID or Fingerprint)",
-    "too_many_attempts": "Too many attempts. Please try again in {{remainingTime}}",
-    "biometric_too_many_attempts": "Too many attempts, please enter your password.",
+    "too_many_attempts": "Too many attempts. Try again in {{remainingTime}}",
+    "biometric_too_many_attempts": "Too many attempts. Enter your password.",
     "apple_button": "Sign in with Apple",
     "google_button": "Sign in with Google",
     "other_methods": "Use a different login method",
@@ -548,10 +548,10 @@
     "reset_wallet_desc_srp": "To restore your wallet, make sure you have your Secret Recovery Phrase. MetaMask doesn’t have this information.",
     "biometric_authentication_cancelled": "Biometric authentication cancelled",
     "biometric_authentication_cancelled_title": "Biometric Setup Failed",
-    "biometric_authentication_cancelled_description": "Please re-setup biometric authentication from the settings.",
+    "biometric_authentication_cancelled_description": "Set up biometric authentication again from the settings.",
     "biometric_authentication_cancelled_button": "Confirm",
     "biometric_changed": "Biometric Changed",
-    "biometric_changed_alert_desc": "Your biometric has been changed. Please re-enable biometric from settings.",
+    "biometric_changed_alert_desc": "Your biometric has been changed. Re-enable biometric from settings.",
     "biometric_changed_alert_confirm": "Confirm"
   },
   "connect_hardware": {
@@ -561,7 +561,7 @@
   },
   "enter_password": {
     "title": "Enter your password",
-    "desc": "Please enter your password in order to continue",
+    "desc": "Enter your password to continue",
     "password": "Password",
     "confirm_button": "Confirm",
     "error": "Error"
@@ -652,7 +652,7 @@
     "changing_password_subtitle": "This shouldn’t take long",
     "checkbox_forgot_password": "If I forget this password, I’ll lose access to my wallet permanently. MetaMask can’t reset it for me.",
     "seedless_change_password_error_modal_title": "Change password failed",
-    "seedless_change_password_error_modal_content": "We were unable to change your password. Please try again.",
+    "seedless_change_password_error_modal_content": "We were unable to change your password. Try again.",
     "seedless_change_password_error_modal_confirm": "Try again"
   },
   "import_from_seed": {
@@ -748,7 +748,7 @@
     "units": "units",
     "next": "Next",
     "title": "Send",
-    "deeplink_failure": "Something went wrong. Please try again",
+    "deeplink_failure": "Something went wrong. Try again",
     "warn_network_change": "Network changed to ",
     "send_to": "Send to",
     "amount": "Amount",
@@ -769,7 +769,7 @@
     "no_tokens_available": "No tokens available",
     "sign": "Sign",
     "network_not_found_title": "Network not found",
-    "network_not_found_description": "Network with chain ID {{chain_id}} not found in your wallet. Please add the network first.",
+    "network_not_found_description": "Network with chain ID {{chain_id}} not found in your wallet. Add the network first.",
     "network_missing_id": "Missing chain ID.",
     "search_tokens": "Search tokens",
     "search_tokens_and_nfts": "Search tokens and NFTs",
@@ -812,7 +812,7 @@
       "kycFormsFetchError": "Failed to fetch KYC forms.",
       "title": "Buy",
       "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
-      "limitError": "Failed to check your deposit limits. Please try again later."
+      "limitError": "Failed to check your deposit limits. Try again later."
     },
     "token_modal": {
       "select_a_token": "Select a token",
@@ -821,7 +821,7 @@
       "no_tokens_found": "No tokens match \"{{searchString}}\"",
       "unsupported_token_title": "Not available",
       "unsupported_token_description": "This token may not be available in your region or supported by any local payment providers",
-      "error_loading_tokens": "Unable to load tokens. Please try again later."
+      "error_loading_tokens": "Unable to load tokens. Try again later."
     },
     "networks_filter_bar": {
       "all_networks": "All networks"
@@ -913,7 +913,7 @@
       "input_placeholder": "name@domain.com",
       "submit_button": "Send email",
       "loading": "Sending email...",
-      "validation_error": "Please enter a valid email address",
+      "validation_error": "Enter a valid email address",
       "error": "An error occurred while sending the email"
     },
     "otp_code": {
@@ -923,7 +923,7 @@
       "submit_button": "Submit",
       "loading": "Verifying code...",
       "invalid_code_error": "Invalid code",
-      "validation_error": "Please enter a valid code",
+      "validation_error": "Enter a valid code",
       "need_help": "Need help?",
       "resend_code_description": "Didn't receive the code?",
       "resend_code_error": "Error resending code.",
@@ -968,13 +968,13 @@
       "enter_phone_number": "Enter phone number",
       "select_region": "Select region",
       "first_name_required": "First name is required",
-      "first_name_invalid": "Please enter a valid first name",
+      "first_name_invalid": "Enter a valid first name",
       "last_name_required": "Last name is required",
-      "last_name_invalid": "Please enter a valid last name",
+      "last_name_invalid": "Enter a valid last name",
       "mobile_number_required": "Phone number is required",
-      "mobile_number_invalid": "Please enter a valid phone number",
+      "mobile_number_invalid": "Enter a valid phone number",
       "dob_required": "Date of birth is required",
-      "dob_invalid": "Please enter a valid date of birth",
+      "dob_invalid": "Enter a valid date of birth",
       "ssn_required": "Social security number is required",
       "unexpected_error": "An unexpected error occurred. Please try again.",
       "phone_already_registered": "This phone number is already in use by {{email}}. Log in using this email to continue.",
@@ -993,14 +993,14 @@
       "country": "Country",
       "select_state": "Select state",
       "address_line_1_required": "Address line 1 is required",
-      "address_line_1_invalid": "Please enter a valid address",
-      "address_line_2_invalid": "Please enter a valid address",
+      "address_line_1_invalid": "Enter a valid address",
+      "address_line_2_invalid": "Enter a valid address",
       "city_required": "City is required",
-      "city_invalid": "Please enter a valid city",
+      "city_invalid": "Enter a valid city",
       "state_required": "State/Region is required",
-      "state_invalid": "Please enter a valid state",
+      "state_invalid": "Enter a valid state",
       "postal_code_required": "Postal code is required",
-      "postal_code_invalid": "Please enter a valid postal code",
+      "postal_code_invalid": "Enter a valid postal code",
       "unexpected_error": "Unexpected error."
     },
     "privacy_section": {
@@ -10348,7 +10348,7 @@
       "description": "The MetaMask Metal Card is subject to eligibility and isn't available in all regions. If you don't qualify, you'll receive an exclusive premium merch reward instead.",
       "contact_info": "Share your contact info and you'll hear back within 2 weeks from @MidwitMilhouse on Telegram or christian.montoya@consensys.net.",
       "email_label": "Email",
-      "email_validation_error": "Please enter a valid email address",
+      "email_validation_error": "Enter a valid email address",
       "telegram_label": "Telegram handle",
       "telegram_placeholder": "Optional"
     },


### PR DESCRIPTION
## **Description**

Per MetaMask content guidelines: UI strings shouldn't ask for favors. Use direct imperative language instead.

Updated strings in `locales/languages/en.json`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A

## **Manual testing steps**

1. Build and run the app.
2. Navigate to any screen that displays the updated strings.
3. Confirm the updated wording appears correctly with no layout regressions.

## **Screenshots/Recordings**

### **Before**

N/A — locale string changes only.

### **After**

N/A — locale string changes only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Locale-only copy edits with no logic, API, or security changes; risk is limited to minor UX wording differences if translations or tests assert exact strings.
> 
> **Overview**
> **Batch 1** updates English copy in `locales/languages/en.json` to follow MetaMask content guidelines: drop favor-asking phrasing (mostly **“Please …”**) and use direct imperatives instead.
> 
> Wording changes span **errors and retries** (fiat buy, send deeplinks, deposit limits/token loading), **security alert setup**, **onboarding** (analytics opt-in), **login/unlock** (vault corruption, too many attempts, biometrics), **password** prompts and seedless change-password errors, **Transak/KYC** validation messages, and **rewards** email validation. One string also normalizes apostrophe style in the Blockaid setup failure message.
> 
> No keys were added or removed—only string values changed—so behavior is unchanged aside from on-screen text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b231828e0d48f380de88cd38a33b50d1c5b8f61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->