### PR TITLE
fix(content): remove "successfully" from mobile locale strings (batch 2 of 2)

### DIFF
--- a/app/components/UI/Card/components/AssetSelectionBottomSheet/AssetSelectionBottomSheet.test.tsx
+++ b/app/components/UI/Card/components/AssetSelectionBottomSheet/AssetSelectionBottomSheet.test.tsx
@@ -752,7 +752,7 @@ describe('AssetSelectionBottomSheet', () => {
 
       expect(mockShowToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          labelOptions: [{ label: 'Spend priority updated successfully' }],
+          labelOptions: [{ label: 'Spend priority updated' }],
         }),
       );
     });

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10106,7 +10106,7 @@
       "withdraw": "Move funds",
       "withdraw_to_money_account": "Move to Money account",
       "withdraw_unavailable": "Redemption unavailable",
-      "withdrawal_success": "Redemption completed successfully",
+      "withdrawal_success": "Redemption completed",
       "withdrawal_failed": "Redemption failed. Please try again.",
       "loading_error": "Failed to load credit. Please try again.",
       "funding_required": {
@@ -10160,7 +10160,7 @@
       "enabled": "Enabled",
       "limited": "Limited",
       "not_enabled": "Not enabled",
-      "update_success": "Spend priority updated successfully",
+      "update_success": "Spend priority updated",
       "update_error": "Failed to update spend priority"
     },
     "card_authentication": {
@@ -10505,7 +10505,7 @@
       "no_linked_accounts": "No accounts opted in",
       "all_accounts_linked_title": "All accounts opted in",
       "all_accounts_linked_description": "You have added all your accounts to Rewards.",
-      "link_account_success_title": "{{accountName}} successfully added",
+      "link_account_success_title": "{{accountName}} added",
       "link_account_error_title": "Failed to add account",
       "link_account_button": "Add",
       "link_account_failed_error": "Failed to add account",
@@ -10601,7 +10601,7 @@
       "untracked": "Not enrolled",
       "unsupported": "Not supported",
       "tracked_count": "{{optedIn}}/{{total}} enrolled",
-      "link_account_success": "{{accountName}} added successfully",
+      "link_account_success": "{{accountName}} added",
       "link_account_error": "Failed to add one or more addresses for {{accountName}}",
       "link_account_address_error": "Failed to add {{address}}"
     },
@@ -11074,7 +11074,7 @@
       "description": "Return to the app to continue."
     },
     "show_cli_link_success": {
-      "title": "Agent wallet successfully linked",
+      "title": "Agent wallet linked",
       "description": "Return to the CLI to continue."
     },
     "push_nudge": {
@@ -11513,7 +11513,7 @@
       "cancel": "Cancel",
       "success": {
         "title": "Plan canceled",
-        "description_prefix": "Your Pro plan was canceled successfully. It won't renew, and you'll keep all your benefits until ",
+        "description_prefix": "Your Pro plan was canceled. It won't renew, and you'll keep all your benefits until ",
         "description_suffix": ".",
         "done": "Done"
       }


### PR DESCRIPTION
## **Description**

Per MetaMask content guidelines: "successfully" is redundant — the success state is implied.

Updated strings in `locales/languages/en.json`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A

## **Manual testing steps**

1. Build and run the app.
2. Navigate to any screen that displays the updated strings.
3. Confirm the updated wording appears correctly with no layout regressions.

## **Screenshots/Recordings**

### **Before**

N/A — locale string changes only.

### **After**

N/A — locale string changes only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.