### PR TITLE
feat: drop MetaMetrics opt-in for profile metrics under Basic Functionality consolidation

### DIFF
--- a/app/core/Engine/controllers/profile-metrics-controller-init.test.ts
+++ b/app/core/Engine/controllers/profile-metrics-controller-init.test.ts
@@ -8,25 +8,43 @@ import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 import { buildMessengerClientInitRequestMock } from '../utils/test-utils';
 import { ProfileMetricsControllerInitMessenger } from '../messengers/profile-metrics-controller-messenger';
+import { selectIsBasicFunctionalityConsolidationEnabled } from '../../../selectors/featureFlagController/basicFunctionalityConsolidation';
 
 jest.mock('@metamask/profile-metrics-controller');
+
+jest.mock(
+  '../../../selectors/featureFlagController/basicFunctionalityConsolidation',
+  () => ({
+    selectIsBasicFunctionalityConsolidationEnabled: jest.fn(() => false),
+  }),
+);
+
+const mockedSelectIsBasicFunctionalityConsolidationEnabled = jest.mocked(
+  selectIsBasicFunctionalityConsolidationEnabled,
+);
 
 function getInitRequestMock({
   analyticsId,
   analyticsEnabled,
   pna25Acknowledged,
   basicFunctionalityEnabled,
+  bftcGateOn,
 }: {
   analyticsId: string;
   analyticsEnabled: boolean;
   pna25Acknowledged: boolean;
   basicFunctionalityEnabled: boolean;
+  bftcGateOn: boolean;
 }): jest.Mocked<
   MessengerClientInitRequest<
     ProfileMetricsControllerMessenger,
     ProfileMetricsControllerInitMessenger
   >
 > {
+  mockedSelectIsBasicFunctionalityConsolidationEnabled.mockReturnValue(
+    bftcGateOn,
+  );
+
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,
   });
@@ -66,36 +84,77 @@ describe.each([
     analyticsEnabled: true,
     pna25Acknowledged: true,
     basicFunctionalityEnabled: true,
+    bftcGateOn: false,
   },
   {
     analyticsId: '898cbad5-7a5e-4ea1-8ca0-822bb4804665',
     analyticsEnabled: false,
     pna25Acknowledged: false,
     basicFunctionalityEnabled: true,
+    bftcGateOn: false,
   },
   {
     analyticsId: '9c9fe89c-76c3-4ad6-89f8-b76061159458',
     analyticsEnabled: false,
     pna25Acknowledged: false,
     basicFunctionalityEnabled: false,
+    bftcGateOn: false,
   },
   {
     analyticsId: '5aed4107-f430-4bb0-84c9-1e7031599cc2',
     analyticsEnabled: true,
     pna25Acknowledged: false,
     basicFunctionalityEnabled: true,
+    bftcGateOn: false,
   },
   {
     analyticsId: '3f4e2d2a-1c4e-4f5e-9f3a-2b6d8c9e7f10',
     analyticsEnabled: true,
     pna25Acknowledged: false,
     basicFunctionalityEnabled: false,
+    bftcGateOn: false,
   },
   {
     analyticsId: '4a5f3e2d-1c4e-4f5e-9f3a-2b6d8c9e7f11',
     analyticsEnabled: true,
     pna25Acknowledged: true,
     basicFunctionalityEnabled: false,
+    bftcGateOn: false,
+  },
+  {
+    analyticsId: '6b7c8d9e-2d3e-4f5e-8a1b-3c4d5e6f7a12',
+    analyticsEnabled: false,
+    pna25Acknowledged: true,
+    basicFunctionalityEnabled: true,
+    bftcGateOn: false,
+  },
+  {
+    analyticsId: '7c8d9e0f-3e4f-5a6b-9c2d-4e5f6a7b8c13',
+    analyticsEnabled: false,
+    pna25Acknowledged: true,
+    basicFunctionalityEnabled: true,
+    bftcGateOn: true,
+  },
+  {
+    analyticsId: '8d9e0f1a-4f5a-6b7c-0d3e-5f6a7b8c9d14',
+    analyticsEnabled: false,
+    pna25Acknowledged: false,
+    basicFunctionalityEnabled: true,
+    bftcGateOn: true,
+  },
+  {
+    analyticsId: '9e0f1a2b-5a6b-7c8d-1e4f-6a7b8c9d0e15',
+    analyticsEnabled: false,
+    pna25Acknowledged: true,
+    basicFunctionalityEnabled: false,
+    bftcGateOn: true,
+  },
+  {
+    analyticsId: '0f1a2b3c-6b7c-8d9e-2f5a-7b8c9d0e1f16',
+    analyticsEnabled: true,
+    pna25Acknowledged: true,
+    basicFunctionalityEnabled: true,
+    bftcGateOn: true,
   },
 ])(
   'profileMetricsControllerInit',
@@ -104,12 +163,13 @@ describe.each([
     analyticsEnabled,
     pna25Acknowledged,
     basicFunctionalityEnabled,
+    bftcGateOn,
   }) => {
     beforeEach(() => {
       jest.clearAllMocks();
     });
 
-    describe(`when analyticsId is ${analyticsId}, analytics is ${analyticsEnabled ? 'enabled' : 'disabled'} and pna25Acknowledged is ${pna25Acknowledged}`, () => {
+    describe(`when analyticsId is ${analyticsId}, analytics is ${analyticsEnabled ? 'enabled' : 'disabled'}, pna25Acknowledged is ${pna25Acknowledged} and consolidation gate is ${bftcGateOn}`, () => {
       it('initializes the controller', () => {
         const { controller } = profileMetricsControllerInit(
           getInitRequestMock({
@@ -117,6 +177,7 @@ describe.each([
             analyticsEnabled,
             pna25Acknowledged,
             basicFunctionalityEnabled,
+            bftcGateOn,
           }),
         );
 
@@ -130,6 +191,7 @@ describe.each([
             analyticsEnabled,
             pna25Acknowledged,
             basicFunctionalityEnabled,
+            bftcGateOn,
           }),
         );
 
@@ -143,7 +205,9 @@ describe.each([
           initialDelayDuration: 60_000,
         });
         expect(controllerMock.mock.calls[0][0].assertUserOptedIn()).toBe(
-          analyticsEnabled && pna25Acknowledged && basicFunctionalityEnabled,
+          pna25Acknowledged &&
+            basicFunctionalityEnabled &&
+            (bftcGateOn || analyticsEnabled),
         );
         expect(controllerMock.mock.calls[0][0].getMetaMetricsId()).toBe(
           analyticsId,
@@ -152,3 +216,32 @@ describe.each([
     });
   },
 );
+
+describe('profileMetricsControllerInit assertUserOptedIn evaluation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('re-evaluates the consolidation gate on each assertUserOptedIn call', () => {
+    mockedSelectIsBasicFunctionalityConsolidationEnabled.mockReturnValue(false);
+
+    profileMetricsControllerInit(
+      getInitRequestMock({
+        analyticsId: '1a2b3c4d-7c8d-9e0f-3a6b-8c9d0e1f2a17',
+        analyticsEnabled: false,
+        pna25Acknowledged: true,
+        basicFunctionalityEnabled: true,
+        bftcGateOn: false,
+      }),
+    );
+
+    const assertUserOptedIn = jest.mocked(ProfileMetricsController).mock
+      .calls[0][0].assertUserOptedIn;
+
+    expect(assertUserOptedIn()).toBe(false);
+
+    mockedSelectIsBasicFunctionalityConsolidationEnabled.mockReturnValue(true);
+
+    expect(assertUserOptedIn()).toBe(true);
+  });
+});

--- a/app/core/Engine/controllers/profile-metrics-controller-init.ts
+++ b/app/core/Engine/controllers/profile-metrics-controller-init.ts
@@ -4,6 +4,7 @@ import {
 } from '@metamask/profile-metrics-controller';
 import { analyticsControllerSelectors } from '@metamask/analytics-controller';
 import { selectBasicFunctionalityEnabled } from '../../../selectors/settings';
+import { selectIsBasicFunctionalityConsolidationEnabled } from '../../../selectors/featureFlagController/basicFunctionalityConsolidation';
 import { MessengerClientInitFunction } from '../types';
 import { ProfileMetricsControllerInitMessenger } from '../messengers/profile-metrics-controller-messenger';
 
@@ -31,12 +32,13 @@ export const profileMetricsControllerInit: MessengerClientInitFunction<
   const assertUserOptedIn = () => {
     const analyticsState = initMessenger.call('AnalyticsController:getState');
     const state = getState();
-    const isEnabled =
+    const isAnalyticsEnabled =
       analyticsControllerSelectors.selectEnabled(analyticsState);
+    const isBftcGateOn = selectIsBasicFunctionalityConsolidationEnabled(state);
     return (
-      isEnabled === true &&
       state.legalNotices.isPna25Acknowledged === true &&
-      selectBasicFunctionalityEnabled(state) === true
+      selectBasicFunctionalityEnabled(state) === true &&
+      (isBftcGateOn || isAnalyticsEnabled === true)
     );
   };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Related to: https://consensyssoftware.atlassian.net/browse/MUL-2235

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

1. Hardcode `export const selectMobileUxBftcConsolidationFlagEnabled = () => true;` in `metamask-mobile/app/selectors/featureFlagController/basicFunctionalityConsolidation/basicFunctionality.ts`
2. Onboard or reload the extension and change the "Participate in MetaMetrics" toggle so it is set to OFF
3. Make sure the Basic functionality toggle is set to ON
4. Add a new account to your wallet and verify in proxyman / dev tools that you see calls to the auth API that submits metrics about this newly created account

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes privacy/consent gating for profile metrics when a feature flag is enabled; PNA25 and basic functionality checks remain, but analytics opt-in can be bypassed under consolidation.
> 
> **Overview**
> When the **Basic Functionality consolidation** feature flag is on, profile metrics no longer require MetaMetrics/analytics to be enabled. `assertUserOptedIn` in `profileMetricsControllerInit` now returns true only when PNA25 is acknowledged and basic functionality is enabled, and either the consolidation flag is on **or** analytics is enabled (previously all three including analytics had to be true).
> 
> Tests mock `selectIsBasicFunctionalityConsolidationEnabled`, extend the parameterized cases for gate on/off, update the expected opt-in formula, and add coverage that the gate is read on every `assertUserOptedIn` invocation (not cached at init).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a982ee526337d5004a205d6997adaec7eca34212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->