### PR TITLE
fix(content): remove "please" from mobile locale strings (batch 11 of 11)

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -976,7 +976,7 @@
       "dob_required": "Date of birth is required",
       "dob_invalid": "Please enter a valid date of birth",
       "ssn_required": "Social security number is required",
-      "unexpected_error": "An unexpected error occurred. Please try again.",
+      "unexpected_error": "An unexpected error occurred. Try again.",
       "phone_already_registered": "This phone number is already in use by {{email}}. Log in using this email to continue.",
       "login_with_email": "Log in with email"
     },
@@ -7655,7 +7655,7 @@
     "ledger_disconnected": "Your device got disconnected",
     "ledger_disconnected_error": "The connection to your device has been lost. Please try again.",
     "unknown_error": "Unexpected error occurred.",
-    "unknown_error_message": "An unexpected error occurred. Please try again.",
+    "unknown_error_message": "An unexpected error occurred. Try again.",
     "error_occured": "An error occurred",
     "how_to_install_eth_app": "How to install the Ethereum app on a Ledger device",
     "ledger_account_count": "You are using 1 account from your Ledger with MetaMask Mobile.",
@@ -11063,7 +11063,7 @@
     },
     "show_error": {
       "title": "Connection error",
-      "description": "Failed to establish connection. Please try again."
+      "description": "Failed to establish connection. Try again."
     },
     "show_rejection": {
       "title": "Approval rejected",
@@ -11097,11 +11097,11 @@
     },
     "show_not_found": {
       "title": "Connection Not Found",
-      "description": "Please establish a new connection from the app to continue."
+      "description": "Establish a new connection from the app to continue."
     },
     "show_internal_error": {
       "title": "Something went wrong",
-      "description": "An unexpected error occurred. Please try again."
+      "description": "An unexpected error occurred. Try again."
     },
     "agentic_cli_dashboard_webview": {
       "title": "Select project",
@@ -11110,7 +11110,7 @@
     },
     "show_method_error": {
       "title": "Request failed",
-      "description": "The request could not be completed. Please try again."
+      "description": "The request could not be completed. Try again."
     }
   },
   "network_connection_banner": {
@@ -11243,7 +11243,7 @@
     },
     "awaiting_app": {
       "title": "Open {{app}}",
-      "message": "Please open the {{app}} app on your {{device}}",
+      "message": "Open the {{app}} app on your {{device}}",
       "current_app": "Currently open: {{app}}"
     },
     "awaiting_confirmation": {
@@ -11256,22 +11256,22 @@
     },
     "errors": {
       "device_locked": "Unlock it and try again to continue",
-      "app_not_open": "Please open the Ethereum app on your device",
-      "device_disconnected": "Your {{device}} was disconnected. Please reconnect and try again",
-      "device_not_found": "Could not find your {{device}}. Please make sure it's connected",
-      "device_not_ready": "Your device is not ready. Please check it and try again",
-      "blind_signing": "Blind signing is disabled. Please enable it in your device settings",
-      "connection_closed": "The connection was lost. Please try again",
-      "connection_timeout": "Connection timed out. Please try again",
+      "app_not_open": "Open the Ethereum app on your device",
+      "device_disconnected": "Your {{device}} was disconnected. Reconnect and try again",
+      "device_not_found": "Could not find your {{device}}. Make sure it's connected",
+      "device_not_ready": "Your device is not ready. Check it and try again",
+      "blind_signing": "Blind signing is disabled. Enable it in your device settings",
+      "connection_closed": "The connection was lost. Try again",
+      "connection_timeout": "Connection timed out. Try again",
       "user_cancelled": "The action was cancelled on your device",
-      "pending_confirmation": "There's a pending action on your device. Please complete or cancel it",
+      "pending_confirmation": "There's a pending action on your device. Complete or cancel it",
       "bluetooth_permission_denied": "Bluetooth permission is required to connect to your device",
       "location_permission_denied": "Location permission is required to scan for devices",
       "nearby_permission_denied": "Nearby devices permission is required",
-      "bluetooth_off": "Please turn on Bluetooth to connect to your device",
-      "bluetooth_scan_failed": "Failed to scan for devices. Please try again",
-      "bluetooth_connection_failed": "The connection to your device failed. Please try again",
-      "camera_permission_denied": "Camera permission is required to scan QR codes. Please enable it in your device settings",
+      "bluetooth_off": "Turn on Bluetooth to connect to your device",
+      "bluetooth_scan_failed": "Failed to scan for devices. Try again",
+      "bluetooth_connection_failed": "The connection to your device failed. Try again",
+      "camera_permission_denied": "Camera permission is required to scan QR codes. Enable it in your device settings",
       "not_supported": "This operation is not supported",
       "only_v4_supported": "Your {{device}} can only sign version 4 (V4) typed data. This site requested an older signature type that isn't supported",
       "unknown_error": "Make sure your {{device}} is set up with the Secret Recovery Phrase or passphrase for this account"


### PR DESCRIPTION
## **Description**

Per MetaMask content guidelines: UI strings shouldn't ask for favors. Use direct imperative language instead.

Updated strings in `locales/languages/en.json`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A

## **Manual testing steps**

1. Build and run the app.
2. Navigate to any screen that displays the updated strings.
3. Confirm the updated wording appears correctly with no layout regressions.

## **Screenshots/Recordings**

### **Before**

N/A — locale string changes only.

### **After**

N/A — locale string changes only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.