### PR TITLE
feat: MUSD-1327 Add Segment event to redesigned Earn row in trade menu cp-8.11.0

### DIFF
--- a/app/components/UI/Earn/Views/EarnSectionListView/EarnSectionListView.test.tsx
+++ b/app/components/UI/Earn/Views/EarnSectionListView/EarnSectionListView.test.tsx
@@ -339,6 +339,7 @@ const createCatalogueResult = (
     errors: [],
     hasError: false,
     isLoading: false,
+    moneyApyDecimal: 0.042,
     moneyApyPercent: 4.2,
     moneyRateStatus: 'ready',
     refresh: mockRefresh,

--- a/app/components/UI/Earn/Views/EarnSectionListView/EarnSectionListView.tsx
+++ b/app/components/UI/Earn/Views/EarnSectionListView/EarnSectionListView.tsx
@@ -221,6 +221,7 @@ const EarnSectionListView = () => {
     assets,
     hasError,
     isLoading,
+    moneyApyDecimal,
     moneyApyPercent,
     moneyRateStatus,
     refresh,
@@ -277,7 +278,7 @@ const EarnSectionListView = () => {
 
   const { totalAssetsFiat, projectedAmount, currency } = useProjectedEarnings(
     moneyAssets,
-    moneyApyPercent === undefined ? undefined : moneyApyPercent / 100,
+    moneyApyDecimal,
   );
 
   const moneyFeeByToken = useMemo(
@@ -578,9 +579,7 @@ const EarnSectionListView = () => {
             key={`${token.address}-${token.chainId}`}
             token={token}
             hasSubsidizedFee={isNoFeeToken(token)}
-            apyDecimal={
-              moneyApyPercent === undefined ? 0 : moneyApyPercent / 100
-            }
+            apyDecimal={moneyApyDecimal ?? 0}
             onCardPress={() => handleTokenCardPress(token, index)}
             onButtonPress={() => handleTokenButtonPress(token, index)}
             testID={EARN_SECTION_LIST_TEST_IDS.MONEY_TOKEN_ROW(index)}
@@ -635,7 +634,7 @@ const EarnSectionListView = () => {
     isNoFeeToken,
     isRetrying,
     moneyAccountItem,
-    moneyApyPercent,
+    moneyApyDecimal,
     moneyAssets,
     privacyMode,
     projectedAmount,

--- a/app/components/UI/Earn/constants/earnModuleEvents.ts
+++ b/app/components/UI/Earn/constants/earnModuleEvents.ts
@@ -18,6 +18,7 @@ export enum EARN_MODULE_ENTRY_POINTS {
   EXPLORE_CRYPTO_TAB = 'explore_crypto_tab',
   EXPLORE_SEARCH = 'explore_search',
   EARN_SECTION_LIST = 'earn_section_list',
+  TRADE_MENU = 'trade_menu',
 }
 
 export enum EARN_MODULE_BUTTON_TYPES {
@@ -46,6 +47,7 @@ export enum EARN_MODULE_COMPONENT_NAMES {
   EARN_SEARCH_ASSET_ROW = 'earn_search_asset_row',
   EARN_SECTION_ERROR_RETRY_BUTTON = 'earn_section_error_retry_button',
   EARN_STRATEGY_SELECTION_MODAL_CLOSE_ICON = 'earn_strategy_selection_modal_close_icon',
+  EARN_TRADE_MENU_ROW = 'earn_trade_menu_row',
 }
 
 export enum EARN_MODULE_STRATEGY_TYPES {

--- a/app/components/UI/Earn/hooks/useEarnAssetCatalogue.test.ts
+++ b/app/components/UI/Earn/hooks/useEarnAssetCatalogue.test.ts
@@ -339,6 +339,13 @@ describe('useEarnAssetCatalogue', () => {
     ).not.toHaveBeenCalled();
   });
 
+  it('exposes raw and rounded Money APY values', () => {
+    const { result } = renderHook(() => useEarnAssetCatalogue());
+
+    expect(result.current.moneyApyDecimal).toBe(0.062);
+    expect(result.current.moneyApyPercent).toBe(6.2);
+  });
+
   it('does not report loading while cached lending markets refresh', () => {
     mockUseEarnSectionLendingMarkets.mockReturnValue({
       markets: [market],

--- a/app/components/UI/Earn/hooks/useEarnAssetCatalogue.ts
+++ b/app/components/UI/Earn/hooks/useEarnAssetCatalogue.ts
@@ -211,6 +211,7 @@ const useEarnAssetCatalogue = ({
   } = useSelector(selectEarnAssetCatalogueInputs);
   const {
     apyPercent: moneyApyPercent,
+    apyDecimal: moneyApyDecimal,
     vaultApyQuery: {
       isLoading: isMoneyApyLoading,
       isError: isMoneyApyError,
@@ -570,6 +571,7 @@ const useEarnAssetCatalogue = ({
       hasError,
       errors,
       refresh,
+      moneyApyDecimal,
       moneyApyPercent,
       moneyRateStatus: createEarnRate({
         type: 'APY',
@@ -586,6 +588,7 @@ const useEarnAssetCatalogue = ({
       isLoading,
       isMoneyApyError,
       isMoneyApyLoading,
+      moneyApyDecimal,
       moneyApyPercent,
       refresh,
     ],

--- a/app/components/UI/Earn/hooks/useEarnSectionAssets.test.ts
+++ b/app/components/UI/Earn/hooks/useEarnSectionAssets.test.ts
@@ -19,6 +19,7 @@ const createCatalogueResult = (
   hasError: false,
   errors: [],
   refresh: jest.fn().mockResolvedValue(undefined),
+  moneyApyDecimal: undefined,
   moneyApyPercent: undefined,
   moneyRateStatus: 'unavailable',
   ...overrides,

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.test.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.test.tsx
@@ -32,6 +32,10 @@ import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetwork
 import { isHardwareAccount } from '../../../util/address';
 import { selectBatchSellEnabled } from '../../../selectors/featureFlagController/batchSell';
 import useEarnHighestRate from '../../UI/Earn/hooks/useEarnHighestRate';
+import {
+  EARN_MODULE_COMPONENT_NAMES,
+  EARN_MODULE_REDIRECT_TARGETS,
+} from '../../UI/Earn/constants/earnModuleEvents';
 import TradeWalletActions from './TradeWalletActions';
 
 jest.mock('react-native-device-info', () => ({
@@ -219,6 +223,13 @@ jest.mock('../../../core/redux/slices/bridge', () => ({
 jest.mock('../../UI/Earn/hooks/useEarnHighestRate', () => ({
   __esModule: true,
   default: jest.fn(),
+}));
+
+const mockTrackEarnSurfaceClicked = jest.fn();
+jest.mock('../../UI/Earn/hooks/useEarnAnalytics', () => ({
+  useEarnAnalytics: () => ({
+    trackSurfaceClicked: mockTrackEarnSurfaceClicked,
+  }),
 }));
 
 const mockGoToSwaps = jest.fn();
@@ -1160,6 +1171,83 @@ describe('TradeWalletActions', () => {
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.EARN.ROOT, {
         screen: Routes.EARN.SEARCH_LIST,
+      });
+    });
+
+    it('tracks Earn click with ready rate details', async () => {
+      mockSelectIsEarnSectionEligible.mockReturnValue(true);
+      mockUseEarnHighestRate.mockReturnValue({
+        highestRate: {
+          type: 'APY',
+          percentage: 6.2,
+          status: 'ready',
+        },
+      });
+
+      const { getByTestId } = renderScreen(
+        TradeWalletActions,
+        { name: 'TradeWalletActions' },
+        { state: mockInitialState },
+      );
+
+      await pressActionButton(
+        getByTestId,
+        WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON,
+      );
+
+      expect(mockTrackEarnSurfaceClicked).toHaveBeenCalledWith({
+        component_name: EARN_MODULE_COMPONENT_NAMES.EARN_TRADE_MENU_ROW,
+        redirect_target: EARN_MODULE_REDIRECT_TARGETS.EARN_SECTION_LIST_VIEW,
+        rate_type: 'apy',
+        rate_percentage: 6.2,
+      });
+    });
+
+    it('tracks Earn click without rate percentage when rate is not ready', async () => {
+      mockSelectIsEarnSectionEligible.mockReturnValue(true);
+      mockUseEarnHighestRate.mockReturnValue({
+        highestRate: {
+          type: 'APR',
+          status: 'error',
+        },
+      });
+
+      const { getByTestId } = renderScreen(
+        TradeWalletActions,
+        { name: 'TradeWalletActions' },
+        { state: mockInitialState },
+      );
+
+      await pressActionButton(
+        getByTestId,
+        WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON,
+      );
+
+      expect(mockTrackEarnSurfaceClicked).toHaveBeenCalledWith({
+        component_name: EARN_MODULE_COMPONENT_NAMES.EARN_TRADE_MENU_ROW,
+        redirect_target: EARN_MODULE_REDIRECT_TARGETS.EARN_SECTION_LIST_VIEW,
+        rate_type: 'apr',
+      });
+    });
+
+    it('tracks Earn click without rate details when no rate is available', async () => {
+      mockSelectIsEarnSectionEligible.mockReturnValue(true);
+      mockUseEarnHighestRate.mockReturnValue({ highestRate: undefined });
+
+      const { getByTestId } = renderScreen(
+        TradeWalletActions,
+        { name: 'TradeWalletActions' },
+        { state: mockInitialState },
+      );
+
+      await pressActionButton(
+        getByTestId,
+        WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON,
+      );
+
+      expect(mockTrackEarnSurfaceClicked).toHaveBeenCalledWith({
+        component_name: EARN_MODULE_COMPONENT_NAMES.EARN_TRADE_MENU_ROW,
+        redirect_target: EARN_MODULE_REDIRECT_TARGETS.EARN_SECTION_LIST_VIEW,
       });
     });
 

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.test.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.test.tsx
@@ -35,6 +35,7 @@ import useEarnHighestRate from '../../UI/Earn/hooks/useEarnHighestRate';
 import {
   EARN_MODULE_COMPONENT_NAMES,
   EARN_MODULE_REDIRECT_TARGETS,
+  EARN_MODULE_ENTRY_POINTS,
 } from '../../UI/Earn/constants/earnModuleEvents';
 import TradeWalletActions from './TradeWalletActions';
 
@@ -1171,6 +1172,11 @@ describe('TradeWalletActions', () => {
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.EARN.ROOT, {
         screen: Routes.EARN.SEARCH_LIST,
+        params: {
+          analyticsContext: {
+            entry_point: EARN_MODULE_ENTRY_POINTS.TRADE_MENU,
+          },
+        },
       });
     });
 

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -91,6 +91,7 @@ import {
   EARN_MODULE_ENTRY_POINTS,
 } from '../../UI/Earn/constants/earnModuleEvents';
 import { EarnRate } from '../../UI/Earn/types/earnAssets';
+import { truncateNumber } from '../../UI/Earn/utils/number';
 
 const bottomMaskHeight = 35;
 const animationDuration = AnimationDuration.Fast;
@@ -271,7 +272,7 @@ function TradeWalletActions() {
         >,
       }),
       ...(highestRate?.status === 'ready' && {
-        rate_percentage: highestRate.percentage,
+        rate_percentage: Number(truncateNumber(highestRate.percentage)),
       }),
     });
     postCallback.current = () => {

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -277,6 +277,11 @@ function TradeWalletActions() {
     postCallback.current = () => {
       navigation.navigate(Routes.EARN.ROOT, {
         screen: Routes.EARN.SEARCH_LIST,
+        params: {
+          analyticsContext: {
+            entry_point: EARN_MODULE_ENTRY_POINTS.TRADE_MENU,
+          },
+        },
       });
     };
     handleNavigateBack();

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -84,6 +84,13 @@ import BottomShape from './components/BottomShape';
 import OverlayWithHole from './components/OverlayWithHole';
 import { selectIsFirstTimePerpsUser } from '../../UI/Perps/selectors/perpsController';
 import { selectIsEarnSectionEligible } from '../../UI/Earn/selectors/eligibility';
+import { useEarnAnalytics } from '../../UI/Earn/hooks/useEarnAnalytics';
+import {
+  EARN_MODULE_COMPONENT_NAMES,
+  EARN_MODULE_REDIRECT_TARGETS,
+  EARN_MODULE_ENTRY_POINTS,
+} from '../../UI/Earn/constants/earnModuleEvents';
+import { EarnRate } from '../../UI/Earn/types/earnAssets';
 
 const bottomMaskHeight = 35;
 const animationDuration = AnimationDuration.Fast;
@@ -168,6 +175,10 @@ function TradeWalletActions() {
 
   const isEarnWalletActionEnabled = useSelector(selectIsEarnSectionEligible);
 
+  const { trackSurfaceClicked: trackEarnSurfaceClicked } = useEarnAnalytics({
+    entry_point: EARN_MODULE_ENTRY_POINTS.TRADE_MENU,
+  });
+
   const { goToSwaps: goToSwapsBase } = useSwapBridgeNavigation({
     location: SwapBridgeNavigationLocation.MainView,
     sourcePage: 'MainView',
@@ -251,13 +262,25 @@ function TradeWalletActions() {
   }, [handleNavigateBack, navigate]);
 
   const onEarn = useCallback(async () => {
+    trackEarnSurfaceClicked({
+      component_name: EARN_MODULE_COMPONENT_NAMES.EARN_TRADE_MENU_ROW,
+      redirect_target: EARN_MODULE_REDIRECT_TARGETS.EARN_SECTION_LIST_VIEW,
+      ...(highestRate?.type && {
+        rate_type: highestRate.type.toLowerCase() as Lowercase<
+          EarnRate['type']
+        >,
+      }),
+      ...(highestRate?.status === 'ready' && {
+        rate_percentage: highestRate.percentage,
+      }),
+    });
     postCallback.current = () => {
       navigation.navigate(Routes.EARN.ROOT, {
         screen: Routes.EARN.SEARCH_LIST,
       });
     };
     handleNavigateBack();
-  }, [handleNavigateBack, navigation]);
+  }, [trackEarnSurfaceClicked, handleNavigateBack, navigation, highestRate]);
 
   useFocusEffect(
     useCallback(() => {

--- a/app/components/Views/TrendingView/feeds/earn/useEarnSearchFeed.test.ts
+++ b/app/components/Views/TrendingView/feeds/earn/useEarnSearchFeed.test.ts
@@ -153,6 +153,7 @@ const mockCatalogue = ({
   isLoading = false,
   errors = [],
   refresh = jest.fn().mockResolvedValue(undefined),
+  moneyApyDecimal = 0.062,
   moneyApyPercent = 6.2,
   moneyRateStatus = 'ready',
 }: {
@@ -160,6 +161,7 @@ const mockCatalogue = ({
   isLoading?: boolean;
   errors?: Error[];
   refresh?: () => Promise<void>;
+  moneyApyDecimal?: number;
   moneyApyPercent?: number;
   moneyRateStatus?: 'loading' | 'ready' | 'error' | 'unavailable';
 } = {}) => {
@@ -170,6 +172,7 @@ const mockCatalogue = ({
     hasError: errors.length > 0,
     errors,
     refresh,
+    moneyApyDecimal,
     moneyApyPercent,
     moneyRateStatus,
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Added Segment tracking for clicks on the redesigned Earn row in the trade menu, including available rate details when present.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
Always write a concise 1-line CHANGELOG entry, prefixed with a conventional-commit
type (`chore:`, `feat:`, `fix:`, or `revert:`), describing the change in past tense.
Never leave this as `null` — if the PR isn't End-User-Facing, describe the internal
change instead (e.g. `chore: Added Sentry tracing for balance service requests`).

`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added Segment tracking for clicks on the redesigned Earn row

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1327: Add Segment event to redesigned Earn row in trade menu](https://consensyssoftware.atlassian.net/browse/MUSD-1327)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Earn row analytics in trade menu

  Scenario: user opens Earn from the trade menu
    Given the redesigned Earn row is visible in the trade menu
    When user taps the Earn row
    Then a Segment event is tracked with the Earn entry point and available rate details
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

<!-- screenshots/recordings -->
N/A — analytics-only change.

### **After**

<!-- screenshots/recordings -->
N/A — analytics-only change.
## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics and navigation params plus a small APY formatting refactor; no auth, payments, or security-sensitive logic.
> 
> **Overview**
> Adds **Segment analytics** when users tap the Earn action in the trade wallet menu. `TradeWalletActions` calls `trackEarnSurfaceClicked` with `earn_trade_menu_row`, redirect to the earn section list, and optional `rate_type` / `rate_percentage` when `useEarnHighestRate` reports a ready rate. Navigation to the earn search list now passes `analyticsContext.entry_point: trade_menu` so downstream earn screens attribute the same entry point.
> 
> New earn module constants: `TRADE_MENU` entry point and `EARN_TRADE_MENU_ROW` component name. Tests cover navigation params and the three analytics shapes (ready rate, non-ready rate type only, no rate).
> 
> **Supporting change:** `useEarnAssetCatalogue` now exposes `moneyApyDecimal` from the vault APY hook; `EarnSectionListView` uses that decimal directly for projected earnings and token rows instead of deriving it from `moneyApyPercent / 100`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa7f621499fdfbeb224117cf515a4c1f9ae04647. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->