### PR TITLE
perf(ios-e2e): warm up WDA pool in parallel (MMQA-2391)

### DIFF
--- a/.github/scripts/qa-automation/appium-runner-prep/prepare-ios-appium-runner.mjs
+++ b/.github/scripts/qa-automation/appium-runner-prep/prepare-ios-appium-runner.mjs
@@ -9,7 +9,7 @@
  *    (sequential per UDID; parallel across UDIDs in pool mode)
  * 5. Grant common simulator permissions + warm-launch MetaMask (once per simulator)
  * 6. Warm WDA via throwaway Appium session(s); leaves Appium running for tests
- *    (sequential across pool UDIDs to avoid shared-server races)
+ *    (parallel across pool UDIDs — each gets distinct wdaLocalPort/mjpegServerPort)
  *
  * Sets GITHUB_OUTPUT: ios-simulator-udid, ios-wda-preinstalled, ios-wda-bundle-id.
  * Pool mode also sets ios-device-pool and fails closed on WDA preparation.
@@ -39,7 +39,7 @@ import {
 } from './wda-lib.mjs';
 import {
   warmUpIosAppiumWda,
-  warmUpIosAppiumWdaSequentially,
+  warmUpIosAppiumWdaPool,
 } from './warm-up-ios-appium-wda.mjs';
 
 const simulatorName = process.env.IOS_SIMULATOR_NAME ?? 'iPhone 16 Pro';
@@ -150,7 +150,7 @@ const { iosWdaPreinstalled, iosWdaBundleIdBase } =
 
 if (iosWdaPreinstalled === 'true' && iosWdaBundleIdBase) {
   if (poolSize > 1) {
-    await warmUpIosAppiumWdaSequentially({
+    await warmUpIosAppiumWdaPool({
       udids,
       wdaBundleIdBase: iosWdaBundleIdBase,
       simulatorName,

--- a/.github/scripts/qa-automation/appium-runner-prep/warm-up-ios-appium-wda.mjs
+++ b/.github/scripts/qa-automation/appium-runner-prep/warm-up-ios-appium-wda.mjs
@@ -123,7 +123,9 @@ export function buildWarmUpCapabilities({
 }
 
 /**
- * Warm every simulator in a pool.
+ * Warm every simulator in a pool concurrently. Each simulator gets a distinct
+ * wdaLocalPort (8100+index) and mjpegServerPort (9100+index), so sessions can
+ * start in parallel without port conflicts on the shared Appium server.
  *
  * @param {{
  *   udids: string[];
@@ -132,21 +134,23 @@ export function buildWarmUpCapabilities({
  *   warmUp?: typeof warmUpIosAppiumWda;
  * }} options
  */
-export async function warmUpIosAppiumWdaSequentially({
+export async function warmUpIosAppiumWdaPool({
   udids,
   wdaBundleIdBase,
   simulatorName,
   warmUp = warmUpIosAppiumWda,
 }) {
-  for (const [workerIndex, udid] of udids.entries()) {
-    await warmUp({
-      udid,
-      wdaBundleIdBase,
-      simulatorName,
-      wdaLocalPort: 8100 + workerIndex,
-      mjpegServerPort: 9100 + workerIndex,
-    });
-  }
+  await Promise.all(
+    udids.map((udid, workerIndex) =>
+      warmUp({
+        udid,
+        wdaBundleIdBase,
+        simulatorName,
+        wdaLocalPort: 8100 + workerIndex,
+        mjpegServerPort: 9100 + workerIndex,
+      }),
+    ),
+  );
 }
 
 /**

--- a/.github/scripts/qa-automation/appium-runner-prep/warm-up-ios-appium-wda.test.ts
+++ b/.github/scripts/qa-automation/appium-runner-prep/warm-up-ios-appium-wda.test.ts
@@ -1,6 +1,6 @@
 import {
   buildWarmUpCapabilities,
-  warmUpIosAppiumWdaSequentially,
+  warmUpIosAppiumWdaPool,
 } from './warm-up-ios-appium-wda.mjs';
 
 const BASE_OPTIONS = {
@@ -29,8 +29,8 @@ describe('buildWarmUpCapabilities', () => {
   });
 });
 
-describe('warmUpIosAppiumWdaSequentially', () => {
-  it('does not start the next shared-Appium warm-up until the prior one resolves', async () => {
+describe('warmUpIosAppiumWdaPool', () => {
+  it('starts all warm-ups concurrently — second begins before first resolves', async () => {
     let resolveFirstWarmUp: (() => void) | undefined;
     const firstWarmUp = new Promise<void>((resolve) => {
       resolveFirstWarmUp = resolve;
@@ -44,31 +44,46 @@ describe('warmUpIosAppiumWdaSequentially', () => {
       return true;
     });
 
-    const completion = warmUpIosAppiumWdaSequentially({
+    const completion = warmUpIosAppiumWdaPool({
       udids: ['first-udid', 'second-udid'],
       wdaBundleIdBase: BASE_OPTIONS.wdaBundleIdBase,
       simulatorName: BASE_OPTIONS.simulatorName,
       warmUp,
     });
 
+    // Both UDIDs should be started before any resolves (parallel, not sequential).
     await Promise.resolve();
-    expect(startedUdids).toEqual(['first-udid']);
+    expect(startedUdids).toEqual(['first-udid', 'second-udid']);
 
     resolveFirstWarmUp?.();
     await completion;
 
-    expect(startedUdids).toEqual(['first-udid', 'second-udid']);
-    expect(warmUp).toHaveBeenNthCalledWith(1, {
+    expect(warmUp).toHaveBeenCalledWith({
       ...BASE_OPTIONS,
       udid: 'first-udid',
       wdaLocalPort: 8100,
       mjpegServerPort: 9100,
     });
-    expect(warmUp).toHaveBeenNthCalledWith(2, {
+    expect(warmUp).toHaveBeenCalledWith({
       ...BASE_OPTIONS,
       udid: 'second-udid',
       wdaLocalPort: 8101,
       mjpegServerPort: 9101,
     });
+  });
+
+  it('assigns distinct ports to each pool index', async () => {
+    const warmUp = jest.fn().mockResolvedValue(true);
+
+    await warmUpIosAppiumWdaPool({
+      udids: ['udid-0', 'udid-1', 'udid-2'],
+      wdaBundleIdBase: BASE_OPTIONS.wdaBundleIdBase,
+      simulatorName: BASE_OPTIONS.simulatorName,
+      warmUp,
+    });
+
+    expect(warmUp).toHaveBeenCalledWith(expect.objectContaining({ udid: 'udid-0', wdaLocalPort: 8100, mjpegServerPort: 9100 }));
+    expect(warmUp).toHaveBeenCalledWith(expect.objectContaining({ udid: 'udid-1', wdaLocalPort: 8101, mjpegServerPort: 9101 }));
+    expect(warmUp).toHaveBeenCalledWith(expect.objectContaining({ udid: 'udid-2', wdaLocalPort: 8102, mjpegServerPort: 9102 }));
   });
 });


### PR DESCRIPTION
## **Description**

Replace the sequential `warmUpIosAppiumWdaSequentially` loop with `warmUpIosAppiumWdaPool`, which warms all simulators in the pool concurrently via `Promise.all`.

For the current CI default of N=2 simulators per shard, both WDA warm-up sessions now start simultaneously instead of one after the other, saving ~30–60s off the **Prepare iOS Appium runner** step per shard.

Port assignments are pre-computed per worker index (`wdaLocalPort: 8100+i`, `mjpegServerPort: 9100+i`) so concurrent sessions share the same Appium server without conflicts. `startAppiumServer()` already had an `appiumStartupPromise` guard making concurrent callers safe. Header comment in `prepare-ios-appium-runner.mjs` updated to reflect the new parallel behaviour. Tests updated to verify concurrent start and distinct port assignment.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://consensys.atlassian.net/browse/MMQA-2391

## **Manual testing steps**

N/A — CI infrastructure change only; no user-facing behaviour. Verified via unit tests and CI run time reduction observable after merge.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.