### PR TITLE
fix(notifications): backfill legacy notification consent

### DIFF
--- a/android/app/src/main/java/io/metamask/MainApplication.kt
+++ b/android/app/src/main/java/io/metamask/MainApplication.kt
@@ -22,6 +22,7 @@ import cl.json.ShareApplication
 import io.branch.rnbranch.RNBranchModule
 import io.metamask.nativeModules.RCTMinimizerPackage
 import io.metamask.nativeModules.RNTar.RNTarPackage
+import io.metamask.nativeModules.BrazePushPackage
 import io.metamask.nativeModules.NotificationPackage
 import com.braze.BrazeActivityLifecycleCallbackListener
 import com.margelo.nitro.nitrofetch.AutoPrefetcher
@@ -44,6 +45,7 @@ class MainApplication : Application(), ShareApplication, ReactApplication {
                 add(RCTMinimizerPackage())
                 add(RNTarPackage())
                 add(NotificationPackage())
+                add(BrazePushPackage())
             },
         )
     }

--- a/android/app/src/main/java/io/metamask/nativeModules/BrazePushModule.kt
+++ b/android/app/src/main/java/io/metamask/nativeModules/BrazePushModule.kt
@@ -1,0 +1,69 @@
+package io.metamask.nativeModules
+
+import com.braze.Braze
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+
+class BrazePushModule(context: ReactApplicationContext) : ReactContextBaseJavaModule(context) {
+
+    override fun getName(): String = "BrazePushModule"
+
+    @ReactMethod
+    fun registerPush(fcmToken: String, promise: Promise) {
+        if (fcmToken.isBlank()) {
+            promise.reject(CODE_INVALID_TOKEN, "FCM token is empty")
+            return
+        }
+
+        try {
+            Braze.getInstance(reactApplicationContext).registeredPushToken = fcmToken
+            promise.resolve(null)
+        } catch (error: Exception) {
+            promise.reject(CODE_SDK_UNAVAILABLE, "Braze is not initialized", error)
+        }
+    }
+
+    @ReactMethod
+    fun unregisterPush(promise: Promise) {
+        try {
+            Braze.getInstance(reactApplicationContext).unregisterPush { result ->
+                result.fold(
+                    onSuccess = {
+                        promise.resolve(successResult())
+                    },
+                    onFailure = { error ->
+                        if (isNoPushTokenError(error)) {
+                            promise.resolve(successResult())
+                        } else {
+                            promise.resolve(failureResult(error))
+                        }
+                    },
+                )
+            }
+        } catch (error: Exception) {
+            promise.reject(CODE_SDK_UNAVAILABLE, "Braze is not initialized", error)
+        }
+    }
+
+    private fun isNoPushTokenError(error: Throwable): Boolean =
+        error.message?.contains("no push token", ignoreCase = true) == true
+
+    private fun successResult() =
+        Arguments.createMap().apply {
+            putBoolean("success", true)
+        }
+
+    private fun failureResult(error: Throwable) =
+        Arguments.createMap().apply {
+            putBoolean("success", false)
+            putString("message", error.message ?: "Failed to unregister Braze push")
+        }
+
+    companion object {
+        private const val CODE_INVALID_TOKEN = "INVALID_TOKEN"
+        private const val CODE_SDK_UNAVAILABLE = "SDK_UNAVAILABLE"
+    }
+}

--- a/android/app/src/main/java/io/metamask/nativeModules/BrazePushPackage.kt
+++ b/android/app/src/main/java/io/metamask/nativeModules/BrazePushPackage.kt
@@ -1,0 +1,16 @@
+package io.metamask.nativeModules
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class BrazePushPackage : ReactPackage {
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
+        emptyList()
+
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
+        listOf(BrazePushModule(reactContext))
+}

--- a/android/app/src/main/res/values/braze.xml
+++ b/android/app/src/main/res/values/braze.xml
@@ -8,8 +8,8 @@
       - MM_BRAZE_SDK_ENDPOINT
   -->
 
-  <!-- Automatic FCM token registration — Braze will obtain and register a push token when permissions are granted -->
-  <bool translatable="false" name="com_braze_firebase_cloud_messaging_registration_enabled">true</bool>
+  <!-- Register FCM tokens manually according to the in-app Notifications setting -->
+  <bool translatable="false" name="com_braze_firebase_cloud_messaging_registration_enabled">false</bool>
   <!-- Resolved at build time from google-services.json via the com.google.gms.google-services plugin -->
   <string translatable="false" name="com_braze_firebase_cloud_messaging_sender_id">@string/gcm_defaultSenderId</string>
 

--- a/app/actions/notification/helpers/index.test.tsx
+++ b/app/actions/notification/helpers/index.test.tsx
@@ -17,6 +17,8 @@ import {
   type subscribeToContentPreviewToken as subscribeToContentPreviewTokenFn,
 } from '.';
 import Engine from '../../../core/Engine';
+import { unregisterBrazePush } from '../../../core/Braze/unregisterPush';
+import { markBrazePushRegistrationDesired } from '../../../core/Braze/pushRegistrationState';
 jest.mock('../../../util/notifications', () => ({
   isNotificationsFeatureEnabled: () => true,
 }));
@@ -37,19 +39,37 @@ jest.mock('../../../core/Engine', () => ({
       enablePushNotifications: jest.fn(),
       disablePushNotifications: jest.fn(),
     },
+    NotificationServicesPushController: {
+      state: {
+        fcmToken: '',
+      },
+    },
   },
   controllerMessenger: {
     call: jest.fn(),
   },
 }));
 
+jest.mock('../../../core/Braze/unregisterPush', () => ({
+  unregisterBrazePush: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('../../../core/Braze/pushRegistrationState', () => ({
+  markBrazePushRegistrationDesired: jest.fn().mockResolvedValue(undefined),
+}));
+
 beforeEach(() => {
   jest.clearAllMocks();
+  jest.resetAllMocks();
+  jest.mocked(unregisterBrazePush).mockResolvedValue(true);
+  Engine.context.NotificationServicesPushController.state.fcmToken = '';
 });
 
 describe('helpers - enableNotificationServices()', () => {
   it('invoke notification services method', async () => {
     await enableNotifications();
+
+    expect(markBrazePushRegistrationDesired).toHaveBeenCalledTimes(1);
     expect(
       Engine.context.NotificationServicesController.enableMetamaskNotifications,
     ).toHaveBeenCalled();
@@ -67,9 +87,23 @@ describe('helpers - enableNotificationServices()', () => {
 
   it('forwards enable notification options', async () => {
     await enableNotifications({ registerPushNotifications: false });
+
+    expect(markBrazePushRegistrationDesired).not.toHaveBeenCalled();
     expect(
       Engine.context.NotificationServicesController.enableMetamaskNotifications,
     ).toHaveBeenCalledWith({ registerPushNotifications: false });
+  });
+
+  it('enables NaaP when Braze registration-state persistence fails', async () => {
+    jest
+      .mocked(markBrazePushRegistrationDesired)
+      .mockRejectedValue(new Error('Storage unavailable'));
+
+    await enableNotifications();
+
+    expect(
+      Engine.context.NotificationServicesController.enableMetamaskNotifications,
+    ).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -152,11 +186,25 @@ describe('helpers - setMarketingNotificationPreferencesEnabled()', () => {
 });
 
 describe('helpers - disableNotificationServices()', () => {
-  it('invoke notification services method', async () => {
+  it('unregisters Braze directly before global disable without an FCM token', async () => {
     await disableNotifications();
+
+    expect(unregisterBrazePush).toHaveBeenCalledTimes(1);
     expect(
       Engine.context.NotificationServicesController.disableNotificationServices,
-    ).toHaveBeenCalled();
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates Braze unregistration to global disable with an FCM token', async () => {
+    Engine.context.NotificationServicesPushController.state.fcmToken =
+      'fcm-token';
+
+    await disableNotifications();
+
+    expect(unregisterBrazePush).not.toHaveBeenCalled();
+    expect(
+      Engine.context.NotificationServicesController.disableNotificationServices,
+    ).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -226,18 +274,63 @@ describe('helpers - markMetamaskNotificationsAsRead()', () => {
 describe('helpers - enablePushNotifications()', () => {
   it('invoke notification services method', async () => {
     await enablePushNotifications();
+
+    expect(markBrazePushRegistrationDesired).toHaveBeenCalledTimes(1);
     expect(
       Engine.context.NotificationServicesController.enablePushNotifications,
     ).toHaveBeenCalled();
   });
+
+  it('enables NaaP push when Braze registration-state persistence fails', async () => {
+    jest
+      .mocked(markBrazePushRegistrationDesired)
+      .mockRejectedValue(new Error('Storage unavailable'));
+
+    await enablePushNotifications();
+
+    expect(
+      Engine.context.NotificationServicesController.enablePushNotifications,
+    ).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('helpers - disablePushNotifications()', () => {
-  it('invoke notification services method', async () => {
+  it('unregisters Braze directly when NaaP has no FCM token', async () => {
     await disablePushNotifications();
+
+    expect(unregisterBrazePush).toHaveBeenCalled();
     expect(
       Engine.context.NotificationServicesController.disablePushNotifications,
     ).toHaveBeenCalled();
+    expect(
+      jest.mocked(unregisterBrazePush).mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      jest.mocked(
+        Engine.context.NotificationServicesController.disablePushNotifications,
+      ).mock.invocationCallOrder[0],
+    );
+  });
+
+  it('delegates Braze unregistration to token deletion when FCM has a token', async () => {
+    Engine.context.NotificationServicesPushController.state.fcmToken =
+      'fcm-token';
+
+    await disablePushNotifications();
+
+    expect(unregisterBrazePush).not.toHaveBeenCalled();
+    expect(
+      Engine.context.NotificationServicesController.disablePushNotifications,
+    ).toHaveBeenCalled();
+  });
+
+  it('continues disabling NaaP when Braze unregistration remains pending', async () => {
+    jest.mocked(unregisterBrazePush).mockResolvedValueOnce(false);
+
+    await disablePushNotifications();
+
+    expect(
+      Engine.context.NotificationServicesController.disablePushNotifications,
+    ).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/app/actions/notification/helpers/index.ts
+++ b/app/actions/notification/helpers/index.ts
@@ -4,6 +4,9 @@ import type {
   NotificationServicesControllerEnableNotificationsOptions,
 } from '@metamask/notification-services-controller/notification-services';
 import Engine from '../../../core/Engine';
+import { unregisterBrazePush } from '../../../core/Braze/unregisterPush';
+import { markBrazePushRegistrationDesired } from '../../../core/Braze/pushRegistrationState';
+import Logger from '../../../util/Logger';
 import { isNotificationsFeatureEnabled } from '../../../util/notifications';
 
 const CLIENT_TYPE = 'mobile' as const;
@@ -42,6 +45,17 @@ export const assertIsFeatureEnabled = () => {
   }
 };
 
+const markBrazePushRegistrationDesiredSafely = async (): Promise<void> => {
+  try {
+    await markBrazePushRegistrationDesired();
+  } catch (error) {
+    Logger.error(
+      error instanceof Error ? error : new Error(String(error)),
+      '[Braze] Failed to persist push registration intent',
+    );
+  }
+};
+
 /**
  * Enable Notifications Switch
  * - This is used during onboarding and for the notifications settings toggle
@@ -51,6 +65,9 @@ export const enableNotifications = async (
   options?: NotificationServicesControllerEnableNotificationsOptions,
 ) => {
   assertIsFeatureEnabled();
+  if (options?.registerPushNotifications !== false) {
+    await markBrazePushRegistrationDesiredSafely();
+  }
   await Engine.context.NotificationServicesController.enableMetamaskNotifications(
     options,
   );
@@ -100,6 +117,9 @@ export const setMarketingNotificationPreferencesEnabled = async (
  */
 export const disableNotifications = async () => {
   assertIsFeatureEnabled();
+  if (!Engine.context.NotificationServicesPushController.state.fcmToken) {
+    await unregisterBrazePush();
+  }
   await Engine.context.NotificationServicesController.disableNotificationServices();
 };
 
@@ -110,15 +130,22 @@ export const disableNotifications = async () => {
  */
 export const enablePushNotifications = async () => {
   assertIsFeatureEnabled();
+  await markBrazePushRegistrationDesiredSafely();
   await Engine.context.NotificationServicesController.enablePushNotifications();
 };
 
 /**
  * Push Notifications Switch
  * - Allows us to disable push notifications
+ * When NaaP has no FCM token, unregisters Braze here because the push
+ * controller otherwise returns before invoking its token-deletion callback.
+ * Failures persist for retry on the next app session.
  */
 export const disablePushNotifications = async () => {
   assertIsFeatureEnabled();
+  if (!Engine.context.NotificationServicesPushController.state.fcmToken) {
+    await unregisterBrazePush();
+  }
   await Engine.context.NotificationServicesController.disablePushNotifications();
 };
 

--- a/app/constants/storage.ts
+++ b/app/constants/storage.ts
@@ -47,6 +47,7 @@ export const LAST_INCOMING_TX_BLOCK_INFO = `${prefix}lastIncomingTxBlockInfo`;
 
 export const PUSH_NOTIFICATIONS_PROMPT_COUNT = `${prefix}pushNotificationsPromptCount`;
 export const PUSH_NOTIFICATIONS_PROMPT_TIME = `${prefix}pushNotificationsPromptTime`;
+export const BRAZE_PUSH_REGISTRATION_STATE = `${prefix}brazePushRegistrationState`;
 
 export const LANGUAGE = `${prefix}language`;
 

--- a/app/constants/storage.ts
+++ b/app/constants/storage.ts
@@ -48,6 +48,7 @@ export const LAST_INCOMING_TX_BLOCK_INFO = `${prefix}lastIncomingTxBlockInfo`;
 export const PUSH_NOTIFICATIONS_PROMPT_COUNT = `${prefix}pushNotificationsPromptCount`;
 export const PUSH_NOTIFICATIONS_PROMPT_TIME = `${prefix}pushNotificationsPromptTime`;
 export const BRAZE_PUSH_REGISTRATION_STATE = `${prefix}brazePushRegistrationState`;
+export const LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING = `${prefix}legacyNotificationAusBackfillPending`;
 
 export const LANGUAGE = `${prefix}language`;
 

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -1719,7 +1719,7 @@ class AuthenticationService {
    * @returns {Promise<void>}
    */
   deleteWallet = async (): Promise<void> => {
-    clearBrazeUser();
+    await clearBrazeUser();
     await this.resetWalletState();
     await this.deleteUser();
     // Clear metrics opt-in UI state and reset onboarding Redux state

--- a/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.test.ts
+++ b/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.test.ts
@@ -1,7 +1,10 @@
-import { renderHook } from '@testing-library/react-native';
+import { renderHook, waitFor } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import { useBrazeIdentity } from './useBrazeIdentity';
 import { setBrazeUser, clearBrazeUser, refreshBrazeBanners } from '../..';
+import { registerBrazePush } from '../../registerPush';
+import { retryPendingBrazePushUnregistration } from '../../unregisterPush';
+import { hasPendingBrazePushUnregistrationSync } from '../../pushRegistrationState';
 import {
   selectCanonicalProfileId,
   selectIsSignedIn,
@@ -18,13 +21,35 @@ jest.mock('../..', () => ({
   refreshBrazeBanners: jest.fn(),
 }));
 
+jest.mock('../../registerPush', () => ({
+  registerBrazePush: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../unregisterPush', () => ({
+  retryPendingBrazePushUnregistration: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('../../pushRegistrationState', () => ({
+  hasPendingBrazePushUnregistrationSync: jest.fn().mockReturnValue(false),
+}));
+
 const mockSetBrazeUser = jest.mocked(setBrazeUser);
 const mockClearBrazeUser = jest.mocked(clearBrazeUser);
 const mockRefreshBrazeBanners = jest.mocked(refreshBrazeBanners);
+const mockRegisterBrazePush = jest.mocked(registerBrazePush);
+const mockRetryPendingBrazePushUnregistration = jest.mocked(
+  retryPendingBrazePushUnregistration,
+);
+const mockHasPendingBrazePushUnregistrationSync = jest.mocked(
+  hasPendingBrazePushUnregistrationSync,
+);
 const mockUseSelector = jest.mocked(useSelector);
 
 let mockIsSignedIn = false;
 let mockCanonicalProfileId: string | undefined;
+let mockAreNotificationsEnabled = true;
+let mockIsPushEnabled = false;
+let mockFcmToken = '';
 
 const createState = (isSignedIn: boolean, canonicalProfileId?: string) =>
   ({
@@ -53,6 +78,15 @@ const createState = (isSignedIn: boolean, canonicalProfileId?: string) =>
               }
             : {}),
         },
+        NotificationServicesController: {
+          ...backgroundState.NotificationServicesController,
+          isNotificationServicesEnabled: mockAreNotificationsEnabled,
+        },
+        NotificationServicesPushController: {
+          isPushEnabled: mockIsPushEnabled,
+          fcmToken: mockFcmToken,
+          isUpdatingFCMToken: false,
+        },
       },
     },
   }) as unknown as Record<string, unknown>;
@@ -61,7 +95,13 @@ describe('useBrazeIdentity', () => {
   beforeEach(() => {
     mockIsSignedIn = false;
     mockCanonicalProfileId = undefined;
+    mockAreNotificationsEnabled = true;
+    mockIsPushEnabled = false;
+    mockFcmToken = '';
     jest.clearAllMocks();
+    mockClearBrazeUser.mockResolvedValue(true);
+    mockRetryPendingBrazePushUnregistration.mockResolvedValue(true);
+    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(false);
     mockUseSelector.mockImplementation((selector) => {
       const state = createState(
         mockIsSignedIn,
@@ -77,12 +117,14 @@ describe('useBrazeIdentity', () => {
     });
   });
 
-  it('calls setBrazeUser and refreshes banners when signed in with a canonical profile ID', () => {
+  it('calls setBrazeUser and refreshes banners when signed in with a canonical profile ID', async () => {
     mockIsSignedIn = true;
     mockCanonicalProfileId = 'canonical-123';
     renderHook(() => useBrazeIdentity());
 
-    expect(mockSetBrazeUser).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mockSetBrazeUser).toHaveBeenCalledTimes(1);
+    });
     expect(mockSetBrazeUser).toHaveBeenCalledWith('canonical-123');
     expect(mockRefreshBrazeBanners).toHaveBeenCalledTimes(1);
     expect(mockClearBrazeUser).not.toHaveBeenCalled();
@@ -97,6 +139,48 @@ describe('useBrazeIdentity', () => {
     expect(mockRefreshBrazeBanners).not.toHaveBeenCalled();
   });
 
+  it('registers push after Braze identifies the signed-in profile', async () => {
+    mockIsSignedIn = true;
+    mockCanonicalProfileId = 'canonical-123';
+    mockIsPushEnabled = true;
+    mockFcmToken = 'fcm-token';
+
+    renderHook(() => useBrazeIdentity());
+
+    await waitFor(() =>
+      expect(mockRegisterBrazePush).toHaveBeenCalledWith('fcm-token'),
+    );
+    expect(mockRetryPendingBrazePushUnregistration).not.toHaveBeenCalled();
+    expect(mockSetBrazeUser.mock.invocationCallOrder[0]).toBeLessThan(
+      mockRegisterBrazePush.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('does not register push when NaaP push is disabled', async () => {
+    mockIsSignedIn = true;
+    mockCanonicalProfileId = 'canonical-123';
+    mockFcmToken = 'fcm-token';
+
+    renderHook(() => useBrazeIdentity());
+
+    await waitFor(() => expect(mockSetBrazeUser).toHaveBeenCalledTimes(1));
+    expect(mockRegisterBrazePush).not.toHaveBeenCalled();
+  });
+
+  it('does not register push when master notifications are disabled', async () => {
+    mockIsSignedIn = true;
+    mockCanonicalProfileId = 'canonical-123';
+    mockAreNotificationsEnabled = false;
+    mockIsPushEnabled = true;
+    mockFcmToken = 'fcm-token';
+
+    renderHook(() => useBrazeIdentity());
+
+    await waitFor(() => expect(mockSetBrazeUser).toHaveBeenCalledTimes(1));
+    expect(mockRetryPendingBrazePushUnregistration).not.toHaveBeenCalled();
+    expect(mockRegisterBrazePush).not.toHaveBeenCalled();
+  });
+
   it('does not clear Braze on initial mount when not signed in', () => {
     renderHook(() => useBrazeIdentity());
 
@@ -104,12 +188,12 @@ describe('useBrazeIdentity', () => {
     expect(mockSetBrazeUser).not.toHaveBeenCalled();
   });
 
-  it('clears Braze after transitioning from signed in to signed out', () => {
+  it('clears Braze after transitioning from signed in to signed out', async () => {
     mockIsSignedIn = true;
     mockCanonicalProfileId = 'canonical-123';
     const { rerender } = renderHook(() => useBrazeIdentity());
 
-    expect(mockSetBrazeUser).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockSetBrazeUser).toHaveBeenCalledTimes(1));
     expect(mockSetBrazeUser).toHaveBeenCalledWith('canonical-123');
     expect(mockClearBrazeUser).not.toHaveBeenCalled();
 
@@ -117,22 +201,22 @@ describe('useBrazeIdentity', () => {
     mockCanonicalProfileId = undefined;
     rerender({});
 
-    expect(mockClearBrazeUser).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockClearBrazeUser).toHaveBeenCalledTimes(1));
   });
 
-  it('re-identifies and refreshes when the canonical profile ID changes', () => {
+  it('re-identifies and refreshes when the canonical profile ID changes', async () => {
     mockIsSignedIn = true;
     mockCanonicalProfileId = 'canonical-123';
     const { rerender } = renderHook(() => useBrazeIdentity());
 
-    expect(mockSetBrazeUser).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockSetBrazeUser).toHaveBeenCalledTimes(1));
     expect(mockSetBrazeUser).toHaveBeenCalledWith('canonical-123');
     expect(mockRefreshBrazeBanners).toHaveBeenCalledTimes(1);
 
     mockCanonicalProfileId = 'canonical-456';
     rerender({});
 
-    expect(mockSetBrazeUser).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(mockSetBrazeUser).toHaveBeenCalledTimes(2));
     expect(mockSetBrazeUser).toHaveBeenLastCalledWith('canonical-456');
     expect(mockRefreshBrazeBanners).toHaveBeenCalledTimes(2);
   });
@@ -141,5 +225,99 @@ describe('useBrazeIdentity', () => {
     renderHook(() => useBrazeIdentity());
 
     expect(mockRefreshBrazeBanners).not.toHaveBeenCalled();
+  });
+
+  it('identifies the user without registering while launch unregistration remains pending', async () => {
+    mockIsSignedIn = true;
+    mockCanonicalProfileId = 'canonical-123';
+    mockAreNotificationsEnabled = true;
+    mockIsPushEnabled = true;
+    mockFcmToken = 'fcm-token';
+    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(true);
+    mockRetryPendingBrazePushUnregistration.mockResolvedValue(false);
+
+    renderHook(() => useBrazeIdentity());
+
+    await waitFor(() =>
+      expect(mockRetryPendingBrazePushUnregistration).toHaveBeenCalled(),
+    );
+    expect(mockSetBrazeUser).toHaveBeenCalledWith('canonical-123');
+    expect(mockRegisterBrazePush).not.toHaveBeenCalled();
+  });
+
+  it('checks pending unregistration only once per app session', async () => {
+    mockIsSignedIn = true;
+    mockCanonicalProfileId = 'canonical-123';
+    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(true);
+    mockRetryPendingBrazePushUnregistration.mockResolvedValue(false);
+    const { rerender } = renderHook(() => useBrazeIdentity());
+
+    await waitFor(() =>
+      expect(mockRetryPendingBrazePushUnregistration).toHaveBeenCalledTimes(1),
+    );
+
+    mockCanonicalProfileId = 'canonical-456';
+    rerender({});
+
+    expect(mockRetryPendingBrazePushUnregistration).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockSetBrazeUser).toHaveBeenCalledTimes(2));
+  });
+
+  it('registers after an explicit enable clears a failed launch intent', async () => {
+    mockIsSignedIn = true;
+    mockCanonicalProfileId = 'canonical-123';
+    mockFcmToken = 'fcm-token';
+    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(true);
+    mockRetryPendingBrazePushUnregistration.mockResolvedValue(false);
+    const { rerender } = renderHook(() => useBrazeIdentity());
+
+    await waitFor(() =>
+      expect(mockRetryPendingBrazePushUnregistration).toHaveBeenCalledTimes(1),
+    );
+
+    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(false);
+    mockIsPushEnabled = true;
+    rerender({});
+
+    await waitFor(() =>
+      expect(mockRegisterBrazePush).toHaveBeenCalledWith('fcm-token'),
+    );
+    expect(mockRetryPendingBrazePushUnregistration).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears deferred Braze data after a launch retry succeeds', async () => {
+    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(true);
+    mockRetryPendingBrazePushUnregistration.mockImplementation(async () => {
+      mockHasPendingBrazePushUnregistrationSync.mockReturnValue(false);
+      return true;
+    });
+
+    renderHook(() => useBrazeIdentity());
+
+    await waitFor(() => expect(mockClearBrazeUser).toHaveBeenCalledTimes(1));
+    expect(
+      mockRetryPendingBrazePushUnregistration.mock.invocationCallOrder[0],
+    ).toBeLessThan(mockClearBrazeUser.mock.invocationCallOrder[0]);
+  });
+
+  it('retries a persisted unregistration before registering enabled push', async () => {
+    mockIsSignedIn = true;
+    mockCanonicalProfileId = 'canonical-123';
+    mockIsPushEnabled = true;
+    mockFcmToken = 'fcm-token';
+    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(true);
+    mockRetryPendingBrazePushUnregistration.mockImplementation(async () => {
+      mockHasPendingBrazePushUnregistrationSync.mockReturnValue(false);
+      return true;
+    });
+
+    renderHook(() => useBrazeIdentity());
+
+    await waitFor(() =>
+      expect(mockRegisterBrazePush).toHaveBeenCalledWith('fcm-token'),
+    );
+    expect(
+      mockRetryPendingBrazePushUnregistration.mock.invocationCallOrder[0],
+    ).toBeLessThan(mockRegisterBrazePush.mock.invocationCallOrder[0]);
   });
 });

--- a/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.ts
+++ b/app/core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.ts
@@ -1,10 +1,18 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import {
   selectCanonicalProfileId,
   selectIsSignedIn,
 } from '../../../../selectors/identity';
+import {
+  selectIsMetamaskNotificationsEnabled,
+  selectIsMetaMaskPushNotificationsEnabled,
+  selectMetaMaskPushNotificationToken,
+} from '../../../../selectors/notifications';
 import { setBrazeUser, clearBrazeUser, refreshBrazeBanners } from '../..';
+import { registerBrazePush } from '../../registerPush';
+import { retryPendingBrazePushUnregistration } from '../../unregisterPush';
+import { hasPendingBrazePushUnregistrationSync } from '../../pushRegistrationState';
 import Logger from '../../../../util/Logger';
 
 /**
@@ -15,26 +23,99 @@ import Logger from '../../../../util/Logger';
  * `refreshBrazeBanners()` runs so placement-targeted banners use the
  * current identity.
  *
+ * While signed in, registers Braze push only after the NaaP push controller
+ * has enabled push and persisted its current FCM token.
+ *
+ * On app launch, retries one push unregistration left pending by a previous
+ * session before changing the Braze identity.
+ *
  * On sign-out `clearBrazeUser()` makes the plugin a no-op so events are no
  * longer attributed to the previous user.
  */
 export function useBrazeIdentity(): void {
   const isSignedIn = useSelector(selectIsSignedIn);
   const canonicalProfileId = useSelector(selectCanonicalProfileId);
+  const areNotificationsEnabled = useSelector(
+    selectIsMetamaskNotificationsEnabled,
+  );
+  const isPushEnabled = useSelector(selectIsMetaMaskPushNotificationsEnabled);
+  const fcmToken = useSelector(selectMetaMaskPushNotificationToken);
   const hasBeenSignedInRef = useRef(false);
+  const hadPendingUnregistrationAtLaunchRef = useRef(
+    hasPendingBrazePushUnregistrationSync(),
+  );
+  const startupUnregistrationRetryRef = useRef<Promise<boolean> | undefined>(
+    undefined,
+  );
+  const [identifiedProfileId, setIdentifiedProfileId] = useState<string>();
 
   useEffect(() => {
-    try {
+    let cancelled = false;
+
+    const syncIdentity = async () => {
+      startupUnregistrationRetryRef.current ??=
+        hadPendingUnregistrationAtLaunchRef.current
+          ? retryPendingBrazePushUnregistration()
+          : Promise.resolve(true);
+      await startupUnregistrationRetryRef.current;
+      if (cancelled) {
+        return;
+      }
+
       if (isSignedIn && canonicalProfileId) {
         hasBeenSignedInRef.current = true;
-        setBrazeUser(canonicalProfileId);
-        refreshBrazeBanners();
-      } else if (!isSignedIn && hasBeenSignedInRef.current) {
+        if (identifiedProfileId !== canonicalProfileId) {
+          setBrazeUser(canonicalProfileId);
+          refreshBrazeBanners();
+          setIdentifiedProfileId(canonicalProfileId);
+        }
+      } else if (
+        !isSignedIn &&
+        (hasBeenSignedInRef.current ||
+          hadPendingUnregistrationAtLaunchRef.current)
+      ) {
         hasBeenSignedInRef.current = false;
-        clearBrazeUser();
+        setIdentifiedProfileId(undefined);
+        await clearBrazeUser();
       }
-    } catch (error) {
-      Logger.error(error as Error, '[Braze] Failed to sync Braze identity');
+    };
+
+    syncIdentity().catch((error) => {
+      Logger.error(
+        error instanceof Error ? error : new Error(String(error)),
+        '[Braze] Failed to sync Braze identity',
+      );
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isSignedIn, canonicalProfileId, identifiedProfileId]);
+
+  useEffect(() => {
+    if (
+      !isSignedIn ||
+      identifiedProfileId !== canonicalProfileId ||
+      !areNotificationsEnabled ||
+      !isPushEnabled ||
+      !fcmToken ||
+      hasPendingBrazePushUnregistrationSync()
+    ) {
+      return;
     }
-  }, [isSignedIn, canonicalProfileId]);
+
+    registerBrazePush(fcmToken).catch((error) => {
+      Logger.error(
+        error instanceof Error ? error : new Error(String(error)),
+        '[Braze] Failed to sync push registration',
+      );
+    });
+  }, [
+    isSignedIn,
+    canonicalProfileId,
+    identifiedProfileId,
+    areNotificationsEnabled,
+    isPushEnabled,
+    fcmToken,
+  ]);
 }

--- a/app/core/Braze/index.test.ts
+++ b/app/core/Braze/index.test.ts
@@ -16,6 +16,7 @@ import {
 
 const mockSetBrazeProfileId = jest.fn();
 const mockSetLanguage = jest.fn();
+const mockHasPendingBrazePushUnregistrationSync = jest.fn();
 
 jest.mock('../Engine/controllers/analytics-controller/BrazePlugin', () => ({
   BrazePlugin: jest.fn().mockImplementation(() => ({
@@ -26,11 +27,27 @@ jest.mock('../Engine/controllers/analytics-controller/BrazePlugin', () => ({
   })),
 }));
 
+jest.mock('./pushRegistrationState', () => ({
+  hasPendingBrazePushUnregistrationSync: () =>
+    mockHasPendingBrazePushUnregistrationSync(),
+}));
+
 const MockBrazePlugin = BrazePlugin as jest.MockedClass<typeof BrazePlugin>;
 
 describe('Braze service', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
+    MockBrazePlugin.mockImplementation(
+      () =>
+        ({
+          type: 'destination',
+          key: 'Appboy',
+          setBrazeProfileId: mockSetBrazeProfileId,
+          setLanguage: mockSetLanguage,
+        }) as unknown as BrazePlugin,
+    );
+    mockHasPendingBrazePushUnregistrationSync.mockReturnValue(false);
     resetBrazePluginForTesting();
   });
 
@@ -55,14 +72,14 @@ describe('Braze service', () => {
   });
 
   describe('clearBrazeUser', () => {
-    it('clears the profile ID on the Braze Segment plugin', () => {
-      clearBrazeUser();
+    it('clears the profile ID on the Braze Segment plugin', async () => {
+      await clearBrazeUser();
 
       expect(mockSetBrazeProfileId).toHaveBeenCalledWith(undefined);
     });
 
-    it('wipes local Braze SDK data and re-enables the SDK', () => {
-      clearBrazeUser();
+    it('wipes local Braze SDK data and re-enables the SDK', async () => {
+      await clearBrazeUser();
 
       expect(Braze.wipeData).toHaveBeenCalledTimes(1);
       expect(Braze.enableSDK).toHaveBeenCalledTimes(1);
@@ -71,6 +88,15 @@ describe('Braze service', () => {
       ).toBeLessThan(
         (Braze.enableSDK as jest.Mock).mock.invocationCallOrder[0],
       );
+    });
+
+    it('defers wiping local data while push unregistration is pending', async () => {
+      mockHasPendingBrazePushUnregistrationSync.mockReturnValue(true);
+
+      await expect(clearBrazeUser()).resolves.toBe(false);
+
+      expect(Braze.wipeData).not.toHaveBeenCalled();
+      expect(Braze.enableSDK).not.toHaveBeenCalled();
     });
   });
 

--- a/app/core/Braze/index.ts
+++ b/app/core/Braze/index.ts
@@ -8,6 +8,7 @@ import {
   BANNER_EVENT_DISMISSED,
   BANNER_EVENT_DISPLAY,
 } from '../../constants/engagement';
+import { hasPendingBrazePushUnregistrationSync } from './pushRegistrationState';
 
 let brazePlugin: BrazePlugin | undefined;
 
@@ -52,19 +53,28 @@ export function setBrazeUser(canonicalProfileId: string): void {
 /**
  * Clear the Braze profile identity so the plugin becomes a no-op.
  * Call on sign-out to stop attributing events to the previous user.
+ *
+ * @returns Whether local Braze data was cleared. Cleanup is deferred while a
+ * push unregistration remains pending so its device and user context survive.
  */
-export function clearBrazeUser(): void {
+export async function clearBrazeUser(): Promise<boolean> {
   if (hasTestOverrides) {
-    return;
+    return true;
   }
 
   getBrazePlugin().setBrazeProfileId(undefined);
+  if (hasPendingBrazePushUnregistrationSync()) {
+    return false;
+  }
+
   try {
     Braze.wipeData();
     Braze.enableSDK();
     Logger.log('[Braze] Cleared Braze user identity and local SDK data');
+    return true;
   } catch (error) {
     Logger.error(error as Error, '[Braze] Failed to clear local SDK data');
+    return false;
   }
 }
 

--- a/app/core/Braze/pushRegistrationState.test.ts
+++ b/app/core/Braze/pushRegistrationState.test.ts
@@ -1,0 +1,67 @@
+import StorageWrapper from '../../store/storage-wrapper';
+import {
+  getBrazePushRegistrationState,
+  hasPendingBrazePushUnregistrationSync,
+  markBrazePushRegistrationDesired,
+  markBrazePushUnregistrationPending,
+  markBrazePushUnregistered,
+} from './pushRegistrationState';
+import { BRAZE_PUSH_REGISTRATION_STATE } from '../../constants/storage';
+
+jest.mock('../../store/storage-wrapper', () => ({
+  __esModule: true,
+  default: {
+    getItemSync: jest.fn(),
+    setItem: jest.fn(),
+  },
+}));
+
+const mockStorageWrapper = jest.mocked(StorageWrapper);
+
+describe('Braze push registration state', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it('persists pending unregistration', async () => {
+    await markBrazePushUnregistrationPending();
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_REGISTRATION_STATE,
+      'unregistration-pending',
+    );
+  });
+
+  it('persists confirmed unregistration', async () => {
+    await markBrazePushUnregistered();
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_REGISTRATION_STATE,
+      'unregistered',
+    );
+  });
+
+  it('persists registration as the latest explicit desired state', async () => {
+    await markBrazePushRegistrationDesired();
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_REGISTRATION_STATE,
+      'registered',
+    );
+  });
+
+  it('reads the persisted registration state', () => {
+    mockStorageWrapper.getItemSync.mockReturnValue('unregistered');
+
+    expect(getBrazePushRegistrationState()).toBe('unregistered');
+  });
+
+  it('reports only unconfirmed unregistration as pending', () => {
+    mockStorageWrapper.getItemSync.mockReturnValue('unregistration-pending');
+
+    expect(hasPendingBrazePushUnregistrationSync()).toBe(true);
+    mockStorageWrapper.getItemSync.mockReturnValue('unregistered');
+    expect(hasPendingBrazePushUnregistrationSync()).toBe(false);
+  });
+});

--- a/app/core/Braze/pushRegistrationState.ts
+++ b/app/core/Braze/pushRegistrationState.ts
@@ -1,0 +1,46 @@
+import { BRAZE_PUSH_REGISTRATION_STATE } from '../../constants/storage';
+import StorageWrapper from '../../store/storage-wrapper';
+
+type BrazePushRegistrationState =
+  | 'registered'
+  | 'unregistered'
+  | 'unregistration-pending';
+
+const isBrazePushRegistrationState = (
+  value: string | null,
+): value is BrazePushRegistrationState =>
+  value === 'registered' ||
+  value === 'unregistered' ||
+  value === 'unregistration-pending';
+
+async function persistBrazePushRegistrationState(
+  state: BrazePushRegistrationState,
+): Promise<void> {
+  await StorageWrapper.setItem(BRAZE_PUSH_REGISTRATION_STATE, state);
+}
+
+export function getBrazePushRegistrationState():
+  | BrazePushRegistrationState
+  | undefined {
+  const storedState = StorageWrapper.getItemSync(BRAZE_PUSH_REGISTRATION_STATE);
+  return isBrazePushRegistrationState(storedState) ? storedState : undefined;
+}
+
+export function hasPendingBrazePushUnregistrationSync(): boolean {
+  return getBrazePushRegistrationState() === 'unregistration-pending';
+}
+
+/**
+ * Record a newer explicit registration intent before enabling NaaP push.
+ */
+export async function markBrazePushRegistrationDesired(): Promise<void> {
+  await persistBrazePushRegistrationState('registered');
+}
+
+export async function markBrazePushUnregistrationPending(): Promise<void> {
+  await persistBrazePushRegistrationState('unregistration-pending');
+}
+
+export async function markBrazePushUnregistered(): Promise<void> {
+  await persistBrazePushRegistrationState('unregistered');
+}

--- a/app/core/Braze/registerPush.test.ts
+++ b/app/core/Braze/registerPush.test.ts
@@ -1,0 +1,105 @@
+import { NativeModules, Platform } from 'react-native';
+import Logger from '../../util/Logger';
+import { registerBrazePush } from './registerPush';
+
+jest.mock('../../util/test/utils', () => ({
+  hasTestOverrides: false,
+}));
+
+jest.mock('../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    log: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const mockGetBrazePushRegistrationState = jest.fn();
+jest.mock('./pushRegistrationState', () => ({
+  getBrazePushRegistrationState: () => mockGetBrazePushRegistrationState(),
+}));
+
+const mockRegisterPush = jest.fn();
+const originalPlatform = Platform.OS;
+
+describe('registerBrazePush', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+    NativeModules.BrazePushModule = {
+      registerPush: mockRegisterPush,
+    };
+    mockGetBrazePushRegistrationState.mockReturnValue('registered');
+    mockRegisterPush.mockResolvedValue(undefined);
+  });
+
+  afterAll(() => {
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      value: originalPlatform,
+    });
+  });
+
+  it('passes the FCM token to Android', async () => {
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      value: 'android',
+    });
+
+    await registerBrazePush('fcm-token');
+
+    expect(mockRegisterPush).toHaveBeenCalledWith('fcm-token');
+  });
+
+  it('does not pass the FCM token to iOS', async () => {
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      value: 'ios',
+    });
+
+    await registerBrazePush('fcm-token');
+
+    expect(mockRegisterPush).toHaveBeenCalledWith();
+  });
+
+  it('throws when the native module is missing', async () => {
+    delete NativeModules.BrazePushModule;
+
+    await expect(registerBrazePush('fcm-token')).rejects.toThrow(
+      'BrazePushModule is not available',
+    );
+
+    expect(Logger.error).toHaveBeenCalledWith(
+      expect.any(Error),
+      '[Braze] Native registerPush module is missing',
+    );
+  });
+
+  it('throws when native registration fails', async () => {
+    const nativeError = new Error('Request failed');
+    mockRegisterPush.mockRejectedValue(nativeError);
+
+    await expect(registerBrazePush('fcm-token')).rejects.toBe(nativeError);
+
+    expect(Logger.error).toHaveBeenCalledWith(
+      nativeError,
+      '[Braze] Failed to register push',
+    );
+  });
+
+  it('does not register while unregistration remains pending', async () => {
+    mockGetBrazePushRegistrationState.mockReturnValue('unregistration-pending');
+
+    await registerBrazePush('fcm-token');
+
+    expect(mockRegisterPush).not.toHaveBeenCalled();
+  });
+
+  it('does not register when unregistration is the latest desired state', async () => {
+    mockGetBrazePushRegistrationState.mockReturnValue('unregistered');
+
+    await registerBrazePush('fcm-token');
+
+    expect(mockRegisterPush).not.toHaveBeenCalled();
+  });
+});

--- a/app/core/Braze/registerPush.ts
+++ b/app/core/Braze/registerPush.ts
@@ -1,0 +1,63 @@
+import { NativeModules, Platform } from 'react-native';
+import Logger from '../../util/Logger';
+import { hasTestOverrides } from '../../util/test/utils';
+import { getBrazePushRegistrationState } from './pushRegistrationState';
+
+interface BrazePushNativeModule {
+  registerPush: (fcmToken?: string) => Promise<void>;
+}
+
+const nativeModules = NativeModules as {
+  BrazePushModule?: BrazePushNativeModule;
+};
+
+const toError = (error: unknown): Error =>
+  error instanceof Error
+    ? error
+    : new Error(
+        typeof error === 'string' ? error : 'Failed to register Braze push',
+      );
+
+/**
+ * Register this device for Braze push.
+ *
+ * Android forwards the supplied FCM token to Braze. iOS deliberately does not
+ * forward it because Braze requires the binary APNs token captured natively by
+ * AppDelegate.
+ *
+ * @param fcmToken - Firebase registration token used by Android.
+ */
+export async function registerBrazePush(fcmToken: string): Promise<void> {
+  if (hasTestOverrides) {
+    return;
+  }
+
+  const registrationState = getBrazePushRegistrationState();
+  if (
+    registrationState === 'unregistration-pending' ||
+    registrationState === 'unregistered'
+  ) {
+    return;
+  }
+
+  const brazePushModule = nativeModules.BrazePushModule;
+  if (!brazePushModule) {
+    const error = new Error('BrazePushModule is not available');
+    Logger.error(error, '[Braze] Native registerPush module is missing');
+    throw error;
+  }
+
+  try {
+    if (Platform.OS === 'ios') {
+      await brazePushModule.registerPush();
+    } else if (Platform.OS === 'android') {
+      await brazePushModule.registerPush(fcmToken);
+    } else {
+      throw new Error(`Unsupported Braze push platform: ${Platform.OS}`);
+    }
+  } catch (nativeError) {
+    const error = toError(nativeError);
+    Logger.error(error, '[Braze] Failed to register push');
+    throw error;
+  }
+}

--- a/app/core/Braze/unregisterPush.test.ts
+++ b/app/core/Braze/unregisterPush.test.ts
@@ -1,0 +1,106 @@
+import { NativeModules } from 'react-native';
+import StorageWrapper from '../../store/storage-wrapper';
+import {
+  retryPendingBrazePushUnregistration,
+  unregisterBrazePush,
+} from './unregisterPush';
+import { BRAZE_PUSH_REGISTRATION_STATE } from '../../constants/storage';
+
+jest.mock('../../util/test/utils', () => ({
+  hasTestOverrides: false,
+}));
+
+jest.mock('../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    log: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('../../store/storage-wrapper', () => ({
+  __esModule: true,
+  default: {
+    getItemSync: jest.fn(),
+    setItem: jest.fn(),
+  },
+}));
+
+const mockUnregisterPush = jest.fn();
+const mockStorageWrapper = jest.mocked(StorageWrapper);
+let registrationState: string | null;
+
+describe('unregisterBrazePush', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+    registrationState = null;
+    mockStorageWrapper.getItemSync.mockImplementation((key) => {
+      if (key === BRAZE_PUSH_REGISTRATION_STATE) {
+        return registrationState;
+      }
+      return null;
+    });
+    mockStorageWrapper.setItem.mockImplementation(async (key, value) => {
+      if (key === BRAZE_PUSH_REGISTRATION_STATE) {
+        registrationState = value;
+      }
+    });
+    NativeModules.BrazePushModule = {
+      unregisterPush: mockUnregisterPush,
+    };
+  });
+
+  it('persists the intent and clears it after confirmed success', async () => {
+    mockUnregisterPush.mockResolvedValue({ success: true });
+
+    await expect(unregisterBrazePush()).resolves.toBe(true);
+
+    expect(mockUnregisterPush).toHaveBeenCalledTimes(1);
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledTimes(2);
+    expect(registrationState).toBe('unregistered');
+  });
+
+  it('keeps the intent pending after a native failure', async () => {
+    mockUnregisterPush.mockResolvedValue({
+      success: false,
+      message: 'Request failed',
+    });
+
+    await expect(unregisterBrazePush()).resolves.toBe(false);
+
+    expect(mockUnregisterPush).toHaveBeenCalledTimes(1);
+    expect(registrationState).toBe('unregistration-pending');
+  });
+
+  it('retains a persisted intent after a retry failure', async () => {
+    registrationState = 'unregistration-pending';
+    mockUnregisterPush.mockResolvedValue({
+      success: false,
+      message: 'Request failed',
+    });
+
+    await expect(retryPendingBrazePushUnregistration()).resolves.toBe(false);
+
+    expect(registrationState).toBe('unregistration-pending');
+  });
+
+  it('retries a persisted intent and clears it on success', async () => {
+    registrationState = 'unregistration-pending';
+    mockUnregisterPush.mockResolvedValue({ success: true });
+
+    await expect(retryPendingBrazePushUnregistration()).resolves.toBe(true);
+
+    expect(mockUnregisterPush).toHaveBeenCalledTimes(1);
+    expect(registrationState).toBe('unregistered');
+  });
+
+  it('keeps the intent pending when the native module is missing', async () => {
+    delete NativeModules.BrazePushModule;
+
+    await expect(unregisterBrazePush()).resolves.toBe(false);
+
+    expect(registrationState).toBe('unregistration-pending');
+  });
+});

--- a/app/core/Braze/unregisterPush.ts
+++ b/app/core/Braze/unregisterPush.ts
@@ -1,0 +1,98 @@
+import { NativeModules } from 'react-native';
+import Logger from '../../util/Logger';
+import { hasTestOverrides } from '../../util/test/utils';
+import {
+  hasPendingBrazePushUnregistrationSync,
+  markBrazePushUnregistrationPending,
+  markBrazePushUnregistered,
+} from './pushRegistrationState';
+
+interface BrazePushNativeModule {
+  unregisterPush: () => Promise<BrazePushUnregistrationResult>;
+}
+
+interface BrazePushUnregistrationResult {
+  success: boolean;
+  message?: string;
+}
+
+const nativeModules = NativeModules as {
+  BrazePushModule?: BrazePushNativeModule;
+};
+
+const toError = (error: unknown): Error =>
+  error instanceof Error
+    ? error
+    : new Error(
+        typeof error === 'string' ? error : 'Failed to unregister Braze push',
+      );
+
+async function unregisterOnce(): Promise<void> {
+  const brazePushModule = nativeModules.BrazePushModule;
+  if (!brazePushModule) {
+    throw new Error('BrazePushModule is not available');
+  }
+
+  const result = await brazePushModule.unregisterPush();
+  if (result.success) {
+    return;
+  }
+
+  throw new Error(result.message ?? 'Failed to unregister Braze push');
+}
+
+async function attemptPendingUnregistration(): Promise<boolean> {
+  if (!hasPendingBrazePushUnregistrationSync()) {
+    return true;
+  }
+
+  try {
+    await unregisterOnce();
+    await markBrazePushUnregistered();
+    return true;
+  } catch (nativeError) {
+    const error = toError(nativeError);
+    Logger.error(error, '[Braze] Push unregistration remains pending');
+    return false;
+  }
+}
+
+/**
+ * Unregister this device from Braze push before disabling NaaP push.
+ *
+ * Failures remain persisted for the next app session, allowing the local
+ * notification preference to turn off without losing the device-scoped
+ * consent intent.
+ *
+ * @returns Whether Braze confirmed unregistration during this call.
+ */
+export async function unregisterBrazePush(): Promise<boolean> {
+  if (hasTestOverrides) {
+    return true;
+  }
+
+  try {
+    await markBrazePushUnregistrationPending();
+    return await attemptPendingUnregistration();
+  } catch (nativeError) {
+    const error = toError(nativeError);
+    Logger.error(error, '[Braze] Failed to unregister push');
+    return false;
+  }
+}
+
+/**
+ * Retry a previously persisted Braze push unregistration.
+ *
+ * The pending marker is retained on failure so the next app launch can try
+ * again.
+ *
+ * @returns Whether no unregistration remains pending.
+ */
+export async function retryPendingBrazePushUnregistration(): Promise<boolean> {
+  if (hasTestOverrides || !hasPendingBrazePushUnregistrationSync()) {
+    return true;
+  }
+
+  return attemptPendingUnregistration();
+}

--- a/app/core/Engine/controllers/notifications/push-utils.test.ts
+++ b/app/core/Engine/controllers/notifications/push-utils.test.ts
@@ -3,11 +3,17 @@ import { type FirebaseMessagingTypes } from '@react-native-firebase/messaging';
 import FCMService from '../../../../util/notifications/services/FCMService';
 import NotificationsService from '../../../../util/notifications/services/NotificationService';
 import { PressActionId } from '../../../../util/notifications';
+import { unregisterBrazePush } from '../../../Braze/unregisterPush';
 import {
   WALLET_ACTIVITY_NOTIFICATION_TYPE,
   createSubscribeToPushNotifications,
+  deleteRegToken,
   shouldDisplayForegroundPushNotification,
 } from './push-utils';
+
+jest.mock('../../../Braze/unregisterPush', () => ({
+  unregisterBrazePush: jest.fn().mockResolvedValue(true),
+}));
 
 jest.mock('../../../../util/notifications/services/FCMService', () => ({
   __esModule: true,
@@ -51,6 +57,36 @@ const setAppState = (state: AppStateStatus) => {
     configurable: true,
   });
 };
+
+describe('deleteRegToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+    jest.mocked(unregisterBrazePush).mockResolvedValue(true);
+    jest.mocked(FCMService.deleteRegToken).mockResolvedValue(true);
+  });
+
+  it('unregisters Braze push before deleting the FCM token', async () => {
+    const result = await deleteRegToken();
+
+    expect(result).toBe(true);
+    expect(unregisterBrazePush).toHaveBeenCalled();
+    expect(FCMService.deleteRegToken).toHaveBeenCalled();
+    expect(
+      jest.mocked(unregisterBrazePush).mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      jest.mocked(FCMService.deleteRegToken).mock.invocationCallOrder[0],
+    );
+  });
+
+  it('deletes the FCM token while Braze unregistration is pending retry', async () => {
+    jest.mocked(unregisterBrazePush).mockResolvedValue(false);
+
+    await expect(deleteRegToken()).resolves.toBe(true);
+
+    expect(FCMService.deleteRegToken).toHaveBeenCalled();
+  });
+});
 
 describe('shouldDisplayForegroundPushNotification', () => {
   afterEach(() => {
@@ -100,6 +136,7 @@ describe('createSubscribeToPushNotifications', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
     mockListen.mockResolvedValue(jest.fn());
     mockDisplay.mockResolvedValue(undefined);
     setAppState('active');

--- a/app/core/Engine/controllers/notifications/push-utils.ts
+++ b/app/core/Engine/controllers/notifications/push-utils.ts
@@ -1,11 +1,21 @@
 import { AppState } from 'react-native';
+import { unregisterBrazePush } from '../../../Braze/unregisterPush';
 import FCMService from '../../../../util/notifications/services/FCMService';
 import NotificationsService from '../../../../util/notifications/services/NotificationService';
 import { PressActionId } from '../../../../util/notifications';
 import { toFcmDataStringRecord } from '../../../../util/notifications/utils/fcm-data';
 
 export const createRegToken = FCMService.createRegToken;
-export const deleteRegToken = FCMService.deleteRegToken;
+
+/**
+ * Unregister this device from Braze before deleting the FCM token.
+ * Braze failures remain persisted for retry during a later app session while
+ * FCM deletion continues so the local preference can turn off immediately.
+ */
+export const deleteRegToken = async (): Promise<boolean> => {
+  await unregisterBrazePush();
+  return FCMService.deleteRegToken();
+};
 
 /**
  * FCM `notification_type` for on-chain wallet activity (send/receive/etc).

--- a/app/selectors/notifications/index.test.ts
+++ b/app/selectors/notifications/index.test.ts
@@ -2,6 +2,7 @@ import { TRIGGER_TYPES } from '@metamask/notification-services-controller/notifi
 import {
   selectIsMetamaskNotificationsEnabled,
   selectIsMetaMaskPushNotificationsEnabled,
+  selectMetaMaskPushNotificationToken,
   selectIsMetamaskNotificationsFeatureSeen,
   selectIsUpdatingMetamaskNotifications,
   selectIsFetchingMetamaskNotifications,
@@ -42,6 +43,12 @@ describe('Notification Selectors', () => {
   it('selectIsMetaMaskPushNotificationsEnabled returns correct value', () => {
     expect(selectIsMetaMaskPushNotificationsEnabled(mockState)).toEqual(
       MOCK_NOTIFICATION_SERVICES_PUSH_CONTROLLER.isPushEnabled,
+    );
+  });
+
+  it('selectMetaMaskPushNotificationToken returns the FCM token', () => {
+    expect(selectMetaMaskPushNotificationToken(mockState)).toEqual(
+      MOCK_NOTIFICATION_SERVICES_PUSH_CONTROLLER.fcmToken,
     );
   });
 

--- a/app/selectors/notifications/index.tsx
+++ b/app/selectors/notifications/index.tsx
@@ -39,6 +39,10 @@ export const selectIsMetaMaskPushNotificationsEnabled = createSelector(
   (state: NotificationServicesPushControllerState) =>
     Boolean(state.isPushEnabled),
 );
+export const selectMetaMaskPushNotificationToken = createSelector(
+  selectNotificationServicesPushControllerState,
+  (state: NotificationServicesPushControllerState) => state.fcmToken,
+);
 export const selectIsMetaMaskPushNotificationsLoading = createSelector(
   selectNotificationServicesPushControllerState,
   (state: NotificationServicesPushControllerState) => state.isUpdatingFCMToken,

--- a/app/store/migrations/153.test.ts
+++ b/app/store/migrations/153.test.ts
@@ -1,0 +1,194 @@
+import { captureException } from '@sentry/react-native';
+import {
+  BRAZE_PUSH_REGISTRATION_STATE,
+  LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+} from '../../constants/storage';
+import StorageWrapper from '../storage-wrapper';
+import migrate, { migrationVersion } from './153';
+import { ensureValidState } from './util';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('../storage-wrapper', () => ({
+  __esModule: true,
+  default: {
+    setItem: jest.fn(),
+  },
+}));
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+}));
+
+const mockCaptureException = jest.mocked(captureException);
+const mockEnsureValidState = jest.mocked(ensureValidState);
+const mockStorageWrapper = jest.mocked(StorageWrapper);
+
+const createState = ({
+  notificationsEnabled,
+  pushEnabled,
+  marketingConsent = false,
+}: {
+  notificationsEnabled?: boolean;
+  pushEnabled?: boolean;
+  marketingConsent?: boolean;
+}) => ({
+  security: {
+    dataCollectionForMarketing: marketingConsent,
+  },
+  engine: {
+    backgroundState: {
+      NotificationServicesController:
+        notificationsEnabled === undefined
+          ? undefined
+          : { isNotificationServicesEnabled: notificationsEnabled },
+      NotificationServicesPushController:
+        pushEnabled === undefined ? undefined : { isPushEnabled: pushEnabled },
+    },
+  },
+});
+
+describe(`Migration ${migrationVersion}: mark legacy notification backfills`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEnsureValidState.mockReturnValue(true);
+    mockStorageWrapper.setItem.mockResolvedValue(undefined);
+  });
+
+  it('returns state unchanged without writing markers when state is invalid', async () => {
+    const state = createState({
+      notificationsEnabled: false,
+      pushEnabled: false,
+    });
+    mockEnsureValidState.mockReturnValue(false);
+
+    const result = await migrate(state);
+
+    expect(result).toBe(state);
+    expect(mockStorageWrapper.setItem).not.toHaveBeenCalled();
+  });
+
+  it('marks enabled notification users for an AUS preferences backfill', async () => {
+    const state = createState({
+      notificationsEnabled: true,
+      pushEnabled: true,
+    });
+
+    await migrate(state);
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+      'true',
+    );
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_REGISTRATION_STATE,
+      'registered',
+    );
+  });
+
+  it('marks devices with push disabled for Braze unregistration', async () => {
+    const state = createState({
+      notificationsEnabled: true,
+      pushEnabled: false,
+    });
+
+    await migrate(state);
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_REGISTRATION_STATE,
+      'unregistration-pending',
+    );
+  });
+
+  it('marks devices with master notifications disabled for Braze unregistration', async () => {
+    const state = createState({
+      notificationsEnabled: false,
+      pushEnabled: true,
+    });
+
+    await migrate(state);
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_REGISTRATION_STATE,
+      'unregistration-pending',
+    );
+  });
+
+  it('marks users with marketing consent for AUS backfill when notification state is disabled', async () => {
+    const state = createState({
+      notificationsEnabled: false,
+      pushEnabled: false,
+      marketingConsent: true,
+    });
+
+    await migrate(state);
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+      'true',
+    );
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_REGISTRATION_STATE,
+      'unregistration-pending',
+    );
+  });
+
+  it('conservatively marks devices with missing notification state for Braze unregistration', async () => {
+    const state = createState({});
+
+    await migrate(state);
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_REGISTRATION_STATE,
+      'unregistration-pending',
+    );
+    expect(mockStorageWrapper.setItem).not.toHaveBeenCalledWith(
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+      expect.anything(),
+    );
+  });
+
+  it('records each marker failure independently', async () => {
+    const state = createState({
+      notificationsEnabled: true,
+      pushEnabled: false,
+    });
+    mockStorageWrapper.setItem.mockImplementation(async (key) => {
+      if (key === LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING) {
+        throw new Error('AUS marker write failed');
+      }
+    });
+
+    await expect(migrate(state)).rejects.toThrow(
+      'Failed to persist backfill value(s): legacy notification AUS backfill',
+    );
+
+    expect(mockStorageWrapper.setItem).toHaveBeenCalledWith(
+      BRAZE_PUSH_REGISTRATION_STATE,
+      'unregistration-pending',
+    );
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('AUS marker write failed'),
+      }),
+    );
+  });
+
+  it('reports Braze registration-state persistence failures', async () => {
+    const state = createState({
+      notificationsEnabled: false,
+      pushEnabled: false,
+    });
+    mockStorageWrapper.setItem.mockImplementation(async (key) => {
+      if (key === BRAZE_PUSH_REGISTRATION_STATE) {
+        throw new Error('Registration state write failed');
+      }
+    });
+
+    await expect(migrate(state)).rejects.toThrow(
+      'Failed to persist backfill value(s): Braze push registration state',
+    );
+  });
+});

--- a/app/store/migrations/153.ts
+++ b/app/store/migrations/153.ts
@@ -1,0 +1,104 @@
+import { captureException } from '@sentry/react-native';
+import { hasProperty, isObject } from '@metamask/utils';
+import {
+  BRAZE_PUSH_REGISTRATION_STATE,
+  LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+} from '../../constants/storage';
+import StorageWrapper from '../storage-wrapper';
+import { ensureValidState } from './util';
+
+export const migrationVersion = 153;
+
+async function setBackfillValue(
+  key: string,
+  value: string,
+  name: string,
+): Promise<boolean> {
+  try {
+    await StorageWrapper.setItem(key, value);
+    return true;
+  } catch (error) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Failed to persist ${name}: ${String(
+          error,
+        )}`,
+      ),
+    );
+    return false;
+  }
+}
+
+/**
+ * Migration 153: schedule independent notification consent backfills.
+ *
+ * Existing users with MetaMask notifications or marketing consent enabled are
+ * checked for missing AUS preferences after login. Devices without both
+ * notification switches enabled are scheduled for Braze push unregistration
+ * on the next launch.
+ */
+const migration = async (state: unknown): Promise<unknown> => {
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  const { backgroundState } = state.engine;
+  const notificationServicesState =
+    hasProperty(backgroundState, 'NotificationServicesController') &&
+    isObject(backgroundState.NotificationServicesController)
+      ? backgroundState.NotificationServicesController
+      : undefined;
+  const pushServicesState =
+    hasProperty(backgroundState, 'NotificationServicesPushController') &&
+    isObject(backgroundState.NotificationServicesPushController)
+      ? backgroundState.NotificationServicesPushController
+      : undefined;
+  const securityState =
+    hasProperty(state, 'security') && isObject(state.security)
+      ? state.security
+      : undefined;
+  const notificationsEnabled =
+    notificationServicesState?.isNotificationServicesEnabled === true;
+  const pushEnabled = pushServicesState?.isPushEnabled === true;
+  const hasMarketingConsent =
+    securityState?.dataCollectionForMarketing === true;
+  const failedValues: string[] = [];
+
+  if (notificationsEnabled || hasMarketingConsent) {
+    if (
+      !(await setBackfillValue(
+        LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+        'true',
+        'legacy notification AUS backfill',
+      ))
+    ) {
+      failedValues.push('legacy notification AUS backfill');
+    }
+  }
+
+  const brazePushRegistrationState =
+    notificationsEnabled && pushEnabled
+      ? 'registered'
+      : 'unregistration-pending';
+  if (
+    !(await setBackfillValue(
+      BRAZE_PUSH_REGISTRATION_STATE,
+      brazePushRegistrationState,
+      'Braze push registration state',
+    ))
+  ) {
+    failedValues.push('Braze push registration state');
+  }
+
+  if (failedValues.length > 0) {
+    throw new Error(
+      `Migration ${migrationVersion}: Failed to persist backfill value(s): ${failedValues.join(
+        ', ',
+      )}`,
+    );
+  }
+
+  return state;
+};
+
+export default migration;

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -153,6 +153,7 @@ import migration149 from './149';
 import migration150 from './150';
 import migration151 from './151';
 import migration152 from './152';
+import migration153 from './153';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -325,6 +326,7 @@ export const migrationList: MigrationsList = {
   150: migration150,
   151: migration151,
   152: migration152,
+  153: migration153,
 };
 
 // Enable both synchronous and asynchronous migrations

--- a/app/store/sagas/backfillLegacyNotificationPreferences.test.ts
+++ b/app/store/sagas/backfillLegacyNotificationPreferences.test.ts
@@ -1,0 +1,195 @@
+import { expectSaga } from 'redux-saga-test-plan';
+import { UserActionType } from '../../actions/user';
+import {
+  HAS_USER_TURNED_OFF_ONCE_NOTIFICATIONS,
+  LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+} from '../../constants/storage';
+import Engine from '../../core/Engine';
+import Logger from '../../util/Logger';
+import initialRootState from '../../util/test/initial-root-state';
+import StorageWrapper from '../storage-wrapper';
+import { backfillLegacyNotificationPreferencesSaga } from './backfillLegacyNotificationPreferences';
+
+jest.mock('../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      NotificationServicesController: {
+        createOnChainTriggers: jest.fn(),
+      },
+    },
+  },
+}));
+
+jest.mock('../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('../storage-wrapper', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn().mockResolvedValue(undefined),
+    getItemSync: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const mockCreateOnChainTriggers = jest.mocked(
+  Engine.context.NotificationServicesController.createOnChainTriggers,
+);
+const mockStorageWrapper = jest.mocked(StorageWrapper);
+const loginAction = { type: UserActionType.LOGIN };
+
+const createState = ({
+  notificationsEnabled = true,
+  marketingConsent = true,
+  featureAnnouncementsEnabled = true,
+}: {
+  notificationsEnabled?: boolean;
+  marketingConsent?: boolean;
+  featureAnnouncementsEnabled?: boolean;
+} = {}) => ({
+  ...initialRootState,
+  security: {
+    ...initialRootState.security,
+    dataCollectionForMarketing: marketingConsent,
+  },
+  engine: {
+    ...initialRootState.engine,
+    backgroundState: {
+      ...initialRootState.engine.backgroundState,
+      NotificationServicesController: {
+        ...initialRootState.engine.backgroundState
+          .NotificationServicesController,
+        isNotificationServicesEnabled: notificationsEnabled,
+        isFeatureAnnouncementsEnabled: featureAnnouncementsEnabled,
+      },
+    },
+  },
+});
+
+describe('backfillLegacyNotificationPreferencesSaga', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStorageWrapper.getItemSync.mockImplementation((key) =>
+      key === LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING ? 'true' : null,
+    );
+    mockStorageWrapper.removeItem.mockResolvedValue(undefined);
+    mockCreateOnChainTriggers.mockResolvedValue(undefined);
+  });
+
+  it('does nothing when no AUS backfill marker exists', async () => {
+    mockStorageWrapper.getItemSync.mockReturnValue(null);
+
+    await expectSaga(backfillLegacyNotificationPreferencesSaga)
+      .withState(createState())
+      .dispatch(loginAction)
+      .run();
+
+    expect(mockCreateOnChainTriggers).not.toHaveBeenCalled();
+    expect(mockStorageWrapper.removeItem).not.toHaveBeenCalled();
+  });
+
+  it('clears the marker when notifications and marketing consent are disabled', async () => {
+    await expectSaga(backfillLegacyNotificationPreferencesSaga)
+      .withState(
+        createState({
+          notificationsEnabled: false,
+          marketingConsent: false,
+        }),
+      )
+      .dispatch(loginAction)
+      .run();
+
+    expect(mockCreateOnChainTriggers).not.toHaveBeenCalled();
+    expect(mockStorageWrapper.removeItem).toHaveBeenCalledWith(
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+    );
+  });
+
+  it('initializes preferences for a marketing-consented user with notifications disabled', async () => {
+    await expectSaga(backfillLegacyNotificationPreferencesSaga)
+      .withState(
+        createState({
+          notificationsEnabled: false,
+          marketingConsent: true,
+          featureAnnouncementsEnabled: false,
+        }),
+      )
+      .dispatch(loginAction)
+      .run();
+
+    expect(mockCreateOnChainTriggers).toHaveBeenCalledWith({
+      hasMarketingConsent: true,
+      productAnnouncementEnabled: false,
+      registerPushNotifications: false,
+    });
+    expect(mockStorageWrapper.removeItem).toHaveBeenCalledWith(
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+    );
+  });
+
+  it('does not override an explicit notification opt-out with marketing consent', async () => {
+    mockStorageWrapper.getItemSync.mockImplementation((key) =>
+      key === LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING ||
+      key === HAS_USER_TURNED_OFF_ONCE_NOTIFICATIONS
+        ? 'true'
+        : null,
+    );
+
+    await expectSaga(backfillLegacyNotificationPreferencesSaga)
+      .withState(
+        createState({
+          notificationsEnabled: false,
+          marketingConsent: true,
+        }),
+      )
+      .dispatch(loginAction)
+      .run();
+
+    expect(mockCreateOnChainTriggers).not.toHaveBeenCalled();
+    expect(mockStorageWrapper.removeItem).toHaveBeenCalledWith(
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+    );
+  });
+
+  it('initializes missing preferences from current notification consent', async () => {
+    await expectSaga(backfillLegacyNotificationPreferencesSaga)
+      .withState(
+        createState({
+          marketingConsent: false,
+          featureAnnouncementsEnabled: true,
+        }),
+      )
+      .dispatch(loginAction)
+      .run();
+
+    expect(mockCreateOnChainTriggers).toHaveBeenCalledWith({
+      hasMarketingConsent: false,
+      productAnnouncementEnabled: true,
+      registerPushNotifications: false,
+    });
+    expect(mockStorageWrapper.removeItem).toHaveBeenCalledWith(
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+    );
+  });
+
+  it('keeps the marker when preference initialization fails', async () => {
+    const error = new Error('AUS request failed');
+    mockCreateOnChainTriggers.mockRejectedValue(error);
+
+    await expectSaga(backfillLegacyNotificationPreferencesSaga)
+      .withState(createState())
+      .dispatch(loginAction)
+      .run();
+
+    expect(mockStorageWrapper.removeItem).not.toHaveBeenCalled();
+    expect(Logger.error).toHaveBeenCalledWith(
+      error,
+      'Failed to backfill legacy notification preferences',
+    );
+  });
+});

--- a/app/store/sagas/backfillLegacyNotificationPreferences.ts
+++ b/app/store/sagas/backfillLegacyNotificationPreferences.ts
@@ -1,0 +1,80 @@
+import { call, select, take } from 'redux-saga/effects';
+import {
+  HAS_USER_TURNED_OFF_ONCE_NOTIFICATIONS,
+  LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+  TRUE,
+} from '../../constants/storage';
+import { UserActionType } from '../../actions/user';
+import Engine from '../../core/Engine';
+import type { RootState } from '../../reducers';
+import {
+  selectIsFeatureAnnouncementsEnabled,
+  selectIsMetamaskNotificationsEnabled,
+} from '../../selectors/notifications';
+import Logger from '../../util/Logger';
+import StorageWrapper from '../storage-wrapper';
+
+/**
+ * Initialize missing AUS notification preferences once for eligible legacy
+ * users. Existing preferences are preserved by `createOnChainTriggers`.
+ */
+export function* backfillLegacyNotificationPreferencesSaga() {
+  yield take(UserActionType.LOGIN);
+
+  if (
+    StorageWrapper.getItemSync(LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING) !==
+    TRUE
+  ) {
+    return;
+  }
+
+  try {
+    const notificationsEnabled: boolean = yield select(
+      selectIsMetamaskNotificationsEnabled,
+    );
+    const hasMarketingConsent: boolean = yield select(
+      (state: RootState) => state.security.dataCollectionForMarketing === true,
+    );
+    const hasExplicitlyDisabledNotifications =
+      StorageWrapper.getItemSync(HAS_USER_TURNED_OFF_ONCE_NOTIFICATIONS) ===
+      TRUE;
+    // The legacy marketing-only onboarding path recorded consent without
+    // initializing notifications or AUS, so either signal makes this eligible.
+    // Never let that inference override a subsequent explicit in-app opt-out.
+    if (
+      !notificationsEnabled &&
+      (!hasMarketingConsent || hasExplicitlyDisabledNotifications)
+    ) {
+      yield call(
+        [StorageWrapper, StorageWrapper.removeItem],
+        LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+      );
+      return;
+    }
+
+    const productAnnouncementEnabled: boolean = yield select(
+      selectIsFeatureAnnouncementsEnabled,
+    );
+
+    yield call(
+      [
+        Engine.context.NotificationServicesController,
+        Engine.context.NotificationServicesController.createOnChainTriggers,
+      ],
+      {
+        hasMarketingConsent,
+        productAnnouncementEnabled,
+        registerPushNotifications: false,
+      },
+    );
+    yield call(
+      [StorageWrapper, StorageWrapper.removeItem],
+      LEGACY_NOTIFICATION_AUS_BACKFILL_PENDING,
+    );
+  } catch (error) {
+    Logger.error(
+      error instanceof Error ? error : new Error(String(error)),
+      'Failed to backfill legacy notification preferences',
+    );
+  }
+}

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -51,6 +51,7 @@ import { AppState, AppStateStatus } from 'react-native';
 import trackErrorAsAnalytics from '../../util/metrics/TrackError/trackErrorAsAnalytics';
 import { providerErrors } from '@metamask/rpc-errors';
 import { backfillSocialLoginMarketingConsentSaga } from './backfillSocialLoginMarketingConsent';
+import { backfillLegacyNotificationPreferencesSaga } from './backfillLegacyNotificationPreferences';
 import { promptIosGoogleWarningSheetSaga } from './onboarding/legacyIosGoogleReminder';
 import {
   watchMarketingAttributionOnClearOnboarding,
@@ -536,6 +537,9 @@ export function* rootSaga() {
   // Send one-time analytics backfill for migrated social login users after
   // persisted state has been rehydrated and app services are available.
   yield fork(backfillSocialLoginMarketingConsentSaga);
+
+  // Initialize missing AUS notification preferences for migrated legacy users.
+  yield fork(backfillLegacyNotificationPreferencesSaga);
 
   yield fork(watchMarketingAttributionOnConsentChange);
   yield fork(watchMarketingAttributionOnClearOnboarding);

--- a/app/util/notifications/hooks/useNotifications.test.tsx
+++ b/app/util/notifications/hooks/useNotifications.test.tsx
@@ -29,6 +29,7 @@ jest.mock('./usePushNotifications', () => ({
 
 beforeEach(() => {
   jest.clearAllMocks();
+  jest.resetAllMocks();
 });
 
 describe('useNotifications - useListNotifications()', () => {
@@ -134,8 +135,9 @@ describe('useNotifications - useEnableNotifications()', () => {
     expect(mocks.mockEnableNotifications).toHaveBeenCalledWith({
       hasMarketingConsent: false,
       productAnnouncementEnabled: true,
-      registerPushNotifications: true,
+      registerPushNotifications: false,
     });
+    expect(mocks.mockTogglePushNotification).toHaveBeenCalledTimes(1);
   });
 
   it('passes the current marketing consent when enabling notifications', async () => {
@@ -152,7 +154,7 @@ describe('useNotifications - useEnableNotifications()', () => {
     expect(mocks.mockEnableNotifications).toHaveBeenCalledWith({
       hasMarketingConsent: true,
       productAnnouncementEnabled: true,
-      registerPushNotifications: true,
+      registerPushNotifications: false,
     });
   });
 
@@ -229,10 +231,9 @@ describe('useNotifications - useDisableNotifications()', () => {
         loading: false,
         togglePushNotification: mockTogglePushNotification,
       });
-    const mockDisableNotifications = jest.spyOn(
-      Actions,
-      'disableNotifications',
-    );
+    const mockDisableNotifications = jest
+      .spyOn(Actions, 'disableNotifications')
+      .mockResolvedValue(undefined);
     const mockSelectLoading = jest.spyOn(
       Selectors,
       'selectIsUpdatingMetamaskNotifications',
@@ -259,28 +260,41 @@ describe('useNotifications - useDisableNotifications()', () => {
 
     // Act
     const hook = renderHookWithProvider(() => useDisableNotifications());
-    await act(() => hook.result.current.disableNotifications());
+    let result: boolean | undefined;
+    await act(async () => {
+      result = await hook.result.current.disableNotifications();
+    });
     await waitFor(() =>
       expect(mocks.mockDisableNotifications).toHaveBeenCalled(),
     );
 
-    return { mocks, hook };
+    return { mocks, hook, result };
   };
 
-  it('successfully invokes action', async () => {
-    const { mocks } = await arrangeAct();
-    expect(mocks.mockUsePushNotificationsToggle).toHaveBeenCalled();
-    expect(mocks.mockTogglePushNotification).toHaveBeenCalled();
+  it('returns true after disabling push and global notifications', async () => {
+    const { mocks, result } = await arrangeAct();
+
+    expect(result).toBe(true);
+    expect(mocks.mockUsePushNotificationsToggle).not.toHaveBeenCalled();
+    expect(mocks.mockTogglePushNotification).not.toHaveBeenCalled();
     expect(mocks.mockSelectLoading).toHaveBeenCalled();
     expect(mocks.mockSelectData).toHaveBeenCalled();
   });
 
-  it('creates an error when fails', async () => {
-    const { hook } = await arrangeAct((m) => {
+  it('returns false when global notification disable fails', async () => {
+    const { hook, result } = await arrangeAct((m) => {
       m.mockDisableNotifications.mockRejectedValue(new Error('Test Error'));
     });
 
+    expect(result).toBe(false);
     expect(hook.result.current.error).toBeDefined();
+  });
+
+  it('delegates push and global disablement to one helper call', async () => {
+    const { mocks } = await arrangeAct();
+
+    expect(mocks.mockDisableNotifications).toHaveBeenCalledTimes(1);
+    expect(mocks.mockTogglePushNotification).not.toHaveBeenCalled();
   });
 });
 

--- a/app/util/notifications/hooks/useNotifications.ts
+++ b/app/util/notifications/hooks/useNotifications.ts
@@ -134,7 +134,9 @@ export function useEnableNotifications(props?: UseEnableNotificationsProps) {
       await enableNotificationsHelper({
         hasMarketingConsent,
         productAnnouncementEnabled,
-        registerPushNotifications: nudgeEnablePush,
+        // Push registration is performed once, below, after shared notification
+        // setup and the OS-permission check.
+        registerPushNotifications: false,
       });
     } catch (enableError) {
       setError(enableError);
@@ -147,7 +149,6 @@ export function useEnableNotifications(props?: UseEnableNotificationsProps) {
     });
     await updateNotificationSubscriptionExpiration();
   }, [
-    nudgeEnablePush,
     throwOnError,
     hasMarketingConsent,
     productAnnouncementEnabled,
@@ -173,26 +174,28 @@ export function useEnableNotifications(props?: UseEnableNotificationsProps) {
  * @returns An object containing the `disableNotifications` function, loading state, and error state.
  */
 export function useDisableNotifications() {
-  const { togglePushNotification, loading: pushLoading } =
-    usePushNotificationsToggle();
-
   const data = useSelector(selectIsMetamaskNotificationsEnabled);
   const loading = useSelector(selectIsUpdatingMetamaskNotifications);
   const [error, setError] = useState<string | undefined>(undefined);
   const disableNotifications = useCallback(async () => {
     assertIsFeatureEnabled();
     setError(undefined);
-    await togglePushNotification(false);
-    await disableNotificationsHelper().catch((e) => {
-      Logger.error(e);
-      setError(`Failed to disable push notifications`);
-    });
+
+    try {
+      await disableNotificationsHelper();
+    } catch (e) {
+      Logger.error(e instanceof Error ? e : new Error(String(e)));
+      setError('Failed to disable notifications');
+      return false;
+    }
+
     await setUserHasTurnedOffNotificationsOnce();
-  }, [togglePushNotification]);
+    return true;
+  }, []);
 
   return {
     disableNotifications,
-    loading: loading && pushLoading,
+    loading,
     // This will be fixed in a separate PR to converge the types correctly
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     error: error as any,

--- a/app/util/notifications/hooks/useSwitchNotifications.test.tsx
+++ b/app/util/notifications/hooks/useSwitchNotifications.test.tsx
@@ -20,6 +20,15 @@ jest.mock('../constants', () => ({
   isNotificationsFeatureEnabled: () => true,
 }));
 
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+  jest.restoreAllMocks();
+});
+
 describe('useSwitchNotifications - useNotificationsToggle', () => {
   const arrangeMocks = () => {
     const mockEnableNotifications = jest.fn();
@@ -34,7 +43,7 @@ describe('useSwitchNotifications - useNotificationsToggle', () => {
         enableNotifications: mockEnableNotifications,
       });
 
-    const mockDisableNotifications = jest.fn();
+    const mockDisableNotifications = jest.fn().mockResolvedValue(true);
     const mockUseDisableNotifications = jest
       .spyOn(UseNotificationsModule, 'useDisableNotifications')
       .mockReturnValue({
@@ -77,6 +86,16 @@ describe('useSwitchNotifications - useNotificationsToggle', () => {
       expect(mocks.mockDisableNotifications).toHaveBeenCalled(),
     );
     expect(mocks.mockEnableNotifications).not.toHaveBeenCalled();
+  });
+
+  it('throws when disabling notifications fails', async () => {
+    const mocks = arrangeMocks();
+    mocks.mockDisableNotifications.mockResolvedValue(false);
+    const hook = renderHookWithProvider(() => useNotificationsToggle());
+
+    await expect(
+      act(() => hook.result.current.switchNotifications(false)),
+    ).rejects.toThrow('Failed to disable notifications');
   });
 });
 

--- a/app/util/notifications/hooks/useSwitchNotifications.ts
+++ b/app/util/notifications/hooks/useSwitchNotifications.ts
@@ -36,7 +36,15 @@ export function useNotificationsToggle() {
   const switchNotifications = useCallback(
     async (val: boolean) => {
       assertIsFeatureEnabled();
-      val ? await enableNotifications() : await disableNotifications();
+      if (val) {
+        await enableNotifications();
+        return;
+      }
+
+      const notificationsDisabled = await disableNotifications();
+      if (!notificationsDisabled) {
+        throw new Error('Failed to disable notifications');
+      }
     },
     [disableNotifications, enableNotifications],
   );

--- a/app/util/test/testSetup.js
+++ b/app/util/test/testSetup.js
@@ -628,6 +628,11 @@ NativeModules.RNTar = {
   unTar: jest.fn().mockResolvedValue('/document-dir/archive'),
 };
 
+NativeModules.BrazePushModule = {
+  registerPush: jest.fn().mockResolvedValue(undefined),
+  unregisterPush: jest.fn().mockResolvedValue({ success: true }),
+};
+
 jest.mock('react-native/Libraries/Interaction/InteractionManager', () => {
   const manager = {
     runAfterInteractions: jest.fn(),

--- a/app/util/test/testSetupView.js
+++ b/app/util/test/testSetupView.js
@@ -589,6 +589,11 @@ NativeModules.RNTar = {
   unTar: jest.fn().mockResolvedValue('/document-dir/archive'),
 };
 
+NativeModules.BrazePushModule = {
+  registerPush: jest.fn().mockResolvedValue(undefined),
+  unregisterPush: jest.fn().mockResolvedValue({ success: true }),
+};
+
 // Mock @notifee/react-native
 jest.mock('@notifee/react-native', () =>
   require('@notifee/react-native/jest-mock'),

--- a/ios/MetaMask.xcodeproj/project.pbxproj
+++ b/ios/MetaMask.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		AA11BB22CC33DD44EE55FF66 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA11BB22CC33DD44EE55FF67 /* SplashScreen.storyboard */; };
 		AA11BB22CC33DD44EE55FF68 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA11BB22CC33DD44EE55FF67 /* SplashScreen.storyboard */; };
 		B0EF7FA927BD16EA00D48B4E /* ThemeColors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B0EF7FA827BD16EA00D48B4E /* ThemeColors.xcassets */; };
+		B4A2E0110100000100000C03 /* BrazePushModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B4A2E0110100000100000C06 /* BrazePushModule.m */; };
+		B4A2E0110100000100000C04 /* BrazePushModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B4A2E0110100000100000C06 /* BrazePushModule.m */; };
 		BAB8A7C7328F48B6AC38DCE9 /* Geist-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = B848D40B87744D32949BDC25 /* Geist-Regular.otf */; };
 		C7B6D2EC4EBB469F9E0658BE /* MMSans-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = D3350113F0764105B1E60002 /* MMSans-Bold.otf */; };
 		C8424AE52CCC01F900F0BEB7 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C8424AE32CCC01F900F0BEB7 /* GoogleService-Info.plist */; };
@@ -178,6 +180,7 @@
 		AA11BB22CC33DD44EE55FF67 /* SplashScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = MetaMask/SplashScreen.storyboard; sourceTree = "<group>"; };
 		AA9EDF17249955C7005D89EE /* MetaMaskDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = MetaMaskDebug.entitlements; path = MetaMask/MetaMaskDebug.entitlements; sourceTree = "<group>"; };
 		B0EF7FA827BD16EA00D48B4E /* ThemeColors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ThemeColors.xcassets; sourceTree = "<group>"; };
+		B4A2E0110100000100000C06 /* BrazePushModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BrazePushModule.m; path = MetaMask/NativeModules/BrazePush/BrazePushModule.m; sourceTree = "<group>"; };
 		B848D40B87744D32949BDC25 /* Geist-Regular.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Geist-Regular.otf"; path = "../app/fonts/Geist-Regular.otf"; sourceTree = "<group>"; };
 		BF485CDA047B4D52852B87F5 /* EvilIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EvilIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf"; sourceTree = "<group>"; };
 		C8424AE32CCC01F900F0BEB7 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -297,6 +300,7 @@
 		15F7796222A1BC1E00B1DF8C /* NativeModules */ = {
 			isa = PBXGroup;
 			children = (
+				B4A2E0110100000100000C07 /* BrazePush */,
 				CF9895742A3B48DC00B4C9B5 /* RCTMinimizer */,
 			);
 			name = NativeModules;
@@ -434,6 +438,14 @@
 				089A67E20C8950FFA11688EA /* MetaMask-Flask */,
 			);
 			name = ExpoModulesProviders;
+			sourceTree = "<group>";
+		};
+		B4A2E0110100000100000C07 /* BrazePush */ = {
+			isa = PBXGroup;
+			children = (
+				B4A2E0110100000100000C06 /* BrazePushModule.m */,
+			);
+			name = BrazePush;
 			sourceTree = "<group>";
 		};
 		CF9895742A3B48DC00B4C9B5 /* RCTMinimizer */ = {
@@ -923,6 +935,7 @@
 			files = (
 				E4B580762E33A001008165E1 /* AppDelegate.swift in Sources */,
 				F0B2A3E101000001000000A1 /* BrazeHelper.mm in Sources */,
+				B4A2E0110100000100000C03 /* BrazePushModule.m in Sources */,
 				2EF283322B17EC1A00D7B4B1 /* RNTar.m in Sources */,
 				654378B0243E2ADC00571B9C /* File.swift in Sources */,
 				2EF2832A2B17EBD600D7B4B1 /* RnTar.swift in Sources */,
@@ -938,6 +951,7 @@
 			files = (
 				E4B580772E33A001008165E1 /* AppDelegate.swift in Sources */,
 				F0B2A3E101000001000000A2 /* BrazeHelper.mm in Sources */,
+				B4A2E0110100000100000C04 /* BrazePushModule.m in Sources */,
 				2EF283342B17EC1A00D7B4B1 /* RNTar.m in Sources */,
 				2EF2825B2B0FF86900D7B4B1 /* File.swift in Sources */,
 				2EF2832C2B17EBD600D7B4B1 /* RnTar.swift in Sources */,

--- a/ios/MetaMask/AppDelegate.swift
+++ b/ios/MetaMask/AppDelegate.swift
@@ -31,6 +31,8 @@ class AppDelegate: ExpoAppDelegate {
   private var isForwardingNotificationResponse = false
 
   @objc static var braze: Braze?
+  @objc static var apnsDeviceToken: Data?
+  @objc static var brazePushRegistrationRequested = false
 
   // Detox's `+[ReactNativeSupport reloadApp]` does
   // `[appDelegate valueForKey:@"rootViewFactory"]` to grab RN's RootViewFactory
@@ -97,10 +99,12 @@ class AppDelegate: ExpoAppDelegate {
        !brazeApiKey.isEmpty, !brazeEndpoint.isEmpty {
       let configuration = Braze.Configuration(apiKey: brazeApiKey, endpoint: brazeEndpoint)
       configuration.logger.level = .info
-      // push.automation handles APNs token registration and Braze-originated notification display.
+      // Keep Braze-originated notification handling automated, but register
+      // APNs tokens manually according to the in-app Notifications setting.
       // requestAuthorizationAtLaunch is false so the existing permission flow (Firebase/Notifee) is preserved.
       configuration.push.automation = true
       configuration.push.automation.requestAuthorizationAtLaunch = false
+      configuration.push.automation.registerDeviceToken = false
       configuration.forwardUniversalLinks = true
       // swiftlint:disable:next force_cast
       let braze = BrazeHelperInit(configuration) as! Braze
@@ -170,6 +174,10 @@ class AppDelegate: ExpoAppDelegate {
     _ application: UIApplication,
     didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
   ) {
+    AppDelegate.apnsDeviceToken = deviceToken
+    if AppDelegate.brazePushRegistrationRequested {
+      AppDelegate.braze?.notifications.register(deviceToken: deviceToken)
+    }
     super.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
   }
 

--- a/ios/MetaMask/NativeModules/BrazePush/BrazePushModule.m
+++ b/ios/MetaMask/NativeModules/BrazePush/BrazePushModule.m
@@ -1,0 +1,69 @@
+#import <Foundation/Foundation.h>
+#import <BrazeKit/BrazeKit-Swift.h>
+#import <React/RCTBridgeModule.h>
+#import "MetaMask-Swift.h"
+
+@interface BrazePushModule : NSObject <RCTBridgeModule>
+@end
+
+@implementation BrazePushModule
+
+RCT_EXPORT_MODULE();
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
+RCT_REMAP_METHOD(
+  registerPush,
+  registerPushWithResolver:(RCTPromiseResolveBlock)resolve
+  rejecter:(RCTPromiseRejectBlock)reject
+) {
+  Braze *braze = AppDelegate.braze;
+  if (braze == nil) {
+    reject(@"SDK_UNAVAILABLE", @"Braze is not initialized", nil);
+    return;
+  }
+
+  AppDelegate.brazePushRegistrationRequested = YES;
+  NSData *deviceToken = AppDelegate.apnsDeviceToken;
+  if (deviceToken == nil) {
+    // APNs token delivery is asynchronous. AppDelegate completes registration
+    // when didRegisterForRemoteNotifications receives the token.
+    resolve(nil);
+    return;
+  }
+
+  [braze.notifications registerDeviceToken:deviceToken];
+  resolve(nil);
+}
+
+RCT_REMAP_METHOD(
+  unregisterPush,
+  unregisterPushWithResolver:(RCTPromiseResolveBlock)resolve
+  rejecter:(RCTPromiseRejectBlock)reject
+) {
+  AppDelegate.brazePushRegistrationRequested = NO;
+  Braze *braze = AppDelegate.braze;
+  if (braze == nil) {
+    reject(@"SDK_UNAVAILABLE", @"Braze is not initialized", nil);
+    return;
+  }
+
+  [braze.notifications unregisterPushWithCompletion:^(NSError *error) {
+    if (error == nil ||
+        [error.localizedDescription rangeOfString:@"no push token"
+                                           options:NSCaseInsensitiveSearch].location != NSNotFound) {
+      resolve(@{@"success": @YES});
+      return;
+    }
+
+    resolve(@{
+      @"success": @NO,
+      @"message": error.localizedDescription
+    });
+  }];
+}
+
+@end


### PR DESCRIPTION
## **Description**

Stacks on #35945.

Adds one-time, independent reconciliation for legacy notification consent:

- Migration 153 initializes Braze device registration state from the persisted MetaMask master and push settings. Devices without both settings enabled are marked `unregistration-pending`; enabled devices are marked `registered`.
- The runtime worker from the parent PR performs pending Braze device unregistration on launch and retains failed work for a later session.
- Eligible users are marked for an authenticated AUS preferences check after login.
- The AUS worker delegates to `createOnChainTriggers`, which initializes missing preferences without overwriting an existing AUS record.
- Historical marketing consent can recover users affected by the legacy onboarding path, while the explicit in-app opt-out marker prevents re-enabling users who later disabled notifications.

Braze device reconciliation and AUS profile reconciliation remain independently tracked, so one can complete without clearing or repeating the other.

## **Changelog**

CHANGELOG entry: Fixed notification consent synchronization for existing users

## **Related issues**

Refs: #35387, #35939

## **Manual testing steps**

1. Upgrade an installation whose master or push notification setting is disabled and verify the device is unregistered from Braze on launch.
2. Simulate a failed Braze unregister, reopen the app, and verify the work retries once.
3. Upgrade an installation with both notification settings enabled and verify Braze remains registered.
4. Sign in with no AUS notification preferences and eligible historical consent, then verify preferences are initialized.
5. Repeat with existing AUS preferences and verify they remain unchanged.
6. Repeat with an explicit MetaMask notification opt-out and verify historical marketing consent does not re-enable notifications.

<!--
## **Screenshots/Recordings**

N/A — one-time migration and background reconciliation with no UI changes.
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!--
#### Performance checks (if applicable)

N/A — one-time marker-gated reconciliation with no polling or rendering work.
-->

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)