### PR TITLE
fix: limit order destination asset picker should only allow source chain

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -629,15 +629,23 @@ jest.mock(
   '../../../../../component-library/components-temp/TabEmptyState',
   () => {
     const { createElement } = jest.requireActual('react');
-    const { View } = jest.requireActual('react-native');
+    const { View, Text } = jest.requireActual('react-native');
     return {
       TabEmptyState: ({
         testID,
+        description,
         children,
       }: {
         testID?: string;
+        description?: React.ReactNode;
         children?: React.ReactNode;
-      }) => createElement(View, { testID }, children),
+      }) =>
+        createElement(
+          View,
+          { testID },
+          description ? createElement(Text, null, description) : null,
+          children,
+        ),
     };
   },
 );
@@ -1787,6 +1795,103 @@ describe('BridgeTokenSelector', () => {
 
       expect(getByTestId('watchlist-empty-cta-container')).toBeTruthy();
       expect(queryByTestId('bridge-token-list')).toBeNull();
+    });
+
+    it('shows the watchlist empty state when favorites exist but none are on the enabled chains', () => {
+      mockIsWatchlistEnabled = true;
+      // Picker is scoped to Ethereum only (e.g. a Limit order dest picker).
+      // selectAllowedChainRanking is mocked to read directly off
+      // bridgeFeatureFlags.chainRanking (see the module mock above), so
+      // narrowing that array is how this picker's enabled-chains scope is
+      // simulated here.
+      mockBridgeFeatureFlags = {
+        chainRanking: [{ chainId: MOCK_CHAIN_IDS.ethereum, name: 'Ethereum' }],
+        chains: {},
+      };
+      // The user's only watchlist item is on Polygon, outside this picker's
+      // enabled chains, so it must not surface under "All".
+      mockUseTokenWatchlistQuery.mockReturnValue({
+        data: [
+          {
+            assetId: 'eip155:137/slip44:60',
+            name: 'Polygon',
+            symbol: 'POL',
+            decimals: 18,
+            balance: '1.5',
+            balanceFiat: 3000,
+            fiatCurrency: 'usd',
+            isInWallet: true,
+          },
+        ],
+        isLoading: false,
+      });
+
+      const { getByTestId, getByText, queryByTestId } = renderWithReduxProvider(
+        <BridgeTokenSelector />,
+      );
+
+      fireEvent.press(getByTestId('bridge-watchlist-filter-watchlist'));
+
+      expect(getByTestId('bridge-watchlist-empty-state')).toBeTruthy();
+      // strings() is mocked to return the raw key in this test file.
+      expect(getByText('bridge.no_watchlist_tokens_found')).toBeTruthy();
+      expect(
+        getByText('bridge.no_watchlist_tokens_found_description'),
+      ).toBeTruthy();
+      expect(queryByTestId('token-POL')).toBeNull();
+    });
+
+    it('shows watchlist tokens whose chain is within the enabled chains and hides the rest', () => {
+      mockIsWatchlistEnabled = true;
+      mockBridgeFeatureFlags = {
+        chainRanking: [{ chainId: MOCK_CHAIN_IDS.ethereum, name: 'Ethereum' }],
+        chains: {},
+      };
+      mockUseTokenWatchlistQuery.mockReturnValue({
+        data: [
+          {
+            assetId: 'eip155:1/slip44:60',
+            name: 'Ethereum',
+            symbol: 'ETH',
+            decimals: 18,
+            balance: '1.5',
+            balanceFiat: 3000,
+            fiatCurrency: 'usd',
+            isInWallet: true,
+          },
+          {
+            assetId: 'eip155:137/slip44:60',
+            name: 'Polygon',
+            symbol: 'POL',
+            decimals: 18,
+            balance: '1.5',
+            balanceFiat: 3000,
+            fiatCurrency: 'usd',
+            isInWallet: true,
+          },
+        ],
+        isLoading: false,
+      });
+      mockBalancesByAssetIdState = {
+        tokensWithBalance: [],
+        balancesByAssetId: {
+          'eip155:1/slip44:60': {
+            balance: '1.5',
+            balanceFiat: '$3,000.00',
+            tokenFiatAmount: 3000,
+          },
+        },
+      };
+
+      const { getByTestId, queryByTestId } = renderWithReduxProvider(
+        <BridgeTokenSelector />,
+      );
+
+      fireEvent.press(getByTestId('bridge-watchlist-filter-watchlist'));
+
+      expect(getByTestId('token-ETH')).toBeTruthy();
+      expect(queryByTestId('token-POL')).toBeNull();
+      expect(queryByTestId('bridge-watchlist-empty-state')).toBeNull();
     });
 
     it('shows watchlist tokens for source picker when bridge balances are available', async () => {

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -61,6 +61,8 @@ import {
 import { useAssetFromTheme } from '../../../../../util/theme';
 import NoSearchResultsLight from '../../../../../images/predictions-no-search-results-light.svg';
 import NoSearchResultsDark from '../../../../../images/predictions-no-search-results-dark.svg';
+import WatchlistEmptyLight from '../../../../../images/watchlist-empty-light.svg';
+import WatchlistEmptyDark from '../../../../../images/watchlist-empty-dark.svg';
 import { SkeletonItem } from '../SkeletonItem';
 import { TabEmptyState } from '../../../../../component-library/components-temp/TabEmptyState';
 import { TokenSelectorItem } from '../TokenSelectorItem';
@@ -171,9 +173,12 @@ const BridgeTokenSelectorRow = React.memo(
   },
 );
 
-interface BridgeTokenSelectorSearchEmptyStateProps {
+interface BridgeTokenSelectorEmptyStateProps {
   containerStyle: StyleProp<ViewStyle>;
-  NoSearchResultsIcon: React.ComponentType<{ width: number; height: number }>;
+  Icon: React.ComponentType<{ width: number; height: number }>;
+  title: string;
+  description: string;
+  testID?: string;
 }
 
 const useRwaFilteredTokens = (
@@ -185,29 +190,33 @@ const useRwaFilteredTokens = (
     [tokens, excludeRwaTokens],
   );
 
-const BridgeTokenSelectorSearchEmptyState = React.memo(
+const BridgeTokenSelectorEmptyState = React.memo(
   ({
     containerStyle,
-    NoSearchResultsIcon,
-  }: BridgeTokenSelectorSearchEmptyStateProps) => (
+    Icon,
+    title,
+    description,
+    testID = 'bridge-token-selector-empty-state',
+  }: BridgeTokenSelectorEmptyStateProps) => (
     <TabEmptyState
-      testID="bridge-token-selector-empty-state"
-      icon={<NoSearchResultsIcon width={72} height={78} />}
-      description={strings('bridge.no_tokens_found')}
+      testID={testID}
+      icon={<Icon width={72} height={78} />}
+      description={title}
       descriptionProps={{
         variant: TextVariant.HeadingMd,
         color: TextColor.TextDefault,
         twClassName: 'text-center',
+        numberOfLines: 1,
       }}
       style={containerStyle}
-      twClassName="self-center"
+      twClassName="self-center max-w-full"
     >
       <Text
         variant={TextVariant.BodyMd}
         color={TextColor.TextAlternative}
         twClassName="text-center -mt-1"
       >
-        {strings('bridge.no_tokens_found_description')}
+        {description}
       </Text>
     </TabEmptyState>
   ),
@@ -239,10 +248,14 @@ export const BridgeTokenSelector: React.FC = () => {
     };
   }, [dispatch]);
 
-  // Get themed SVG for empty state
+  // Get themed SVGs for empty states
   const NoSearchResultsIcon = useAssetFromTheme(
     NoSearchResultsLight,
     NoSearchResultsDark,
+  );
+  const WatchlistEmptyIcon = useAssetFromTheme(
+    WatchlistEmptyLight,
+    WatchlistEmptyDark,
   );
 
   // Check if search string meets minimum length requirement
@@ -564,6 +577,9 @@ export const BridgeTokenSelector: React.FC = () => {
       excludeRwaTokens ? filterOutRwaTokens(mappedTokens) : mappedTokens,
       {
         selectedChainId,
+        allowedChainIds: enabledChainRanking.map(
+          (chain: { chainId: CaipChainId }) => chain.chainId,
+        ),
         searchQuery: isValidSearch ? searchString : undefined,
       },
     );
@@ -576,6 +592,7 @@ export const BridgeTokenSelector: React.FC = () => {
     balancesByAssetId,
     currentCurrency,
     excludeRwaTokens,
+    enabledChainRanking,
   ]);
 
   const watchlistMergedSearchResults = useMemo(() => {
@@ -952,20 +969,38 @@ export const BridgeTokenSelector: React.FC = () => {
 
   const renderEmptyState = useCallback(() => {
     if (isWatchlistListMode && hasWatchlistItems) {
-      if (
-        isWatchlistLoading ||
-        !isValidSearch ||
-        isSearchLoading ||
-        isLoadingMore ||
-        isAwaitingMoreSearchResults
-      ) {
+      if (isWatchlistLoading) {
+        return null;
+      }
+
+      // No active search: this picker's watchlist has items overall, but
+      // none matched the current chain scope (either a specific network
+      // pill, or this picker's narrower `enabledChainIds` under "All"), so
+      // show favorites-specific empty copy instead of a blank list.
+      if (!isValidSearch) {
+        return (
+          <BridgeTokenSelectorEmptyState
+            containerStyle={styles.emptyStateContainer}
+            Icon={WatchlistEmptyIcon}
+            title={strings('bridge.no_watchlist_tokens_found')}
+            description={strings(
+              'bridge.no_watchlist_tokens_found_description',
+            )}
+            testID="bridge-watchlist-empty-state"
+          />
+        );
+      }
+
+      if (isSearchLoading || isLoadingMore || isAwaitingMoreSearchResults) {
         return null;
       }
 
       return (
-        <BridgeTokenSelectorSearchEmptyState
+        <BridgeTokenSelectorEmptyState
           containerStyle={styles.emptyStateContainer}
-          NoSearchResultsIcon={NoSearchResultsIcon}
+          Icon={NoSearchResultsIcon}
+          title={strings('bridge.no_tokens_found')}
+          description={strings('bridge.no_tokens_found_description')}
         />
       );
     }
@@ -982,9 +1017,11 @@ export const BridgeTokenSelector: React.FC = () => {
     }
 
     return (
-      <BridgeTokenSelectorSearchEmptyState
+      <BridgeTokenSelectorEmptyState
         containerStyle={styles.emptyStateContainer}
-        NoSearchResultsIcon={NoSearchResultsIcon}
+        Icon={NoSearchResultsIcon}
+        title={strings('bridge.no_tokens_found')}
+        description={strings('bridge.no_tokens_found_description')}
       />
     );
   }, [
@@ -997,6 +1034,7 @@ export const BridgeTokenSelector: React.FC = () => {
     isAwaitingMoreSearchResults,
     styles.emptyStateContainer,
     NoSearchResultsIcon,
+    WatchlistEmptyIcon,
   ]);
 
   return (

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
@@ -268,6 +268,38 @@ describe('NetworkPills', () => {
       expect(queryByTestId('network-pills-more-button')).toBeNull();
     });
 
+    it('does not render the All pill when only one network is available', () => {
+      const singleChainRanking = [
+        { chainId: 'eip155:1' as CaipChainId, name: 'Ethereum' },
+      ];
+      jest
+        .mocked(selectAllowedChainRanking)
+        .mockReturnValue(singleChainRanking);
+
+      const { getByText, queryByText } = render(
+        <NetworkPills
+          selectedChainId={undefined}
+          onChainSelect={mockOnChainSelect}
+          onMorePress={mockOnMorePress}
+        />,
+      );
+
+      expect(queryByText('All')).toBeNull();
+      expect(getByText('Ethereum')).toBeOnTheScreen();
+    });
+
+    it('renders the All pill when more than one network is available', () => {
+      const { getByText } = render(
+        <NetworkPills
+          selectedChainId={undefined}
+          onChainSelect={mockOnChainSelect}
+          onMorePress={mockOnMorePress}
+        />,
+      );
+
+      expect(getByText('All')).toBeOnTheScreen();
+    });
+
     it('shows first MAX_VISIBLE_PILLS from any chainRanking order', () => {
       const customRanking = [
         { chainId: 'eip155:137' as CaipChainId, name: 'Polygon' },
@@ -396,6 +428,29 @@ describe('NetworkPills', () => {
       );
 
       expect(getByText('All')).toBeTruthy();
+    });
+
+    it('treats the single network as selected when no chain filter is set and All is hidden', () => {
+      const singleChainRanking = [
+        { chainId: 'eip155:1' as CaipChainId, name: 'Ethereum' },
+      ];
+      jest
+        .mocked(selectAllowedChainRanking)
+        .mockReturnValue(singleChainRanking);
+
+      const { getByText } = render(
+        <NetworkPills
+          selectedChainId={undefined}
+          onChainSelect={mockOnChainSelect}
+          onMorePress={mockOnMorePress}
+        />,
+      );
+
+      // No assertion on visual active styling here (mocked ButtonToggle
+      // doesn't forward isActive), but pressing it should still behave
+      // like a normal chain selection.
+      fireEvent.press(getByText('Ethereum'));
+      expect(mockOnChainSelect).toHaveBeenCalledWith('eip155:1');
     });
   });
 

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
@@ -139,6 +139,11 @@ const NetworkPillsContent: React.FC<NetworkPillsContentProps> = ({
 
   const remainingCount = chainRanking.length - visibleChains.length;
 
+  // When only one blockchain is available, "All networks" and that single
+  // network are functionally identical, so the "All" pill is redundant and
+  // should be hidden.
+  const hasSingleChain = chainRanking.length === 1;
+
   // On selection change only:
   // - Out-of-list chain → pin [selected, ...current visible].slice(0, N) in
   //   Redux for the Swaps session, then scroll to start.
@@ -188,8 +193,12 @@ const NetworkPillsContent: React.FC<NetworkPillsContentProps> = ({
 
   const renderChainPill = (chain: ChainRankingEntry) => {
     // Only one pill may appear selected at a time (star, All, or one network).
+    // When the "All" pill is hidden (single-chain case), an unset filter is
+    // equivalent to that one chain being selected, so treat it as such.
     const isSelected =
-      !isWatchlistFilterActive && selectedChainId === chain.chainId;
+      !isWatchlistFilterActive &&
+      (selectedChainId === chain.chainId ||
+        (hasSingleChain && !selectedChainId));
     const imageSource = getNetworkImageSource({ chainId: chain.chainId });
 
     return (
@@ -259,14 +268,17 @@ const NetworkPillsContent: React.FC<NetworkPillsContentProps> = ({
           accessibilityLabel={strings('perps.watchlist.filter_badge_label')}
         />
       ) : null}
-      {/* All networks pill */}
-      <ButtonToggle
-        label={strings('bridge.all')}
-        isActive={!selectedChainId && !isWatchlistFilterActive}
-        onPress={() => onChainSelect(undefined)}
-        style={tw.style('rounded-xl py-2 px-3')}
-        size={ButtonSize.Md}
-      />
+      {/* All networks pill — hidden when only one blockchain is available,
+          since "All" and that single network would be redundant. */}
+      {!hasSingleChain && (
+        <ButtonToggle
+          label={strings('bridge.all')}
+          isActive={!selectedChainId && !isWatchlistFilterActive}
+          onPress={() => onChainSelect(undefined)}
+          style={tw.style('rounded-xl py-2 px-3')}
+          size={ButtonSize.Md}
+        />
+      )}
       {visibleChains.map(renderChainPill)}
       {remainingCount > 0 && (
         <ButtonToggle

--- a/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.test.ts
@@ -323,7 +323,7 @@ describe('useLimitOrderSwapInputs', () => {
       );
     });
 
-    it('opens the destination picker scoped to the enabled chains and without RWAs', () => {
+    it("opens the destination picker scoped to the source token's chain and without RWAs", () => {
       const { result } = renderLimitOrderSwapInputsHook(
         {
           sourceToken: getNativeSourceToken('eip155:1'),
@@ -339,7 +339,53 @@ describe('useLimitOrderSwapInputs', () => {
         Routes.BRIDGE.TOKEN_SELECTOR,
         expect.objectContaining({
           type: TokenSelectorType.Dest,
-          enabledChainIds: ENABLED_CHAIN_IDS,
+          enabledChainIds: ['eip155:1'],
+          excludeRwaTokens: true,
+          featureId: FeatureId.LIMIT_ORDER,
+        }),
+      );
+    });
+
+    it('scopes the destination picker to the CAIP form of a hex source chain id', () => {
+      const { result } = renderLimitOrderSwapInputsHook(
+        {
+          sourceToken: createMockToken({ chainId: '0x38' }),
+          destToken: undefined,
+          sourceAmount: undefined,
+        },
+        ENABLED_CHAIN_IDS,
+      );
+
+      result.current.handleDestTokenPress();
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.BRIDGE.TOKEN_SELECTOR,
+        expect.objectContaining({
+          type: TokenSelectorType.Dest,
+          enabledChainIds: ['eip155:56'],
+          excludeRwaTokens: true,
+          featureId: FeatureId.LIMIT_ORDER,
+        }),
+      );
+    });
+
+    it('opens the destination picker with no enabled chains when there is no source token', () => {
+      const { result } = renderLimitOrderSwapInputsHook(
+        {
+          sourceToken: undefined,
+          destToken: undefined,
+          sourceAmount: undefined,
+        },
+        ENABLED_CHAIN_IDS,
+      );
+
+      result.current.handleDestTokenPress();
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.BRIDGE.TOKEN_SELECTOR,
+        expect.objectContaining({
+          type: TokenSelectorType.Dest,
+          enabledChainIds: [],
           excludeRwaTokens: true,
           featureId: FeatureId.LIMIT_ORDER,
         }),

--- a/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.ts
+++ b/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
-import { FeatureId } from '@metamask/bridge-controller';
+import { FeatureId, formatChainIdToCaip } from '@metamask/bridge-controller';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import Routes from '../../../../../constants/navigation/Routes';
 import type { RootState } from '../../../../../reducers';
@@ -182,11 +182,13 @@ export const useLimitOrderSwapInputs = ({
   const handleDestTokenPress = useCallback(() => {
     navigation.navigate(Routes.BRIDGE.TOKEN_SELECTOR, {
       type: TokenSelectorType.Dest,
-      enabledChainIds,
+      enabledChainIds: sourceToken?.chainId
+      ? [formatChainIdToCaip(sourceToken.chainId)]
+      : [],
       excludeRwaTokens: true,
       featureId: FeatureId.LIMIT_ORDER,
     });
-  }, [enabledChainIds, navigation]);
+  }, [navigation, sourceToken?.chainId]);
 
   return {
     enabledChainIds,

--- a/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.ts
+++ b/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.ts
@@ -183,8 +183,8 @@ export const useLimitOrderSwapInputs = ({
     navigation.navigate(Routes.BRIDGE.TOKEN_SELECTOR, {
       type: TokenSelectorType.Dest,
       enabledChainIds: sourceToken?.chainId
-      ? [formatChainIdToCaip(sourceToken.chainId)]
-      : [],
+        ? [formatChainIdToCaip(sourceToken.chainId)]
+        : [],
       excludeRwaTokens: true,
       featureId: FeatureId.LIMIT_ORDER,
     });

--- a/app/components/UI/Bridge/utils/filterWatchlistBridgeTokens.test.ts
+++ b/app/components/UI/Bridge/utils/filterWatchlistBridgeTokens.test.ts
@@ -75,4 +75,44 @@ describe('filterWatchlistBridgeTokens', () => {
       'USDC',
     ]);
   });
+
+  describe('allowedChainIds', () => {
+    it('restricts results to the allowed chains when no specific chain is selected', () => {
+      const result = filterWatchlistBridgeTokens(tokens, {
+        allowedChainIds: [MOCK_CHAIN_IDS.ethereum],
+      });
+
+      expect(result.map((token) => token.symbol)).toStrictEqual([
+        'ETH',
+        'USDC',
+      ]);
+    });
+
+    it('returns an empty list when no watchlist token is on an allowed chain', () => {
+      const result = filterWatchlistBridgeTokens(tokens, {
+        allowedChainIds: [MOCK_CHAIN_IDS.optimism],
+      });
+
+      expect(result).toStrictEqual([]);
+    });
+
+    it('combines with selectedChainId as an additional, narrower filter', () => {
+      const result = filterWatchlistBridgeTokens(tokens, {
+        allowedChainIds: [MOCK_CHAIN_IDS.ethereum, MOCK_CHAIN_IDS.polygon],
+        selectedChainId: MOCK_CHAIN_IDS.polygon,
+      });
+
+      expect(result.map((token) => token.symbol)).toStrictEqual(['POL']);
+    });
+
+    it('does not restrict results when allowedChainIds is undefined', () => {
+      const result = filterWatchlistBridgeTokens(tokens, {});
+
+      expect(result.map((token) => token.symbol)).toStrictEqual([
+        'ETH',
+        'POL',
+        'USDC',
+      ]);
+    });
+  });
 });

--- a/app/components/UI/Bridge/utils/filterWatchlistBridgeTokens.ts
+++ b/app/components/UI/Bridge/utils/filterWatchlistBridgeTokens.ts
@@ -6,6 +6,7 @@ import { tokenMatchesQuery } from './tokenUtils';
 
 export interface FilterWatchlistBridgeTokensOptions {
   selectedChainId?: CaipChainId;
+  allowedChainIds?: CaipChainId[];
   searchQuery?: string;
 }
 
@@ -15,9 +16,20 @@ export interface FilterWatchlistBridgeTokensOptions {
  */
 export const filterWatchlistBridgeTokens = (
   tokens: readonly (BridgeToken & { assetId: string })[],
-  { selectedChainId, searchQuery }: FilterWatchlistBridgeTokensOptions,
+  {
+    selectedChainId,
+    allowedChainIds,
+    searchQuery,
+  }: FilterWatchlistBridgeTokensOptions,
 ): BridgeToken[] => {
   let filtered = [...tokens];
+
+  if (allowedChainIds) {
+    const allowedSet = new Set(allowedChainIds);
+    filtered = filtered.filter((token) =>
+      allowedSet.has(getCaipChainIdFromAssetId(String(token.assetId))),
+    );
+  }
 
   if (selectedChainId) {
     filtered = filtered.filter(

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9031,6 +9031,8 @@
     "robinhood_banner_subtitle": "Explore trending tokens",
     "no_tokens_found": "No tokens found",
     "no_tokens_found_description": "We couldn't find any tokens with this name. Try a different search.",
+    "no_watchlist_tokens_found": "No assets in watchlist",
+    "no_watchlist_tokens_found_description": "Tap the star icon on any asset to add it to your watchlist.",
     "select_network": "Select network",
     "all_networks": "All networks",
     "num_networks": "{{numNetworks}} networks",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Limit orders are single-chain swaps — the destination token must be on the same chain as the source token. Previously, opening the destination token picker passed the full `enabledChainIds` list from the limit-order feature flags, so users could browse tokens on other enabled chains (e.g. BSC, Base) even when the source token was on Ethereum.

This change scopes the destination picker to only the source token's chain by passing `[formatChainIdToCaip(sourceToken.chainId)]` instead of the full enabled chain list. When no source token is selected, an empty list is passed.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed limit order destination token picker showing tokens from chains other than the selected source chain

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:  https://consensyssoftware.atlassian.net/browse/SWAPS-5031

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Limit order destination token picker chain scoping

  Scenario: Destination picker only shows tokens on the source chain
    Given the user is on the Limit Order tab in Swaps
    And the source token is ETH on Ethereum mainnet
    When the user taps the destination token selector
    Then only tokens on Ethereum mainnet are shown
    And tokens from other enabled chains (e.g. BSC, Base) are not available

  Scenario: Destination picker updates when source chain changes
    Given the user is on the Limit Order tab in Swaps
    And the source token is on BSC
    When the user taps the destination token selector
    Then only tokens on BSC are shown

  Scenario: Source token picker still shows all enabled chains
    Given the user is on the Limit Order tab in Swaps
    When the user taps the source token selector
    Then tokens from all limit-order-enabled chains are available
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes limit-order destination chain scoping and shared token-picker/watchlist filtering; incorrect chain id conversion could hide valid tokens or show wrong networks.
> 
> **Overview**
> **Limit order destination picker** is now scoped to the source token’s chain only: navigation passes a single CAIP chain id (or an empty list when no source is selected) instead of all limit-order-enabled chains. Hex source chain ids are normalized via `formatChainIdToCaip`.
> 
> **Bridge token selector** applies the picker’s enabled chains to watchlist filtering (`allowedChainIds` on `filterWatchlistBridgeTokens`) and shows a dedicated watchlist empty state (new copy + themed artwork) when the user has favorites but none on the allowed chains. Search empty UI is generalized into a reusable empty-state component.
> 
> **Network pills** hide the redundant **All** control when only one network is available and treat “no filter” as that chain being selected for pill highlighting/selection behavior.
> 
> Tests and English locale strings cover the new scoping, watchlist filtering, and single-chain pill behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 768c9db46036f775a25fae2a3c3239ee44b5bba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->