### PR TITLE
fix: submit add-device scans via QRTabSwitcher messenger

### DIFF
--- a/app/components/Views/AddDeviceToWallet/index.test.tsx
+++ b/app/components/Views/AddDeviceToWallet/index.test.tsx
@@ -11,19 +11,6 @@ import {
 import { defaultQrSyncControllerState } from '../../../core/QrSync/QrSyncController';
 import AddDeviceToWallet from './index';
 import { AddDeviceToWalletTestIds } from './AddDeviceToWallet.testIds';
-import {
-  QrSyncOperations,
-  QrSyncSurfaces,
-  QrSyncTelemetrySources,
-  reportQrSyncFailure,
-} from '../../../core/QrSync/qrSyncTelemetry';
-
-jest.mock('../../../core/QrSync/qrSyncTelemetry', () => ({
-  ...jest.requireActual('../../../core/QrSync/qrSyncTelemetry'),
-  reportQrSyncFailure: jest.fn(),
-}));
-
-const mockReportQrSyncFailure = jest.mocked(reportQrSyncFailure);
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => ({
@@ -275,37 +262,9 @@ describe('AddDeviceToWallet', () => {
           initialScreen: 'Scanner',
           disableTabber: true,
           origin: Routes.ONBOARDING.ADD_DEVICE_TO_WALLET,
-          onScanSuccess: expect.any(Function),
         }),
       );
-    });
-
-    it('reports scan submit failures to Sentry', async () => {
-      mockHandleScannedQrPayload.mockRejectedValueOnce(
-        new Error('scan submit failed'),
-      );
-      const { getByText } = renderComponent();
-
-      fireEvent.press(
-        getByText(strings('app_settings.add_device.scan_qr_code_button')),
-      );
-
-      const onScanSuccess = mockNavigate.mock.calls[0][1].onScanSuccess as (
-        data: { content?: string },
-        content?: string,
-      ) => void;
-      onScanSuccess({ content: 'metamask://connect/mwp?p=test' });
-
-      await waitFor(() => {
-        expect(mockReportQrSyncFailure).toHaveBeenCalledWith(
-          expect.any(Error),
-          {
-            surface: QrSyncSurfaces.SCANNER,
-            operation: QrSyncOperations.SUBMIT_SCANNED_PAYLOAD,
-            source: QrSyncTelemetrySources.ADD_DEVICE_ON_SCAN_SUCCESS,
-          },
-        );
-      });
+      expect(mockNavigate.mock.calls[0][1].onScanSuccess).toBeUndefined();
     });
   });
 

--- a/app/components/Views/AddDeviceToWallet/index.tsx
+++ b/app/components/Views/AddDeviceToWallet/index.tsx
@@ -19,7 +19,6 @@ import { strings } from '../../../../locales/i18n';
 import Routes from '../../../constants/navigation/Routes';
 import {
   QRTabSwitcherScreens,
-  type ScanSuccess,
   // eslint-disable-next-line import-x/no-restricted-paths
 } from '../QRTabSwitcher';
 import DeviceAdded from './DeviceAdded';
@@ -29,12 +28,6 @@ import { showAddDeviceVerificationSheet } from '../../../core/QrSync/showAddDevi
 import { useAddDeviceResetToInstructionsListener } from '../../../core/QrSync/useAddDeviceResetToInstructionsListener';
 import { useIsQrTabSwitcherOpen } from '../../../core/QrSync/useIsQrTabSwitcherOpen';
 import { useQrSyncImportNavigation } from '../../../core/QrSync/useQrSyncImportNavigation';
-import {
-  QrSyncOperations,
-  QrSyncSurfaces,
-  QrSyncTelemetrySources,
-  reportQrSyncFailure,
-} from '../../../core/QrSync/qrSyncTelemetry';
 import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import {
   selectQrSyncIsBusy,
@@ -116,31 +109,6 @@ const AddDeviceToWallet = () => {
     enabled: !isScannerOpen,
   });
 
-  const submitQrPayload = useCallback(
-    async (qrPayload: string) => {
-      await messenger.call(
-        'QrSyncController:handleScannedQrPayload',
-        qrPayload,
-      );
-    },
-    [messenger],
-  );
-
-  const onScanSuccess = useCallback(
-    (data: ScanSuccess, content?: string) => {
-      const scannedQrPayload = content ?? data.content ?? '';
-
-      submitQrPayload(scannedQrPayload).catch((err: unknown) => {
-        reportQrSyncFailure(err, {
-          surface: QrSyncSurfaces.SCANNER,
-          operation: QrSyncOperations.SUBMIT_SCANNED_PAYLOAD,
-          source: QrSyncTelemetrySources.ADD_DEVICE_ON_SCAN_SUCCESS,
-        });
-      });
-    },
-    [submitQrPayload],
-  );
-
   const openQRScanner = useCallback(() => {
     if (isSessionActive) {
       Promise.resolve(messenger.call('QrSyncController:resetState')).catch(
@@ -148,13 +116,14 @@ const AddDeviceToWallet = () => {
       );
     }
 
+    // Do not pass a messenger-bound onScanSuccess. QRTabSwitcher submits the
+    // payload on its own live route messenger.
     navigation.navigate(Routes.QR_TAB_SWITCHER, {
       initialScreen: QRTabSwitcherScreens.Scanner,
       disableTabber: true,
       origin: Routes.ONBOARDING.ADD_DEVICE_TO_WALLET,
-      onScanSuccess,
     });
-  }, [messenger, navigation, onScanSuccess, isSessionActive]);
+  }, [messenger, navigation, isSessionActive]);
 
   if (presentation === 'device-linked' && !isScannerOpen) {
     return <DeviceAdded />;

--- a/app/components/Views/QRTabSwitcher/QRTabSwitcher.test.tsx
+++ b/app/components/Views/QRTabSwitcher/QRTabSwitcher.test.tsx
@@ -65,6 +65,7 @@ jest.mock('../../../core/Engine', () => {
 import Engine from '../../../core/Engine';
 
 const mockResetState = jest.fn();
+const mockHandleScannedQrPayload = jest.fn(() => Promise.resolve());
 const mockImportRemainingSecrets = jest.fn(() => Promise.resolve());
 const mockGetAccounts = jest.fn<Promise<string[]>, []>(() =>
   Promise.resolve([]),
@@ -82,6 +83,11 @@ jest.mock('../../../core/QrSync/showExtensionCancelledErrorSheet', () => {
     showExtensionCancelledErrorSheet: jest.fn(),
   };
 });
+
+jest.mock('../../../core/QrSync/qrSyncTelemetry', () => ({
+  ...jest.requireActual('../../../core/QrSync/qrSyncTelemetry'),
+  reportQrSyncFailure: jest.fn(),
+}));
 
 const mockShowExtensionCancelledErrorSheet = jest.mocked(
   showExtensionCancelledErrorSheet,
@@ -109,7 +115,7 @@ const wrapQrTabSwitcher = (ui: React.ReactElement = <QRTabSwitcher />) => (
     value={createMockRouteMessenger({
       'QrSyncController:resetState': mockResetState,
       'QrSyncController:importRemainingSecrets': mockImportRemainingSecrets,
-      'QrSyncController:handleScannedQrPayload': jest.fn(),
+      'QrSyncController:handleScannedQrPayload': mockHandleScannedQrPayload,
       'QrSyncController:hasPendingSecretImports': mockHasPendingSecretImports,
       'KeyringController:getAccounts': mockGetAccounts,
     })}
@@ -122,6 +128,7 @@ const renderQrTabSwitcher = () => render(wrapQrTabSwitcher());
 
 jest.mock('../QRScanner', () => jest.fn(() => null));
 
+const MockQRScanner = jest.requireMock('../QRScanner') as jest.Mock;
 jest.mock('../AddDeviceToWallet/DeviceAdded', () => {
   const ReactActual = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
@@ -264,6 +271,57 @@ describe('QRTabSwitcher', () => {
     });
 
     expect(getByTestId('device-added-loader-screen')).toBeOnTheScreen();
+  });
+
+  it('submits add-device scans via the live QRTabSwitcher route messenger', async () => {
+    const staleParentOnScanSuccess = jest.fn();
+    (useRoute as jest.Mock).mockReturnValue({
+      params: {
+        onScanError: jest.fn(),
+        // Stale parent callback must not be used for add-device submit.
+        onScanSuccess: staleParentOnScanSuccess,
+        origin: Routes.ONBOARDING.ADD_DEVICE_TO_WALLET,
+      },
+    });
+
+    renderWithQrSyncState({});
+
+    const scannerProps = MockQRScanner.mock.calls.at(-1)?.[0] as {
+      onScanSuccess: (data: { content?: string }, content?: string) => void;
+    };
+    scannerProps.onScanSuccess({ content: 'metamask://connect/mwp?p=test' });
+
+    await waitFor(() => {
+      expect(mockHandleScannedQrPayload).toHaveBeenCalledWith(
+        'metamask://connect/mwp?p=test',
+      );
+    });
+    expect(staleParentOnScanSuccess).not.toHaveBeenCalled();
+  });
+
+  it('reports add-device scan submit failures to Sentry', async () => {
+    const { reportQrSyncFailure } = jest.requireMock(
+      '../../../core/QrSync/qrSyncTelemetry',
+    ) as { reportQrSyncFailure: jest.Mock };
+
+    mockHandleScannedQrPayload.mockRejectedValueOnce(
+      new Error('scan submit failed'),
+    );
+
+    renderAddDeviceFlow({});
+
+    const scannerProps = MockQRScanner.mock.calls.at(-1)?.[0] as {
+      onScanSuccess: (data: { content?: string }, content?: string) => void;
+    };
+    scannerProps.onScanSuccess({ content: 'metamask://connect/mwp?p=test' });
+
+    await waitFor(() => {
+      expect(reportQrSyncFailure).toHaveBeenCalledWith(expect.any(Error), {
+        surface: 'scanner',
+        operation: 'submit_scanned_payload',
+        source: 'QRTabSwitcher.addDeviceScan',
+      });
+    });
   });
 
   it('resets QR sync session when closing scanner during add-device flow', async () => {

--- a/app/components/Views/QRTabSwitcher/QRTabSwitcher.tsx
+++ b/app/components/Views/QRTabSwitcher/QRTabSwitcher.tsx
@@ -21,6 +21,12 @@ import {
 import { endTrace, trace, TraceName } from '../../../util/trace';
 import { QrSyncPhases } from '../../../core/QrSync/constants';
 import type { QrSyncPhase } from '../../../core/QrSync/types';
+import {
+  QrSyncOperations,
+  QrSyncSurfaces,
+  QrSyncTelemetrySources,
+  reportQrSyncFailure,
+} from '../../../core/QrSync/qrSyncTelemetry';
 import { useMessenger } from '../../../hooks/useMessenger';
 import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import { RouteMessengerInstance } from './messenger';
@@ -65,7 +71,12 @@ export interface StartScan {
 const USER_CANCELLED = 'USER_CANCELLED';
 
 export interface QRTabSwitcherParams {
-  onScanSuccess: (data: ScanSuccess, content?: string) => void;
+  /**
+   * Required for non-add-device origins. For add-device (`origin` =
+   * `ADD_DEVICE_TO_WALLET`), omit this — QRTabSwitcher submits via its own
+   * route messenger so it does not depend on a stale parent-screen callback.
+   */
+  onScanSuccess?: (data: ScanSuccess, content?: string) => void;
   onStartScan?: (data: StartScan) => Promise<void>;
   onScanError?: (error: string) => void;
   initialScreen?: QRTabSwitcherScreens;
@@ -206,6 +217,35 @@ const QRTabSwitcher = () => {
     endTrace({ name: TraceName.QRTabSwitcher });
   }, []);
 
+  /**
+   * Submit on this screen's live route messenger. Do not call through a
+   * nav-param callback from AddDeviceToWallet — that screen can unmount in
+   * post-onboarding AppFlow and revoke its messenger handlers.
+   */
+  const handleAddDeviceScanSuccess = useCallback(
+    (data: ScanSuccess, content?: string) => {
+      const scannedQrPayload = content ?? data.content ?? '';
+
+      Promise.resolve(
+        messenger.call(
+          'QrSyncController:handleScannedQrPayload',
+          scannedQrPayload,
+        ),
+      ).catch((err: unknown) => {
+        reportQrSyncFailure(err, {
+          surface: QrSyncSurfaces.SCANNER,
+          operation: QrSyncOperations.SUBMIT_SCANNED_PAYLOAD,
+          source: QrSyncTelemetrySources.QR_TAB_SWITCHER_ADD_DEVICE_SCAN,
+        });
+      });
+    },
+    [messenger],
+  );
+
+  const resolvedOnScanSuccess = isAddDeviceOrigin
+    ? handleAddDeviceScanSuccess
+    : onScanSuccess;
+
   const goBack = () => {
     if (isAddDeviceOrigin && isSessionActive) {
       Promise.resolve(messenger.call('QrSyncController:resetState')).catch(
@@ -237,7 +277,7 @@ const QRTabSwitcher = () => {
       {selectedIndex === QRTabSwitcherScreens.Scanner ? (
         <QRScanner
           onScanError={onScanError}
-          onScanSuccess={onScanSuccess}
+          onScanSuccess={resolvedOnScanSuccess ?? (() => undefined)}
           onStartScan={onStartScan}
           origin={origin}
           shouldDismissOnScan={

--- a/app/core/QrSync/qrSyncTelemetry.test.ts
+++ b/app/core/QrSync/qrSyncTelemetry.test.ts
@@ -193,7 +193,7 @@ describe('qrSyncTelemetry', () => {
       reportQrSyncFailure(new Error('scan submit failed'), {
         surface: QrSyncSurfaces.SCANNER,
         operation: QrSyncOperations.SUBMIT_SCANNED_PAYLOAD,
-        source: QrSyncTelemetrySources.ADD_DEVICE_ON_SCAN_SUCCESS,
+        source: QrSyncTelemetrySources.QR_TAB_SWITCHER_ADD_DEVICE_SCAN,
         extras: { qrPayload: TEST_MWP_DEEPLINK },
       });
 

--- a/app/core/QrSync/qrSyncTelemetry.ts
+++ b/app/core/QrSync/qrSyncTelemetry.ts
@@ -46,6 +46,7 @@ export type QrSyncOperation =
 export const QrSyncTelemetrySources = {
   QR_SCANNER_ADD_DEVICE: 'QRScanner.addDevice',
   ADD_DEVICE_ON_SCAN_SUCCESS: 'AddDeviceToWallet.onScanSuccess',
+  QR_TAB_SWITCHER_ADD_DEVICE_SCAN: 'QRTabSwitcher.addDeviceScan',
   FINISH_EXISTING_USER_WITHOUT_MNEMONIC:
     'finishExistingUserSyncWithoutMnemonic',
   USE_QR_SYNC_IMPORT_NAVIGATION: 'useQrSyncImportNavigation',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
After the onboarding route-messenger migration, post-onboarding **Add Device → QR sync** could hang on “code detected” and never open the OTP bottomsheet. Onboarding still worked.

**Cause:** `AddDeviceToWallet` passed an `onScanSuccess` nav param that called `QrSyncController:handleScannedQrPayload` on **its** route messenger. In AppFlow, navigating to `QRTabSwitcher` can unmount Add Device, which revokes that messenger’s handlers. The scanner still invoked the stale callback → `A handler for QrSyncController:handleScannedQrPayload has not been delegated to AddDeviceToWalletRoute`.

**Fix:** For add-device origin, `QRTabSwitcher` submits the scan on **its own** live route messenger (already in `ALLOWED_CAPABILITIES`). `AddDeviceToWallet` no longer passes a messenger-bound `onScanSuccess`.


<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where scanning an extension QR code after onboarding could hang on the scanner instead of showing the verification code

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TO-1040

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Post-onboarding QR sync Add Device

  Scenario: existing user scans extension QR from Add Device
    Given the user has completed onboarding and is in the wallet
    And the user opens Add wallet → Add a new device
    When the user taps Scan QR code
    And scans a valid MetaMask extension QR sync code
    Then the scanner does not hang on "code detected"
    And the OTP / verification bottomsheet is shown

```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/73569b48-b530-48df-ae6c-df1b1b48807c


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
