### PR TITLE
fix: Add build attribution option to separate mix panel events

### DIFF
--- a/.github/workflows/build-and-upload-to-testflight.yml
+++ b/.github/workflows/build-and-upload-to-testflight.yml
@@ -23,6 +23,13 @@ on:
         required: false
         type: boolean
         default: true
+      build_attribution:
+        description: >-
+          Optional analytics build attribution forwarded to build.yml as METAMASK_BUILD_ATTRIBUTION.
+          Set to 'nightly' by nightly-build.yml; leave empty for the default suffixes.
+        required: false
+        type: string
+        default: ''
       runner_provider:
         description: >-
           Runner provider forwarded from the caller. Leave empty to defer to the repo
@@ -61,6 +68,11 @@ on:
         required: false
         type: boolean
         default: true
+      build_attribution:
+        description: "Analytics build attribution (METAMASK_BUILD_ATTRIBUTION). Use 'nightly' to report -rc-nightly / -exp-nightly; leave empty for the default suffixes"
+        required: false
+        type: string
+        default: ''
       runner_provider:
         description: 'Runner provider: inherit uses the repo NAMESPACE_RUNNER_* variables'
         required: false
@@ -91,6 +103,7 @@ jobs:
       platform: ios
       source_branch: ${{ inputs.source_branch }}
       build_number: ${{ needs.generate-build-version.outputs.build-version }}
+      build_attribution: ${{ inputs.build_attribution }}
       runner_provider: ${{ inputs.runner_provider }}
     secrets: inherit
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,16 @@ on:
         required: false
         type: boolean
         default: false
+      build_attribution:
+        description: >-
+          Optional analytics build attribution, exported as METAMASK_BUILD_ATTRIBUTION and
+          inlined into the JS bundle. Set to 'nightly' by nightly-build.yml so
+          getAnalyticsAppVersion reports `-rc-nightly` / `-exp-nightly` instead of the
+          `-release-candidate` / `-experimental` suffixes that Runway builds use. Any other
+          value keeps the default suffixes. Distinct from builds.yml build names (main-rc, etc.).
+        required: false
+        type: string
+        default: ''
       runner_provider:
         description: >-
           Runner provider forwarded from the caller. Leave empty to defer to the repo
@@ -98,6 +108,11 @@ on:
         required: false
         type: boolean
         default: false
+      build_attribution:
+        description: "Analytics build attribution (METAMASK_BUILD_ATTRIBUTION). Use 'nightly' to report -rc-nightly / -exp-nightly; leave empty for the default suffixes"
+        required: false
+        type: string
+        default: ''
       runner_provider:
         description: 'Runner provider: inherit uses the repo NAMESPACE_RUNNER_* variables'
         required: false
@@ -559,6 +574,9 @@ jobs:
           # builds.yml entry (e.g. main-e2e-bs-with-srp), not generic main-e2e (sim-only).
           BUILD_CONFIG_NAME: ${{ inputs.build_name }}
           GIT_BRANCH: ${{ inputs.source_branch }}
+          # Deliberately absent from builds.yml: build.sh's loadBuildConfig re-evals the
+          # builds.yml exports, so a name defined there would overwrite this value.
+          METAMASK_BUILD_ATTRIBUTION: ${{ inputs.build_attribution }}
           # React Native 0.81's ReactAndroid/build.gradle.kts requests CMake 3.30.5
           # via `System.getenv("CMAKE_VERSION") ?: "3.30.5"`. The self-hosted runner
           # only ships CMake 3.22.1 in /opt/android-sdk/cmake/ and AGP cannot auto-

--- a/.github/workflows/eas-update-platform.yml
+++ b/.github/workflows/eas-update-platform.yml
@@ -27,6 +27,14 @@ on:
         description: 'Build name from builds.yml (e.g. main-exp)'
         type: string
         required: true
+      build_attribution:
+        description: >-
+          Optional analytics build attribution, exported as METAMASK_BUILD_ATTRIBUTION and inlined
+          into the rebuilt JS bundle. Set to 'nightly' for OTA pushes to nightly builds so the
+          update keeps reporting `-rc-nightly` / `-exp-nightly` instead of the Runway suffixes.
+        type: string
+        required: false
+        default: ''
       github_environment:
         description: 'GitHub environment name for secrets/approvals'
         type: string
@@ -67,6 +75,10 @@ jobs:
       TARGET_CHANNEL: ${{ inputs.channel }}
       OTA_PUSH_PLATFORM: ${{ inputs.platform }}
       GIT_BRANCH: ${{ github.ref_name }}
+      # Job-level so both bundling steps (the isolated expo export diagnostic and the
+      # build.sh push) inline the same value. Deliberately absent from builds.yml, so the
+      # "Apply build config" step cannot overwrite it via GITHUB_ENV.
+      METAMASK_BUILD_ATTRIBUTION: ${{ inputs.build_attribution }}
     steps:
       - name: Checkout repository (Namespace)
         uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
@@ -195,6 +207,7 @@ jobs:
           echo "🔬 Running expo export in isolation (platform: ${{ inputs.platform }}) ..."
           echo "   METAMASK_ENVIRONMENT=${METAMASK_ENVIRONMENT:-<not set>}"
           echo "   METAMASK_BUILD_TYPE=${METAMASK_BUILD_TYPE:-<not set>}"
+          echo "   METAMASK_BUILD_ATTRIBUTION=${METAMASK_BUILD_ATTRIBUTION:-<not set>}"
           echo "   EXPO_PROJECT_ID is set: $([[ -n "${EXPO_PROJECT_ID}" ]] && echo yes || echo NO)"
           echo "   EXPO_TOKEN is set:      $([[ -n "${EXPO_TOKEN}" ]] && echo yes || echo NO)"
           yarn expo export \

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -35,6 +35,7 @@ jobs:
       environment: exp
       testflight_group: 'MetaMask BETA & Release Candidates'
       distribute_external: true
+      build_attribution: nightly
       runner_provider: ${{ inputs.runner_provider }}
     secrets: inherit
 
@@ -47,6 +48,7 @@ jobs:
       environment: rc
       testflight_group: 'MetaMask BETA & Release Candidates'
       distribute_external: true
+      build_attribution: nightly
       runner_provider: ${{ inputs.runner_provider }}
     secrets: inherit
 
@@ -62,6 +64,7 @@ jobs:
       platform: android
       source_branch: main
       build_number: ${{ needs.android-exp-generate.outputs.build-version }}
+      build_attribution: nightly
       runner_provider: ${{ inputs.runner_provider }}
     secrets: inherit
 
@@ -78,6 +81,7 @@ jobs:
       platform: android
       source_branch: main
       build_number: ${{ needs.android-rc-generate.outputs.build-version }}
+      build_attribution: nightly
       runner_provider: ${{ inputs.runner_provider }}
     secrets: inherit
 

--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -33,6 +33,11 @@ on:
           - ios
           - android
         default: all
+      build_attribution:
+        description: "Analytics build attribution (METAMASK_BUILD_ATTRIBUTION). Set to 'nightly' for OTA pushes to nightly builds, or analytics will report the update as a Runway RC"
+        required: false
+        type: string
+        default: ''
 
   workflow_call:
     inputs:
@@ -58,6 +63,14 @@ on:
         type: string
         required: false
         default: all
+      build_attribution:
+        description: >-
+          Optional analytics build attribution forwarded to eas-update-platform.yml as
+          METAMASK_BUILD_ATTRIBUTION. Set to 'nightly' for OTA pushes to nightly builds so the
+          rebuilt bundle keeps reporting `-rc-nightly` / `-exp-nightly`.
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -438,6 +451,7 @@ jobs:
       channel: ${{ inputs.channel }}
       message: ${{ inputs.message }}
       build_name: ${{ needs.prepare.outputs.build_name }}
+      build_attribution: ${{ inputs.build_attribution }}
       github_environment: ${{ needs.prepare.outputs.github_environment }}
       secrets_json: ${{ needs.prepare.outputs.secrets_json }}
     secrets: inherit
@@ -469,6 +483,7 @@ jobs:
       channel: ${{ inputs.channel }}
       message: ${{ inputs.message }}
       build_name: ${{ needs.prepare.outputs.build_name }}
+      build_attribution: ${{ inputs.build_attribution }}
       github_environment: ${{ needs.prepare.outputs.github_environment }}
       secrets_json: ${{ needs.prepare.outputs.secrets_json }}
     secrets: inherit

--- a/app/util/metrics/getAnalyticsAppVersion.test.ts
+++ b/app/util/metrics/getAnalyticsAppVersion.test.ts
@@ -53,6 +53,57 @@ describe('formatAnalyticsAppVersion', () => {
     expect(formatAnalyticsAppVersion(baseVersion, 'test')).toBe('8.6.0-test');
     expect(formatAnalyticsAppVersion(baseVersion, 'e2e')).toBe('8.6.0-e2e');
   });
+
+  it('keeps the raw environment code and appends nightly for rc', () => {
+    const result = formatAnalyticsAppVersion(baseVersion, 'rc', 'nightly');
+
+    expect(result).toBe('8.6.0-rc-nightly');
+  });
+
+  it('keeps the raw environment code and appends nightly for exp', () => {
+    const result = formatAnalyticsAppVersion(baseVersion, 'exp', 'nightly');
+
+    expect(result).toBe('8.6.0-exp-nightly');
+  });
+
+  it('appends only nightly for production', () => {
+    const result = formatAnalyticsAppVersion(
+      baseVersion,
+      'production',
+      'nightly',
+    );
+
+    expect(result).toBe('8.6.0-nightly');
+  });
+
+  // Runway and every other caller omit build attribution, so the CI env var is
+  // either an empty string or absent. Both must keep the friendly suffixes.
+  it('keeps friendly suffixes when build attribution is omitted or empty', () => {
+    expect(formatAnalyticsAppVersion(baseVersion, 'rc')).toBe(
+      '8.6.0-release-candidate',
+    );
+    expect(formatAnalyticsAppVersion(baseVersion, 'rc', '')).toBe(
+      '8.6.0-release-candidate',
+    );
+    expect(formatAnalyticsAppVersion(baseVersion, 'exp')).toBe(
+      '8.6.0-experimental',
+    );
+    expect(formatAnalyticsAppVersion(baseVersion, 'exp', '')).toBe(
+      '8.6.0-experimental',
+    );
+    expect(formatAnalyticsAppVersion(baseVersion, 'dev', '')).toBe(
+      '8.6.0-development',
+    );
+    expect(formatAnalyticsAppVersion(baseVersion, 'beta', '')).toBe(
+      '8.6.0-beta',
+    );
+  });
+
+  it('keeps friendly suffixes for unrecognized build attribution', () => {
+    const result = formatAnalyticsAppVersion(baseVersion, 'rc', 'runway');
+
+    expect(result).toBe('8.6.0-release-candidate');
+  });
 });
 
 describe('getAnalyticsAppVersion', () => {
@@ -60,16 +111,20 @@ describe('getAnalyticsAppVersion', () => {
     jest.clearAllMocks();
   });
 
-  // METAMASK_ENVIRONMENT is inlined by babel at transform time, so runtime
-  // mutation is ignored here. Env→suffix mapping is covered by
-  // formatAnalyticsAppVersion tests above.
-  it('formats native getVersion with the build METAMASK_ENVIRONMENT', () => {
+  // METAMASK_ENVIRONMENT and METAMASK_BUILD_ATTRIBUTION are inlined by babel at
+  // transform time, so runtime mutation is ignored here. Env→suffix mapping and
+  // nightly handling are covered by formatAnalyticsAppVersion tests above.
+  it('formats native getVersion with METAMASK_ENVIRONMENT and METAMASK_BUILD_ATTRIBUTION', () => {
     mockGetVersion.mockReturnValue('8.6.0');
 
     const result = getAnalyticsAppVersion();
 
     expect(result).toBe(
-      formatAnalyticsAppVersion('8.6.0', process.env.METAMASK_ENVIRONMENT),
+      formatAnalyticsAppVersion(
+        '8.6.0',
+        process.env.METAMASK_ENVIRONMENT,
+        process.env.METAMASK_BUILD_ATTRIBUTION,
+      ),
     );
     expect(mockGetVersion).toHaveBeenCalledTimes(1);
   });

--- a/app/util/metrics/getAnalyticsAppVersion.ts
+++ b/app/util/metrics/getAnalyticsAppVersion.ts
@@ -6,21 +6,33 @@ const ENVIRONMENT_SUFFIXES: Record<string, string> = {
   dev: 'development',
 };
 
+const NIGHTLY_ATTRIBUTION = 'nightly';
+
 /**
- * Formats the analytics App Version string from a native version and
- * METAMASK_ENVIRONMENT value.
+ * Formats the analytics App Version string from a native version, a
+ * METAMASK_ENVIRONMENT value and a METAMASK_BUILD_ATTRIBUTION value.
  *
  * Production (or unset/empty) stays unsuffixed. Known non-prod envs use
  * friendly suffixes; any other non-prod env uses `-{environment}`.
+ *
+ * Nightly builds keep the raw environment code instead of the friendly suffix
+ * (`-rc-nightly`, `-exp-nightly`) so they can be told apart from the Runway
+ * release candidates that share the same METAMASK_ENVIRONMENT.
  */
 export const formatAnalyticsAppVersion = (
   baseVersion: string,
   environment: string | undefined,
+  buildAttribution?: string,
 ): string => {
   const env = environment?.trim();
+  const isNightly = buildAttribution?.trim() === NIGHTLY_ATTRIBUTION;
 
   if (!env || env === 'production') {
-    return baseVersion;
+    return isNightly ? `${baseVersion}-${NIGHTLY_ATTRIBUTION}` : baseVersion;
+  }
+
+  if (isNightly) {
+    return `${baseVersion}-${env}-${NIGHTLY_ATTRIBUTION}`;
   }
 
   const suffix = ENVIRONMENT_SUFFIXES[env] ?? env;
@@ -33,6 +45,10 @@ export const formatAnalyticsAppVersion = (
  * Does not change native CFBundleShortVersionString / Android versionName.
  */
 const getAnalyticsAppVersion = (): string =>
-  formatAnalyticsAppVersion(getVersion(), process.env.METAMASK_ENVIRONMENT);
+  formatAnalyticsAppVersion(
+    getVersion(),
+    process.env.METAMASK_ENVIRONMENT,
+    process.env.METAMASK_BUILD_ATTRIBUTION,
+  );
 
 export default getAnalyticsAppVersion;

--- a/docs/nightly-ota-updates.md
+++ b/docs/nightly-ota-updates.md
@@ -90,6 +90,10 @@ Once the PR is ready:
    - **`pr_number`**: The PR number for `chore/temp-ota-updates-nightly` → `chore/temp-nightly`.
    - **`base_branch`**: `chore/temp-nightly`
      (this is the baseline used for Expo fingerprint comparison).
+   - **`build_attribution`**: `nightly` — **required for nightly pushes**. An OTA update rebuilds the
+     JS bundle, so this value is re-inlined as `METAMASK_BUILD_ATTRIBUTION`. Leaving it empty makes
+     the update report its analytics App Version as `X.Y.Z-release-candidate` instead of
+     `X.Y.Z-rc-nightly`, mixing nightly data in with the Runway release candidates.
 
 6. Click **“Run workflow”**.
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Nightly and Runway release-candidate / experimental binaries both used `METAMASK_ENVIRONMENT` of `rc` or `exp`, so analytics App Version was `X.Y.Z-release-candidate` or `X.Y.Z-experimental` for both. That made it impossible to filter Mixpanel / Segment events to Runway-only builds.

This PR adds an optional `build_attribution` workflow input (exported as `METAMASK_BUILD_ATTRIBUTION`, kept out of `builds.yml` so `build.sh` cannot overwrite it). Nightly native and OTA jobs pass `nightly`, so `formatAnalyticsAppVersion` reports `X.Y.Z-rc-nightly` / `X.Y.Z-exp-nightly`. Every other caller omits the input and keeps the existing friendly suffixes. Native version strings, signing, and build names are unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MCRM-142

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Analytics App Version build attribution

  Scenario: nightly native build reports a nightly suffix
    Given nightly-build.yml is dispatched (or the scheduled run completes)
    And the iOS and Android jobs pass build_attribution: nightly

    When the built app reports analytics App Version
    Then rc builds use X.Y.Z-rc-nightly
    And exp builds use X.Y.Z-exp-nightly
    And the Build step env includes METAMASK_BUILD_ATTRIBUTION=nightly

  Scenario: Runway RC keeps the friendly suffix
    Given runway-rc-builds.yml is dispatched without build_attribution

    When the built app reports analytics App Version
    Then the version is X.Y.Z-release-candidate

  Scenario: nightly OTA keeps the nightly suffix
    Given push-eas-update.yml is dispatched with build_attribution set to nightly

    When the EAS update is published
    Then the Diagnose expo export log shows METAMASK_BUILD_ATTRIBUTION=nightly
    And devices on the nightly channel report X.Y.Z-rc-nightly (or -exp-nightly) after the update
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — CI and analytics version-string change only; no UI.

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics version-string and CI wiring only; no auth, signing, or native version changes, with backward-compatible defaults when attribution is omitted.
> 
> **Overview**
> Adds an optional **`build_attribution`** input to native build, TestFlight, nightly, and EAS OTA workflows. It is passed through as **`METAMASK_BUILD_ATTRIBUTION`** at build/bundle time (kept out of `builds.yml` so apply-build-config cannot overwrite it).
> 
> **`formatAnalyticsAppVersion`** now accepts build attribution: when set to **`nightly`**, Segment/Mixpanel App Version uses raw env codes (`X.Y.Z-rc-nightly`, `X.Y.Z-exp-nightly`) instead of the Runway-style `-release-candidate` / `-experimental` suffixes. Empty or omitted attribution leaves existing behavior unchanged. Native store version strings are unaffected.
> 
> **`nightly-build.yml`** sets `build_attribution: nightly` for iOS and Android jobs. OTA docs and **`push-eas-update`** / **`eas-update-platform`** require operators to pass `nightly` when pushing to nightly channels so rebuilt bundles keep the same analytics labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70e59639512abfd205d7356d77f02a8252afc995. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
