### PR TITLE
fix(explore): keep token search results in API ranking order

### DIFF
--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.test.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.test.ts
@@ -242,6 +242,82 @@ describe('useTrendingSearch', () => {
     );
   });
 
+  it('keeps search API order ahead of trending matches for the query', async () => {
+    // Trending ETH (0x123) also matches 'ETH'; the API ranked a different token
+    // first, and that ranking must be preserved.
+    const apiRankedFirst = {
+      assetId: 'eip155:8453/erc20:0xabc' as CaipChainId,
+      symbol: 'ETH2',
+      name: 'Ether Two',
+      decimals: 18,
+      price: '1',
+      aggregatedUsdVolume: 1,
+      marketCap: 0,
+      pricePercentChange1d: '0',
+    };
+    mockUseSearchRequest.mockReturnValue({
+      results: [apiRankedFirst],
+      isLoading: false,
+      error: null,
+      search: jest.fn(),
+      loadMore: jest.fn(),
+      isLoadingMore: false,
+      hasNextPage: false,
+      totalCount: undefined,
+    });
+
+    const { result } = renderHookWithProvider(() =>
+      useTrendingSearch({ searchQuery: 'ETH', sortBy: 'h24_trending' }),
+    );
+
+    jest.advanceTimersByTime(200);
+
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(2);
+    });
+
+    expect(result.current.data.map((item) => item.assetId)).toEqual([
+      'eip155:8453/erc20:0xabc',
+      'eip155:1/erc20:0x123',
+    ]);
+  });
+
+  it('keeps the trending object for a token in both sets but at the API position', async () => {
+    const duplicateOfTrendingEth = {
+      assetId: mockTrendingResults[0].assetId as CaipChainId,
+      symbol: 'ETH',
+      name: 'Ethereum',
+      decimals: 18,
+      price: '2000',
+      aggregatedUsdVolume: 1000000,
+      marketCap: 500000000,
+      pricePercentChange1d: '3',
+    };
+    mockUseSearchRequest.mockReturnValue({
+      results: [mockSearchResults[0], duplicateOfTrendingEth],
+      isLoading: false,
+      error: null,
+      search: jest.fn(),
+      loadMore: jest.fn(),
+      isLoadingMore: false,
+      hasNextPage: false,
+      totalCount: undefined,
+    });
+
+    const { result } = renderHookWithProvider(() =>
+      useTrendingSearch({ searchQuery: 'ETH', sortBy: 'h24_trending' }),
+    );
+
+    jest.advanceTimersByTime(200);
+
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(2);
+    });
+
+    expect(result.current.data[0].assetId).toBe('eip155:1/erc20:0x789');
+    expect(result.current.data[1]).toBe(mockTrendingResults[0]);
+  });
+
   it('returns trending loading state when no search query', () => {
     mockUseTrendingRequest.mockReturnValue({
       results: [],

--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
@@ -109,21 +109,25 @@ export const useTrendingSearch = (opts?: {
     }
 
     const query = debouncedQuery.toLowerCase().trim();
-    const filteredTrendingResults = trendingResults.filter(
+    const trendingMatches = trendingResults.filter(
       (item) =>
         item.symbol?.toLowerCase().includes(query) ||
         item.name?.toLowerCase().includes(query),
     );
-
-    const resultMap = new Map(
-      filteredTrendingResults.map((result) => [result.assetId, result]),
+    const trendingByAssetId = new Map(
+      trendingMatches.map((result) => [result.assetId, result]),
     );
+
+    // The search API ranks results (relevance, verification, pinned assets).
+    // Keep that order; trending matches the API did not return are appended.
+    const resultMap = new Map<string, TrendingAsset>();
 
     searchResults
       .filter((item) => includeStocks || !item.rwaData)
       .forEach((asset) => {
-        if (!resultMap.has(asset.assetId)) {
-          resultMap.set(asset.assetId, {
+        resultMap.set(
+          asset.assetId,
+          trendingByAssetId.get(asset.assetId) ?? {
             assetId: asset.assetId,
             symbol: asset.symbol,
             name: asset.name,
@@ -138,9 +142,15 @@ export const useTrendingSearch = (opts?: {
               | TrendingAsset['rwaData']
               | undefined,
             securityData: asset.securityData,
-          });
-        }
+          },
+        );
       });
+
+    trendingMatches.forEach((item) => {
+      if (!resultMap.has(item.assetId)) {
+        resultMap.set(item.assetId, item);
+      }
+    });
 
     return Array.from(resultMap.values());
   }, [

--- a/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.test.ts
+++ b/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.test.ts
@@ -60,23 +60,17 @@ describe('useTokensFeed', () => {
     expect(result.current.refetch).toBe(mockRefetch);
   });
 
-  it('when query is active, returns all data sorted by market cap (skips Fuse re-filter)', () => {
+  it('when query is active, preserves the order returned by the search API', () => {
     const { result } = renderHook(() => useTokensFeed({ query: 'wrap' }));
 
-    // useTrendingSearch already searched the API; all items in `data` are
-    // considered relevant. We only sort by marketCap, not fuzzy-filter.
+    // The API ranks results (relevance, verification); the client must not
+    // re-sort them, e.g. by market cap, or lower-quality tokens can outrank
+    // the intended match.
     expect(result.current.data.map((t) => t.symbol)).toEqual([
+      'AAA',
       'WBTC',
       'WETH',
-      'AAA',
     ]);
-  });
-
-  it('when query is absent, fuzzy-filters by Fuse and returns only matching items', () => {
-    const { result } = renderHook(() => useTokensFeed({ query: undefined }));
-
-    // Without a query, fuseSearch is a no-op (returns data unchanged).
-    expect(result.current.data).toEqual(sampleTokens);
   });
 
   it('refetches when refresh trigger increments past initial mount', async () => {

--- a/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.ts
+++ b/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.ts
@@ -1,9 +1,8 @@
-import { useMemo, useRef, useEffect } from 'react';
+import { useMemo } from 'react';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import { useTrendingSearch } from '../../../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch';
 import { useFeedRefresh } from '../../hooks/useFeedRefresh';
 import type { RefreshConfig } from '../../hooks/useExploreRefresh';
-import { fuseSearch, TOKEN_FUSE_OPTIONS } from '../search-utils';
 import {
   mapTimeOptionToSortBy,
   PriceChangeOption,
@@ -12,7 +11,7 @@ import {
 } from '../../../../UI/Trending/components/TrendingTokensBottomSheet';
 
 interface UseTokensFeedOptions {
-  /** Search query; when present, results are sorted by market cap descending. */
+  /** Search query; when present, results keep the order returned by the search API. */
   query?: string;
   refresh?: RefreshConfig;
   /**
@@ -67,60 +66,16 @@ export const useTokensFeed = ({
 
   useFeedRefresh(refresh, refetch);
 
-  /**
-   * firstPageSizeRef records how many items were in the first page response so
-   * that subsequent pages can be appended without resorting. A single effect
-   * handles both concerns: reset on query change (and bail out immediately so
-   * a stale data.length is never captured on the same render), then capture the
-   * boundary once the initial load settles.
-   */
-  const firstPageSizeRef = useRef<number | null>(null);
-  const prevQueryRef = useRef(query);
-
-  useEffect(() => {
-    if (prevQueryRef.current !== query) {
-      firstPageSizeRef.current = null;
-      prevQueryRef.current = query;
-      return;
-    }
-    if (!isLoading && !isLoadingMore && firstPageSizeRef.current === null) {
-      firstPageSizeRef.current = data.length;
-    }
-  }, [query, isLoading, isLoadingMore, data.length]);
-
   const filteredData = useMemo(() => {
-    let searched: TrendingAsset[];
+    if (!hideRiskyTokens) return data;
 
-    if (query?.trim()) {
-      // Sort only the first-page slice; subsequent pages are appended as-is so
-      // that pagination order is preserved rather than interleaved by market cap.
-      const boundary = firstPageSizeRef.current ?? data.length;
-      const firstPage = data
-        .slice(0, boundary)
-        .sort((a, b) => (b.marketCap ?? 0) - (a.marketCap ?? 0));
-      const rest = data.slice(boundary);
-      searched = [...firstPage, ...rest];
-    } else {
-      searched = fuseSearch(
-        data,
-        query,
-        TOKEN_FUSE_OPTIONS,
-        (a, b) => (b.marketCap ?? 0) - (a.marketCap ?? 0),
-      );
-    }
-
-    if (!hideRiskyTokens) return searched;
-
-    return searched.filter(({ securityData }) => {
+    return data.filter(({ securityData }) => {
       const { resultType } = securityData ?? {};
       return (
         !resultType || resultType === 'Verified' || resultType === 'Benign'
       );
     });
-    // firstPageSizeRef is a ref — intentionally excluded from deps so that
-    // boundary captures the snapshot set by the effect, not a stale closure.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, query, hideRiskyTokens]);
+  }, [data, hideRiskyTokens]);
 
   return {
     data: filteredData,


### PR DESCRIPTION
## **Description**

The token search API ranks results by relevance, verification and pinned assets. The mobile client then re-ordered those results in two places, so a spam or lookalike token could show above the token the API ranked first. This PR removes both client-side reorders so the app displays the API's ranking as-is.

**What**
- **Removed the client-side market cap sort** on search results in `useTokensFeed`. It also removes the first-page boundary ref that only existed to protect that sort.
- **Merged trending name-matches after API results** instead of before in `useTrendingSearch`. Dedupe is unchanged; a token present in both sets keeps the trending object but takes the API's position.

**Why**
- The API returns a pinned token at #0 with the app's exact request parameters, but it has market cap 0, so the client sort dropped it below a lookalike with a higher cap.
- A Spam-flagged token with the same name is in the current trending set. The client merge prepended it ahead of the API's #0. `filterLowQualityTokens` keeps Spam/Warning tokens by design, so it did not remove it.
- Market cap is not an input to the API ranking, so the client sort was not mirroring anything server-side.

**Surfaces affected:** Explore search, Watchlist search, Trending "View all" search, and Add Asset search all go through these hooks and now honor API order. The Explore Crypto tab and "View all" trending list are unchanged (still sorted by 24h price change).

<details>
<summary>More info: how the API ranks, and the simulation that found both reorders</summary>

**API ranking** (`TokensServiceV2.searchTokens` in `va-mmcx-token-api`): `match-sorter` substring match on symbol/name, then a full re-sort by `occurrences + bonus` where `occurrences` is the number of aggregators listing the token, and bonus is pinned +1000, Ondo +7, MetaMask aggregator +5, Verified +5. Market cap is never used. `defaultAssetIds` is a separate hard prepend. `/tokens/search` has no sort parameter; `sort`, `sortBy`, `orderBy` are silently ignored.

**Simulation** using the app's exact search + trending requests for the query `laptop`, run through the client merge/sort logic:

| Build | Row 0 | Row 1 | Pinned token at |
| --- | --- | --- | --- |
| `main` (market cap sort + trending-first merge) | Solana lookalike (206k cap) | Spam "Laptop" (Base) | #2 |
| Market cap sort removed only | **Spam "Laptop" (Base)** | Pinned token | #1 |
| This PR (both removed) | **Pinned token** | Solana "laptop" | **#0** |

The middle row matched the in-app screenshot exactly, which is how the trending merge was confirmed as the second cause.

The analytics `sortOption: 'relevance'` already sent from the search screen is now accurate. `TOKEN_FUSE_OPTIONS` in `feeds/search-utils.ts` has no remaining consumers but is left in place.
</details>

## **Changelog**

CHANGELOG entry: Fixed token search results showing a higher market cap or trending lookalike above the best match

## **Related issues**

Refs: No Jira ticket yet. Raised by product for a token launch; the API-side pin landed in `va-mmcx-token-api` PR #507.

## **Manual testing steps**

```gherkin
Feature: Explore token search honors API ranking

  Scenario: user searches for a pinned token by name
    Given the app is open on Explore search
    When user types "laptop"
    Then the first Crypto result is LAPTOP on Base (0xB095...6ec29)
    And the Risky-badged "Laptop" on Base appears below it

  Scenario: user searches for a token that is also trending
    Given a trending token's name contains the search query
    When user types that query
    Then results keep the order returned by the search API
    And the trending token is appended only if the API did not return it

  Scenario: trending lists are unchanged
    Given the app is open on the Explore Crypto tab
    When the trending tokens section loads
    Then tokens are still sorted by 24h price change
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/d36e4756-f5b8-4568-8430-44ad55ac037e

### **Before**

https://github.com/user-attachments/assets/d36e4756-f5b8-4568-8430-44ad55ac037e

### **After**

https://github.com/user-attachments/assets/1b7d06f1-fa21-4322-b0bb-3e9e3182183a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
