### PR TITLE
ci(e2e): drop per-shard GitHub ffmpeg cache

### DIFF
--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -223,6 +223,10 @@ jobs:
 
       # No `cache: cocoapods`: this job passes skip-pod-install=true, so it
       # never runs pod install.
+      #
+      # ~/.cache/mms-ffmpeg is a pinned static binary — last-write-wins on the
+      # volume is safe (unlike ~/.android/avd). Do not also use actions/cache
+      # for this path; that was a per-shard restore/save on every iOS job.
       - name: Configure Namespace cache (iOS)
         if: ${{ inputs.runner_provider == 'namespace' && inputs.platform == 'ios' && steps.select-specs.outputs.spec_count != '0' }}
         uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
@@ -294,14 +298,9 @@ jobs:
           install-applesimutils: 'false'
           runner_provider: ${{ inputs.runner_provider }}
 
-      - name: Cache static ffmpeg
-        if: ${{ inputs.platform == 'ios' && steps.select-specs.outputs.spec_count != '0' }}
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/mms-ffmpeg
-          key: static-ffmpeg-b6.1.1-${{ runner.os }}-${{ runner.arch }}
-
-      - name: Install ffmpeg for XCUITest screen recording
+      # No-op when ~/.cache/mms-ffmpeg is already on the Namespace volume or
+      # ffmpeg is on PATH. Downloads only on a cold volume.
+      - name: Ensure ffmpeg for XCUITest screen recording
         if: ${{ inputs.platform == 'ios' && steps.select-specs.outputs.spec_count != '0' }}
         timeout-minutes: 2
         continue-on-error: true

--- a/.github/workflows/run-e2e-api-specs.yml
+++ b/.github/workflows/run-e2e-api-specs.yml
@@ -72,6 +72,16 @@ jobs:
           ref: ${{ github.head_ref || github.ref }}
           clean: true
 
+      - name: Configure Namespace cache (iOS)
+        if: ${{ (inputs.runner_provider || 'current') == 'namespace' }}
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+        with:
+          path: |
+            ~/.cache/yarn
+            ~/.cache/mms-ffmpeg
+            .metamask
+            .yarn/cache
+
       - name: Setup E2E environment (iOS)
         uses: ./.github/actions/setup-e2e-env
         with:
@@ -83,13 +93,7 @@ jobs:
           install-applesimutils: 'false'
           runner_provider: ${{ inputs.runner_provider || 'current' }}
 
-      - name: Cache static ffmpeg
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/mms-ffmpeg
-          key: static-ffmpeg-b6.1.1-${{ runner.os }}-${{ runner.arch }}
-
-      - name: Install ffmpeg for XCUITest screen recording
+      - name: Ensure ffmpeg for XCUITest screen recording
         timeout-minutes: 2
         continue-on-error: true
         run: bash .github/scripts/qa-automation/appium-runner-prep/ensure-ffmpeg-ci.sh


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

iOS Appium shards were paying a GitHub `actions/cache` restore (and save on miss) for the pinned static ffmpeg binary on every job, on top of the Namespace volume that already persists `~/.cache/mms-ffmpeg`.

This removes the redundant GitHub cache step. ffmpeg is still required for XCUITest failure videos: `ensure-ffmpeg-ci.sh` puts the volume binary on `PATH` (no-op when warm) and downloads only on a cold volume. The API specs workflow now mounts the same Namespace cache paths so it can share that binary when enabled.

Expected save is on the order of tens of seconds per iOS shard (GitHub cache round-trip), not sim-boot or test time.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — CI workflow only. Confirm an iOS Appium shard logs ffmpeg restored from cache or already on PATH, still uploads failure videos when tests fail, and does not run `Cache static ffmpeg`.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)