### PR TITLE
fix(explore): limit API ranking preservation to LAPTOP searches cp-8.10.2

### DIFF
--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.test.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.test.ts
@@ -242,6 +242,82 @@ describe('useTrendingSearch', () => {
     );
   });
 
+  it('keeps search API order ahead of trending matches for the query', async () => {
+    // Trending ETH (0x123) also matches 'ETH'; the API ranked a different token
+    // first, and that ranking must be preserved.
+    const apiRankedFirst = {
+      assetId: 'eip155:8453/erc20:0xabc' as CaipChainId,
+      symbol: 'ETH2',
+      name: 'Ether Two',
+      decimals: 18,
+      price: '1',
+      aggregatedUsdVolume: 1,
+      marketCap: 0,
+      pricePercentChange1d: '0',
+    };
+    mockUseSearchRequest.mockReturnValue({
+      results: [apiRankedFirst],
+      isLoading: false,
+      error: null,
+      search: jest.fn(),
+      loadMore: jest.fn(),
+      isLoadingMore: false,
+      hasNextPage: false,
+      totalCount: undefined,
+    });
+
+    const { result } = renderHookWithProvider(() =>
+      useTrendingSearch({ searchQuery: 'ETH', sortBy: 'h24_trending' }),
+    );
+
+    jest.advanceTimersByTime(200);
+
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(2);
+    });
+
+    expect(result.current.data.map((item) => item.assetId)).toEqual([
+      'eip155:8453/erc20:0xabc',
+      'eip155:1/erc20:0x123',
+    ]);
+  });
+
+  it('keeps the trending object for a token in both sets but at the API position', async () => {
+    const duplicateOfTrendingEth = {
+      assetId: mockTrendingResults[0].assetId as CaipChainId,
+      symbol: 'ETH',
+      name: 'Ethereum',
+      decimals: 18,
+      price: '2000',
+      aggregatedUsdVolume: 1000000,
+      marketCap: 500000000,
+      pricePercentChange1d: '3',
+    };
+    mockUseSearchRequest.mockReturnValue({
+      results: [mockSearchResults[0], duplicateOfTrendingEth],
+      isLoading: false,
+      error: null,
+      search: jest.fn(),
+      loadMore: jest.fn(),
+      isLoadingMore: false,
+      hasNextPage: false,
+      totalCount: undefined,
+    });
+
+    const { result } = renderHookWithProvider(() =>
+      useTrendingSearch({ searchQuery: 'ETH', sortBy: 'h24_trending' }),
+    );
+
+    jest.advanceTimersByTime(200);
+
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(2);
+    });
+
+    expect(result.current.data[0].assetId).toBe('eip155:1/erc20:0x789');
+    expect(result.current.data[1]).toBe(mockTrendingResults[0]);
+  });
+
   it('returns trending loading state when no search query', () => {
     mockUseTrendingRequest.mockReturnValue({
       results: [],

--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.test.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.test.ts
@@ -188,13 +188,10 @@ describe('useTrendingSearch', () => {
       expect(result.current.data).toHaveLength(2);
     });
 
-    // Should contain ETH from trending (matches query) and USDC from search
-    expect(result.current.data).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ symbol: 'ETH' }),
-        expect.objectContaining({ symbol: 'USDC' }),
-      ]),
-    );
+    expect(result.current.data.map((item) => item.symbol)).toEqual([
+      'ETH',
+      'USDC',
+    ]);
   });
 
   it('removes duplicate results when combining search and trending', async () => {
@@ -242,19 +239,88 @@ describe('useTrendingSearch', () => {
     );
   });
 
-  it('keeps search API order ahead of trending matches for the query', async () => {
-    // Trending ETH (0x123) also matches 'ETH'; the API ranked a different token
-    // first, and that ranking must be preserved.
+  it.each([
+    ['laptop', 'Laptop'],
+    ['$laptop', '$Laptop'],
+  ])(
+    'keeps search API order ahead of trending matches for "%s"',
+    async (searchQuery, trendingName) => {
+      const trendingLaptop = {
+        ...mockTrendingResults[0],
+        symbol: 'LAPTOP',
+        name: trendingName,
+      };
+      const apiRankedFirst = {
+        assetId: 'eip155:8453/erc20:0xabc' as CaipChainId,
+        symbol: 'LAPTOP',
+        name: 'Laptop Official',
+        decimals: 18,
+        price: '1',
+        aggregatedUsdVolume: 1,
+        marketCap: 0,
+        pricePercentChange1d: '0',
+      };
+      mockUseTrendingRequest.mockReturnValue({
+        results: [trendingLaptop],
+        isLoading: false,
+        error: null,
+        fetch: mockFetchTrendingTokens,
+      });
+      mockUseSearchRequest.mockReturnValue({
+        results: [apiRankedFirst],
+        isLoading: false,
+        error: null,
+        search: jest.fn(),
+        loadMore: jest.fn(),
+        isLoadingMore: false,
+        hasNextPage: false,
+        totalCount: undefined,
+      });
+
+      const { result } = renderHookWithProvider(() =>
+        useTrendingSearch({ searchQuery, sortBy: 'h24_trending' }),
+      );
+
+      jest.advanceTimersByTime(200);
+
+      await waitFor(() => {
+        expect(result.current.data).toHaveLength(2);
+      });
+
+      expect(result.current.data.map((item) => item.assetId)).toEqual([
+        'eip155:8453/erc20:0xabc',
+        'eip155:1/erc20:0x123',
+      ]);
+      expect(mockUseSearchRequest).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          query: searchQuery.replace(/^\$/, ''),
+        }),
+      );
+    },
+  );
+
+  it('prepends trending matches for LAPTOP when the remote flag is off', async () => {
+    const trendingLaptop = {
+      ...mockTrendingResults[0],
+      symbol: 'LAPTOP',
+      name: 'Laptop',
+    };
     const apiRankedFirst = {
       assetId: 'eip155:8453/erc20:0xabc' as CaipChainId,
-      symbol: 'ETH2',
-      name: 'Ether Two',
+      symbol: 'LAPTOP',
+      name: 'Laptop Official',
       decimals: 18,
       price: '1',
       aggregatedUsdVolume: 1,
       marketCap: 0,
       pricePercentChange1d: '0',
     };
+    mockUseTrendingRequest.mockReturnValue({
+      results: [trendingLaptop],
+      isLoading: false,
+      error: null,
+      fetch: mockFetchTrendingTokens,
+    });
     mockUseSearchRequest.mockReturnValue({
       results: [apiRankedFirst],
       isLoading: false,
@@ -266,8 +332,25 @@ describe('useTrendingSearch', () => {
       totalCount: undefined,
     });
 
-    const { result } = renderHookWithProvider(() =>
-      useTrendingSearch({ searchQuery: 'ETH', sortBy: 'h24_trending' }),
+    const { result } = renderHookWithProvider(
+      () =>
+        useTrendingSearch({ searchQuery: 'laptop', sortBy: 'h24_trending' }),
+      {
+        state: {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  exploreLaptopSearchApiRanking: {
+                    enabled: false,
+                    minimumVersion: '8.12.0',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     );
 
     jest.advanceTimersByTime(200);
@@ -277,24 +360,35 @@ describe('useTrendingSearch', () => {
     });
 
     expect(result.current.data.map((item) => item.assetId)).toEqual([
-      'eip155:8453/erc20:0xabc',
       'eip155:1/erc20:0x123',
+      'eip155:8453/erc20:0xabc',
     ]);
   });
 
-  it('keeps the trending object for a token in both sets but at the API position', async () => {
-    const duplicateOfTrendingEth = {
-      assetId: mockTrendingResults[0].assetId as CaipChainId,
-      symbol: 'ETH',
-      name: 'Ethereum',
+  it('keeps the trending object for duplicate LAPTOP at its API position', async () => {
+    const trendingLaptop = {
+      ...mockTrendingResults[0],
+      symbol: 'LAPTOP',
+      name: 'Laptop',
+    };
+    const duplicateOfTrendingLaptop = {
+      assetId: trendingLaptop.assetId as CaipChainId,
+      symbol: trendingLaptop.symbol,
+      name: trendingLaptop.name,
       decimals: 18,
       price: '2000',
       aggregatedUsdVolume: 1000000,
       marketCap: 500000000,
       pricePercentChange1d: '3',
     };
+    mockUseTrendingRequest.mockReturnValue({
+      results: [trendingLaptop],
+      isLoading: false,
+      error: null,
+      fetch: mockFetchTrendingTokens,
+    });
     mockUseSearchRequest.mockReturnValue({
-      results: [mockSearchResults[0], duplicateOfTrendingEth],
+      results: [mockSearchResults[0], duplicateOfTrendingLaptop],
       isLoading: false,
       error: null,
       search: jest.fn(),
@@ -305,7 +399,7 @@ describe('useTrendingSearch', () => {
     });
 
     const { result } = renderHookWithProvider(() =>
-      useTrendingSearch({ searchQuery: 'ETH', sortBy: 'h24_trending' }),
+      useTrendingSearch({ searchQuery: 'laptop', sortBy: 'h24_trending' }),
     );
 
     jest.advanceTimersByTime(200);
@@ -315,7 +409,7 @@ describe('useTrendingSearch', () => {
     });
 
     expect(result.current.data[0].assetId).toBe('eip155:1/erc20:0x789');
-    expect(result.current.data[1]).toBe(mockTrendingResults[0]);
+    expect(result.current.data[1]).toBe(trendingLaptop);
   });
 
   it('returns trending loading state when no search query', () => {

--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
@@ -109,21 +109,25 @@ export const useTrendingSearch = (opts?: {
     }
 
     const query = debouncedQuery.toLowerCase().trim();
-    const filteredTrendingResults = trendingResults.filter(
+    const trendingMatches = trendingResults.filter(
       (item) =>
         item.symbol?.toLowerCase().includes(query) ||
         item.name?.toLowerCase().includes(query),
     );
-
-    const resultMap = new Map(
-      filteredTrendingResults.map((result) => [result.assetId, result]),
+    const trendingByAssetId = new Map(
+      trendingMatches.map((result) => [result.assetId, result]),
     );
+
+    // The search API ranks results (relevance, verification, pinned assets).
+    // Keep that order; trending matches the API did not return are appended.
+    const resultMap = new Map<string, TrendingAsset>();
 
     searchResults
       .filter((item) => includeStocks || !item.rwaData)
       .forEach((asset) => {
-        if (!resultMap.has(asset.assetId)) {
-          resultMap.set(asset.assetId, {
+        resultMap.set(
+          asset.assetId,
+          trendingByAssetId.get(asset.assetId) ?? {
             assetId: asset.assetId,
             symbol: asset.symbol,
             name: asset.name,
@@ -138,9 +142,15 @@ export const useTrendingSearch = (opts?: {
               | TrendingAsset['rwaData']
               | undefined,
             securityData: asset.securityData,
-          });
-        }
+          },
+        );
       });
+
+    trendingMatches.forEach((item) => {
+      if (!resultMap.has(item.assetId)) {
+        resultMap.set(item.assetId, item);
+      }
+    });
 
     return Array.from(resultMap.values());
   }, [

--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
@@ -1,4 +1,5 @@
 import { useMemo, useState, useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
 import type { CaipChainId } from '@metamask/utils';
 import { SortTrendingBy, TrendingAsset } from '@metamask/assets-controllers';
 import { useSearchRequest } from '../useSearchRequest/useSearchRequest';
@@ -9,6 +10,8 @@ import {
   SortDirection,
   TimeOption,
 } from '../../components/TrendingTokensBottomSheet';
+import { selectExploreLaptopSearchApiRankingEnabled } from '../../selectors/featureFlags';
+import { usesTemporaryApiRanking } from '../../utils/usesTemporaryApiRanking';
 import { isEqual } from 'lodash';
 
 const useStableReference = <T>(value: T) => {
@@ -61,7 +64,16 @@ export const useTrendingSearch = (opts?: {
     },
   } = useStableReference(opts ?? {});
 
+  const isLaptopApiRankingEnabled = useSelector(
+    selectExploreLaptopSearchApiRankingEnabled,
+  );
   const [debouncedQuery, setDebouncedQuery] = useState(searchQuery);
+  const searchRequestQuery = usesTemporaryApiRanking(
+    debouncedQuery,
+    isLaptopApiRankingEnabled,
+  )
+    ? (debouncedQuery?.trim().replace(/^\$/, '') ?? '')
+    : debouncedQuery || '';
 
   // Debounce the search query
   useEffect(() => {
@@ -82,7 +94,7 @@ export const useTrendingSearch = (opts?: {
     hasNextPage,
     totalCount,
   } = useSearchRequest({
-    query: debouncedQuery || '',
+    query: searchRequestQuery,
     limit: 20,
     chainIds: chainIds ?? undefined,
     includeMarketData,
@@ -118,9 +130,17 @@ export const useTrendingSearch = (opts?: {
       trendingMatches.map((result) => [result.assetId, result]),
     );
 
-    // The search API ranks results (relevance, verification, pinned assets).
-    // Keep that order; trending matches the API did not return are appended.
-    const resultMap = new Map<string, TrendingAsset>();
+    // TEMPORARY: Preserve API ranking only for the LAPTOP launch. All other
+    // queries retain the existing trending-first merge behavior.
+    const preserveApiRanking = usesTemporaryApiRanking(
+      debouncedQuery,
+      isLaptopApiRankingEnabled,
+    );
+    const resultMap = new Map<string, TrendingAsset>(
+      preserveApiRanking
+        ? []
+        : trendingMatches.map((result) => [result.assetId, result]),
+    );
 
     searchResults
       .filter((item) => includeStocks || !item.rwaData)
@@ -155,6 +175,7 @@ export const useTrendingSearch = (opts?: {
     return Array.from(resultMap.values());
   }, [
     debouncedQuery,
+    isLaptopApiRankingEnabled,
     trendingResults,
     searchResults,
     sortTrendingTokensOptions,

--- a/app/components/UI/Trending/selectors/featureFlags.test.ts
+++ b/app/components/UI/Trending/selectors/featureFlags.test.ts
@@ -1,0 +1,55 @@
+import {
+  EXPLORE_LAPTOP_SEARCH_API_RANKING_FLAG_NAME,
+  selectExploreLaptopSearchApiRankingEnabled,
+} from './featureFlags';
+// eslint-disable-next-line import-x/no-namespace
+import * as remoteFeatureFlagModule from '../../../../util/remoteFeatureFlag';
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn(() => '8.12.0'),
+}));
+
+describe('selectExploreLaptopSearchApiRankingEnabled', () => {
+  let mockHasMinimumRequiredVersion: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasMinimumRequiredVersion = jest.spyOn(
+      remoteFeatureFlagModule,
+      'hasMinimumRequiredVersion',
+    );
+    mockHasMinimumRequiredVersion.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    mockHasMinimumRequiredVersion.mockRestore();
+  });
+
+  it('returns true when the remote flag is enabled', () => {
+    const result = selectExploreLaptopSearchApiRankingEnabled.resultFunc({
+      [EXPLORE_LAPTOP_SEARCH_API_RANKING_FLAG_NAME]: {
+        enabled: true,
+        minimumVersion: '8.12.0',
+      },
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when the remote flag is disabled', () => {
+    const result = selectExploreLaptopSearchApiRankingEnabled.resultFunc({
+      [EXPLORE_LAPTOP_SEARCH_API_RANKING_FLAG_NAME]: {
+        enabled: false,
+        minimumVersion: '8.12.0',
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true when the remote flag is missing', () => {
+    const result = selectExploreLaptopSearchApiRankingEnabled.resultFunc({});
+
+    expect(result).toBe(true);
+  });
+});

--- a/app/components/UI/Trending/selectors/featureFlags.ts
+++ b/app/components/UI/Trending/selectors/featureFlags.ts
@@ -1,0 +1,30 @@
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '../../../../selectors/featureFlagController';
+import {
+  validatedVersionGatedFeatureFlag,
+  type VersionGatedFeatureFlag,
+} from '../../../../util/remoteFeatureFlag';
+
+export const EXPLORE_LAPTOP_SEARCH_API_RANKING_FLAG_NAME =
+  'exploreLaptopSearchApiRanking';
+
+/**
+ * TEMPORARY: Defaults on so the LAPTOP search pin works before the remote
+ * flag exists. Set the remote flag `enabled` to false to restore the existing
+ * trending-first merge and market-cap sort without a new app release.
+ */
+const DEFAULT_EXPLORE_LAPTOP_SEARCH_API_RANKING_ENABLED = true;
+
+export const selectExploreLaptopSearchApiRankingEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags): boolean => {
+    const remoteFlag = remoteFeatureFlags?.[
+      EXPLORE_LAPTOP_SEARCH_API_RANKING_FLAG_NAME
+    ] as unknown as VersionGatedFeatureFlag;
+
+    return (
+      validatedVersionGatedFeatureFlag(remoteFlag) ??
+      DEFAULT_EXPLORE_LAPTOP_SEARCH_API_RANKING_ENABLED
+    );
+  },
+);

--- a/app/components/UI/Trending/utils/usesTemporaryApiRanking.test.ts
+++ b/app/components/UI/Trending/utils/usesTemporaryApiRanking.test.ts
@@ -1,16 +1,23 @@
 import { usesTemporaryApiRanking } from './usesTemporaryApiRanking';
 
 describe('usesTemporaryApiRanking', () => {
-  it.each(['lapt', 'lapto', 'laptop', 'LAPTOP', ' laptop ', 'laptop token'])(
-    'returns true for LAPTOP query "%s"',
-    (query) => {
-      const result = usesTemporaryApiRanking(query);
+  it.each([
+    'l',
+    'la',
+    'lap',
+    'lapt',
+    'lapto',
+    'laptop',
+    'LAPTOP',
+    ' laptop ',
+    'laptop token',
+  ])('returns true for LAPTOP query "%s"', (query) => {
+    const result = usesTemporaryApiRanking(query);
 
-      expect(result).toBe(true);
-    },
-  );
+    expect(result).toBe(true);
+  });
 
-  it.each(['$lapt', '$lapto', '$laptop', ' $LAPTOP '])(
+  it.each(['$l', '$lap', '$lapt', '$lapto', '$laptop', ' $LAPTOP '])(
     'returns true for ticker-prefixed LAPTOP query "%s"',
     (query) => {
       const result = usesTemporaryApiRanking(query);
@@ -19,7 +26,7 @@ describe('usesTemporaryApiRanking', () => {
     },
   );
 
-  it.each([undefined, '', '   ', 'lap', '$lap', 'eth', '$eth', 'desktop'])(
+  it.each([undefined, '', '   ', 'eth', '$eth', 'desktop'])(
     'returns false for unrelated query "%s"',
     (query) => {
       const result = usesTemporaryApiRanking(query);

--- a/app/components/UI/Trending/utils/usesTemporaryApiRanking.test.ts
+++ b/app/components/UI/Trending/utils/usesTemporaryApiRanking.test.ts
@@ -1,0 +1,36 @@
+import { usesTemporaryApiRanking } from './usesTemporaryApiRanking';
+
+describe('usesTemporaryApiRanking', () => {
+  it.each(['lapt', 'lapto', 'laptop', 'LAPTOP', ' laptop ', 'laptop token'])(
+    'returns true for LAPTOP query "%s"',
+    (query) => {
+      const result = usesTemporaryApiRanking(query);
+
+      expect(result).toBe(true);
+    },
+  );
+
+  it.each(['$lapt', '$lapto', '$laptop', ' $LAPTOP '])(
+    'returns true for ticker-prefixed LAPTOP query "%s"',
+    (query) => {
+      const result = usesTemporaryApiRanking(query);
+
+      expect(result).toBe(true);
+    },
+  );
+
+  it.each([undefined, '', '   ', 'lap', '$lap', 'eth', '$eth', 'desktop'])(
+    'returns false for unrelated query "%s"',
+    (query) => {
+      const result = usesTemporaryApiRanking(query);
+
+      expect(result).toBe(false);
+    },
+  );
+
+  it('returns false when the remote flag is disabled', () => {
+    const result = usesTemporaryApiRanking('laptop', false);
+
+    expect(result).toBe(false);
+  });
+});

--- a/app/components/UI/Trending/utils/usesTemporaryApiRanking.ts
+++ b/app/components/UI/Trending/utils/usesTemporaryApiRanking.ts
@@ -1,0 +1,36 @@
+const TEMPORARY_API_RANKED_SEARCH_TERM = 'laptop';
+const MINIMUM_SEARCH_PREFIX_LENGTH = 4;
+
+/**
+ * TEMPORARY: Remove after the LAPTOP launch.
+ *
+ * Returns whether token search should preserve API ranking for the LAPTOP
+ * launch. An optional ticker-style "$" prefix is ignored, and prefixes from
+ * "lapt" onward are included to avoid changing order on the final keystroke.
+ *
+ * @param query - Token search query.
+ * @param isEnabled - Remote kill switch. Defaults to true.
+ * @returns Whether API ranking should be preserved.
+ */
+export const usesTemporaryApiRanking = (
+  query?: string,
+  isEnabled = true,
+): boolean => {
+  if (!isEnabled) {
+    return false;
+  }
+
+  const normalizedQuery = query?.trim().toLowerCase().replace(/^\$/, '');
+
+  if (
+    !normalizedQuery ||
+    normalizedQuery.length < MINIMUM_SEARCH_PREFIX_LENGTH
+  ) {
+    return false;
+  }
+
+  return (
+    TEMPORARY_API_RANKED_SEARCH_TERM.startsWith(normalizedQuery) ||
+    normalizedQuery.includes(TEMPORARY_API_RANKED_SEARCH_TERM)
+  );
+};

--- a/app/components/UI/Trending/utils/usesTemporaryApiRanking.ts
+++ b/app/components/UI/Trending/utils/usesTemporaryApiRanking.ts
@@ -1,12 +1,12 @@
 const TEMPORARY_API_RANKED_SEARCH_TERM = 'laptop';
-const MINIMUM_SEARCH_PREFIX_LENGTH = 4;
+const MINIMUM_SEARCH_PREFIX_LENGTH = 1;
 
 /**
  * TEMPORARY: Remove after the LAPTOP launch.
  *
  * Returns whether token search should preserve API ranking for the LAPTOP
  * launch. An optional ticker-style "$" prefix is ignored, and prefixes from
- * "lapt" onward are included to avoid changing order on the final keystroke.
+ * "l" onward are included to avoid changing order on the final keystroke.
  *
  * @param query - Token search query.
  * @param isEnabled - Remote kill switch. Defaults to true.

--- a/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.test.ts
+++ b/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import { useTrendingSearch } from '../../../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch';
+import { selectExploreLaptopSearchApiRankingEnabled } from '../../../../UI/Trending/selectors/featureFlags';
 import { TimeOption } from '../../../../UI/Trending/components/TrendingTokensBottomSheet';
 import type { RefreshConfig } from '../../hooks/useExploreRefresh';
 import { useTokensFeed } from './useTokensFeed';
@@ -11,8 +12,18 @@ jest.mock(
     useTrendingSearch: jest.fn(),
   }),
 );
+jest.mock('../../../../UI/Trending/selectors/featureFlags', () => ({
+  selectExploreLaptopSearchApiRankingEnabled: jest.fn(() => true),
+}));
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn((selector: () => boolean) => selector()),
+}));
 
 const mockUseTrendingSearch = jest.mocked(useTrendingSearch);
+const mockSelectExploreLaptopSearchApiRankingEnabled = jest.mocked(
+  selectExploreLaptopSearchApiRankingEnabled,
+);
 
 describe('useTokensFeed', () => {
   const mockRefetch = jest.fn().mockResolvedValue(undefined);
@@ -41,6 +52,7 @@ describe('useTokensFeed', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSelectExploreLaptopSearchApiRankingEnabled.mockReturnValue(true);
     mockUseTrendingSearch.mockReturnValue({
       data: sampleTokens,
       isLoading: false,
@@ -60,16 +72,38 @@ describe('useTokensFeed', () => {
     expect(result.current.refetch).toBe(mockRefetch);
   });
 
-  it('when query is active, preserves the order returned by the search API', () => {
+  it('sorts non-LAPTOP search results by market cap', () => {
     const { result } = renderHook(() => useTokensFeed({ query: 'wrap' }));
 
-    // The API ranks results (relevance, verification); the client must not
-    // re-sort them, e.g. by market cap, or lower-quality tokens can outrank
-    // the intended match.
     expect(result.current.data.map((t) => t.symbol)).toEqual([
-      'AAA',
       'WBTC',
       'WETH',
+      'AAA',
+    ]);
+  });
+
+  it.each(['laptop', '$laptop'])(
+    'preserves API order for temporary query "%s"',
+    (query) => {
+      const { result } = renderHook(() => useTokensFeed({ query }));
+
+      expect(result.current.data.map((token) => token.symbol)).toEqual([
+        'AAA',
+        'WBTC',
+        'WETH',
+      ]);
+    },
+  );
+
+  it('sorts LAPTOP search results by market cap when the remote flag is off', () => {
+    mockSelectExploreLaptopSearchApiRankingEnabled.mockReturnValue(false);
+
+    const { result } = renderHook(() => useTokensFeed({ query: 'laptop' }));
+
+    expect(result.current.data.map((token) => token.symbol)).toEqual([
+      'WBTC',
+      'WETH',
+      'AAA',
     ]);
   });
 

--- a/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.test.ts
+++ b/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.test.ts
@@ -60,23 +60,17 @@ describe('useTokensFeed', () => {
     expect(result.current.refetch).toBe(mockRefetch);
   });
 
-  it('when query is active, returns all data sorted by market cap (skips Fuse re-filter)', () => {
+  it('when query is active, preserves the order returned by the search API', () => {
     const { result } = renderHook(() => useTokensFeed({ query: 'wrap' }));
 
-    // useTrendingSearch already searched the API; all items in `data` are
-    // considered relevant. We only sort by marketCap, not fuzzy-filter.
+    // The API ranks results (relevance, verification); the client must not
+    // re-sort them, e.g. by market cap, or lower-quality tokens can outrank
+    // the intended match.
     expect(result.current.data.map((t) => t.symbol)).toEqual([
+      'AAA',
       'WBTC',
       'WETH',
-      'AAA',
     ]);
-  });
-
-  it('when query is absent, fuzzy-filters by Fuse and returns only matching items', () => {
-    const { result } = renderHook(() => useTokensFeed({ query: undefined }));
-
-    // Without a query, fuseSearch is a no-op (returns data unchanged).
-    expect(result.current.data).toEqual(sampleTokens);
   });
 
   it('refetches when refresh trigger increments past initial mount', async () => {

--- a/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.ts
+++ b/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.ts
@@ -1,8 +1,12 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
+import { useSelector } from 'react-redux';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import { useTrendingSearch } from '../../../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch';
+import { selectExploreLaptopSearchApiRankingEnabled } from '../../../../UI/Trending/selectors/featureFlags';
+import { usesTemporaryApiRanking } from '../../../../UI/Trending/utils/usesTemporaryApiRanking';
 import { useFeedRefresh } from '../../hooks/useFeedRefresh';
 import type { RefreshConfig } from '../../hooks/useExploreRefresh';
+import { fuseSearch, TOKEN_FUSE_OPTIONS } from '../search-utils';
 import {
   mapTimeOptionToSortBy,
   PriceChangeOption,
@@ -11,7 +15,7 @@ import {
 } from '../../../../UI/Trending/components/TrendingTokensBottomSheet';
 
 interface UseTokensFeedOptions {
-  /** Search query; when present, results keep the order returned by the search API. */
+  /** Search query; results are sorted by market cap unless temporarily exempted. */
   query?: string;
   refresh?: RefreshConfig;
   /**
@@ -40,6 +44,9 @@ export const useTokensFeed = ({
   hideRiskyTokens = false,
   timeOption,
 }: UseTokensFeedOptions = {}): UseTokensFeedResult => {
+  const isLaptopApiRankingEnabled = useSelector(
+    selectExploreLaptopSearchApiRankingEnabled,
+  );
   const sortBy = timeOption ? mapTimeOptionToSortBy(timeOption) : undefined;
 
   const {
@@ -66,16 +73,65 @@ export const useTokensFeed = ({
 
   useFeedRefresh(refresh, refetch);
 
-  const filteredData = useMemo(() => {
-    if (!hideRiskyTokens) return data;
+  /**
+   * firstPageSizeRef records how many items were in the first page response so
+   * that subsequent pages can be appended without resorting. A single effect
+   * handles both concerns: reset on query change (and bail out immediately so
+   * a stale data.length is never captured on the same render), then capture the
+   * boundary once the initial load settles.
+   */
+  const firstPageSizeRef = useRef<number | null>(null);
+  const prevQueryRef = useRef(query);
 
-    return data.filter(({ securityData }) => {
+  useEffect(() => {
+    if (prevQueryRef.current !== query) {
+      firstPageSizeRef.current = null;
+      prevQueryRef.current = query;
+      return;
+    }
+    if (!isLoading && !isLoadingMore && firstPageSizeRef.current === null) {
+      firstPageSizeRef.current = data.length;
+    }
+  }, [query, isLoading, isLoadingMore, data.length]);
+
+  const filteredData = useMemo(() => {
+    let searched: TrendingAsset[];
+
+    if (query?.trim()) {
+      if (usesTemporaryApiRanking(query, isLaptopApiRankingEnabled)) {
+        // TEMPORARY: Preserve API order only for the LAPTOP launch.
+        searched = data;
+      } else {
+        // Sort only the first-page slice; subsequent pages are appended as-is
+        // so pagination order is not interleaved by market cap.
+        const boundary = firstPageSizeRef.current ?? data.length;
+        const firstPage = data
+          .slice(0, boundary)
+          .sort((a, b) => (b.marketCap ?? 0) - (a.marketCap ?? 0));
+        const rest = data.slice(boundary);
+        searched = [...firstPage, ...rest];
+      }
+    } else {
+      searched = fuseSearch(
+        data,
+        query,
+        TOKEN_FUSE_OPTIONS,
+        (a, b) => (b.marketCap ?? 0) - (a.marketCap ?? 0),
+      );
+    }
+
+    if (!hideRiskyTokens) return searched;
+
+    return searched.filter(({ securityData }) => {
       const { resultType } = securityData ?? {};
       return (
         !resultType || resultType === 'Verified' || resultType === 'Benign'
       );
     });
-  }, [data, hideRiskyTokens]);
+    // firstPageSizeRef is a ref — intentionally excluded from deps so that
+    // boundary captures the snapshot set by the effect, not a stale closure.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, query, hideRiskyTokens, isLaptopApiRankingEnabled]);
 
   return {
     data: filteredData,

--- a/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.ts
+++ b/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.ts
@@ -1,9 +1,8 @@
-import { useMemo, useRef, useEffect } from 'react';
+import { useMemo } from 'react';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import { useTrendingSearch } from '../../../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch';
 import { useFeedRefresh } from '../../hooks/useFeedRefresh';
 import type { RefreshConfig } from '../../hooks/useExploreRefresh';
-import { fuseSearch, TOKEN_FUSE_OPTIONS } from '../search-utils';
 import {
   mapTimeOptionToSortBy,
   PriceChangeOption,
@@ -12,7 +11,7 @@ import {
 } from '../../../../UI/Trending/components/TrendingTokensBottomSheet';
 
 interface UseTokensFeedOptions {
-  /** Search query; when present, results are sorted by market cap descending. */
+  /** Search query; when present, results keep the order returned by the search API. */
   query?: string;
   refresh?: RefreshConfig;
   /**
@@ -67,60 +66,16 @@ export const useTokensFeed = ({
 
   useFeedRefresh(refresh, refetch);
 
-  /**
-   * firstPageSizeRef records how many items were in the first page response so
-   * that subsequent pages can be appended without resorting. A single effect
-   * handles both concerns: reset on query change (and bail out immediately so
-   * a stale data.length is never captured on the same render), then capture the
-   * boundary once the initial load settles.
-   */
-  const firstPageSizeRef = useRef<number | null>(null);
-  const prevQueryRef = useRef(query);
-
-  useEffect(() => {
-    if (prevQueryRef.current !== query) {
-      firstPageSizeRef.current = null;
-      prevQueryRef.current = query;
-      return;
-    }
-    if (!isLoading && !isLoadingMore && firstPageSizeRef.current === null) {
-      firstPageSizeRef.current = data.length;
-    }
-  }, [query, isLoading, isLoadingMore, data.length]);
-
   const filteredData = useMemo(() => {
-    let searched: TrendingAsset[];
+    if (!hideRiskyTokens) return data;
 
-    if (query?.trim()) {
-      // Sort only the first-page slice; subsequent pages are appended as-is so
-      // that pagination order is preserved rather than interleaved by market cap.
-      const boundary = firstPageSizeRef.current ?? data.length;
-      const firstPage = data
-        .slice(0, boundary)
-        .sort((a, b) => (b.marketCap ?? 0) - (a.marketCap ?? 0));
-      const rest = data.slice(boundary);
-      searched = [...firstPage, ...rest];
-    } else {
-      searched = fuseSearch(
-        data,
-        query,
-        TOKEN_FUSE_OPTIONS,
-        (a, b) => (b.marketCap ?? 0) - (a.marketCap ?? 0),
-      );
-    }
-
-    if (!hideRiskyTokens) return searched;
-
-    return searched.filter(({ securityData }) => {
+    return data.filter(({ securityData }) => {
       const { resultType } = securityData ?? {};
       return (
         !resultType || resultType === 'Verified' || resultType === 'Benign'
       );
     });
-    // firstPageSizeRef is a ref — intentionally excluded from deps so that
-    // boundary captures the snapshot set by the effect, not a stale closure.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, query, hideRiskyTokens]);
+  }, [data, hideRiskyTokens]);
 
   return {
     data: filteredData,

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -5964,6 +5964,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  exploreLaptopSearchApiRanking: {
+    name: 'exploreLaptopSearchApiRanking',
+    type: FeatureFlagType.Remote,
+    inProd: false,
+    productionDefault: {
+      enabled: true,
+      minimumVersion: '8.12.0',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   exploreSectionsOrder: {
     name: 'exploreSectionsOrder',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Temporary follow-up to [#35928](https://github.com/MetaMask/metamask-mobile/pull/35928). That branch honors search-API ranking for every token query. We only want that for the LAPTOP launch; every other query should keep the existing trending-first merge and first-page market-cap sort.

**What**

- Preserve API order only when the query is `l` / `la` / `lap` / `lapt` / `lapto` / `laptop`, contains `laptop`, or uses a `$` prefix (`$laptop`). `$` is stripped before the search request.
- Restore trending-first merge and market-cap sorting for all other searches.
- Gate the workaround with remote flag `exploreLaptopSearchApiRanking` (default **on** when the flag is missing). Set `enabled: false` in client-config to restore `main` ranking without a new app release.

**Why**

The API pins LAPTOP at #0, but the client then prepends trending name-matches and re-sorts the first page by market cap. A 0-cap pin loses to lookalikes. We have only verified API ranking for LAPTOP, so unrelated searches (ETH, USDC, etc.) stay on the old client order.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed LAPTOP token searches while preserving existing ranking for other tokens

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/metamask-mobile/pull/35928

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Temporary LAPTOP token search ranking

  Scenario: user searches for LAPTOP by name
    Given the app is open on Explore search
    When user searches for "laptop"
    Then the first Crypto result matches the first token returned by the search API
    And remaining results preserve the search API order

  Scenario: user searches for LAPTOP by ticker
    Given the app is open on Explore search
    When user searches for "$laptop"
    Then the first Crypto result matches the first token returned by the search API

  Scenario: user searches for another token
    Given the app is open on Explore search
    When user searches for a token unrelated to LAPTOP
    Then Crypto results retain the existing trending-first merge
    And the first page is sorted by market cap

  Scenario: remote flag turns the workaround off
    Given remote flag exploreLaptopSearchApiRanking is enabled false
    When user searches for "laptop"
    Then Crypto results use trending-first merge and market-cap sort
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/63d3cc30-a6cd-43ca-bd0f-7d4dacfae703


<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/bf2557d7-a9a0-411b-80d9-919587437ea4
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Explore search merge/sort behavior for many queries and introduces a remote kill switch; wrong matching on `usesTemporaryApiRanking` could affect unrelated searches that contain "laptop".
> 
> **Overview**
> Narrows **search-API ranking** to a temporary **LAPTOP launch** path instead of applying it to every Explore token query. Queries that match `laptop` (including prefixes like `l`–`lapto`, `$laptop`, and strings containing `laptop`) keep API order end-to-end; everything else keeps **trending-first merge** and **first-page market-cap sort**.
> 
> **`useTrendingSearch`** reads remote flag `exploreLaptopSearchApiRanking` (defaults **on** when the flag is absent). For LAPTOP-style queries it strips a leading `$` for the search request, builds results from search order first, appends unmatched trending matches, and prefers the **trending** object when the same asset appears in both lists. **`useTokensFeed`** skips market-cap re-sort when that same temporary ranking applies.
> 
> Adds **`usesTemporaryApiRanking`**, a Trending **`selectExploreLaptopSearchApiRankingEnabled`** selector, registry entry, and tests covering order, duplicates, and flag-off rollback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c78b52db4795bb7f694c91cfa8213da2162a237c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->