### PR TITLE
feat: keep Rewards behind Money after sweepstakes Add Funds and flag lagging qualifying deposits

### DIFF
--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -22,6 +22,7 @@ import { MoneyActivityLoadingTestIds } from '../../components/MoneyActivityLoadi
 import { MoneyCondensedInfoCardsTestIds } from '../../components/MoneyCondensedInfoCards/MoneyCondensedInfoCards.testIds';
 import { MoneySectionHeaderTestIds } from '../../components/MoneySectionHeader/MoneySectionHeader.testIds';
 import Routes from '../../../../../constants/navigation/Routes';
+import { ConfirmationLaunchSource } from '../../../../Views/confirmations/components/confirm/confirm-component';
 import AppConstants from '../../../../../core/AppConstants';
 import { useMoneyAccountTransactions } from '../../hooks/useMoneyAccountTransactions';
 import { useMoneyAccountApiActivity } from '../../hooks/useMoneyAccountApiActivity';
@@ -1311,6 +1312,24 @@ describe('MoneyHomeView', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.MODALS.ROOT, {
       screen: Routes.MONEY.MODALS.ADD_MONEY_SHEET,
+    });
+  });
+
+  it('carries the Rewards launch source into Add money when this home was opened from a Rewards deposit', () => {
+    mockRouteParams = {
+      showBackButton: true,
+      launchedFrom: ConfirmationLaunchSource.Rewards,
+    };
+
+    const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+
+    fireEvent.press(getByTestId(MoneyActionButtonRowTestIds.ADD_BUTTON));
+
+    // Without this the next confirmation defaults to a HOME_TABS switch and
+    // drops the Rewards campaign the user came from.
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.MODALS.ROOT, {
+      screen: Routes.MONEY.MODALS.ADD_MONEY_SHEET,
+      params: { launchedFrom: ConfirmationLaunchSource.RewardsMoneyHome },
     });
   });
 

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -78,6 +78,8 @@ const mockMoneyFormatUsd = moneyFormatUsd as jest.MockedFunction<
   typeof moneyFormatUsd
 >;
 
+let mockRouteParams: object | undefined;
+
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
   return {
@@ -88,7 +90,7 @@ jest.mock('@react-navigation/native', () => {
       setParams: jest.fn(),
     }),
     useFocusEffect: (callback: () => void) => callback(),
-    useRoute: () => ({ params: undefined }),
+    useRoute: () => ({ params: mockRouteParams }),
   };
 });
 
@@ -479,6 +481,7 @@ describe('MoneyHomeView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     global.alert = jest.fn();
+    mockRouteParams = undefined;
 
     // clearAllMocks() resets call history but not a previously-set
     // mockReturnValue, so explicitly restore the default (visible) state.
@@ -1308,6 +1311,34 @@ describe('MoneyHomeView', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.MODALS.ROOT, {
       screen: Routes.MONEY.MODALS.ADD_MONEY_SHEET,
+    });
+  });
+
+  describe('back button', () => {
+    it('is not rendered as the Money tab, which has nothing to go back to', () => {
+      const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      expect(
+        queryByTestId(MoneyHeaderTestIds.BACK_BUTTON),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('is rendered when the stack was pushed with showBackButton', () => {
+      mockRouteParams = { showBackButton: true };
+
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      expect(getByTestId(MoneyHeaderTestIds.BACK_BUTTON)).toBeOnTheScreen();
+    });
+
+    it('pops back to the screen that pushed this stack when pressed', () => {
+      mockRouteParams = { showBackButton: true };
+
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      fireEvent.press(getByTestId(MoneyHeaderTestIds.BACK_BUTTON));
+
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -9,7 +9,10 @@ import { RefreshControl, ScrollView } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
-import { navigateWithDetails } from '../../../../../util/navigation/navUtils';
+import {
+  navigateWithDetails,
+  useParams,
+} from '../../../../../util/navigation/navUtils';
 import { useSelector } from 'react-redux';
 import BigNumber from 'bignumber.js';
 import {
@@ -68,6 +71,7 @@ import { useTheme } from '../../../../../util/theme';
 import { MoneyBalanceDisplayState } from '../../types';
 import { Hex } from '@metamask/utils';
 import type { MoneyDepositAsset } from '../../selectors/depositTokens';
+import type { MoneyHomeParams } from '../../types/navigation';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import {
@@ -106,6 +110,7 @@ const ACTION_BUTTON_ROW_BUTTON_COUNT = 3;
 
 const MoneyHomeView = () => {
   const navigation = useNavigation<AppNavigationProp>();
+  const { showBackButton } = useParams<MoneyHomeParams>();
   const insets = useSafeAreaInsets();
   const { styles } = useStyles(styleSheet, {});
   const { colors } = useTheme();
@@ -373,6 +378,12 @@ const MoneyHomeView = () => {
     navigation.navigate(Routes.PRO_SUBSCRIPTION.ROOT, {
       source: 'money_header',
     });
+  }, [navigation]);
+
+  // Only set when this stack was pushed over the caller's (e.g. a Rewards
+  // campaign funding flow), so back returns there instead of to a tab.
+  const handleBackPress = useCallback(() => {
+    navigation.goBack();
   }, [navigation]);
 
   const handleAddPress = useCallback(
@@ -886,6 +897,7 @@ const MoneyHomeView = () => {
       <MoneyHeader
         onMenuPress={handleMenuPress}
         onGetProPress={handleGetProPress}
+        onBack={showBackButton ? handleBackPress : undefined}
       />
       <ScrollView
         testID={MoneyHomeViewTestIds.SCROLL_VIEW}

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -72,6 +72,7 @@ import { MoneyBalanceDisplayState } from '../../types';
 import { Hex } from '@metamask/utils';
 import type { MoneyDepositAsset } from '../../selectors/depositTokens';
 import type { MoneyHomeParams } from '../../types/navigation';
+import { ConfirmationLaunchSource } from '../../../../Views/confirmations/components/confirm/confirm-component';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import {
@@ -110,7 +111,7 @@ const ACTION_BUTTON_ROW_BUTTON_COUNT = 3;
 
 const MoneyHomeView = () => {
   const navigation = useNavigation<AppNavigationProp>();
-  const { showBackButton } = useParams<MoneyHomeParams>();
+  const { showBackButton, launchedFrom } = useParams<MoneyHomeParams>();
   const insets = useSafeAreaInsets();
   const { styles } = useStyles(styleSheet, {});
   const { colors } = useTheme();
@@ -412,9 +413,14 @@ const MoneyHomeView = () => {
 
       navigation.navigate(Routes.MONEY.MODALS.ROOT, {
         screen: Routes.MONEY.MODALS.ADD_MONEY_SHEET,
+        // A Rewards-originated Money home is already on the stack, so the
+        // deposit it starts should return here rather than switch tabs.
+        ...(launchedFrom && {
+          params: { launchedFrom: ConfirmationLaunchSource.RewardsMoneyHome },
+        }),
       });
     },
-    [navigation, trackButtonClicked],
+    [navigation, trackButtonClicked, launchedFrom],
   );
 
   const handleTransferPress = useCallback(() => {

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.pendingTransaction.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.pendingTransaction.test.tsx
@@ -51,6 +51,10 @@ jest.mock('@react-navigation/native', () => {
   return {
     ...actual,
     useNavigation: () => ({ navigate: mockNavigate, goBack: mockGoBack }),
+    // The harness renders the sheet outside a navigator, so the real
+    // `useRoute` throws. No params models the Money home entry point, which
+    // passes no launch source.
+    useRoute: () => ({ params: undefined }),
   };
 });
 

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.pendingTransaction.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.pendingTransaction.test.tsx
@@ -208,6 +208,8 @@ function renderHarness(pendingTransactions: TransactionMeta[]) {
  * Regression test for the Money-home "Add funds" bug where tapping "Add"
  * landed the user back on money home, with an empty 'Deposited activity'.
  */
+const originalRequestAnimationFrame = global.requestAnimationFrame;
+
 describe('MoneyAddMoneySheet — Add funds with a pending transaction', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -237,6 +239,10 @@ describe('MoneyAddMoneySheet — Add funds with a pending transaction', () => {
       trackBottomSheetViewed: jest.fn(),
       trackSurfaceClicked: jest.fn(),
     });
+  });
+
+  afterEach(() => {
+    global.requestAnimationFrame = originalRequestAnimationFrame;
   });
 
   it('navigates to the Add funds flow even when an unconfirmed transaction is already pending', async () => {

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -125,11 +125,7 @@ jest.mock('@metamask/design-system-react-native', () => {
 describe('MoneyAddMoneySheet', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.resetAllMocks();
     mockRouteParams = undefined;
-    // Re-establish implementations wiped by resetAllMocks.
-    mockOnCloseBottomSheet.mockImplementation((cb?: () => void) => cb?.());
-    mockInitiateDeposit.mockImplementation(() => Promise.resolve());
 
     (useMoneyAnalytics as jest.Mock).mockReturnValue({
       trackBottomSheetViewed: mockTrackBottomSheetViewed,

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -7,6 +7,7 @@ import MoneyAddMoneySheet from './MoneyAddMoneySheet';
 import { MoneyAddMoneySheetTestIds } from './MoneyAddMoneySheet.testIds';
 import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
 import { useMoneyAccountDeposit } from '../../hooks/useMoneyAccount';
+import { ConfirmationLaunchSource } from '../../../../Views/confirmations/components/confirm/confirm-component';
 import { useMMPayFiatConfig } from '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig';
 import { useRegionHasFiatProvider } from '../../../Ramp/hooks/useRegionHasFiatProvider';
 import { selectHasAnyNonZeroTokenBalance } from '../../../../../selectors/tokenBalancesController';
@@ -35,6 +36,8 @@ const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 const mockInitiateDeposit = jest.fn(() => Promise.resolve());
 
+let mockRouteParams: object | undefined;
+
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
   return {
@@ -43,6 +46,7 @@ jest.mock('@react-navigation/native', () => {
       navigate: mockNavigate,
       goBack: mockGoBack,
     }),
+    useRoute: () => ({ params: mockRouteParams }),
   };
 });
 
@@ -122,6 +126,7 @@ describe('MoneyAddMoneySheet', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetAllMocks();
+    mockRouteParams = undefined;
     // Re-establish implementations wiped by resetAllMocks.
     mockOnCloseBottomSheet.mockImplementation((cb?: () => void) => cb?.());
     mockInitiateDeposit.mockImplementation(() => Promise.resolve());
@@ -348,6 +353,33 @@ describe('MoneyAddMoneySheet', () => {
       intent: 'card',
     });
   });
+
+  it.each([
+    [
+      'Convert crypto',
+      MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
+      { intent: 'convert' },
+    ],
+    [
+      'Deposit funds',
+      MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
+      { autoSelectFiatPayment: true, intent: 'card' },
+    ],
+  ])(
+    'forwards the launch source of the caller that opened the sheet when %s is pressed',
+    (_label, testID, expectedOptions) => {
+      mockRouteParams = { launchedFrom: ConfirmationLaunchSource.Rewards };
+
+      const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+
+      fireEvent.press(getByTestId(testID));
+
+      expect(mockInitiateDeposit).toHaveBeenCalledWith({
+        ...expectedOptions,
+        launchedFrom: ConfirmationLaunchSource.Rewards,
+      });
+    },
+  );
 
   it('initiates a deposit when Convert crypto is pressed', () => {
     const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -39,6 +39,8 @@ import { selectHasUnapprovedTransactions } from '../../../../../selectors/transa
 import { selectHasAnyNonZeroTokenBalance } from '../../../../../selectors/tokenBalancesController';
 import { selectMoneyMovementBrazilNeobankEnabled } from '../../../../../selectors/featureFlagController/moneyAccount';
 import Routes from '../../../../../constants/navigation/Routes';
+import { useParams } from '../../../../../util/navigation/navUtils';
+import type { MoneyAddMoneySheetParams } from '../../types/navigation';
 import MoneySheetOptionsList, {
   type MoneySheetOption,
 } from '../MoneySheetOptionsList';
@@ -59,6 +61,7 @@ const log = createProjectLogger('money-add-money-sheet');
 const MoneyAddMoneySheet: React.FC = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation<AppNavigationProp>();
+  const { launchedFrom } = useParams<MoneyAddMoneySheetParams>();
   const { styles } = useStyles(styleSheet, {});
 
   const {
@@ -116,15 +119,20 @@ const MoneyAddMoneySheet: React.FC = () => {
   // letting it race the unmount.
   const startDeposit = useCallback(
     (options?: InitiateDepositOptions) => {
+      // Applied here rather than per row so every funding method inherits the
+      // caller's launch source.
+      const depositOptions = launchedFrom
+        ? { ...options, launchedFrom }
+        : options;
       if (hasPendingTransaction) {
         log('Rejecting pending transaction before starting deposit');
         rejectPendingTransactions();
-        setDeferredDeposit({ options });
+        setDeferredDeposit({ options: depositOptions });
         return;
       }
-      closeAndStartDeposit(options);
+      closeAndStartDeposit(depositOptions);
     },
-    [hasPendingTransaction, closeAndStartDeposit],
+    [hasPendingTransaction, closeAndStartDeposit, launchedFrom],
   );
 
   useEffect(() => {

--- a/app/components/UI/Money/components/MoneyHeader/MoneyHeader.test.tsx
+++ b/app/components/UI/Money/components/MoneyHeader/MoneyHeader.test.tsx
@@ -60,6 +60,60 @@ describe('MoneyHeader', () => {
     });
   });
 
+  describe('back button', () => {
+    it('is not rendered without an onBack handler', () => {
+      const { queryByTestId } = render(
+        <MoneyHeader onMenuPress={jest.fn()} onGetProPress={jest.fn()} />,
+      );
+
+      expect(
+        queryByTestId(MoneyHeaderTestIds.BACK_BUTTON),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('is rendered with an onBack handler', () => {
+      const { getByTestId } = render(
+        <MoneyHeader
+          onMenuPress={jest.fn()}
+          onGetProPress={jest.fn()}
+          onBack={jest.fn()}
+        />,
+      );
+
+      expect(getByTestId(MoneyHeaderTestIds.BACK_BUTTON)).toBeOnTheScreen();
+    });
+
+    it('calls onBack when pressed', () => {
+      const mockOnBack = jest.fn();
+      const { getByTestId } = render(
+        <MoneyHeader
+          onMenuPress={jest.fn()}
+          onGetProPress={jest.fn()}
+          onBack={mockOnBack}
+        />,
+      );
+
+      fireEvent.press(getByTestId(MoneyHeaderTestIds.BACK_BUTTON));
+
+      expect(mockOnBack).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the Money title and the menu button alongside it', () => {
+      const { getByTestId } = render(
+        <MoneyHeader
+          onMenuPress={jest.fn()}
+          onGetProPress={jest.fn()}
+          onBack={jest.fn()}
+        />,
+      );
+
+      expect(getByTestId(MoneyHeaderTestIds.TITLE)).toHaveTextContent(
+        strings('money.title'),
+      );
+      expect(getByTestId(MoneyHeaderTestIds.MENU_BUTTON)).toBeOnTheScreen();
+    });
+  });
+
   describe('"Get Pro" button', () => {
     it('is not shown when the Pro subscription flag is disabled', () => {
       mockUseProSubscriptionEnabled.mockReturnValue({

--- a/app/components/UI/Money/components/MoneyHeader/MoneyHeader.testIds.ts
+++ b/app/components/UI/Money/components/MoneyHeader/MoneyHeader.testIds.ts
@@ -1,6 +1,7 @@
 export const MoneyHeaderTestIds = {
   CONTAINER: 'money-header-container',
   TITLE: 'money-header-title',
+  BACK_BUTTON: 'money-header-back-button',
   MENU_BUTTON: 'money-header-menu-button',
   GET_PRO_BUTTON: 'money-header-get-pro-button',
 } as const;

--- a/app/components/UI/Money/components/MoneyHeader/MoneyHeader.tsx
+++ b/app/components/UI/Money/components/MoneyHeader/MoneyHeader.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import {
   Box,
+  BoxAlignItems,
+  BoxFlexDirection,
   Button,
   ButtonIcon,
   ButtonSize,
   HeaderRoot,
   IconName,
+  Text,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { MoneyHeaderTestIds } from './MoneyHeader.testIds';
@@ -21,15 +25,24 @@ interface MoneyHeaderProps {
    * Only fired when the Pro subscription flow flag is enabled.
    */
   onGetProPress: () => void;
+  /**
+   * Handler for the back button. Omit it — as the Money tab does — to render
+   * the plain title with no back affordance.
+   */
+  onBack?: () => void;
 }
 
-const MoneyHeader = ({ onMenuPress, onGetProPress }: MoneyHeaderProps) => {
+const MoneyHeader = ({
+  onMenuPress,
+  onGetProPress,
+  onBack,
+}: MoneyHeaderProps) => {
   const { isProSubscriptionEnabled } = useProSubscriptionEnabled();
 
   return (
     <HeaderRoot
       testID={MoneyHeaderTestIds.CONTAINER}
-      twClassName="pl-4 pr-3"
+      twClassName={onBack ? 'pl-1 pr-3' : 'pl-4 pr-3'}
       title={strings('money.title')}
       titleProps={{
         testID: MoneyHeaderTestIds.TITLE,
@@ -54,7 +67,30 @@ const MoneyHeader = ({ onMenuPress, onGetProPress }: MoneyHeaderProps) => {
           />
         </Box>
       }
-    />
+    >
+      {/* `HeaderRoot` renders children in place of the title row, so this is
+          undefined without a back handler to leave the title path untouched. */}
+      {onBack ? (
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="flex-1 gap-1"
+        >
+          <ButtonIcon
+            iconName={IconName.ArrowLeft}
+            onPress={onBack}
+            accessibilityLabel={strings('navigation.back')}
+            testID={MoneyHeaderTestIds.BACK_BUTTON}
+          />
+          <Text
+            variant={TextVariant.HeadingLg}
+            testID={MoneyHeaderTestIds.TITLE}
+          >
+            {strings('money.title')}
+          </Text>
+        </Box>
+      ) : undefined}
+    </HeaderRoot>
   );
 };
 

--- a/app/components/UI/Money/hooks/useMoneyAccount.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.test.ts
@@ -12,7 +12,10 @@ import Logger from '../../../../util/Logger';
 import Engine from '../../../../core/Engine';
 import NavigationService from '../../../../core/NavigationService/NavigationService';
 import Routes from '../../../../constants/navigation/Routes';
-import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
+import {
+  ConfirmationLoader,
+  type ConfirmationLaunchSource,
+} from '../../../Views/confirmations/components/confirm/confirm-component';
 import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
 import { selectEvmAddress } from '../../../../selectors/accountsController';
@@ -340,6 +343,20 @@ describe('useMoneyAccountDeposit', () => {
         disableUpgrade: true,
         skipInitialGasEstimate: true,
       }),
+    );
+  });
+
+  it('passes launchedFrom to navigateToConfirmation so it can pick the landing screen', async () => {
+    const { result } = renderHook(() => useMoneyAccountDeposit());
+
+    await act(async () => {
+      await result.current.initiateDeposit({
+        launchedFrom: 'rewards' as ConfirmationLaunchSource,
+      });
+    });
+
+    expect(getNavigateToConfirmation()).toHaveBeenCalledWith(
+      expect.objectContaining({ launchedFrom: 'rewards' }),
     );
   });
 

--- a/app/components/UI/Money/hooks/useMoneyAccount.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.ts
@@ -22,7 +22,10 @@ import { isMonadMainnetChainId } from '../../../../util/networks';
 import Engine from '../../../../core/Engine';
 import NavigationService from '../../../../core/NavigationService/NavigationService';
 import Routes from '../../../../constants/navigation/Routes';
-import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
+import {
+  ConfirmationLoader,
+  type ConfirmationLaunchSource,
+} from '../../../Views/confirmations/components/confirm/confirm-component';
 import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
 import { useMoneyAccountDepositPrefillEnabled } from '../../../Views/confirmations/hooks/transactions/useMoneyAccountDepositPrefillEnabled';
 import { ensureError } from '../../../../util/errorUtils';
@@ -50,6 +53,11 @@ export interface InitiateDepositOptions {
   intent?: MoneyAccountDepositIntent;
   autoSelectFiatPayment?: boolean;
   replaceConfirmation?: boolean;
+  /**
+   * Where the deposit was started from. Carried to the confirmation so it can
+   * land somewhere other than the Money tab — see `navigateOnConfirm`.
+   */
+  launchedFrom?: ConfirmationLaunchSource;
   onDepositSetupFailure?: (error: Error) => void;
 }
 
@@ -155,6 +163,7 @@ export function useMoneyAccountDeposit() {
           : ConfirmationLoader.AdvancedCustomAmount,
         preferredPaymentToken,
         autoSelectFiatPayment: options?.autoSelectFiatPayment,
+        launchedFrom: options?.launchedFrom,
       };
 
       // Navigate early for better UX; recover on failure below.

--- a/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.test.ts
+++ b/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.test.ts
@@ -11,11 +11,13 @@ import Engine from '../../../../core/Engine';
 import ReactQueryService from '../../../../core/ReactQueryService';
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
 import { invalidateMoneyAccountBalanceCaches } from '../utils/invalidateMoneyAccountBalanceCaches';
+import { store } from '../../../../store';
+import { setLastLocalMoneyFlowConfirmedAt } from '../../../../core/redux/slices/moneyBalance';
 import { useRefreshMoneyBalanceOnTxConfirm } from './useRefreshMoneyBalanceOnTxConfirm';
 
 jest.mock('../../../../core/Engine');
 jest.mock('../../../../store', () => ({
-  store: { getState: jest.fn(() => ({})) },
+  store: { getState: jest.fn(() => ({})), dispatch: jest.fn() },
 }));
 jest.mock('../../../../selectors/moneyAccountController', () => ({
   selectPrimaryMoneyAccount: jest.fn(),
@@ -49,6 +51,8 @@ const mockSelectPrimaryMoneyAccount =
   selectPrimaryMoneyAccount as jest.MockedFunction<
     typeof selectPrimaryMoneyAccount
   >;
+
+const mockDispatch = store.dispatch as unknown as jest.Mock;
 
 type TransactionConfirmedHandler = (transactionMeta: TransactionMeta) => void;
 
@@ -282,5 +286,35 @@ describe('useRefreshMoneyBalanceOnTxConfirm', () => {
     });
 
     expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(1);
+  });
+
+  describe('local flow marker', () => {
+    // `clearAllMocks` would leave a stubbed `Date.now` returning undefined for
+    // every later test in the file.
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it.each([
+      ['a deposit', TransactionType.moneyAccountDeposit],
+      ['a withdrawal', TransactionType.moneyAccountWithdraw],
+    ])('records the confirmation time for %s', (_case, type) => {
+      jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+      renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+
+      getConfirmedHandler()(makeTx(type));
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setLastLocalMoneyFlowConfirmedAt(1_700_000_000_000),
+      );
+    });
+
+    it('does not record a marker for a tx that leaves the Money balance alone', () => {
+      renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+
+      getConfirmedHandler()(makeTx(TransactionType.contractInteraction));
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.test.ts
+++ b/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.test.ts
@@ -12,7 +12,7 @@ import ReactQueryService from '../../../../core/ReactQueryService';
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
 import { invalidateMoneyAccountBalanceCaches } from '../utils/invalidateMoneyAccountBalanceCaches';
 import { store } from '../../../../store';
-import { setLastLocalMoneyFlowConfirmedAt } from '../../../../core/redux/slices/moneyBalance';
+import { setLastLocalMoneyFlow } from '../../../../core/redux/slices/moneyBalance';
 import { useRefreshMoneyBalanceOnTxConfirm } from './useRefreshMoneyBalanceOnTxConfirm';
 
 jest.mock('../../../../core/Engine');
@@ -305,7 +305,10 @@ describe('useRefreshMoneyBalanceOnTxConfirm', () => {
       getConfirmedHandler()(makeTx(type));
 
       expect(mockDispatch).toHaveBeenCalledWith(
-        setLastLocalMoneyFlowConfirmedAt(1_700_000_000_000),
+        setLastLocalMoneyFlow({
+          address: MOCK_ADDRESS,
+          confirmedAt: 1_700_000_000_000,
+        }),
       );
     });
 

--- a/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.ts
+++ b/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.ts
@@ -7,6 +7,7 @@ import type { CanonicalMoneyAccountBalanceResponse } from '@metamask/money-accou
 import Engine from '../../../../core/Engine';
 import ReactQueryService from '../../../../core/ReactQueryService';
 import { store } from '../../../../store';
+import { setLastLocalMoneyFlowConfirmedAt } from '../../../../core/redux/slices/moneyBalance';
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
 import { MoneyAccountBalanceServiceQueryKeys } from '../queryKeys';
 import {
@@ -93,6 +94,10 @@ export const useRefreshMoneyBalanceOnTxConfirm = () => {
         isMoneyAccountTx(transactionMeta) ||
         isPerpsPredictMoneyActivity(transactionMeta);
       if (!affectsMoneyBalance) return;
+
+      // Marks the live balance as ahead of anything the backend derives from
+      // its on-chain ingest, so those surfaces can say they're catching up.
+      store.dispatch(setLastLocalMoneyFlowConfirmedAt(Date.now()));
 
       refreshMoneyBalanceQueries(address).catch((error) => {
         Logger.error(error, `${LOG_PREFIX} Balance refresh failed`);

--- a/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.ts
+++ b/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.ts
@@ -7,7 +7,7 @@ import type { CanonicalMoneyAccountBalanceResponse } from '@metamask/money-accou
 import Engine from '../../../../core/Engine';
 import ReactQueryService from '../../../../core/ReactQueryService';
 import { store } from '../../../../store';
-import { setLastLocalMoneyFlowConfirmedAt } from '../../../../core/redux/slices/moneyBalance';
+import { setLastLocalMoneyFlow } from '../../../../core/redux/slices/moneyBalance';
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
 import { MoneyAccountBalanceServiceQueryKeys } from '../queryKeys';
 import {
@@ -97,7 +97,10 @@ export const useRefreshMoneyBalanceOnTxConfirm = () => {
 
       // Marks the live balance as ahead of anything the backend derives from
       // its on-chain ingest, so those surfaces can say they're catching up.
-      store.dispatch(setLastLocalMoneyFlowConfirmedAt(Date.now()));
+      // Scoped to the account that moved, so it cannot speak for another one.
+      store.dispatch(
+        setLastLocalMoneyFlow({ address, confirmedAt: Date.now() }),
+      );
 
       refreshMoneyBalanceQueries(address).catch((error) => {
         Logger.error(error, `${LOG_PREFIX} Balance refresh failed`);

--- a/app/components/UI/Money/types/navigation.ts
+++ b/app/components/UI/Money/types/navigation.ts
@@ -2,7 +2,10 @@ import type { NavigatorScreenParams } from '@react-navigation/native';
 import type { Hex } from '@metamask/utils';
 import type { AccountsApiActivity } from './moneyActivity';
 import type { CardTransaction } from '../../../../core/Engine/controllers/card-controller/provider-types';
-import type { ConfirmationParams } from '../../../Views/confirmations/components/confirm/confirm-component';
+import type {
+  ConfirmationLaunchSource,
+  ConfirmationParams,
+} from '../../../Views/confirmations/components/confirm/confirm-component';
 import type { NavigationAnalyticsRouteParams } from '../../../../util/analytics/navigationAnalyticsAttribution';
 
 export enum MoneyPostOnboardingRedirectType {
@@ -21,13 +24,22 @@ export interface MoneyOnboardingParams extends NavigationAnalyticsRouteParams {
   };
 }
 
+export interface MoneyHomeParams extends NavigationAnalyticsRouteParams {
+  /**
+   * Renders a back button on Money home. Set when the Money stack is pushed
+   * over the stack that opened it (e.g. a Rewards campaign) instead of being
+   * shown as the Money tab, where there is nothing to go back to.
+   */
+  showBackButton?: boolean;
+}
+
 /**
  * Param list for screens inside the Money tab stack (`MoneyTabScreenStack`).
  */
 // ParamListBase requires `type`; `interface` cannot satisfy it.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type MoneyScreensStackParamList = {
-  MoneyHome: NavigationAnalyticsRouteParams | undefined;
+  MoneyHome: MoneyHomeParams | undefined;
   MoneyActivity: undefined;
   MoneyHowItWorks: undefined;
 };
@@ -43,13 +55,21 @@ export type MoneyConfirmationsNavigationParamList = {
   RedesignedConfirmations: ConfirmationParams | undefined;
 };
 
+export interface MoneyAddMoneySheetParams {
+  /**
+   * Forwarded to the deposit confirmation so it can land somewhere other than
+   * the Money tab. Unset for the sheet's usual entry points on Money home.
+   */
+  launchedFrom?: ConfirmationLaunchSource;
+}
+
 /**
  * Param list for screens inside the Money modal stack (`MoneyModalStack`).
  */
 // ParamListBase requires `type`; `interface` cannot satisfy it.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type MoneyModalsNavigationParamList = {
-  MoneyAddMoneySheet: undefined;
+  MoneyAddMoneySheet: MoneyAddMoneySheetParams | undefined;
   MoneyMoreSheet: undefined;
   MoneyTransferSheet: undefined;
   MoneyApyInfoSheet: { apy?: number; variant?: 'default' | 'deposit' };

--- a/app/components/UI/Money/types/navigation.ts
+++ b/app/components/UI/Money/types/navigation.ts
@@ -31,6 +31,12 @@ export interface MoneyHomeParams extends NavigationAnalyticsRouteParams {
    * shown as the Money tab, where there is nothing to go back to.
    */
   showBackButton?: boolean;
+  /**
+   * What opened this Money home. Kept separate from `showBackButton`, which
+   * only says a stack sits underneath and not whose it is. Forwarded to Add
+   * Money so a further deposit lands back here rather than on the Money tab.
+   */
+  launchedFrom?: ConfirmationLaunchSource;
 }
 
 /**

--- a/app/components/UI/Rewards/Views/MoneyAccountSweepstakesCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/MoneyAccountSweepstakesCampaignDetailsView.test.tsx
@@ -13,6 +13,7 @@ import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
 import { useMoneyAccountSweepstakesSeries } from '../hooks/useMoneyAccountSweepstakesSeries';
 import { useMoneyAccountSweepstakesParticipation } from '../hooks/useMoneyAccountSweepstakesParticipation';
 import { useGetMoneyAccountSweepstakesStatsMe } from '../hooks/useGetMoneyAccountSweepstakesStatsMe';
+import { useMoneyAccountSweepstakesIngestLag } from '../hooks/useMoneyAccountSweepstakesIngestLag';
 import type { MoneyAccountSweepstakesSeries } from '../utils/moneyAccountSweepstakesSeries';
 import { createMoneyAccountSweepstakesLocalizedText } from '../components/Campaigns/MoneyAccountSweepstakes/testUtils';
 
@@ -219,6 +220,12 @@ jest.mock('../hooks/useRewardsToast', () => ({
   }),
 }));
 
+jest.mock('../hooks/useMoneyAccountSweepstakesIngestLag', () => ({
+  useMoneyAccountSweepstakesIngestLag: jest.fn(() => ({
+    isIngestLagging: false,
+  })),
+}));
+
 jest.mock('../../../../../locales/i18n', () => ({
   strings: (key: string) => key,
 }));
@@ -238,6 +245,9 @@ const mockUseGetMoneyAccountSweepstakesStatsMe =
   useGetMoneyAccountSweepstakesStatsMe as jest.MockedFunction<
     typeof useGetMoneyAccountSweepstakesStatsMe
   >;
+const mockUseMoneyAccountSweepstakesIngestLag = jest.mocked(
+  useMoneyAccountSweepstakesIngestLag,
+);
 
 const localizedText = createMoneyAccountSweepstakesLocalizedText();
 
@@ -320,6 +330,9 @@ function setupHooks({
     isLoading: isStatsLoading,
     hasError: hasStatsError,
     refetch: mockRefetchStats,
+  });
+  mockUseMoneyAccountSweepstakesIngestLag.mockReturnValue({
+    isIngestLagging: false,
   });
 }
 
@@ -524,6 +537,41 @@ describe('MoneyAccountSweepstakesCampaignDetailsView', () => {
 
     await waitFor(() => {
       expect(mockEnsureBound).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('backend ingest lag', () => {
+    it('flags the deposit figures as catching up, measured against the ingest watermark', () => {
+      setupHooks({
+        optedInAny: true,
+        stats: { ...statsWithBalance, dataAsOf: '2026-08-24T09:15:00.000Z' },
+      });
+      mockUseMoneyAccountSweepstakesIngestLag.mockReturnValue({
+        isIngestLagging: true,
+      });
+
+      const { getByTestId } = render(
+        <MoneyAccountSweepstakesCampaignDetailsView />,
+      );
+
+      expect(mockUseMoneyAccountSweepstakesIngestLag).toHaveBeenCalledWith(
+        '2026-08-24T09:15:00.000Z',
+      );
+      expect(
+        getByTestId('money-account-sweepstakes-pending-ingest-label'),
+      ).toBeOnTheScreen();
+    });
+
+    it('leaves the figures unqualified when the ingest is current', () => {
+      setupHooks({ optedInAny: true, stats: statsWithBalance });
+
+      const { queryByTestId } = render(
+        <MoneyAccountSweepstakesCampaignDetailsView />,
+      );
+
+      expect(
+        queryByTestId('money-account-sweepstakes-pending-ingest-label'),
+      ).toBeNull();
     });
   });
 });

--- a/app/components/UI/Rewards/Views/MoneyAccountSweepstakesCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/MoneyAccountSweepstakesCampaignDetailsView.tsx
@@ -21,6 +21,7 @@ import MoneyAccountSweepstakesLearnMoreRows from '../components/Campaigns/MoneyA
 import RewardsErrorBanner from '../components/RewardsErrorBanner';
 import { useGetMoneyAccountSweepstakesStatsMe } from '../hooks/useGetMoneyAccountSweepstakesStatsMe';
 import { useMoneyAccountSweepstakesBinding } from '../hooks/useMoneyAccountSweepstakesBinding';
+import { useMoneyAccountSweepstakesIngestLag } from '../hooks/useMoneyAccountSweepstakesIngestLag';
 import { useMoneyAccountSweepstakesParticipation } from '../hooks/useMoneyAccountSweepstakesParticipation';
 import { useMoneyAccountSweepstakesSeries } from '../hooks/useMoneyAccountSweepstakesSeries';
 import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
@@ -120,6 +121,10 @@ const MoneyAccountSweepstakesCampaignDetailsView: React.FC = () => {
     hasError: hasStatsError,
     refetch: refetchStats,
   } = useGetMoneyAccountSweepstakesStatsMe(displayCampaign?.id);
+
+  const { isIngestLagging } = useMoneyAccountSweepstakesIngestLag(
+    stats?.dataAsOf,
+  );
 
   const tileCampaign = useMemo(
     () => buildMoneyAccountSweepstakesTileCampaign(series),
@@ -242,6 +247,7 @@ const MoneyAccountSweepstakesCampaignDetailsView: React.FC = () => {
                 isStatsLoading={isStatsLoading}
                 hasStatsError={hasStatsError}
                 onRetryStats={refetchStats}
+                isIngestLagging={isIngestLagging}
               >
                 {optedInAny && (
                   <MoneyAccountSweepstakesCampaignCTA

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignCTA.test.tsx
@@ -7,6 +7,7 @@ import {
   type CampaignDto,
 } from '../../../../../../core/Engine/controllers/rewards-controller/types';
 import Routes from '../../../../../../constants/navigation/Routes';
+import { ConfirmationLaunchSource } from '../../../../../Views/confirmations/components/confirm/confirm-component';
 import { createMoneyAccountSweepstakesLocalizedText } from './testUtils';
 
 const mockNavigate = jest.fn();
@@ -220,8 +221,11 @@ describe('MoneyAccountSweepstakesCampaignCTA', () => {
 
     await waitFor(() => {
       expect(mockEnsureBound).toHaveBeenCalledTimes(1);
+      // The Rewards launch source lands the funded user on Money home pushed
+      // over this campaign, so back returns to Rewards.
       expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.MODALS.ROOT, {
         screen: Routes.MONEY.MODALS.ADD_MONEY_SHEET,
+        params: { launchedFrom: ConfirmationLaunchSource.Rewards },
       });
     });
   });
@@ -243,6 +247,7 @@ describe('MoneyAccountSweepstakesCampaignCTA', () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.MODALS.ROOT, {
         screen: Routes.MONEY.MODALS.ADD_MONEY_SHEET,
+        params: { launchedFrom: ConfirmationLaunchSource.Rewards },
       });
     });
     expect(mockShowToast).not.toHaveBeenCalled();

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignCTA.tsx
@@ -13,6 +13,7 @@ import type {
   MoneyAccountSweepstakesLocalizedTextDto,
 } from '../../../../../../core/Engine/controllers/rewards-controller/types';
 import Routes from '../../../../../../constants/navigation/Routes';
+import { ConfirmationLaunchSource } from '../../../../../Views/confirmations/components/confirm/confirm-component';
 import useCampaignGeoRestriction from '../../../hooks/useCampaignGeoRestriction';
 import { useHasActionableAddMoneyOptions } from '../../../hooks/useHasActionableAddMoneyOptions';
 import { useMoneyAccountSweepstakesBinding } from '../../../hooks/useMoneyAccountSweepstakesBinding';
@@ -94,6 +95,9 @@ const MoneyAccountSweepstakesCampaignCTA: React.FC<
     }
     navigation.navigate(Routes.MONEY.MODALS.ROOT, {
       screen: Routes.MONEY.MODALS.ADD_MONEY_SHEET,
+      // Lands the funded user on Money home pushed over this campaign, so back
+      // returns to Rewards instead of dropping them on the Money tab.
+      params: { launchedFrom: ConfirmationLaunchSource.Rewards },
     });
   }, [hasActionableAddMoneyOptions, navigation]);
 

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.test.tsx
@@ -8,7 +8,14 @@ import {
   type CampaignDto,
   type MoneyAccountSweepstakesStatsMeDto,
 } from '../../../../../../core/Engine/controllers/rewards-controller/types';
+import Routes from '../../../../../../constants/navigation/Routes';
 import { createMoneyAccountSweepstakesLocalizedText } from './testUtils';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
 
 jest.mock('@metamask/design-system-twrnc-preset', () => {
   const tw = (..._args: unknown[]) => ({});
@@ -88,6 +95,10 @@ const stats: MoneyAccountSweepstakesStatsMeDto = {
 };
 
 describe('MoneyAccountSweepstakesCampaignOverview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('uses qualifying deposits for the balance display and qualification shortfall', () => {
     const { getByText, queryByText } = render(
       <MoneyAccountSweepstakesCampaignOverview
@@ -255,4 +266,80 @@ describe('MoneyAccountSweepstakesCampaignOverview', () => {
       ).toBeNull();
     },
   );
+
+  it('flags the deposit figure as still catching up to a confirmed transaction', () => {
+    const { getByTestId, getByText } = render(
+      <MoneyAccountSweepstakesCampaignOverview
+        campaign={campaign}
+        localizedText={localizedText}
+        isParticipating
+        stats={stats}
+        isIngestLagging
+      />,
+    );
+
+    expect(
+      getByTestId(
+        MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.PENDING_INGEST_LABEL,
+      ),
+    ).toBeOnTheScreen();
+    // The figure and its qualification verdict still show — the label qualifies
+    // them rather than replacing them with a spinner.
+    expect(getByText('$40.00')).toBeOnTheScreen();
+    expect(
+      getByText("Add $60.00 today to reach $100 and earn today's entry."),
+    ).toBeOnTheScreen();
+  });
+
+  it('explains the delay in an info sheet rather than inline', () => {
+    const { getByTestId, queryByText } = render(
+      <MoneyAccountSweepstakesCampaignOverview
+        campaign={campaign}
+        localizedText={localizedText}
+        isParticipating
+        stats={stats}
+        isIngestLagging
+      />,
+    );
+
+    expect(
+      queryByText(localizedText.eligibleBalancePendingDescription),
+    ).toBeNull();
+
+    fireEvent.press(
+      getByTestId(
+        MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.PENDING_INGEST_INFO_BUTTON,
+      ),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.MODAL.REWARDS_INFO_SHEET_MODAL,
+      {
+        title: localizedText.eligibleBalanceTitle,
+        description: localizedText.eligibleBalancePendingDescription,
+      },
+    );
+  });
+
+  it('omits the catching-up label when the figures are up to date', () => {
+    const { queryByTestId } = render(
+      <MoneyAccountSweepstakesCampaignOverview
+        campaign={campaign}
+        localizedText={localizedText}
+        isParticipating
+        stats={stats}
+      />,
+    );
+
+    expect(
+      queryByTestId(
+        MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.PENDING_INGEST_LABEL,
+      ),
+    ).toBeNull();
+    expect(
+      queryByTestId(
+        MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.PENDING_INGEST_INFO_BUTTON,
+      ),
+    ).toBeNull();
+  });
 });

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
@@ -1,17 +1,24 @@
-import React, { type ReactNode } from 'react';
+import React, { useCallback, type ReactNode } from 'react';
 import { ImageBackground } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
+  ButtonIcon,
+  ButtonIconSize,
   FontWeight,
+  IconColor,
+  IconName,
   Skeleton,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import type { AppNavigationProp } from '../../../../../../core/NavigationService/types';
+import Routes from '../../../../../../constants/navigation/Routes';
 import type {
   CampaignDto,
   MoneyAccountSweepstakesLocalizedTextDto,
@@ -32,6 +39,9 @@ export const MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS = {
   MONEY_ACCOUNT_BALANCE_ROW:
     'money-account-sweepstakes-money-account-balance-row',
   LAST_CHECKED_ROW: 'money-account-sweepstakes-last-checked-row',
+  PENDING_INGEST_LABEL: 'money-account-sweepstakes-pending-ingest-label',
+  PENDING_INGEST_INFO_BUTTON:
+    'money-account-sweepstakes-pending-ingest-info-button',
 } as const;
 
 interface MoneyAccountSweepstakesCampaignOverviewProps {
@@ -42,6 +52,11 @@ interface MoneyAccountSweepstakesCampaignOverviewProps {
   isStatsLoading?: boolean;
   hasStatsError?: boolean;
   onRetryStats?: () => void;
+  /**
+   * Whether the deposit figures predate a Money Account transaction the user
+   * has already had confirmed, in which case they are labelled as catching up.
+   */
+  isIngestLagging?: boolean;
   children?: ReactNode;
 }
 
@@ -55,12 +70,23 @@ const MoneyAccountSweepstakesCampaignOverview: React.FC<
   isStatsLoading = false,
   hasStatsError = false,
   onRetryStats,
+  isIngestLagging = false,
   children,
 }) => {
   const tw = useTailwind();
+  const navigation = useNavigation<AppNavigationProp>();
   const backgroundImageUrl = campaign.image?.lightModeUrl;
   const { totalFiatFormatted, lastKnownTotalFiatFormatted, isBalanceLoading } =
     useMoneyAccountBalance();
+
+  // Headed with what the sheet is about rather than the inline label, which
+  // only reads as a status marker next to the figure.
+  const handlePendingIngestInfoPress = useCallback(() => {
+    navigation.navigate(Routes.MODAL.REWARDS_INFO_SHEET_MODAL, {
+      title: localizedText.eligibleBalanceTitle,
+      description: localizedText.eligibleBalancePendingDescription,
+    });
+  }, [navigation, localizedText]);
 
   if (isParticipating) {
     const showStatsLoading = isStatsLoading && !stats;
@@ -200,9 +226,42 @@ const MoneyAccountSweepstakesCampaignOverview: React.FC<
               </Box>
             )}
           </Box>
-          <Text variant={TextVariant.DisplayLg} fontWeight={FontWeight.Bold}>
-            {balanceDisplay}
-          </Text>
+          <Box
+            alignItems={BoxAlignItems.Center}
+            flexDirection={BoxFlexDirection.Row}
+            twClassName="gap-2"
+          >
+            <Text variant={TextVariant.DisplayLg} fontWeight={FontWeight.Bold}>
+              {balanceDisplay}
+            </Text>
+            {isIngestLagging && (
+              <Box
+                alignItems={BoxAlignItems.Center}
+                flexDirection={BoxFlexDirection.Row}
+                twClassName="gap-1"
+              >
+                <Text
+                  variant={TextVariant.BodyXs}
+                  color={TextColor.TextAlternative}
+                  testID={
+                    MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.PENDING_INGEST_LABEL
+                  }
+                >
+                  {localizedText.eligibleBalancePendingTitle}
+                </Text>
+                <ButtonIcon
+                  iconName={IconName.Info}
+                  iconProps={{ color: IconColor.IconAlternative }}
+                  size={ButtonIconSize.Sm}
+                  onPress={handlePendingIngestInfoPress}
+                  accessibilityLabel={localizedText.eligibleBalancePendingTitle}
+                  testID={
+                    MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.PENDING_INGEST_INFO_BUTTON
+                  }
+                />
+              </Box>
+            )}
+          </Box>
           <Box twClassName="gap-1">
             <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-1">
               <Text

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
@@ -240,19 +240,21 @@ const MoneyAccountSweepstakesCampaignOverview: React.FC<
                 flexDirection={BoxFlexDirection.Row}
                 twClassName="gap-1"
               >
-                <Text
-                  variant={TextVariant.BodyXs}
-                  color={TextColor.TextAlternative}
-                  testID={
-                    MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.PENDING_INGEST_LABEL
-                  }
-                >
-                  {localizedText.eligibleBalancePendingTitle}
-                </Text>
+                <Box twClassName="rounded-md bg-info-muted px-2 py-1">
+                  <Text
+                    variant={TextVariant.BodyXs}
+                    color={TextColor.InfoDefault}
+                    testID={
+                      MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.PENDING_INGEST_LABEL
+                    }
+                  >
+                    {localizedText.eligibleBalancePendingTitle}
+                  </Text>
+                </Box>
                 <ButtonIcon
                   iconName={IconName.Info}
                   iconProps={{ color: IconColor.IconAlternative }}
-                  size={ButtonIconSize.Sm}
+                  size={ButtonIconSize.Xs}
                   onPress={handlePendingIngestInfoPress}
                   accessibilityLabel={localizedText.eligibleBalancePendingTitle}
                   testID={

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/testUtils.ts
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/testUtils.ts
@@ -7,6 +7,9 @@ export const createMoneyAccountSweepstakesLocalizedText = (
   eligibleBalanceTitle: 'Qualifying deposits',
   eligibleBalanceDescription:
     "Net new deposits in your Money Account since you joined. Reach $100 and don't drop below it before midnight UTC to earn today's entry. Balance from before joining doesn't count.",
+  eligibleBalancePendingTitle: 'Updating',
+  eligibleBalancePendingDescription:
+    'Your latest Money Account transaction is still being processed, so qualifying deposits and entries may not be up to date yet. This usually takes a few minutes.',
   entriesTitle: 'Entries',
   entriesDescription:
     'One entry for each UTC day your qualifying deposits stayed at $100 or above. Max 7 per week.',

--- a/app/components/UI/Rewards/hooks/useMoneyAccountSweepstakesIngestLag.test.ts
+++ b/app/components/UI/Rewards/hooks/useMoneyAccountSweepstakesIngestLag.test.ts
@@ -1,0 +1,91 @@
+import { renderHook } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import {
+  INGEST_LAG_MAX_AGE_MS,
+  useMoneyAccountSweepstakesIngestLag,
+} from './useMoneyAccountSweepstakesIngestLag';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+const mockUseSelector = jest.mocked(useSelector);
+
+const NOW = 1_700_000_000_000;
+const CONFIRMED_AT = NOW - 60_000;
+
+/** Stands in for the last locally-confirmed Money flow in the store. */
+const mockConfirmedAt = (value: number | null) => {
+  mockUseSelector.mockReturnValue(value);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(Date, 'now').mockReturnValue(NOW);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('useMoneyAccountSweepstakesIngestLag', () => {
+  it('reports a lag when the ingest watermark predates the confirmed flow', () => {
+    mockConfirmedAt(CONFIRMED_AT);
+
+    const { result } = renderHook(() =>
+      useMoneyAccountSweepstakesIngestLag(
+        new Date(CONFIRMED_AT - 30_000).toISOString(),
+      ),
+    );
+
+    expect(result.current.isIngestLagging).toBe(true);
+  });
+
+  it('clears the lag once the ingest has caught up to the flow', () => {
+    mockConfirmedAt(CONFIRMED_AT);
+
+    const { result } = renderHook(() =>
+      useMoneyAccountSweepstakesIngestLag(
+        new Date(CONFIRMED_AT + 30_000).toISOString(),
+      ),
+    );
+
+    expect(result.current.isIngestLagging).toBe(false);
+  });
+
+  it('reports no lag when no local flow has been confirmed', () => {
+    mockConfirmedAt(null);
+
+    const { result } = renderHook(() =>
+      useMoneyAccountSweepstakesIngestLag(new Date(NOW).toISOString()),
+    );
+
+    expect(result.current.isIngestLagging).toBe(false);
+  });
+
+  it.each([
+    ['the field is absent on an older backend build', undefined],
+    ['the ingest has never run', null],
+    ['the watermark is unparseable', 'not-a-date'],
+  ])('treats the figures as lagging when %s', (_case, dataAsOf) => {
+    mockConfirmedAt(CONFIRMED_AT);
+
+    const { result } = renderHook(() =>
+      useMoneyAccountSweepstakesIngestLag(dataAsOf),
+    );
+
+    expect(result.current.isIngestLagging).toBe(true);
+  });
+
+  it('stops reporting a lag for a flow the ingest never caught up to', () => {
+    mockConfirmedAt(NOW - INGEST_LAG_MAX_AGE_MS - 1);
+
+    const { result } = renderHook(() =>
+      useMoneyAccountSweepstakesIngestLag(
+        new Date(NOW - INGEST_LAG_MAX_AGE_MS - 60_000).toISOString(),
+      ),
+    );
+
+    expect(result.current.isIngestLagging).toBe(false);
+  });
+});

--- a/app/components/UI/Rewards/hooks/useMoneyAccountSweepstakesIngestLag.test.ts
+++ b/app/components/UI/Rewards/hooks/useMoneyAccountSweepstakesIngestLag.test.ts
@@ -1,5 +1,7 @@
 import { renderHook } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
+import type { PersistedLocalMoneyFlow } from '../../../../core/redux/slices/moneyBalance';
+import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
 import {
   INGEST_LAG_MAX_AGE_MS,
   useMoneyAccountSweepstakesIngestLag,
@@ -8,15 +10,39 @@ import {
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
+jest.mock('../../../../selectors/moneyAccountController', () => ({
+  selectPrimaryMoneyAccount: jest.fn(),
+}));
 
 const mockUseSelector = jest.mocked(useSelector);
 
 const NOW = 1_700_000_000_000;
 const CONFIRMED_AT = NOW - 60_000;
+const ACCOUNT_ADDRESS = '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B';
+const OTHER_ADDRESS = '0x1234567890123456789012345678901234567890';
 
-/** Stands in for the last locally-confirmed Money flow in the store. */
+/**
+ * Serves the stored marker and the active Money Account to the hook's two
+ * selectors. The marker type is widened to cover the bare timestamp that
+ * older builds persisted.
+ */
+const mockStoredFlow = (
+  marker: PersistedLocalMoneyFlow | number | null,
+  activeAddress: string | undefined,
+) => {
+  mockUseSelector.mockImplementation((selector) =>
+    selector === selectPrimaryMoneyAccount
+      ? activeAddress && { address: activeAddress }
+      : marker,
+  );
+};
+
+/** Stands in for a flow confirmed on the currently active Money Account. */
 const mockConfirmedAt = (value: number | null) => {
-  mockUseSelector.mockReturnValue(value);
+  mockStoredFlow(
+    value === null ? null : { address: ACCOUNT_ADDRESS, confirmedAt: value },
+    ACCOUNT_ADDRESS,
+  );
 };
 
 beforeEach(() => {
@@ -75,6 +101,48 @@ describe('useMoneyAccountSweepstakesIngestLag', () => {
     );
 
     expect(result.current.isIngestLagging).toBe(true);
+  });
+
+  it('ignores a marker left by a different Money Account', () => {
+    mockStoredFlow(
+      { address: OTHER_ADDRESS, confirmedAt: CONFIRMED_AT },
+      ACCOUNT_ADDRESS,
+    );
+
+    const { result } = renderHook(() =>
+      useMoneyAccountSweepstakesIngestLag(
+        new Date(CONFIRMED_AT - 30_000).toISOString(),
+      ),
+    );
+
+    expect(result.current.isIngestLagging).toBe(false);
+  });
+
+  it('ignores the bare-timestamp marker persisted by older builds', () => {
+    mockStoredFlow(CONFIRMED_AT, ACCOUNT_ADDRESS);
+
+    const { result } = renderHook(() =>
+      useMoneyAccountSweepstakesIngestLag(
+        new Date(CONFIRMED_AT - 30_000).toISOString(),
+      ),
+    );
+
+    expect(result.current.isIngestLagging).toBe(false);
+  });
+
+  it('reports no lag while no Money Account is active', () => {
+    mockStoredFlow(
+      { address: ACCOUNT_ADDRESS, confirmedAt: CONFIRMED_AT },
+      undefined,
+    );
+
+    const { result } = renderHook(() =>
+      useMoneyAccountSweepstakesIngestLag(
+        new Date(CONFIRMED_AT - 30_000).toISOString(),
+      ),
+    );
+
+    expect(result.current.isIngestLagging).toBe(false);
   });
 
   it('stops reporting a lag for a flow the ingest never caught up to', () => {

--- a/app/components/UI/Rewards/hooks/useMoneyAccountSweepstakesIngestLag.ts
+++ b/app/components/UI/Rewards/hooks/useMoneyAccountSweepstakesIngestLag.ts
@@ -1,0 +1,57 @@
+import { useSelector } from 'react-redux';
+import { selectLastLocalMoneyFlowConfirmedAt } from '../../../../core/redux/slices/moneyBalance';
+
+/**
+ * How long a locally-confirmed Money Account transaction may sit ahead of the
+ * ingest watermark before we stop flagging the figures as catching up. Past
+ * this the ingest is stuck rather than lagging, and telling the user to wait
+ * would be a lie.
+ */
+export const INGEST_LAG_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Whether the user has a confirmed Money Account transaction that the backend's
+ * on-chain ingest has not caught up to, leaving the sweepstakes figures
+ * describing the pre-transaction state.
+ *
+ * Both timestamps are wall-clock values from different machines, so clock skew
+ * can shift the verdict by its own magnitude either way. That only changes how
+ * long a soft "catching up" hint shows, so it is not corrected for.
+ *
+ * @param confirmedAt - Epoch ms of the last locally-confirmed Money flow.
+ * @param dataAsOf - ISO ingest watermark from the stats response. Absent on
+ * older backend builds and null where the ingest has never run; either way any
+ * local flow counts as un-ingested.
+ */
+export const isFlowAheadOfIngest = (
+  confirmedAt: number | null,
+  dataAsOf?: string | null,
+): boolean => {
+  if (
+    confirmedAt === null ||
+    Date.now() - confirmedAt > INGEST_LAG_MAX_AGE_MS
+  ) {
+    return false;
+  }
+  const ingestedAt = dataAsOf ? new Date(dataAsOf).getTime() : NaN;
+  // An unparseable watermark says nothing about freshness, so it is treated
+  // like an absent one rather than trusted to clear the flag.
+  return Number.isNaN(ingestedAt) || ingestedAt < confirmedAt;
+};
+
+/**
+ * Tells the sweepstakes surfaces whether their deposit figures are still
+ * catching up to a Money Account transaction the user has already had
+ * confirmed. The transaction is confirmed on the Money side, so the campaign
+ * surface is the first place that can account for figures that have not moved.
+ *
+ * @param dataAsOf - Ingest watermark from the sweepstakes stats response.
+ */
+export const useMoneyAccountSweepstakesIngestLag = (
+  dataAsOf?: string | null,
+): { isIngestLagging: boolean } => {
+  const confirmedAt = useSelector(selectLastLocalMoneyFlowConfirmedAt);
+  return { isIngestLagging: isFlowAheadOfIngest(confirmedAt, dataAsOf) };
+};
+
+export default useMoneyAccountSweepstakesIngestLag;

--- a/app/components/UI/Rewards/hooks/useMoneyAccountSweepstakesIngestLag.ts
+++ b/app/components/UI/Rewards/hooks/useMoneyAccountSweepstakesIngestLag.ts
@@ -1,5 +1,9 @@
 import { useSelector } from 'react-redux';
-import { selectLastLocalMoneyFlowConfirmedAt } from '../../../../core/redux/slices/moneyBalance';
+import {
+  getUsableLastLocalFlowConfirmedAt,
+  selectLastLocalMoneyFlow,
+} from '../../../../core/redux/slices/moneyBalance';
+import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
 
 /**
  * How long a locally-confirmed Money Account transaction may sit ahead of the
@@ -50,8 +54,15 @@ export const isFlowAheadOfIngest = (
 export const useMoneyAccountSweepstakesIngestLag = (
   dataAsOf?: string | null,
 ): { isIngestLagging: boolean } => {
-  const confirmedAt = useSelector(selectLastLocalMoneyFlowConfirmedAt);
-  return { isIngestLagging: isFlowAheadOfIngest(confirmedAt, dataAsOf) };
+  const lastLocalFlow = useSelector(selectLastLocalMoneyFlow);
+  const primaryMoneyAccount = useSelector(selectPrimaryMoneyAccount);
+  const confirmedAt = getUsableLastLocalFlowConfirmedAt(
+    lastLocalFlow,
+    primaryMoneyAccount?.address,
+  );
+  return {
+    isIngestLagging: isFlowAheadOfIngest(confirmedAt ?? null, dataAsOf),
+  };
 };
 
 export default useMoneyAccountSweepstakesIngestLag;

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -83,6 +83,12 @@ export enum ConfirmationLaunchSource {
    * confirmation, so the landing preserves it rather than switching tabs.
    */
   Rewards = 'rewards',
+  /**
+   * Money home, itself already pushed over a Rewards campaign by an earlier
+   * deposit. That screen is still on the stack underneath the confirmation, so
+   * the landing returns to it instead of stacking a second copy on top.
+   */
+  RewardsMoneyHome = 'rewards-money-home',
 }
 
 export interface ConfirmationParams {

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -72,8 +72,22 @@ export enum PayWithOption {
   MoneyAccount = 'money_account',
 }
 
+/**
+ * The surface a confirmation was opened from, for the cases where the
+ * post-confirmation landing has to differ from the default for that
+ * transaction type.
+ */
+export enum ConfirmationLaunchSource {
+  /**
+   * A Rewards campaign. The pushed Rewards stack sits underneath the
+   * confirmation, so the landing preserves it rather than switching tabs.
+   */
+  Rewards = 'rewards',
+}
+
 export interface ConfirmationParams {
   autoSelectFiatPayment?: boolean;
+  launchedFrom?: ConfirmationLaunchSource;
   loader?: ConfirmationLoader;
   maxValueMode?: boolean;
   forceBottomSheet?: boolean;

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -28,12 +28,17 @@ import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 import { useGaslessSupportedSmartTransactions } from '../gas/useGaslessSupportedSmartTransactions';
 import { isHardwareAccount } from '../../../../../util/address';
 import { useParams } from '../../../../../util/navigation/navUtils';
-import { PayWithOption } from '../../components/confirm/confirm-component';
+import {
+  ConfirmationLaunchSource,
+  PayWithOption,
+} from '../../components/confirm/confirm-component';
 import { useFiatConfirm } from '../pay/useFiatConfirm';
 import { useHandleHwSend } from '../../../../UI/HardwareWallet/Swaps/useHandleHwSend';
+import { StackActions } from '@react-navigation/native';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
+const mockDispatch = jest.fn();
 
 jest.mock('../useApprovalRequest');
 jest.mock('./useTransactionMetadataRequest');
@@ -61,6 +66,7 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
     navigate: mockNavigate,
     goBack: mockGoBack,
+    dispatch: mockDispatch,
   }),
 }));
 
@@ -515,6 +521,34 @@ describe('useTransactionConfirm', () => {
         },
         { pop: true },
       );
+      expect(mockGoBack).not.toHaveBeenCalled();
+    });
+
+    it('money home over the Rewards stack if money account deposit was launched from Rewards', async () => {
+      useParamsMock.mockReturnValue({
+        launchedFrom: ConfirmationLaunchSource.Rewards,
+      });
+
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: transactionIdMock,
+        type: TransactionType.moneyAccountDeposit,
+      } as TransactionMeta);
+
+      const { result } = renderHook();
+
+      await act(async () => {
+        await result.current.onConfirm();
+      });
+
+      // Replacing keeps the Rewards campaign underneath, so Money home's back
+      // button returns there; a HOME_TABS switch would strand the user.
+      expect(mockDispatch).toHaveBeenCalledWith(
+        StackActions.replace(Routes.MONEY.ROOT, {
+          screen: Routes.MONEY.HOME,
+          params: { showBackButton: true },
+        }),
+      );
+      expect(mockNavigate).not.toHaveBeenCalled();
       expect(mockGoBack).not.toHaveBeenCalled();
     });
 

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -545,11 +545,39 @@ describe('useTransactionConfirm', () => {
       expect(mockDispatch).toHaveBeenCalledWith(
         StackActions.replace(Routes.MONEY.ROOT, {
           screen: Routes.MONEY.HOME,
-          params: { showBackButton: true },
+          params: {
+            showBackButton: true,
+            launchedFrom: ConfirmationLaunchSource.Rewards,
+          },
         }),
       );
       expect(mockNavigate).not.toHaveBeenCalled();
       expect(mockGoBack).not.toHaveBeenCalled();
+    });
+
+    it('back to the existing money home if the deposit was launched from a Rewards-originated money home', async () => {
+      useParamsMock.mockReturnValue({
+        launchedFrom: ConfirmationLaunchSource.RewardsMoneyHome,
+      });
+
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: transactionIdMock,
+        type: TransactionType.moneyAccountDeposit,
+      } as TransactionMeta);
+
+      const { result } = renderHook();
+
+      await act(async () => {
+        await result.current.onConfirm();
+      });
+
+      // Money home is already on the stack, so popping back to it avoids
+      // landing the user on a second copy stacked over the first.
+      expect(mockGoBack).toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalledWith(
+        StackActions.replace(Routes.MONEY.ROOT, expect.anything()),
+      );
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
 
     it('defers money account deposit navigation until requested', async () => {

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useNavigation } from '@react-navigation/native';
+import { StackActions, useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import Routes from '../../../../../constants/navigation/Routes';
 import useApprovalRequest from '../useApprovalRequest';
@@ -15,6 +15,7 @@ import { isHardwareAccount } from '../../../../../util/address';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { useNavigateToPerpsHome } from '../../../../UI/Perps/utils/perpsModeSwitch';
 import {
+  ConfirmationLaunchSource,
   ConfirmationParams,
   PayWithOption,
 } from '../../components/confirm/confirm-component';
@@ -56,7 +57,7 @@ export function useTransactionConfirm() {
   const navigateToPerpsHome = useNavigateToPerpsHome();
 
   const { tryEnableEvmNetwork } = useNetworkEnablement();
-  const { payWithOption } = useParams<ConfirmationParams>({});
+  const { launchedFrom, payWithOption } = useParams<ConfirmationParams>({});
 
   const { isSupported: isGaslessSupportedSTX, isSmartTransaction } =
     useGaslessSupportedSmartTransactions();
@@ -146,14 +147,26 @@ export function useTransactionConfirm() {
         TransactionType.moneyAccountDeposit,
       ])
     ) {
-      navigation.navigate(
-        Routes.HOME_TABS,
-        {
-          screen: Routes.MONEY.ROOT,
-          params: { screen: Routes.MONEY.HOME },
-        },
-        { pop: true },
-      );
+      if (launchedFrom === ConfirmationLaunchSource.Rewards) {
+        // Replacing this confirmation — rather than switching to the Money tab
+        // — keeps the Rewards stack that opened the deposit underneath, so
+        // Money home's back button returns to the campaign.
+        navigation.dispatch(
+          StackActions.replace(Routes.MONEY.ROOT, {
+            screen: Routes.MONEY.HOME,
+            params: { showBackButton: true },
+          }),
+        );
+      } else {
+        navigation.navigate(
+          Routes.HOME_TABS,
+          {
+            screen: Routes.MONEY.ROOT,
+            params: { screen: Routes.MONEY.HOME },
+          },
+          { pop: true },
+        );
+      }
     } else if (
       isFullScreenConfirmation &&
       !hasTransactionType(transactionMetadata, GO_BACK_TYPES)
@@ -167,6 +180,7 @@ export function useTransactionConfirm() {
   }, [
     chainId,
     isFullScreenConfirmation,
+    launchedFrom,
     navigateToPerpsHome,
     navigation,
     payWithOption,

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -147,14 +147,25 @@ export function useTransactionConfirm() {
         TransactionType.moneyAccountDeposit,
       ])
     ) {
-      if (launchedFrom === ConfirmationLaunchSource.Rewards) {
+      if (launchedFrom === ConfirmationLaunchSource.RewardsMoneyHome) {
+        // The deposit started from a Money home that is already on the stack
+        // beneath this confirmation, so popping back to it returns the user
+        // there with the Rewards campaign still underneath. Replacing would
+        // leave a second Money home stacked on the first.
+        navigation.goBack();
+      } else if (launchedFrom === ConfirmationLaunchSource.Rewards) {
         // Replacing this confirmation — rather than switching to the Money tab
         // — keeps the Rewards stack that opened the deposit underneath, so
         // Money home's back button returns to the campaign.
         navigation.dispatch(
           StackActions.replace(Routes.MONEY.ROOT, {
             screen: Routes.MONEY.HOME,
-            params: { showBackButton: true },
+            params: {
+              showBackButton: true,
+              // Marks this Money home as Rewards-originated so a further
+              // deposit started from it lands back here, not on the Money tab.
+              launchedFrom: ConfirmationLaunchSource.Rewards,
+            },
           }),
         );
       } else {

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -1288,6 +1288,8 @@ export type PredictThePitchCampaignDetails = CampaignDetails;
 export type MoneyAccountSweepstakesLocalizedTextDto = {
   eligibleBalanceTitle: string;
   eligibleBalanceDescription: string;
+  eligibleBalancePendingTitle: string;
+  eligibleBalancePendingDescription: string;
   entriesTitle: string;
   entriesDescription: string;
   entriesCountValue: string;

--- a/app/core/redux/slices/moneyBalance/index.test.ts
+++ b/app/core/redux/slices/moneyBalance/index.test.ts
@@ -3,7 +3,9 @@ import reducer, {
   setLastKnownMoneyBalance,
   clearLastKnownMoneyBalance,
   setMoneyAccountRedeemableRaw,
+  setLastLocalMoneyFlowConfirmedAt,
   selectLastKnownMoneyBalance,
+  selectLastLocalMoneyFlowConfirmedAt,
   selectMoneyAccountRedeemable,
   getUsableMoneyAccountRedeemableRaw,
   isPersistedMoneyBalanceUsable,
@@ -30,6 +32,7 @@ describe('moneyBalance slice', () => {
     expect(reducer(undefined, { type: '@@INIT' })).toEqual(initialState);
     expect(initialState.lastKnownBalance).toBeNull();
     expect(initialState.redeemable).toBeNull();
+    expect(initialState.lastLocalFlowConfirmedAt).toBeNull();
   });
 
   it('setLastKnownMoneyBalance stores the balance', () => {
@@ -42,6 +45,7 @@ describe('moneyBalance slice', () => {
     const populated: MoneyBalanceSliceState = {
       lastKnownBalance: balance,
       redeemable: null,
+      lastLocalFlowConfirmedAt: null,
     };
 
     const state = reducer(populated, clearLastKnownMoneyBalance());
@@ -58,6 +62,31 @@ describe('moneyBalance slice', () => {
 
     const cleared = reducer(stored, setMoneyAccountRedeemableRaw(null));
     expect(cleared.redeemable).toBeNull();
+  });
+
+  it('setLastLocalMoneyFlowConfirmedAt stores the confirmation time', () => {
+    const state = reducer(
+      initialState,
+      setLastLocalMoneyFlowConfirmedAt(1700000000000),
+    );
+
+    expect(state.lastLocalFlowConfirmedAt).toBe(1700000000000);
+  });
+
+  it('selectLastLocalMoneyFlowConfirmedAt returns the stored time', () => {
+    const state = {
+      moneyBalance: { lastLocalFlowConfirmedAt: 1700000000000 },
+    } as unknown as RootState;
+
+    expect(selectLastLocalMoneyFlowConfirmedAt(state)).toBe(1700000000000);
+  });
+
+  it('selectLastLocalMoneyFlowConfirmedAt returns null for state persisted before the field existed', () => {
+    const state = {
+      moneyBalance: { lastKnownBalance: null, redeemable: null },
+    } as unknown as RootState;
+
+    expect(selectLastLocalMoneyFlowConfirmedAt(state)).toBeNull();
   });
 
   it('selectLastKnownMoneyBalance returns the stored balance', () => {

--- a/app/core/redux/slices/moneyBalance/index.test.ts
+++ b/app/core/redux/slices/moneyBalance/index.test.ts
@@ -3,14 +3,16 @@ import reducer, {
   setLastKnownMoneyBalance,
   clearLastKnownMoneyBalance,
   setMoneyAccountRedeemableRaw,
-  setLastLocalMoneyFlowConfirmedAt,
+  setLastLocalMoneyFlow,
   selectLastKnownMoneyBalance,
-  selectLastLocalMoneyFlowConfirmedAt,
+  selectLastLocalMoneyFlow,
   selectMoneyAccountRedeemable,
   getUsableMoneyAccountRedeemableRaw,
+  getUsableLastLocalFlowConfirmedAt,
   isPersistedMoneyBalanceUsable,
   PersistedMoneyBalance,
   PersistedRedeemableRaw,
+  PersistedLocalMoneyFlow,
   MoneyBalanceSliceState,
 } from '.';
 import { RootState } from '../../../../reducers';
@@ -26,6 +28,13 @@ const redeemable: PersistedRedeemableRaw = {
   address: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
   raw: '15019083',
 };
+
+const localFlow: PersistedLocalMoneyFlow = {
+  address: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
+  confirmedAt: 1700000000000,
+};
+
+const OTHER_ADDRESS = '0x1234567890123456789012345678901234567890';
 
 describe('moneyBalance slice', () => {
   it('returns the initial state', () => {
@@ -64,29 +73,26 @@ describe('moneyBalance slice', () => {
     expect(cleared.redeemable).toBeNull();
   });
 
-  it('setLastLocalMoneyFlowConfirmedAt stores the confirmation time', () => {
-    const state = reducer(
-      initialState,
-      setLastLocalMoneyFlowConfirmedAt(1700000000000),
-    );
+  it('setLastLocalMoneyFlow stores the account and confirmation time', () => {
+    const state = reducer(initialState, setLastLocalMoneyFlow(localFlow));
 
-    expect(state.lastLocalFlowConfirmedAt).toBe(1700000000000);
+    expect(state.lastLocalFlowConfirmedAt).toEqual(localFlow);
   });
 
-  it('selectLastLocalMoneyFlowConfirmedAt returns the stored time', () => {
+  it('selectLastLocalMoneyFlow returns the stored marker', () => {
     const state = {
-      moneyBalance: { lastLocalFlowConfirmedAt: 1700000000000 },
+      moneyBalance: { lastLocalFlowConfirmedAt: localFlow },
     } as unknown as RootState;
 
-    expect(selectLastLocalMoneyFlowConfirmedAt(state)).toBe(1700000000000);
+    expect(selectLastLocalMoneyFlow(state)).toEqual(localFlow);
   });
 
-  it('selectLastLocalMoneyFlowConfirmedAt returns null for state persisted before the field existed', () => {
+  it('selectLastLocalMoneyFlow returns null for state persisted before the field existed', () => {
     const state = {
       moneyBalance: { lastKnownBalance: null, redeemable: null },
     } as unknown as RootState;
 
-    expect(selectLastLocalMoneyFlowConfirmedAt(state)).toBeNull();
+    expect(selectLastLocalMoneyFlow(state)).toBeNull();
   });
 
   it('selectLastKnownMoneyBalance returns the stored balance', () => {
@@ -127,6 +133,41 @@ describe('moneyBalance slice', () => {
     it('returns undefined when no active address is provided', () => {
       expect(
         getUsableMoneyAccountRedeemableRaw(redeemable, undefined),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('getUsableLastLocalFlowConfirmedAt', () => {
+    it('returns the confirmation time when the address matches', () => {
+      expect(
+        getUsableLastLocalFlowConfirmedAt(localFlow, localFlow.address),
+      ).toBe(1700000000000);
+    });
+
+    it('returns undefined when the marker belongs to another account', () => {
+      expect(
+        getUsableLastLocalFlowConfirmedAt(localFlow, OTHER_ADDRESS),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined for the bare-timestamp shape persisted by older builds', () => {
+      expect(
+        getUsableLastLocalFlowConfirmedAt(1700000000000, localFlow.address),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when no marker has been recorded', () => {
+      expect(
+        getUsableLastLocalFlowConfirmedAt(null, localFlow.address),
+      ).toBeUndefined();
+      expect(
+        getUsableLastLocalFlowConfirmedAt(undefined, localFlow.address),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when there is no active Money account', () => {
+      expect(
+        getUsableLastLocalFlowConfirmedAt(localFlow, undefined),
       ).toBeUndefined();
     });
   });

--- a/app/core/redux/slices/moneyBalance/index.ts
+++ b/app/core/redux/slices/moneyBalance/index.ts
@@ -24,11 +24,23 @@ export interface PersistedRedeemableRaw {
 export interface MoneyBalanceSliceState {
   lastKnownBalance: PersistedMoneyBalance | null;
   redeemable: PersistedRedeemableRaw | null;
+  /**
+   * Epoch milliseconds of the most recent locally-confirmed transaction that
+   * moved the Money Account balance, in either direction.
+   *
+   * The live balance reflects such a transaction immediately, while anything
+   * derived from the backend's on-chain ingest (e.g. Rewards qualifying
+   * deposits) only catches up on the next ingest run. Consumers compare this
+   * against their own freshness watermark to tell the user their figure is
+   * still catching up. Persisted, because the ingest lag outlives a session.
+   */
+  lastLocalFlowConfirmedAt: number | null;
 }
 
 export const initialState: MoneyBalanceSliceState = {
   lastKnownBalance: null,
   redeemable: null,
+  lastLocalFlowConfirmedAt: null,
 };
 
 const name = 'moneyBalance';
@@ -52,6 +64,12 @@ const slice = createSlice({
     ) => {
       state.redeemable = action.payload;
     },
+    setLastLocalMoneyFlowConfirmedAt: (
+      state,
+      action: PayloadAction<number>,
+    ) => {
+      state.lastLocalFlowConfirmedAt = action.payload;
+    },
   },
 });
 
@@ -69,6 +87,12 @@ export const selectLastKnownMoneyBalance = createSelector(
 export const selectMoneyAccountRedeemable = createSelector(
   selectMoneyBalanceState,
   (moneyBalance) => moneyBalance.redeemable,
+);
+
+export const selectLastLocalMoneyFlowConfirmedAt = createSelector(
+  selectMoneyBalanceState,
+  // Falls back to null for state persisted before this field existed.
+  (moneyBalance) => moneyBalance.lastLocalFlowConfirmedAt ?? null,
 );
 
 /**
@@ -106,4 +130,5 @@ export const {
   setLastKnownMoneyBalance,
   clearLastKnownMoneyBalance,
   setMoneyAccountRedeemableRaw,
+  setLastLocalMoneyFlowConfirmedAt,
 } = actions;

--- a/app/core/redux/slices/moneyBalance/index.ts
+++ b/app/core/redux/slices/moneyBalance/index.ts
@@ -21,20 +21,32 @@ export interface PersistedRedeemableRaw {
   raw: string;
 }
 
+export interface PersistedLocalMoneyFlow {
+  /** Money account address the confirmed transaction moved funds for. */
+  address: string;
+  /** Epoch milliseconds when that transaction was confirmed locally. */
+  confirmedAt: number;
+}
+
 export interface MoneyBalanceSliceState {
   lastKnownBalance: PersistedMoneyBalance | null;
   redeemable: PersistedRedeemableRaw | null;
   /**
-   * Epoch milliseconds of the most recent locally-confirmed transaction that
-   * moved the Money Account balance, in either direction.
+   * The most recent locally-confirmed transaction that moved the Money Account
+   * balance, in either direction.
    *
    * The live balance reflects such a transaction immediately, while anything
    * derived from the backend's on-chain ingest (e.g. Rewards qualifying
    * deposits) only catches up on the next ingest run. Consumers compare this
    * against their own freshness watermark to tell the user their figure is
    * still catching up. Persisted, because the ingest lag outlives a session.
+   *
+   * Builds before the marker carried an address persisted a bare epoch-ms
+   * number here. That shape cannot be attributed to an account, so
+   * {@link getUsableLastLocalFlowConfirmedAt} discards it. The key name is kept
+   * so redux-persist keeps reconciling into the same slot.
    */
-  lastLocalFlowConfirmedAt: number | null;
+  lastLocalFlowConfirmedAt: PersistedLocalMoneyFlow | number | null;
 }
 
 export const initialState: MoneyBalanceSliceState = {
@@ -64,9 +76,9 @@ const slice = createSlice({
     ) => {
       state.redeemable = action.payload;
     },
-    setLastLocalMoneyFlowConfirmedAt: (
+    setLastLocalMoneyFlow: (
       state,
-      action: PayloadAction<number>,
+      action: PayloadAction<PersistedLocalMoneyFlow>,
     ) => {
       state.lastLocalFlowConfirmedAt = action.payload;
     },
@@ -89,7 +101,7 @@ export const selectMoneyAccountRedeemable = createSelector(
   (moneyBalance) => moneyBalance.redeemable,
 );
 
-export const selectLastLocalMoneyFlowConfirmedAt = createSelector(
+export const selectLastLocalMoneyFlow = createSelector(
   selectMoneyBalanceState,
   // Falls back to null for state persisted before this field existed.
   (moneyBalance) => moneyBalance.lastLocalFlowConfirmedAt ?? null,
@@ -112,6 +124,26 @@ export const getUsableMoneyAccountRedeemableRaw = (
     : undefined;
 
 /**
+ * A confirmed local flow only says something about the account it moved funds
+ * for. Reading it without that check would let a marker left by a previously
+ * active Money Account tell the current one its figures are catching up, when
+ * nothing local has happened on it at all.
+ *
+ * Also discards the bare-timestamp shape persisted by builds before the marker
+ * carried an address, which cannot be attributed to any account.
+ */
+export const getUsableLastLocalFlowConfirmedAt = (
+  marker: PersistedLocalMoneyFlow | number | null | undefined,
+  address: string | undefined,
+): number | undefined =>
+  typeof marker === 'object' &&
+  marker !== null &&
+  address &&
+  areAddressesEqual(marker.address, address)
+    ? marker.confirmedAt
+    : undefined;
+
+/**
  * A persisted balance is only safe to show as the "last known" figure when it
  * belongs to the account currently in view and was formatted in the currency
  * currently selected — otherwise the figure would be stale in a misleading way
@@ -130,5 +162,5 @@ export const {
   setLastKnownMoneyBalance,
   clearLastKnownMoneyBalance,
   setMoneyAccountRedeemableRaw,
-  setLastLocalMoneyFlowConfirmedAt,
+  setLastLocalMoneyFlow,
 } = actions;

--- a/tests/framework/fixtures/json/default-fixture.json
+++ b/tests/framework/fixtures/json/default-fixture.json
@@ -816,6 +816,7 @@
     },
     "moneyBalance": {
       "lastKnownBalance": null,
+      "lastLocalFlowConfirmedAt": null,
       "redeemable": null
     },
     "navigation": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Two Money Account Sweepstakes UX gaps: Add Funds dropped users on the Money tab with no way back to the campaign, and qualifying deposits stayed stale after a just-confirmed deposit or withdrawal while the live Money balance updated immediately.

### 1. Back to Rewards after Add Funds

The campaign CTA already opened the Add Money sheet, but a successful `moneyAccountDeposit` confirmation always landed on `HOME_TABS` → Money home with `pop: true`. That switched tabs and discarded the Rewards stack, so there was nothing to go back to.

This PR threads a `ConfirmationLaunchSource.Rewards` flag from the sweepstakes CTA through the Add Money sheet and `initiateDeposit` into confirmation params. When that source is set, post-confirm navigation `StackActions.replace`s the confirmation with Money home (`showBackButton: true`) instead of switching tabs. The Rewards campaign stays underneath; MoneyHeader renders a back button that `goBack()`s to it. Deposits started from Money itself are unchanged.

The "Learn more mUSD" row is left on the existing Money deeplink and does not get this stack.

### 2. Qualifying-deposit ingest lag

`useMoneyAccountBalance` is a live vault/RPC read, so the Balance row updates as soon as a Money Account transaction confirms. Qualifying deposits and entries come from backend ingest (`stats.dataAsOf`). That pipeline can lag minutes (or get stuck), so the campaign figure looked "wrong" next to a freshly updated balance.

On any confirmed tx that moves the Money Account (`deposit`, `withdraw`, and Perps/Predict transfers that pay with or land as mUSD), `useRefreshMoneyBalanceOnTxConfirm` now also stamps `lastLocalFlowConfirmedAt` in the persisted `moneyBalance` slice.

`useMoneyAccountSweepstakesIngestLag` treats qualifying deposits as lagging when that stamp is newer than `stats.dataAsOf` (absent / null / unparseable watermarks count as un-ingested) and the stamp is less than 24 hours old. While lagging, the overview shows a muted "Updating" label plus an info icon next to the qualifying-deposits figure. The icon opens `RewardsInfoSheetModal` with the longer pending-ingest copy. There is no toast.

Copy keys (`eligibleBalancePendingTitle`, `eligibleBalancePendingDescription`) live on campaign `localizedText` rather than `en.json`. Backend defaults ship in a companion PR in `va-mmcx-rewards`; until that deploys, the keys are absent from older campaign payloads.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a back button to Money after adding funds from the Money Account Sweepstakes campaign, and an Updating indicator when qualifying deposits have not yet caught up to a confirmed Money Account transaction.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money Account Sweepstakes Add Funds return and qualifying-deposit lag

  Scenario: user adds funds from the sweepstakes campaign and returns to Rewards
    Given the user is opted into an active Money Account Sweepstakes campaign
    And they are on the campaign details screen

    When they tap Add funds and complete a Money Account deposit
    Then they land on Money home with a back button
    And tapping back returns them to the sweepstakes campaign, not the Money tab

  Scenario: user adds funds from Money home
    Given the user is on the Money tab

    When they add funds through the usual Add Money sheet
    Then they land on Money home with no back button

  Scenario: qualifying deposits lag a confirmed Money flow
    Given the user is opted into the sweepstakes campaign
    And they have just confirmed a Money Account deposit or withdrawal
    And backend stats.dataAsOf is still older than that confirmation

    When they open the campaign details screen
    Then an Updating label and info icon appear next to qualifying deposits
    And tapping the info icon opens RewardsInfoSheet with the pending-ingest explanation
    And the live Money Account balance row already reflects the new amount

  Scenario: ingest has caught up
    Given lastLocalFlowConfirmedAt is older than stats.dataAsOf

    When they open the campaign details screen
    Then the Updating label and info icon are not shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — will attach device recordings of the Add Funds return path and the Updating info sheet after a local deposit.

### **After**
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-09-08 at 13 17 47" src="https://github.com/user-attachments/assets/a75fbb39-c884-41d3-8347-73ac31477900" />
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-09-08 at 13 17 56" src="https://github.com/user-attachments/assets/57f4a42c-1b4c-4205-beaa-963a7df6b6df" />



https://github.com/user-attachments/assets/e7c7cce9-07d9-40db-98b6-6db45431d286


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)