### PR TITLE
test: sync FF defaults for confirmations

### DIFF
--- a/tests/api-mocking/helpers/remoteFeatureFlagsHelper.test.ts
+++ b/tests/api-mocking/helpers/remoteFeatureFlagsHelper.test.ts
@@ -111,6 +111,43 @@ describe('Remote Feature Flags Helper', () => {
       }
     });
 
+    it('replaces versioned registry flags when a flat RC override is provided', () => {
+      const baseline = createRemoteFeatureFlagsMock();
+      const baselineResponse = baseline.response as Record<string, unknown>[];
+      const baselinePayExtended = baselineResponse.find(
+        (obj: Record<string, unknown>) => 'confirmations_pay_extended' in obj,
+      );
+      const baselineValue = (
+        baselinePayExtended as Record<string, Record<string, unknown>>
+      )?.confirmations_pay_extended;
+
+      // Registry sync may ship versioned pay_extended; pay smoke fixtures use a
+      // flat RC object. Deep-merging would keep newer version keys and break UI.
+      expect(baselineValue).toEqual(
+        expect.objectContaining({ versions: expect.any(Object) }),
+      );
+
+      const flatOverride = {
+        enableDepositWalletWithdraw: true,
+        name: 'rc-fixture',
+        payStrategies: { relay: { gaslessEnabled: true } },
+      };
+
+      const result = createRemoteFeatureFlagsMock({
+        confirmations_pay_extended: flatOverride,
+      });
+      const response = result.response as Record<string, unknown>[];
+      const payExtendedObj = response.find(
+        (obj: Record<string, unknown>) => 'confirmations_pay_extended' in obj,
+      );
+      const payExtended = (
+        payExtendedObj as Record<string, Record<string, unknown>>
+      ).confirmations_pay_extended;
+
+      expect(payExtended).toEqual(flatOverride);
+      expect(payExtended).not.toHaveProperty('versions');
+    });
+
     it('preserves and overrides deeply nested objects', () => {
       // Test behavior: partial override should preserve other nested properties
       const result = createRemoteFeatureFlagsMock({

--- a/tests/api-mocking/helpers/remoteFeatureFlagsHelper.ts
+++ b/tests/api-mocking/helpers/remoteFeatureFlagsHelper.ts
@@ -109,11 +109,16 @@ export const createRemoteFeatureFlagsMock = (
         !Array.isArray(existingFlag) &&
         !Array.isArray(flagValue)
       ) {
-        // Deep merge for nested objects
-        existingObj[flagName] = deepMerge(
-          existingFlag as Record<string, unknown>,
-          flagValue as Record<string, unknown>,
-        );
+        const existingRecord = existingFlag as Record<string, unknown>;
+        const overrideRecord = flagValue as Record<string, unknown>;
+        // Versioned client-config flags must not deep-merge with RC/test fixtures:
+        // newer registry `versions` keys (e.g. 8.9.0) would otherwise outrank a flat
+        // or older versioned override and change Pay confirmation UI under E2E.
+        if ('versions' in existingRecord || 'versions' in overrideRecord) {
+          existingObj[flagName] = flagValue;
+        } else {
+          existingObj[flagName] = deepMerge(existingRecord, overrideRecord);
+        }
       } else {
         // Replace simple values, arrays, or when types don't match
         existingObj[flagName] = flagValue;

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -973,20 +973,12 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     inProd: true,
     productionDefault: {
       contracts: {
-        '0xa4ba': [
+        '0x1': [
           {
             address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Arbitrum Nova',
+            name: 'Mainnet',
             signature:
-              '0x818898e7f90f2f1f47dc7bec74dd683dfcc11efc7025d81f57644d366a3d9e442edb789731045ccb5ba89ee0d84bb517194bb9a097b152922bbd39ffd022ff421c',
-          },
-        ],
-        '0xaa37dc': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Optimism Sepolia',
-            signature:
-              '0xa60cab833af6a8aa2dcc80d5e12d9e1566edb6cdf51c38e7cf43d441dac561007f05643e73e6b00107e18dbf15de98aae14192306276e92d654f62bd7c3023241c',
+              '0xffb37facfedf12f1e98b56203de1c855391b791a20ee361234c546f4b50eb11853283cfc311419049f0325ad0a806ec232cc519073e3b5d4ad59ff331964d2e71b',
           },
         ],
         '0x1012': [
@@ -997,100 +989,20 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
               '0x6818c8c50d25e23dd3810758f3fc45d41c5444bec8fe0983660387414fab00366f6d8a0462b2e8985c16cdff5898d6bf9787e255b1a668d083728b448a5c3f641c',
           },
         ],
-        '0x38': [
+        '0x1079': [
           {
-            name: 'BNB',
-            signature:
-              '0x28ae371904b3ba71344e426c8de0e2cee0b8529a9510c059b412671655881ad646b8cf544342a5f8e0753eda83221e14e3c9dae5435417401f5fee8ee1d63dce1b',
             address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Tempo',
+            signature:
+              '0x810496170fb570d0d976c58273ad4a423252bac1f2e10c8a63adbbbfc4e79d2c5d894bae20c28e90a577338e68506138ac6dea142a1e80a31c0c2dd2999efa651b',
           },
         ],
-        '0x515': [
-          {
-            name: 'Unichain Sepolia',
-            signature:
-              '0x64487330691a05700a2321ee1db4092adce9590e7aded6e489df024838ecec734c935d182f74883818cb7659d5c784163573afdf8221252fa68d960cbe1c312f1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x138c5': [
-          {
-            name: 'Berachain Testnet',
-            signature:
-              '0x66940bcb2c4b95ec2c1c1024fee1e3a8e51c8f072a52a9f0252a793604c8a6ba58ac3153d4dd041873d33eec349450c4a9acd51ddaed117bee448ed7a388208c1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x14a34': [
-          {
-            signature:
-              '0xaed94ac035e745629423c547200eb2411fd7194d832a6b4cf459d3e3d34a6b62124e88640a0bf623146bdef63b0ce1c8797bd2a6c8357fab86c8be466744f55d1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Base Sepolia',
-          },
-        ],
-        '0x18c6': [
+        '0x1237': [
           {
             address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'MegaEth Testnet',
+            name: 'Robinhood Chain',
             signature:
-              '0x6743135a8dfc8f58133d827b4997bc5316c8eb92883d2704a30b1d8a7bf494ce226b523e5f85a681eb5de8349c9564e62d389876d0e5fe5cc06fb9412d9d1cb61b',
-          },
-        ],
-        '0x152': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Cronos Testnet',
-            signature:
-              '0x8fec0190a311f6ba5dc9df8d76fef3673e6c4081c087f779bca7e3247bb40a5070d393d29c6b268deb3fa231a138b7914b25395cd6dec0fdf4b2b7701975e78b1c',
-          },
-        ],
-        '0xa5bf': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Tempo Testnet',
-            signature:
-              '0x2413338e5c47c56853195d1870988d721ec502c78e54fe5b98468a401538b942237a2769461ffbfa8269936bf309243d5b0d69f7114938653469c4d8225715ee1c',
-          },
-        ],
-        '0x531': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sei Mainnet',
-            signature:
-              '0xde089fc9af662bc4b0f873e4dc79760f6c3539f6f1cf32d9bc46baccf86ebae070a9062436f29ee86d04cc55699b27579f657922a2292ec2f1c5170d587917401b',
-          },
-        ],
-        '0x27d8': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Chiado',
-            signature:
-              '0x0ff531d6afcc191c3b3bdffc1596d9ce8d1d52fa500ea2097c0823820a66f97963b88b646d4d4edbc0f781127d7985b87132d89c62c3cb4ad42848ce289645fa1b',
-          },
-        ],
-        '0x19': [
-          {
-            name: 'Cronos',
-            signature:
-              '0xa1856ef8c948b0a5204da687d53231848de2a585def9faac05c23c47412615dc476db943010164356b1d2ca8a8a66a8b0ae2d30c11b6b2aaf1cca116f0a333761c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x82': [
-          {
-            signature:
-              '0x54c423b1af4abbd1fb226e260dddba757acbcd8881e6b55b842c6b839874fa3f0e2f77685389ad5c28e096f12ef22557cebf6a77f6064baa071453a445a4c7d51c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Unichain Mainnet',
-          },
-        ],
-        '0x92': [
-          {
-            name: 'Sonic Mainnet',
-            signature:
-              '0x9f2a94332f2b71bff8a772053f47dbb65e26e5286341be0a3c55270d5549351f1dddb7566be0619b0150d42d540b0847cb0acbd0ab118ff608a40a18400834711b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+              '0x58bad06882c339b16db39cb62d2f7f57675c7c8dbe31d635e93141356aaaaff6496d04614ddf842c16c225bee6f6eb02eb10aec9daced3e47e11ff9a86c479f51c',
           },
         ],
         '0x13882': [
@@ -1101,20 +1013,236 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
               '0x472bb78ebb6686ddf0bb2e75265e1f4266cd050f8b498e88f97e9380afd8bfbd169c4d3221ec8845cb81ba7e9ddb7de9b819a15617803e20aee2aaa07664b6c81b',
           },
         ],
+        '0x138c5': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Berachain Testnet',
+            signature:
+              '0x66940bcb2c4b95ec2c1c1024fee1e3a8e51c8f072a52a9f0252a793604c8a6ba58ac3153d4dd041873d33eec349450c4a9acd51ddaed117bee448ed7a388208c1b',
+          },
+        ],
         '0x138de': [
           {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
             name: 'Berachain',
             signature:
               '0x2c2037ddedcdfb9b7d8ea7c546259eef371a86b0e3610192eb15ece0114c59d86134791cd9e9df4208bbbdc83776d80b30b1fea6bf1a05bb072575217492497a1b',
+          },
+        ],
+        '0x13fb': [
+          {
             address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Citrea Testnet',
+            signature:
+              '0xf9e4aa35fc098468212352c2b9662022f9565bd713ca66e634c804f9820b5e0c266d710afba58aed00e5b7e24134dd9b52e2e331076de745137531a6d245a7521b',
+          },
+        ],
+        '0x14a34': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Base Sepolia',
+            signature:
+              '0xaed94ac035e745629423c547200eb2411fd7194d832a6b4cf459d3e3d34a6b62124e88640a0bf623146bdef63b0ce1c8797bd2a6c8357fab86c8be466744f55d1c',
+          },
+        ],
+        '0x152': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Cronos Testnet',
+            signature:
+              '0x8fec0190a311f6ba5dc9df8d76fef3673e6c4081c087f779bca7e3247bb40a5070d393d29c6b268deb3fa231a138b7914b25395cd6dec0fdf4b2b7701975e78b1c',
+          },
+        ],
+        '0x18c6': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'MegaEth Testnet',
+            signature:
+              '0x6743135a8dfc8f58133d827b4997bc5316c8eb92883d2704a30b1d8a7bf494ce226b523e5f85a681eb5de8349c9564e62d389876d0e5fe5cc06fb9412d9d1cb61b',
+          },
+        ],
+        '0x19': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Cronos',
+            signature:
+              '0xa1856ef8c948b0a5204da687d53231848de2a585def9faac05c23c47412615dc476db943010164356b1d2ca8a8a66a8b0ae2d30c11b6b2aaf1cca116f0a333761c',
+          },
+        ],
+        '0x2105': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Base',
+            signature:
+              '0xbdddd2e925cf2cc7e148d3c11b02c917995fba8f3a3dc0b73c0059d029feca88014e723b8a32b2310a60c5b1cc17dfb3ae180b5a39f1d3264f985314b9168e0a1c',
+          },
+        ],
+        '0x279f': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Monad Testnet',
+            signature:
+              '0x85ec60e9dbac6404b66803b5abace8517ce1325bb6391b7d1ff8ec4433bbe62f4363031873a11ed79364290e196a47830fc36346a9aaf2e44518c1101496983c1b',
+          },
+        ],
+        '0x27d8': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Chiado',
+            signature:
+              '0x0ff531d6afcc191c3b3bdffc1596d9ce8d1d52fa500ea2097c0823820a66f97963b88b646d4d4edbc0f781127d7985b87132d89c62c3cb4ad42848ce289645fa1b',
+          },
+        ],
+        '0x38': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'BNB',
+            signature:
+              '0x28ae371904b3ba71344e426c8de0e2cee0b8529a9510c059b412671655881ad646b8cf544342a5f8e0753eda83221e14e3c9dae5435417401f5fee8ee1d63dce1b',
+          },
+        ],
+        '0x3909': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Sonic Testnet',
+            signature:
+              '0xc092cc0bcf804f95eb659d281c00586bc72018a242d66fefacdc33a990faf99478c368612277cbbf72aee4a10b7ace6d8666f2c8c4fece9daada40cb360190631b',
+          },
+        ],
+        '0x483': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Intuition Mainnet',
+            signature:
+              '0x0bb2e5471222492f516a6f1d92fd2b592645bf4124db1b53a6e1b2c505da9c3877fbbdc03642dc8be4ffdfb84a880662dde7b9be394114271b7dd1c217dca9ed1b',
+          },
+        ],
+        '0x515': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Unichain Sepolia',
+            signature:
+              '0x64487330691a05700a2321ee1db4092adce9590e7aded6e489df024838ecec734c935d182f74883818cb7659d5c784163573afdf8221252fa68d960cbe1c312f1b',
+          },
+        ],
+        '0x530': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Sei Testnet',
+            signature:
+              '0x91135fcd7bfb9e2456c227ff12905128c3854db36775278d47b96c3c669f730c4063e3a62d94884617769bbad2868f35d725cb3b611d9bd1231bceb5967724711c',
+          },
+        ],
+        '0x531': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Sei Mainnet',
+            signature:
+              '0xde089fc9af662bc4b0f873e4dc79760f6c3539f6f1cf32d9bc46baccf86ebae070a9062436f29ee86d04cc55699b27579f657922a2292ec2f1c5170d587917401b',
+          },
+        ],
+        '0x61': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'BNB Testnet',
+            signature:
+              '0x80aaf42c70b0b9efdf26e38ced69fce70f6b4f5496e7e59888819c14fb16290301ad049299d99e3650fa1a616a87bb80eb52ae9f02ddd8b53dd6b983275d0eb61b',
+          },
+        ],
+        '0x64': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Gnosis',
+            signature:
+              '0xd0cfc2959c866e5218faf675f852e0c7021a454064e509d40256c5bec395e300381c19dcbec2e921b2f6d7d9a925a39dee8ea2e8dd8f595633b8dc333d91f1af1b',
+          },
+        ],
+        '0x66eee': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Arbitrum Sepolia',
+            signature:
+              '0x6fdb53ecf8f575b85ff9895277b1f8e11349970fbb42225fe41587a072bbcef43e8d54303c4e1aa38d44cae9ba2c8bf825e9e138176d6b09a729cd82a14356cf1b',
+          },
+        ],
+        '0x82': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Unichain Mainnet',
+            signature:
+              '0x54c423b1af4abbd1fb226e260dddba757acbcd8881e6b55b842c6b839874fa3f0e2f77685389ad5c28e096f12ef22557cebf6a77f6064baa071453a445a4c7d51c',
+          },
+        ],
+        '0x88bb0': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Hoodi Testnet',
+            signature:
+              '0x23de8eb645a65b08721e5d2194063acead5f5f818474b7884ae767c7aaf9bb9b22233ab92684bc41087f8509e945d96083124ae1919a9357f2ae65267df4f0e21b',
+          },
+        ],
+        '0x89': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Polygon',
+            signature:
+              '0x302aa2d59940e88f35d2fa140fe6a1e9dc682218a444a7fb2d88f007fbe7792b2b8d615f5ae1e4f184533a02c47d8ac0f6ba3f591679295dff93c65095c0f03d1b',
+          },
+        ],
+        '0x8f': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Monad',
+            signature:
+              '0x12d31e58c92cdc29dac8af0405883b3b0ee44156d7fdf5c3c2ffa4138f2461cc20e7f8625431dbd24bb784407d1a1d9bdb75b191a6cf127eac68b67d13bd11e41c',
+          },
+        ],
+        '0x92': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Sonic Mainnet',
+            signature:
+              '0x9f2a94332f2b71bff8a772053f47dbb65e26e5286341be0a3c55270d5549351f1dddb7566be0619b0150d42d540b0847cb0acbd0ab118ff608a40a18400834711b',
           },
         ],
         '0xa': [
           {
-            signature:
-              '0x60e12ffc04e098bd26a897ed2a974e4e255fc6db3b052fe3a2647372bfbac76f096bf5236510ddc217e12b802e08617cc27292d69ca51b0467ba91c6df74cd7b1c',
             address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
             name: 'Optimism',
+            signature:
+              '0x60e12ffc04e098bd26a897ed2a974e4e255fc6db3b052fe3a2647372bfbac76f096bf5236510ddc217e12b802e08617cc27292d69ca51b0467ba91c6df74cd7b1c',
+          },
+        ],
+        '0xa4b1': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Arbitrum One',
+            signature:
+              '0xc3be82057efec197d92b0cbb7cef9d50dba0345646524687a3ae7235a8fcb1706ba79f197d45fcf4c6cfb5808ef70258c5f6bb29b7e3553a4b9660692eb5e81d1b',
+          },
+        ],
+        '0xa4ba': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Arbitrum Nova',
+            signature:
+              '0x818898e7f90f2f1f47dc7bec74dd683dfcc11efc7025d81f57644d366a3d9e442edb789731045ccb5ba89ee0d84bb517194bb9a097b152922bbd39ffd022ff421c',
+          },
+        ],
+        '0xa4ec': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Celo Mainnet',
+            signature:
+              '0x1421ea4d014170a4fc5d0559f267974f4aa095a6e6047b107eff1807afa425774775f796a52a90b767810eade3b5919087bb361651a7b8f4f9679f1f46adb60e1b',
+          },
+        ],
+        '0xa5bf': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Tempo Testnet',
+            signature:
+              '0x2413338e5c47c56853195d1870988d721ec502c78e54fe5b98468a401538b942237a2769461ffbfa8269936bf309243d5b0d69f7114938653469c4d8225715ee1c',
           },
         ],
         '0xaa044c': [
@@ -1123,22 +1251,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
             name: 'Celo Sepolia',
             signature:
               '0x1590458cdfa10225e4fe734ed44deec95ac1887c877e63deb5ad35b41025c9ef2f33666cdd2c189b1999a78072ab9f8f122d93a52eaf12687fb2ff5b74d8de9f1c',
-          },
-        ],
-        '0x61': [
-          {
-            name: 'BNB Testnet',
-            signature:
-              '0x80aaf42c70b0b9efdf26e38ced69fce70f6b4f5496e7e59888819c14fb16290301ad049299d99e3650fa1a616a87bb80eb52ae9f02ddd8b53dd6b983275d0eb61b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x64': [
-          {
-            signature:
-              '0xd0cfc2959c866e5218faf675f852e0c7021a454064e509d40256c5bec395e300381c19dcbec2e921b2f6d7d9a925a39dee8ea2e8dd8f595633b8dc333d91f1af1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Gnosis',
           },
         ],
         '0xaa36a7': [
@@ -1155,116 +1267,20 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
               '0x016cf109489c415ba28e695eb3cb06ac46689c5c49e2aba101d7ec2f68c890282563b324f5c8df5e0536994451825aa235438b7346e8c18b4e64161d990781891c',
           },
         ],
-        '0x89': [
+        '0xaa37dc': [
           {
             address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Polygon',
+            name: 'Optimism Sepolia',
             signature:
-              '0x302aa2d59940e88f35d2fa140fe6a1e9dc682218a444a7fb2d88f007fbe7792b2b8d615f5ae1e4f184533a02c47d8ac0f6ba3f591679295dff93c65095c0f03d1b',
-          },
-        ],
-        '0xa4b1': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Arbitrum One',
-            signature:
-              '0xc3be82057efec197d92b0cbb7cef9d50dba0345646524687a3ae7235a8fcb1706ba79f197d45fcf4c6cfb5808ef70258c5f6bb29b7e3553a4b9660692eb5e81d1b',
-          },
-        ],
-        '0xa4ec': [
-          {
-            name: 'Celo Mainnet',
-            signature:
-              '0x1421ea4d014170a4fc5d0559f267974f4aa095a6e6047b107eff1807afa425774775f796a52a90b767810eade3b5919087bb361651a7b8f4f9679f1f46adb60e1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x66eee': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Arbitrum Sepolia',
-            signature:
-              '0x6fdb53ecf8f575b85ff9895277b1f8e11349970fbb42225fe41587a072bbcef43e8d54303c4e1aa38d44cae9ba2c8bf825e9e138176d6b09a729cd82a14356cf1b',
-          },
-        ],
-        '0x13fb': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Citrea Testnet',
-            signature:
-              '0xf9e4aa35fc098468212352c2b9662022f9565bd713ca66e634c804f9820b5e0c266d710afba58aed00e5b7e24134dd9b52e2e331076de745137531a6d245a7521b',
-          },
-        ],
-        '0x530': [
-          {
-            signature:
-              '0x91135fcd7bfb9e2456c227ff12905128c3854db36775278d47b96c3c669f730c4063e3a62d94884617769bbad2868f35d725cb3b611d9bd1231bceb5967724711c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sei Testnet',
-          },
-        ],
-        '0x8f': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Monad',
-            signature:
-              '0x12d31e58c92cdc29dac8af0405883b3b0ee44156d7fdf5c3c2ffa4138f2461cc20e7f8625431dbd24bb784407d1a1d9bdb75b191a6cf127eac68b67d13bd11e41c',
-          },
-        ],
-        '0x1079': [
-          {
-            signature:
-              '0x810496170fb570d0d976c58273ad4a423252bac1f2e10c8a63adbbbfc4e79d2c5d894bae20c28e90a577338e68506138ac6dea142a1e80a31c0c2dd2999efa651b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Tempo',
-          },
-        ],
-        '0x279f': [
-          {
-            signature:
-              '0x85ec60e9dbac6404b66803b5abace8517ce1325bb6391b7d1ff8ec4433bbe62f4363031873a11ed79364290e196a47830fc36346a9aaf2e44518c1101496983c1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Monad Testnet',
-          },
-        ],
-        '0x2105': [
-          {
-            name: 'Base',
-            signature:
-              '0xbdddd2e925cf2cc7e148d3c11b02c917995fba8f3a3dc0b73c0059d029feca88014e723b8a32b2310a60c5b1cc17dfb3ae180b5a39f1d3264f985314b9168e0a1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+              '0xa60cab833af6a8aa2dcc80d5e12d9e1566edb6cdf51c38e7cf43d441dac561007f05643e73e6b00107e18dbf15de98aae14192306276e92d654f62bd7c3023241c',
           },
         ],
         '0xe708': [
           {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
             name: 'Linea',
             signature:
               '0x8bad472a54f1be8adbcce8badc512045a467d64aa2affce55eb6ecb9b6eda8a142eee478bc99a81580ff52d5daea857eb9e482e457b1e121c0574191e01ec9f21c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x88bb0': [
-          {
-            name: 'Hoodi Testnet',
-            signature:
-              '0x23de8eb645a65b08721e5d2194063acead5f5f818474b7884ae767c7aaf9bb9b22233ab92684bc41087f8509e945d96083124ae1919a9357f2ae65267df4f0e21b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x3909': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sonic Testnet',
-            signature:
-              '0xc092cc0bcf804f95eb659d281c00586bc72018a242d66fefacdc33a990faf99478c368612277cbbf72aee4a10b7ace6d8666f2c8c4fece9daada40cb360190631b',
-          },
-        ],
-        '0x1': [
-          {
-            name: 'Mainnet',
-            signature:
-              '0xffb37facfedf12f1e98b56203de1c855391b791a20ee361234c546f4b50eb11853283cfc311419049f0325ad0a806ec232cc519073e3b5d4ad59ff331964d2e71b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
           },
         ],
       },
@@ -1273,6 +1289,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
         '0x1',
         '0x1012',
         '0x1079',
+        '0x1237',
         '0x13882',
         '0x138c5',
         '0x138de',
@@ -1286,6 +1303,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
         '0x27d8',
         '0x38',
         '0x3909',
+        '0x483',
         '0x515',
         '0x530',
         '0x531',
@@ -1316,30 +1334,38 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
+      default: 1,
       included: 1.5,
       perChainConfig: {
-        '0xa4b1': {
-          base: 1.2,
-          name: 'arbitrum',
+        '0x1237': {
+          base: 1.5,
+          name: 'robinhood',
         },
         '0x18c6': {
           base: 1.3,
           name: 'megaeth',
         },
+        '0x18c7': {
+          base: 1.3,
+          name: 'megaeth',
+        },
         '0x2105': {
-          name: 'base',
           eip7702: 1.3,
+          name: 'base',
         },
         '0x38': {
           eip7702: 1.3,
           name: 'bnb',
         },
         '0xa': {
-          name: 'optimism',
           eip7702: 1.3,
+          name: 'optimism',
+        },
+        '0xa4b1': {
+          base: 1.2,
+          name: 'arbitrum',
         },
       },
-      default: 1,
     },
     status: FeatureFlagStatus.Active,
   },
@@ -1744,9 +1770,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
             predictWithdraw: {
               enabled: true,
               tokens: {
-                '0x89': ['0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'],
-                '0xa4b1': ['0xaf88d065e77c8cC2239327C5EDb3A432268e5831'],
-                '0xe708': ['0xacA92E438df0B2401fF60dA7E4337B687a2435DA'],
                 '0x1': [
                   '0x0000000000000000000000000000000000000000',
                   '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
@@ -1763,23 +1786,22 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
                   '0x55d398326f99059fF775485246999027B3197955',
                   '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
                 ],
+                '0x89': ['0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'],
+                '0xa4b1': ['0xaf88d065e77c8cC2239327C5EDb3A432268e5831'],
+                '0xe708': ['0xacA92E438df0B2401fF60dA7E4337B687a2435DA'],
               },
             },
           },
         },
         '7.74.0': {
+          default: {
+            enabled: true,
+            tokens: {},
+          },
           overrides: {
             perpsWithdraw: {
+              enabled: true,
               tokens: {
-                '0xa4b1': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-                  '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
-                ],
-                '0xe708': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
-                ],
                 '0x1': [
                   '0x0000000000000000000000000000000000000000',
                   '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
@@ -1801,14 +1823,20 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
                   '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
                   '0xc2132d05d31c914a87c6611c10748aeb04b58e8f',
                 ],
+                '0xa4b1': [
+                  '0x0000000000000000000000000000000000000000',
+                  '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+                  '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
+                ],
+                '0xe708': [
+                  '0x0000000000000000000000000000000000000000',
+                  '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
+                ],
               },
-              enabled: true,
             },
             predictWithdraw: {
               enabled: true,
               tokens: {
-                '0xa4b1': ['0xaf88d065e77c8cC2239327C5EDb3A432268e5831'],
-                '0xe708': ['0xacA92E438df0B2401fF60dA7E4337B687a2435DA'],
                 '0x1': [
                   '0x0000000000000000000000000000000000000000',
                   '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
@@ -1826,19 +1854,40 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
                   '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
                 ],
                 '0x89': ['0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'],
+                '0xa4b1': ['0xaf88d065e77c8cC2239327C5EDb3A432268e5831'],
+                '0xe708': ['0xacA92E438df0B2401fF60dA7E4337B687a2435DA'],
               },
             },
           },
-          default: {
-            tokens: {},
-            enabled: true,
-          },
         },
         '7.78.0': {
+          default: {
+            enabled: true,
+            tokens: {},
+          },
           overrides: {
             perpsWithdraw: {
               enabled: true,
+              hyperliquidActivationFee: {
+                enabled: true,
+              },
               tokens: {
+                '0x1': [
+                  '0x0000000000000000000000000000000000000000',
+                  '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+                  '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+                  '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
+                  '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+                ],
+                '0x2105': [
+                  '0x0000000000000000000000000000000000000000',
+                  '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+                ],
+                '0x38': [
+                  '0x0000000000000000000000000000000000000000',
+                  '0x55d398326f99059fF775485246999027B3197955',
+                  '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
+                ],
                 '0x89': [
                   '0x0000000000000000000000000000000000001010',
                   '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
@@ -1853,6 +1902,11 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
                   '0x0000000000000000000000000000000000000000',
                   '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
                 ],
+              },
+            },
+            predictWithdraw: {
+              enabled: true,
+              tokens: {
                 '0x1': [
                   '0x0000000000000000000000000000000000000000',
                   '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
@@ -1869,11 +1923,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
                   '0x55d398326f99059fF775485246999027B3197955',
                   '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
                 ],
-              },
-            },
-            predictWithdraw: {
-              enabled: true,
-              tokens: {
                 '0x89': [
                   '0x0000000000000000000000000000000000001010',
                   '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
@@ -1883,128 +1932,74 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
                 ],
                 '0xa4b1': ['0xaf88d065e77c8cC2239327C5EDb3A432268e5831'],
                 '0xe708': ['0xacA92E438df0B2401fF60dA7E4337B687a2435DA'],
-                '0x1': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-                  '0xdAC17F958D2ee523a2206206994597C13D831ec7',
-                  '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
-                  '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
-                ],
-                '0x2105': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-                ],
-                '0x38': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0x55d398326f99059fF775485246999027B3197955',
-                  '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
-                ],
               },
             },
-          },
-          default: {
-            tokens: {},
-            enabled: true,
           },
         },
         '8.0.0': {
           default: {
-            tokens: {},
             enabled: true,
+            hyperliquidActivationFee: {
+              enabled: true,
+            },
+            tokens: {
+              '0x1': [
+                '0x0000000000000000000000000000000000000000',
+                '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+                '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+                '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
+                '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+                '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+              ],
+              '0x1237': [
+                '0x0000000000000000000000000000000000000000',
+                '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168',
+              ],
+              '0x2105': [
+                '0x0000000000000000000000000000000000000000',
+                '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+                '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2',
+              ],
+              '0x38': [
+                '0x0000000000000000000000000000000000000000',
+                '0x55d398326f99059fF775485246999027B3197955',
+                '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
+              ],
+              '0x89': [
+                '0x0000000000000000000000000000000000001010',
+                '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+                '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+                '0xc2132d05d31c914a87c6611c10748aeb04b58e8f',
+                '0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB',
+              ],
+              '0x8f': [
+                '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
+                '0x754704Bc059F8C67012fEd69BC8A327a5aafb603',
+              ],
+              '0xa4b1': [
+                '0x0000000000000000000000000000000000000000',
+                '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+                '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
+                '0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f',
+              ],
+              '0xe708': [
+                '0x0000000000000000000000000000000000000000',
+                '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
+                '0x176211869cA2b568f2A7D4EE941E073a821EE1ff',
+              ],
+            },
           },
           overrides: {
-            perpsWithdraw: {
-              tokens: {
-                '0xa4b1': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-                  '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
-                ],
-                '0xe708': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
-                ],
-                '0x1': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-                  '0xdAC17F958D2ee523a2206206994597C13D831ec7',
-                  '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
-                  '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
-                ],
-                '0x2105': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-                ],
-                '0x38': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0x55d398326f99059fF775485246999027B3197955',
-                  '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
-                ],
-                '0x89': [
-                  '0x0000000000000000000000000000000000001010',
-                  '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
-                  '0xc2132d05d31c914a87c6611c10748aeb04b58e8f',
-                ],
-              },
+            moneyAccountWithdraw: {
               enabled: true,
+            },
+            perpsWithdraw: {
+              enabled: true,
+              hyperliquidActivationFee: {
+                enabled: true,
+              },
             },
             predictWithdraw: {
-              enabled: true,
-              tokens: {
-                '0x38': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0x55d398326f99059fF775485246999027B3197955',
-                  '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
-                ],
-                '0x89': [
-                  '0x0000000000000000000000000000000000001010',
-                  '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
-                  '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
-                  '0xc2132d05d31c914a87c6611c10748aeb04b58e8f',
-                  '0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB',
-                ],
-                '0xa4b1': ['0xaf88d065e77c8cC2239327C5EDb3A432268e5831'],
-                '0xe708': ['0xacA92E438df0B2401fF60dA7E4337B687a2435DA'],
-                '0x1': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-                  '0xdAC17F958D2ee523a2206206994597C13D831ec7',
-                  '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
-                  '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
-                ],
-                '0x2105': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-                ],
-              },
-            },
-            moneyAccountWithdraw: {
-              tokens: {
-                '0x38': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0x55d398326f99059fF775485246999027B3197955',
-                  '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
-                ],
-                '0x89': ['0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'],
-                '0x8f': ['0xacA92E438df0B2401fF60dA7E4337B687a2435DA'],
-                '0xa4b1': ['0xaf88d065e77c8cC2239327C5EDb3A432268e5831'],
-                '0xe708': [
-                  '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
-                  '0x176211869cA2b568f2A7D4EE941E073a821EE1ff',
-                ],
-                '0x1': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-                  '0xdAC17F958D2ee523a2206206994597C13D831ec7',
-                  '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
-                  '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
-                  '0x6B175474E89094C44Da98b954EedeAC495271d0F',
-                ],
-                '0x2105': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-                ],
-              },
               enabled: true,
             },
           },
@@ -2019,15 +2014,195 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
+      blockedTokens: {
+        default: {
+          chainIds: ['0xaa36a7', '0xe705', '0x4cef52'],
+          tokens: [
+            {
+              address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
+              chainId: '0x1',
+            },
+            {
+              address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
+              chainId: '0x38',
+            },
+            {
+              address: '0x5ca42204cdaa70d5c773946e69de942b85ca6706',
+              chainId: '0x38',
+            },
+            {
+              address: '0x683e9dcf085e5efcc7925858aace94d4b8882024',
+              chainId: '0x38',
+            },
+            {
+              address: '0xe90d1567ecEF9282CC1AB348D9e9E2ac95659B99',
+              chainId: '0x38',
+            },
+            {
+              address: '0xEF1f39d8391cdDcaee62b8b383cB992F46a6ce4f',
+              chainId: '0x38',
+            },
+            {
+              address: '0xf0f9D895aCa5c8678f706FB8216fa22957685A13',
+              chainId: '0x1',
+            },
+            {
+              address: '0xb1ced2e320e3f4c8e3511b1dc59203303493f382',
+              chainId: '0x38',
+            },
+            {
+              address: '0x73a15fed60bf67631dc6cd7bc5b6e8da8190acf5',
+              chainId: '0x1',
+            },
+            {
+              address: '0xfecbda1b8dbd73c4eea7843c04db816107fa6666',
+              chainId: '0x38',
+            },
+            {
+              address: '0x8C907e0a72C3d55627E853f4ec6a96b0C8771145',
+              chainId: '0x38',
+            },
+            {
+              address: '0x619940C0F69f1612245f94b7659403623239Fb20',
+              chainId: '0x38',
+            },
+            {
+              address: '0x0000000000000000000000000000000000000000',
+              chainId: '0x8f',
+            },
+          ],
+        },
+        overrides: {
+          perpsDeposit: {
+            chainIds: ['0xaa36a7', '0xe705', '0x4cef52'],
+            tokens: [
+              {
+                address: '0x33A3d962955A3862C8093D1273344719f03cA17C',
+                chainId: '0x38',
+              },
+              {
+                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
+                chainId: '0x1',
+              },
+              {
+                address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
+                chainId: '0x38',
+              },
+              {
+                address: '0x5ca42204cdaa70d5c773946e69de942b85ca6706',
+                chainId: '0x38',
+              },
+              {
+                address: '0x683e9dcf085e5efcc7925858aace94d4b8882024',
+                chainId: '0x38',
+              },
+              {
+                address: '0xe90d1567ecEF9282CC1AB348D9e9E2ac95659B99',
+                chainId: '0x38',
+              },
+              {
+                address: '0xEF1f39d8391cdDcaee62b8b383cB992F46a6ce4f',
+                chainId: '0x38',
+              },
+              {
+                address: '0xf0f9D895aCa5c8678f706FB8216fa22957685A13',
+                chainId: '0x1',
+              },
+              {
+                address: '0xb1ced2e320e3f4c8e3511b1dc59203303493f382',
+                chainId: '0x38',
+              },
+              {
+                address: '0x73a15fed60bf67631dc6cd7bc5b6e8da8190acf5',
+                chainId: '0x1',
+              },
+              {
+                address: '0xfecbda1b8dbd73c4eea7843c04db816107fa6666',
+                chainId: '0x38',
+              },
+              {
+                address: '0x8C907e0a72C3d55627E853f4ec6a96b0C8771145',
+                chainId: '0x38',
+              },
+              {
+                address: '0x619940C0F69f1612245f94b7659403623239Fb20',
+                chainId: '0x38',
+              },
+              {
+                address: '0x0000000000000000000000000000000000000000',
+                chainId: '0x8f',
+              },
+            ],
+          },
+          predictDeposit: {
+            chainIds: ['0xaa36a7', '0xe705', '0x4cef52'],
+            tokens: [
+              {
+                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
+                chainId: '0x1',
+              },
+              {
+                address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
+                chainId: '0x38',
+              },
+              {
+                address: '0x5ca42204cdaa70d5c773946e69de942b85ca6706',
+                chainId: '0x38',
+              },
+              {
+                address: '0x683e9dcf085e5efcc7925858aace94d4b8882024',
+                chainId: '0x38',
+              },
+              {
+                address: '0xe90d1567ecEF9282CC1AB348D9e9E2ac95659B99',
+                chainId: '0x38',
+              },
+              {
+                address: '0xEF1f39d8391cdDcaee62b8b383cB992F46a6ce4f',
+                chainId: '0x38',
+              },
+              {
+                address: '0xf0f9D895aCa5c8678f706FB8216fa22957685A13',
+                chainId: '0x1',
+              },
+              {
+                address: '0xb1ced2e320e3f4c8e3511b1dc59203303493f382',
+                chainId: '0x38',
+              },
+              {
+                address: '0x73a15fed60bf67631dc6cd7bc5b6e8da8190acf5',
+                chainId: '0x1',
+              },
+              {
+                address: '0xfecbda1b8dbd73c4eea7843c04db816107fa6666',
+                chainId: '0x38',
+              },
+              {
+                address: '0x8C907e0a72C3d55627E853f4ec6a96b0C8771145',
+                chainId: '0x38',
+              },
+              {
+                address: '0x619940C0F69f1612245f94b7659403623239Fb20',
+                chainId: '0x38',
+              },
+              {
+                address: '0x0000000000000000000000000000000000000000',
+                chainId: '0x8f',
+              },
+            ],
+          },
+        },
+      },
+      minimumRequiredTokenBalance: 10,
       preferredTokens: {
         default: [],
         overrides: {
           perpsDeposit: [
             {
-              name: 'ETH',
-              successRate: 93.89,
               address: '0x0000000000000000000000000000000000000000',
               chainId: '0x1',
+              name: 'ETH',
+              successRate: 93.89,
             },
             {
               address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eb48',
@@ -2042,16 +2217,16 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
               successRate: 90.73,
             },
             {
-              successRate: 90.4,
               address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
               chainId: '0x1',
               name: 'USDT',
+              successRate: 90.4,
             },
             {
+              address: '0x55d398326f99059fF775485246999027B3197955',
               chainId: '0x38',
               name: 'USDT',
               successRate: 91.4,
-              address: '0x55d398326f99059fF775485246999027B3197955',
             },
             {
               address: '0x0000000000000000000000000000000000000000',
@@ -2066,16 +2241,16 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
               successRate: 91.15,
             },
             {
-              successRate: 97.5,
               address: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
               chainId: '0xa4b1',
               name: 'USDT',
+              successRate: 97.5,
             },
             {
-              name: 'USDC',
-              successRate: 96.38,
               address: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
               chainId: '0x38',
+              name: 'USDC',
+              successRate: 96.38,
             },
             {
               address: '0x0000000000000000000000000000000000000000',
@@ -2084,23 +2259,23 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
               successRate: 89.94,
             },
             {
+              address: '0x0000000000000000000000000000000000000000',
               chainId: '0x89',
               name: 'POL',
               successRate: 89.65,
-              address: '0x0000000000000000000000000000000000000000',
             },
             {
-              name: 'MUSD',
-              successRate: 96.66,
               address: '0xe2fceAc20813592220b8C56999000d08C7844E6c',
               chainId: '0x1',
+              name: 'MUSD',
+              successRate: 96.66,
             },
           ],
           perpsWithdraw: [
             {
-              name: 'mUSD',
               address: '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
               chainId: '0x1',
+              name: 'mUSD',
             },
           ],
           predictDeposit: [
@@ -2111,34 +2286,34 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
               successRate: 88.47,
             },
             {
+              address: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
               chainId: '0x89',
               name: 'USDC',
               successRate: 87.55,
-              address: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
             },
             {
-              name: 'USDC.e',
-              successRate: 90.04,
               address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
               chainId: '0x89',
+              name: 'USDC.e',
+              successRate: 90.04,
             },
             {
+              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eb48',
               chainId: '0x1',
               name: 'USDC',
               successRate: 88.36,
-              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eb48',
             },
             {
-              successRate: 92.22,
               address: '0x0000000000000000000000000000000000000000',
               chainId: '0x38',
               name: 'BNB',
+              successRate: 92.22,
             },
             {
-              successRate: 88.5,
               address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
               chainId: '0x1',
               name: 'USDT',
+              successRate: 88.5,
             },
             {
               address: '0x0000000000000000000000000000000000000000',
@@ -2153,10 +2328,10 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
               successRate: 89.34,
             },
             {
-              successRate: 93.61,
               address: '0xe2fceAc20813592220b8C56999000d08C7844E6c',
               chainId: '0x1',
               name: 'MUSD',
+              successRate: 93.61,
             },
             {
               address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
@@ -2167,193 +2342,13 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
           ],
           predictWithdraw: [
             {
-              name: 'mUSD',
               address: '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
               chainId: '0x1',
+              name: 'mUSD',
             },
           ],
         },
       },
-      blockedTokens: {
-        overrides: {
-          perpsDeposit: {
-            tokens: [
-              {
-                chainId: '0x38',
-                address: '0x33A3d962955A3862C8093D1273344719f03cA17C',
-              },
-              {
-                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
-                chainId: '0x1',
-              },
-              {
-                address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
-                chainId: '0x38',
-              },
-              {
-                address: '0x5ca42204cdaa70d5c773946e69de942b85ca6706',
-                chainId: '0x38',
-              },
-              {
-                chainId: '0x38',
-                address: '0x683e9dcf085e5efcc7925858aace94d4b8882024',
-              },
-              {
-                address: '0xe90d1567ecEF9282CC1AB348D9e9E2ac95659B99',
-                chainId: '0x38',
-              },
-              {
-                address: '0xEF1f39d8391cdDcaee62b8b383cB992F46a6ce4f',
-                chainId: '0x38',
-              },
-              {
-                chainId: '0x1',
-                address: '0xf0f9D895aCa5c8678f706FB8216fa22957685A13',
-              },
-              {
-                address: '0xb1ced2e320e3f4c8e3511b1dc59203303493f382',
-                chainId: '0x38',
-              },
-              {
-                address: '0x73a15fed60bf67631dc6cd7bc5b6e8da8190acf5',
-                chainId: '0x1',
-              },
-              {
-                address: '0xfecbda1b8dbd73c4eea7843c04db816107fa6666',
-                chainId: '0x38',
-              },
-              {
-                address: '0x8C907e0a72C3d55627E853f4ec6a96b0C8771145',
-                chainId: '0x38',
-              },
-              {
-                chainId: '0x38',
-                address: '0x619940C0F69f1612245f94b7659403623239Fb20',
-              },
-              {
-                address: '0x0000000000000000000000000000000000000000',
-                chainId: '0x8f',
-              },
-            ],
-            chainIds: ['0xaa36a7', '0xe705'],
-          },
-          predictDeposit: {
-            tokens: [
-              {
-                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
-                chainId: '0x1',
-              },
-              {
-                address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
-                chainId: '0x38',
-              },
-              {
-                chainId: '0x38',
-                address: '0x5ca42204cdaa70d5c773946e69de942b85ca6706',
-              },
-              {
-                chainId: '0x38',
-                address: '0x683e9dcf085e5efcc7925858aace94d4b8882024',
-              },
-              {
-                chainId: '0x38',
-                address: '0xe90d1567ecEF9282CC1AB348D9e9E2ac95659B99',
-              },
-              {
-                address: '0xEF1f39d8391cdDcaee62b8b383cB992F46a6ce4f',
-                chainId: '0x38',
-              },
-              {
-                chainId: '0x1',
-                address: '0xf0f9D895aCa5c8678f706FB8216fa22957685A13',
-              },
-              {
-                address: '0xb1ced2e320e3f4c8e3511b1dc59203303493f382',
-                chainId: '0x38',
-              },
-              {
-                chainId: '0x1',
-                address: '0x73a15fed60bf67631dc6cd7bc5b6e8da8190acf5',
-              },
-              {
-                address: '0xfecbda1b8dbd73c4eea7843c04db816107fa6666',
-                chainId: '0x38',
-              },
-              {
-                chainId: '0x38',
-                address: '0x8C907e0a72C3d55627E853f4ec6a96b0C8771145',
-              },
-              {
-                address: '0x619940C0F69f1612245f94b7659403623239Fb20',
-                chainId: '0x38',
-              },
-              {
-                address: '0x0000000000000000000000000000000000000000',
-                chainId: '0x8f',
-              },
-            ],
-            chainIds: ['0xaa36a7', '0xe705'],
-          },
-        },
-        default: {
-          tokens: [
-            {
-              address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
-              chainId: '0x1',
-            },
-            {
-              chainId: '0x38',
-              address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
-            },
-            {
-              address: '0x5ca42204cdaa70d5c773946e69de942b85ca6706',
-              chainId: '0x38',
-            },
-            {
-              chainId: '0x38',
-              address: '0x683e9dcf085e5efcc7925858aace94d4b8882024',
-            },
-            {
-              address: '0xe90d1567ecEF9282CC1AB348D9e9E2ac95659B99',
-              chainId: '0x38',
-            },
-            {
-              chainId: '0x38',
-              address: '0xEF1f39d8391cdDcaee62b8b383cB992F46a6ce4f',
-            },
-            {
-              address: '0xf0f9D895aCa5c8678f706FB8216fa22957685A13',
-              chainId: '0x1',
-            },
-            {
-              chainId: '0x38',
-              address: '0xb1ced2e320e3f4c8e3511b1dc59203303493f382',
-            },
-            {
-              address: '0x73a15fed60bf67631dc6cd7bc5b6e8da8190acf5',
-              chainId: '0x1',
-            },
-            {
-              address: '0xfecbda1b8dbd73c4eea7843c04db816107fa6666',
-              chainId: '0x38',
-            },
-            {
-              chainId: '0x38',
-              address: '0x8C907e0a72C3d55627E853f4ec6a96b0C8771145',
-            },
-            {
-              address: '0x619940C0F69f1612245f94b7659403623239Fb20',
-              chainId: '0x38',
-            },
-            {
-              address: '0x0000000000000000000000000000000000000000',
-              chainId: '0x8f',
-            },
-          ],
-          chainIds: ['0xaa36a7', '0xe705'],
-        },
-      },
-      minimumRequiredTokenBalance: 10,
     },
     status: FeatureFlagStatus.Active,
   },
@@ -2362,7 +2357,50 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'confirmations_relay_fixed_spread',
     type: FeatureFlagType.Remote,
     inProd: true,
-    productionDefault: {},
+    productionDefault: {
+      chains: {
+        arbitrum: '0xa4b1',
+        base: '0x2105',
+        bsc: '0x38',
+        eth: '0x1',
+        linea: '0xe708',
+        monad: '0x8f',
+      },
+      routes: [
+        ['monad', 'musd', 'monad', 'musd'],
+        ['monad', 'monad_usdc', 'monad', 'musd'],
+        ['arbitrum', 'arbitrum_usdc', 'monad', 'musd'],
+        ['arbitrum', 'arbitrum_ausdcn', 'monad', 'musd'],
+        ['base', 'base_usdc', 'monad', 'musd'],
+        ['base', 'base_ausdc', 'monad', 'musd'],
+        ['bsc', 'bsc_usdc', 'monad', 'musd'],
+        ['bsc', 'bsc_ausdc', 'monad', 'musd'],
+        ['eth', 'eth_usdc', 'monad', 'musd'],
+        ['eth', 'eth_ausdc', 'monad', 'musd'],
+        ['eth', 'eth_dai', 'monad', 'musd'],
+        ['eth', 'eth_adai', 'monad', 'musd'],
+        ['eth', 'musd', 'monad', 'musd'],
+        ['linea', 'musd', 'monad', 'musd'],
+      ],
+      tokens: {
+        arbitrum_ausdcn: '0x724dc807b04555b71ed48a6896b6f41593b8c637',
+        arbitrum_usdc: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+        base_ausdc: '0x4e65fe4dba92790696d040ac24aa414708f5c0ab',
+        base_usdc: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        bsc_ausdc: '0x00901a076785e0906d1028c7d6372d247bec7d61',
+        bsc_ausdt: '0xa9251ca9de909cb71783723713b21e4233fbf1b1',
+        bsc_usdc: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
+        bsc_usdt: '0x55d398326f99059ff775485246999027b3197955',
+        eth_adai: '0x018008bfb33d285247a21d44e50697654f754e63',
+        eth_ausdc: '0x98c23e9d8f34fefb1b7bd6a91b7ff122f4e16f5c',
+        eth_ausdt: '0x23878914efe38d27c4d67ab83ed1b93a74d4086a',
+        eth_dai: '0x6b175474e89094c44da98b954eedeac495271d0f',
+        eth_usdc: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        eth_usdt: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+        monad_usdc: '0x754704bc059f8c67012fed69bc8a327a5aafb603',
+        musd: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+      },
+    },
     status: FeatureFlagStatus.Active,
   },
 
@@ -2371,678 +2409,30 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      gasFeeRandomisation: {
-        randomisedGasFeeDigits: {
-          '0x2105': 5,
-        },
-      },
-      timeoutAttempts: {
-        perChainConfig: {
-          '0xa4b1': 100,
-        },
-        default: 30,
-      },
       acceleratedPolling: {
         defaultCountMax: 10,
         defaultIntervalMs: 3000,
         perChainConfig: {
-          '0xcc': {
-            blockTime: 1000,
-            chainId: '204',
-            countMax: 10,
-            intervalMs: 700,
-            name: 'OPBNB',
-          },
-          '0x8f': {
-            name: 'MONAD',
-            blockTime: 500,
-            chainId: '143',
-            countMax: 15,
-            intervalMs: 500,
-          },
-          '0x813df': {
-            intervalMs: 500,
-            name: 'LAYER_K',
-            blockTime: 250,
-            chainId: '529375',
-            countMax: 15,
-          },
-          '0x13e31': {
-            blockTime: 2000,
-            chainId: '81457',
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'BLAST',
-          },
-          '0xbde31': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'WINR',
-            blockTime: 250,
-            chainId: '777777',
-          },
-          '0xa867': {
-            name: 'HEMI',
-            blockTime: 1200,
-            chainId: '43111',
-            countMax: 10,
-            intervalMs: 800,
-          },
-          '0xa4ba': {
-            blockTime: 250,
-            chainId: '42170',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'ARBITRUM_NOVA',
-          },
-          '0x1142c': {
-            chainId: '70700',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'PROOF_OF_PLAY_APEX',
-            blockTime: 250,
-          },
-          '0xa3c3': {
-            chainId: '41923',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'EDUCHAIN',
-            blockTime: 250,
-          },
-          '0x28c58': {
-            countMax: 10,
-            intervalMs: 3000,
-            name: 'TAIKO',
-            blockTime: 6000,
-            chainId: '167000',
-          },
-          '0x1388': {
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'MANTLE',
-            blockTime: 2000,
-            chainId: '5000',
-          },
-          '0x18232': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'PLUME',
-            blockTime: 667,
-            chainId: '98866',
-          },
-          '0x16fd8': {
-            chainId: '94168',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'LUMITERRA',
-            blockTime: 250,
-          },
-          '0x2eb': {
-            name: 'FLOW',
-            blockTime: 1000,
-            chainId: '747',
-            countMax: 10,
-            intervalMs: 700,
-          },
-          '0xe705': {
-            chainId: '59141',
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'LINEA_SEPOLIA',
-            blockTime: 2000,
-          },
-          '0x13a43': {
-            intervalMs: 500,
-            name: 'GEO_GENESIS',
-            blockTime: 250,
-            chainId: '80451',
-            countMax: 15,
-          },
-          '0x99797f': {
-            name: 'SPOTLIGHT',
-            blockTime: 250,
-            chainId: '10058111',
-            countMax: 15,
-            intervalMs: 500,
-          },
-          '0x123': {
-            name: 'ORDERLY',
-            blockTime: 2000,
-            chainId: '291',
-            countMax: 10,
-            intervalMs: 1300,
-          },
-          '0xaa37dc': {
-            blockTime: 2000,
-            chainId: '11155420',
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'OPTIMISM_SEPOLIA',
-          },
-          '0x61': {
-            blockTime: 333,
-            chainId: '97',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'BNB_TESTNET',
-          },
-          '0x7cc': {
-            blockTime: 250,
-            chainId: '1996',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'SANKO',
-          },
-          '0x82': {
-            blockTime: 2000,
-            chainId: '130',
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'UNICHAIN',
-          },
-          '0x1b254': {
-            chainId: '111188',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'REAL',
-            blockTime: 250,
-          },
-          '0x2105': {
-            name: 'BASE',
-            blockTime: 2000,
-            chainId: '8453',
-            countMax: 10,
-            intervalMs: 1300,
-          },
-          '0xaa36a7': {
-            name: 'ETHEREUM_SEPOLIA',
-            blockTime: 12000,
-            chainId: '11155111',
-            countMax: 10,
-            intervalMs: 3000,
-          },
-          '0xa4b1': {
-            name: 'ARBITRUM_ONE',
-            blockTime: 250,
-            chainId: '42161',
-            countMax: 15,
-            intervalMs: 500,
-          },
-          '0x88bb0': {
-            countMax: 10,
-            intervalMs: 3000,
-            name: 'HOODI',
-            blockTime: 12000,
-            chainId: '560048',
-          },
-          '0x6c1': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'REYA',
-            blockTime: 250,
-            chainId: '1729',
-          },
-          '0x13881': {
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'POLYGON_MUMBAI',
-            blockTime: 2000,
-            chainId: '80001',
-          },
-          '0x8274f': {
-            name: 'SCROLL_SEPOLIA',
-            blockTime: 4667,
-            chainId: '534351',
-            countMax: 10,
-            intervalMs: 3000,
-          },
-          '0x725': {
-            blockTime: 250,
-            chainId: '1829',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'PLAYBLOCK',
-          },
-          '0xa9': {
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'MANTA',
-            blockTime: 2000,
-            chainId: '169',
-          },
-          '0x18c6': {
-            countMax: 10,
-            intervalMs: 2700,
-            name: 'MEGAETH_TESTNET',
-            blockTime: 4000,
-            chainId: '6342',
-          },
-          '0x14a34': {
-            name: 'BASE_SEPOLIA_TESTNET',
-            blockTime: 250,
-            chainId: '84532',
-            countMax: 15,
-            intervalMs: 500,
-          },
-          '0x171': {
-            countMax: 10,
-            intervalMs: 3000,
-            name: 'PULSECHAIN',
-            blockTime: 10000,
-            chainId: '369',
-          },
-          '0x1713c': {
-            blockTime: 250,
-            chainId: '94524',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'IDEX',
-          },
-          '0xe708': {
-            blockTime: 2000,
-            chainId: '59144',
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'LINEA',
-          },
-          '0x38': {
-            intervalMs: 700,
-            name: 'BNB',
-            blockTime: 1000,
-            chainId: '56',
-            countMax: 10,
-          },
-          '0xd7cc': {
-            chainId: '55244',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'SUPERPOSITION',
-            blockTime: 250,
-          },
-          '0x46f': {
-            chainId: '1135',
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'LISK',
-            blockTime: 2000,
-          },
-          '0x98967f': {
-            chainId: '9999999',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'FLUENCE',
-            blockTime: 250,
-          },
-          '0x88b': {
-            blockTime: 250,
-            chainId: '2187',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'GAME7',
-          },
-          '0xe8': {
-            countMax: 10,
-            intervalMs: 3000,
-            name: 'LENS',
-            blockTime: 48333,
-            chainId: '232',
-          },
-          '0x34a1': {
-            intervalMs: 1300,
-            name: 'IMMUTABLE_TESTNET',
-            blockTime: 2000,
-            chainId: '13473',
-            countMax: 10,
-          },
-          '0x1ecf': {
-            name: 'KINTO',
-            blockTime: 250,
-            chainId: '7887',
-            countMax: 15,
-            intervalMs: 500,
-          },
-          '0x82750': {
-            chainId: '534352',
-            countMax: 10,
-            intervalMs: 2000,
-            name: 'SCROLL',
-            blockTime: 3000,
-          },
-          '0x13f8': {
-            blockTime: 2000,
-            chainId: '5112',
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'HAM',
-          },
-          '0x3023': {
-            name: 'HUDDLE01',
-            blockTime: 250,
-            chainId: '12323',
-            countMax: 15,
-            intervalMs: 500,
-          },
-          '0xa6': {
-            blockTime: 1667,
-            chainId: '166',
-            countMax: 10,
-            intervalMs: 1100,
-            name: 'OMNI',
-          },
-          '0x42af': {
-            name: 'ONCHAIN_POINTS',
-            blockTime: 250,
-            chainId: '17071',
-            countMax: 15,
-            intervalMs: 500,
-          },
-          '0x138de': {
-            chainId: '80094',
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'BERACHAIN',
-            blockTime: 2000,
-          },
-          '0xe4': {
-            chainId: '228',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'MIND',
-            blockTime: 250,
-          },
-          '0xd0d0': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'DODO',
-            blockTime: 250,
-            chainId: '53456',
-          },
-          '0xb5f': {
-            chainId: '2911',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'HYTOPIA',
-            blockTime: 250,
-          },
-          '0x13882': {
-            name: 'POLYGON_AMOY',
-            blockTime: 2000,
-            chainId: '80002',
-            countMax: 10,
-            intervalMs: 1300,
-          },
-          '0x9dd': {
-            blockTime: 250,
-            chainId: '2525',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'INEVM',
-          },
-          '0x15b43': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'UNITE',
-            blockTime: 250,
-            chainId: '88899',
-          },
-          '0x142b6': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'VEMP',
-            blockTime: 250,
-            chainId: '82614',
-          },
-          '0x515': {
-            chainId: '1301',
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'UNICHAIN_SEPOLIA',
-            blockTime: 2000,
-          },
-          '0x27bc86aa': {
-            blockTime: 250,
-            chainId: '666666666',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'DEGEN_CHAIN',
-          },
-          '0x3bd': {
-            blockTime: 2000,
-            chainId: '957',
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'LYRA',
-          },
-          '0x2611': {
-            blockTime: 1000,
-            chainId: '9745',
-            countMax: 10,
-            intervalMs: 700,
-            name: 'PLASMA',
-          },
-          '0x34fb5e38': {
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'ANXIENT8',
-            blockTime: 2000,
-            chainId: '888888888',
-          },
-          '0x9c4400': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'ALIENX',
-            blockTime: 250,
-            chainId: '10241024',
-          },
-          '0xfc': {
-            name: 'FRAXTAL',
-            blockTime: 2000,
-            chainId: '252',
-            countMax: 10,
-            intervalMs: 1300,
-          },
-          '0x2a': {
-            chainId: '42',
-            countMax: 10,
-            intervalMs: 2700,
-            name: 'LUKSO',
-            blockTime: 4000,
-          },
-          '0x11c3': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'TRUMPCHAIN',
-            blockTime: 250,
-            chainId: '4547',
-          },
-          '0xe35': {
-            name: 'BOTANIX',
-            blockTime: 4333,
-            chainId: '3637',
-            countMax: 10,
-            intervalMs: 2900,
-          },
-          '0x16876': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'MIRACLE',
-            blockTime: 250,
-            chainId: '92278',
-          },
-          '0x19': {
-            chainId: '25',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'CRONOS',
-            blockTime: 667,
-          },
-          '0x13bf8': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'ONYX',
-            blockTime: 250,
-            chainId: '80888',
-          },
-          '0x62ef': {
-            blockTime: 250,
-            chainId: '25327',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'EVERCLEAR',
-          },
           '0x1': {
+            blockTime: 12000,
             chainId: '1',
             countMax: 10,
             intervalMs: 3000,
             name: 'ETHEREUM',
-            blockTime: 12000,
           },
-          '0x76adf1': {
-            chainId: '7777777',
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'ZORA',
-            blockTime: 2000,
-          },
-          '0x15a9': {
-            chainId: '5545',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'DUCK',
+          '0x1042': {
             blockTime: 250,
-          },
-          '0x74c': {
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'SONEIUM',
-            blockTime: 2000,
-            chainId: '1868',
-          },
-          '0x659': {
+            chainId: '4162',
+            countMax: 15,
             intervalMs: 500,
-            name: 'GRAVITY',
+            name: 'SX_ROLLUP',
+          },
+          '0x1142c': {
             blockTime: 250,
-            chainId: '1625',
-            countMax: 15,
-          },
-          '0xa1ef': {
+            chainId: '70700',
             countMax: 15,
             intervalMs: 500,
-            name: 'ALEPH_ZERO',
-            blockTime: 250,
-            chainId: '41455',
-          },
-          '0xfa': {
-            chainId: '250',
-            countMax: 10,
-            intervalMs: 2700,
-            name: 'FANTOM',
-            blockTime: 4000,
-          },
-          '0x1b58': {
-            intervalMs: 2400,
-            name: 'ZETACHAIN',
-            blockTime: 3667,
-            chainId: '7000',
-            countMax: 10,
-          },
-          '0x163e7': {
-            chainId: '91111',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'HENEZ',
-            blockTime: 250,
-          },
-          '0x2272': {
-            chainId: '8818',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'CLINK',
-            blockTime: 250,
-          },
-          '0x1406f40': {
-            intervalMs: 500,
-            name: 'CORN',
-            blockTime: 250,
-            chainId: '21000000',
-            countMax: 15,
-          },
-          '0x15eb': {
-            countMax: 10,
-            intervalMs: 700,
-            name: 'OPBNB_TESTNET',
-            blockTime: 1000,
-            chainId: '5611',
-          },
-          '0x4268': {
-            countMax: 10,
-            intervalMs: 2700,
-            name: 'ETHEREUM_HOLESKY',
-            blockTime: 4000,
-            chainId: '17000',
-          },
-          '0x279f': {
-            name: 'MONAD_TESTNET',
-            blockTime: 500,
-            chainId: '10143',
-            countMax: 15,
-            intervalMs: 500,
-          },
-          '0x128ca': {
-            blockTime: 250,
-            chainId: '75978',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'FUSION',
-          },
-          '0x316b8': {
-            intervalMs: 500,
-            name: 'BLOCKFIT',
-            blockTime: 250,
-            chainId: '202424',
-            countMax: 15,
-          },
-          '0x8279': {
-            name: 'SLINGSHOTDAO',
-            blockTime: 250,
-            chainId: '33401',
-            countMax: 15,
-            intervalMs: 500,
-          },
-          '0x134b3cf': {
-            name: 'DERI',
-            blockTime: 250,
-            chainId: '20231119',
-            countMax: 15,
-            intervalMs: 500,
-          },
-          '0x13a': {
-            name: 'FILECOIN',
-            blockTime: 30000,
-            chainId: '314',
-            countMax: 10,
-            intervalMs: 3000,
-          },
-          '0x531': {
-            blockTime: 333,
-            chainId: '1329',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'SEI',
-          },
-          '0xa0c71fd': {
-            chainId: '168587773',
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'BLAST_SEPOLIA',
-            blockTime: 2000,
-          },
-          '0xf4290': {
-            blockTime: 250,
-            chainId: '1000080',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'SCOREKOUNT',
+            name: 'PROOF_OF_PLAY_APEX',
           },
           '0x1142d': {
             blockTime: 250,
@@ -3051,159 +2441,306 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
             intervalMs: 500,
             name: 'PROOF_OF_PLAY_BOSS',
           },
-          '0x89': {
-            intervalMs: 1300,
-            name: 'POLYGON',
+          '0x11c3': {
+            blockTime: 250,
+            chainId: '4547',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'TRUMPCHAIN',
+          },
+          '0x123': {
             blockTime: 2000,
-            chainId: '137',
+            chainId: '291',
             countMax: 10,
-          },
-          '0x64': {
-            name: 'GNOSIS',
-            blockTime: 5000,
-            chainId: '100',
-            countMax: 10,
-            intervalMs: 3000,
-          },
-          '0x3e7': {
-            countMax: 10,
-            intervalMs: 700,
-            name: 'HYPEREVM',
-            blockTime: 1000,
-            chainId: '999',
-          },
-          '0xe49b1': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'LOGX',
-            blockTime: 250,
-            chainId: '936369',
-          },
-          '0xab5': {
-            countMax: 10,
-            intervalMs: 700,
-            name: 'ABSTRACT',
-            blockTime: 1000,
-            chainId: '2741',
-          },
-          '0x974': {
-            name: 'DOGELON',
-            blockTime: 250,
-            chainId: '2420',
-            countMax: 15,
-            intervalMs: 500,
-          },
-          '0xa1337': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'XAI',
-            blockTime: 250,
-            chainId: '660279',
-          },
-          '0x52415249': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'RARIBLE',
-            blockTime: 250,
-            chainId: '1380012617',
-          },
-          '0xa': {
             intervalMs: 1300,
-            name: 'OPTIMISM',
-            blockTime: 2000,
-            chainId: '10',
-            countMax: 10,
+            name: 'ORDERLY',
           },
-          '0x13c23': {
-            name: 'FORTA',
+          '0x128ca': {
             blockTime: 250,
-            chainId: '80931',
+            chainId: '75978',
             countMax: 15,
             intervalMs: 500,
-          },
-          '0x343b': {
-            intervalMs: 1300,
-            name: 'IMMUTABLE',
-            blockTime: 2000,
-            chainId: '13371',
-            countMax: 10,
-          },
-          '0x144': {
-            intervalMs: 700,
-            name: 'ZKSYNC',
-            blockTime: 1000,
-            chainId: '324',
-            countMax: 10,
-          },
-          '0xca74': {
-            blockTime: 250,
-            chainId: '51828',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'CHAINBOUNTY',
-          },
-          '0x1042': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'SX_ROLLUP',
-            blockTime: 250,
-            chainId: '4162',
-          },
-          '0x1b59': {
-            chainId: '7001',
-            countMax: 10,
-            intervalMs: 2400,
-            name: 'ZETACHAIN_TESTNET',
-            blockTime: 3667,
-          },
-          '0xb67d2': {
-            intervalMs: 700,
-            name: 'KATANA',
-            blockTime: 1000,
-            chainId: '747474',
-            countMax: 10,
-          },
-          '0x2f0': {
-            name: 'RIVALZ',
-            blockTime: 250,
-            chainId: '752',
-            countMax: 15,
-            intervalMs: 500,
-          },
-          '0x6f0': {
-            chainId: '1776',
-            countMax: 15,
-            intervalMs: 500,
-            name: 'INJECTIVE',
-            blockTime: 667,
-          },
-          '0xc350': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'CITRONUS',
-            blockTime: 250,
-            chainId: '50000',
+            name: 'FUSION',
           },
           '0x1331': {
-            name: 'API3',
             blockTime: 250,
             chainId: '4913',
             countMax: 15,
             intervalMs: 500,
+            name: 'API3',
           },
-          '0x868b': {
-            chainId: '34443',
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'MODE',
-            blockTime: 2000,
-          },
-          '0xfee': {
-            chainId: '4078',
+          '0x134b3cf': {
+            blockTime: 250,
+            chainId: '20231119',
             countMax: 15,
             intervalMs: 500,
-            name: 'COMETH',
+            name: 'DERI',
+          },
+          '0x1388': {
+            blockTime: 2000,
+            chainId: '5000',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'MANTLE',
+          },
+          '0x13881': {
+            blockTime: 2000,
+            chainId: '80001',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'POLYGON_MUMBAI',
+          },
+          '0x13882': {
+            blockTime: 2000,
+            chainId: '80002',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'POLYGON_AMOY',
+          },
+          '0x138de': {
+            blockTime: 2000,
+            chainId: '80094',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'BERACHAIN',
+          },
+          '0x13a': {
+            blockTime: 30000,
+            chainId: '314',
+            countMax: 10,
+            intervalMs: 3000,
+            name: 'FILECOIN',
+          },
+          '0x13a43': {
             blockTime: 250,
+            chainId: '80451',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'GEO_GENESIS',
+          },
+          '0x13bf8': {
+            blockTime: 250,
+            chainId: '80888',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'ONYX',
+          },
+          '0x13c23': {
+            blockTime: 250,
+            chainId: '80931',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'FORTA',
+          },
+          '0x13e31': {
+            blockTime: 2000,
+            chainId: '81457',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'BLAST',
+          },
+          '0x13f8': {
+            blockTime: 2000,
+            chainId: '5112',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'HAM',
+          },
+          '0x1406f40': {
+            blockTime: 250,
+            chainId: '21000000',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'CORN',
+          },
+          '0x142b6': {
+            blockTime: 250,
+            chainId: '82614',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'VEMP',
+          },
+          '0x144': {
+            blockTime: 1000,
+            chainId: '324',
+            countMax: 10,
+            intervalMs: 700,
+            name: 'ZKSYNC',
+          },
+          '0x14a34': {
+            blockTime: 250,
+            chainId: '84532',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'BASE_SEPOLIA_TESTNET',
+          },
+          '0x15a9': {
+            blockTime: 250,
+            chainId: '5545',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'DUCK',
+          },
+          '0x15b43': {
+            blockTime: 250,
+            chainId: '88899',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'UNITE',
+          },
+          '0x15eb': {
+            blockTime: 1000,
+            chainId: '5611',
+            countMax: 10,
+            intervalMs: 700,
+            name: 'OPBNB_TESTNET',
+          },
+          '0x163e7': {
+            blockTime: 250,
+            chainId: '91111',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'HENEZ',
+          },
+          '0x16876': {
+            blockTime: 250,
+            chainId: '92278',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'MIRACLE',
+          },
+          '0x16fd8': {
+            blockTime: 250,
+            chainId: '94168',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'LUMITERRA',
+          },
+          '0x171': {
+            blockTime: 10000,
+            chainId: '369',
+            countMax: 10,
+            intervalMs: 3000,
+            name: 'PULSECHAIN',
+          },
+          '0x1713c': {
+            blockTime: 250,
+            chainId: '94524',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'IDEX',
+          },
+          '0x18232': {
+            blockTime: 667,
+            chainId: '98866',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'PLUME',
+          },
+          '0x18c6': {
+            blockTime: 4000,
+            chainId: '6342',
+            countMax: 10,
+            intervalMs: 2700,
+            name: 'MEGAETH_TESTNET',
+          },
+          '0x19': {
+            blockTime: 667,
+            chainId: '25',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'CRONOS',
+          },
+          '0x1b254': {
+            blockTime: 250,
+            chainId: '111188',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'REAL',
+          },
+          '0x1b58': {
+            blockTime: 3667,
+            chainId: '7000',
+            countMax: 10,
+            intervalMs: 2400,
+            name: 'ZETACHAIN',
+          },
+          '0x1b59': {
+            blockTime: 3667,
+            chainId: '7001',
+            countMax: 10,
+            intervalMs: 2400,
+            name: 'ZETACHAIN_TESTNET',
+          },
+          '0x1ecf': {
+            blockTime: 250,
+            chainId: '7887',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'KINTO',
+          },
+          '0x2105': {
+            blockTime: 2000,
+            chainId: '8453',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'BASE',
+          },
+          '0x2272': {
+            blockTime: 250,
+            chainId: '8818',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'CLINK',
+          },
+          '0x2611': {
+            blockTime: 1000,
+            chainId: '9745',
+            countMax: 10,
+            intervalMs: 700,
+            name: 'PLASMA',
+          },
+          '0x2780b': {
+            blockTime: 250,
+            chainId: '161803',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'EVENTUM',
+          },
+          '0x279f': {
+            blockTime: 500,
+            chainId: '10143',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'MONAD_TESTNET',
+          },
+          '0x27bc86aa': {
+            blockTime: 250,
+            chainId: '666666666',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'DEGEN_CHAIN',
+          },
+          '0x28c58': {
+            blockTime: 6000,
+            chainId: '167000',
+            countMax: 10,
+            intervalMs: 3000,
+            name: 'TAIKO',
+          },
+          '0x28c61': {
+            blockTime: 4000,
+            chainId: '167009',
+            countMax: 10,
+            intervalMs: 2700,
+            name: 'TAIKO_HEKLA',
+          },
+          '0x2a': {
+            blockTime: 4000,
+            chainId: '42',
+            countMax: 10,
+            intervalMs: 2700,
+            name: 'LUKSO',
           },
           '0x2b2': {
             blockTime: 2000,
@@ -3212,61 +2749,40 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
             intervalMs: 1300,
             name: 'REDSTONE',
           },
-          '0xb9': {
+          '0x2ba': {
             blockTime: 2000,
-            chainId: '185',
+            chainId: '698',
             countMax: 10,
             intervalMs: 1300,
-            name: 'MINT',
+            name: 'MATCHAIN',
           },
-          '0x5d979': {
-            countMax: 15,
-            intervalMs: 500,
-            name: 'CHEESE',
-            blockTime: 250,
-            chainId: '383353',
-          },
-          '0x28c61': {
-            name: 'TAIKO_HEKLA',
-            blockTime: 4000,
-            chainId: '167009',
-            countMax: 10,
-            intervalMs: 2700,
-          },
-          '0xa86a': {
-            chainId: '43114',
+          '0x2eb': {
+            blockTime: 1000,
+            chainId: '747',
             countMax: 10,
             intervalMs: 700,
-            name: 'AVALANCHE',
-            blockTime: 1000,
+            name: 'FLOW',
           },
-          '0xb1c9': {
-            name: 'BLESSNET',
+          '0x2f0': {
             blockTime: 250,
-            chainId: '45513',
+            chainId: '752',
             countMax: 15,
             intervalMs: 500,
+            name: 'RIVALZ',
           },
-          '0x8173': {
-            intervalMs: 500,
-            name: 'APECHAIN',
+          '0x3023': {
             blockTime: 250,
-            chainId: '33139',
-            countMax: 15,
-          },
-          '0x7ea': {
-            blockTime: 2000,
-            chainId: '2026',
-            countMax: 10,
-            intervalMs: 1300,
-            name: 'EDGELESS',
-          },
-          '0x2780b': {
-            chainId: '161803',
+            chainId: '12323',
             countMax: 15,
             intervalMs: 500,
-            name: 'EVENTUM',
+            name: 'HUDDLE01',
+          },
+          '0x316b8': {
             blockTime: 250,
+            chainId: '202424',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'BLOCKFIT',
           },
           '0x32': {
             blockTime: 2000,
@@ -3275,19 +2791,327 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
             intervalMs: 1300,
             name: 'XDC',
           },
-          '0x2ba': {
+          '0x343b': {
             blockTime: 2000,
-            chainId: '698',
+            chainId: '13371',
             countMax: 10,
             intervalMs: 1300,
-            name: 'MATCHAIN',
+            name: 'IMMUTABLE',
+          },
+          '0x34a1': {
+            blockTime: 2000,
+            chainId: '13473',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'IMMUTABLE_TESTNET',
+          },
+          '0x34fb5e38': {
+            blockTime: 2000,
+            chainId: '888888888',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'ANXIENT8',
+          },
+          '0x38': {
+            blockTime: 1000,
+            chainId: '56',
+            countMax: 10,
+            intervalMs: 700,
+            name: 'BNB',
+          },
+          '0x3bd': {
+            blockTime: 2000,
+            chainId: '957',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'LYRA',
+          },
+          '0x3e7': {
+            blockTime: 1000,
+            chainId: '999',
+            countMax: 10,
+            intervalMs: 700,
+            name: 'HYPEREVM',
+          },
+          '0x4268': {
+            blockTime: 4000,
+            chainId: '17000',
+            countMax: 10,
+            intervalMs: 2700,
+            name: 'ETHEREUM_HOLESKY',
+          },
+          '0x42af': {
+            blockTime: 250,
+            chainId: '17071',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'ONCHAIN_POINTS',
+          },
+          '0x46f': {
+            blockTime: 2000,
+            chainId: '1135',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'LISK',
+          },
+          '0x515': {
+            blockTime: 2000,
+            chainId: '1301',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'UNICHAIN_SEPOLIA',
+          },
+          '0x52415249': {
+            blockTime: 250,
+            chainId: '1380012617',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'RARIBLE',
+          },
+          '0x531': {
+            blockTime: 333,
+            chainId: '1329',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'SEI',
+          },
+          '0x5d979': {
+            blockTime: 250,
+            chainId: '383353',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'CHEESE',
+          },
+          '0x61': {
+            blockTime: 333,
+            chainId: '97',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'BNB_TESTNET',
+          },
+          '0x62ef': {
+            blockTime: 250,
+            chainId: '25327',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'EVERCLEAR',
+          },
+          '0x64': {
+            blockTime: 5000,
+            chainId: '100',
+            countMax: 10,
+            intervalMs: 3000,
+            name: 'GNOSIS',
+          },
+          '0x659': {
+            blockTime: 250,
+            chainId: '1625',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'GRAVITY',
+          },
+          '0x6c1': {
+            blockTime: 250,
+            chainId: '1729',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'REYA',
+          },
+          '0x6f0': {
+            blockTime: 667,
+            chainId: '1776',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'INJECTIVE',
+          },
+          '0x725': {
+            blockTime: 250,
+            chainId: '1829',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'PLAYBLOCK',
+          },
+          '0x74c': {
+            blockTime: 2000,
+            chainId: '1868',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'SONEIUM',
+          },
+          '0x76adf1': {
+            blockTime: 2000,
+            chainId: '7777777',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'ZORA',
+          },
+          '0x7c5': {
+            blockTime: 250,
+            chainId: '1989',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'LYDIA',
+          },
+          '0x7cc': {
+            blockTime: 250,
+            chainId: '1996',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'SANKO',
+          },
+          '0x7ea': {
+            blockTime: 2000,
+            chainId: '2026',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'EDGELESS',
+          },
+          '0x813df': {
+            blockTime: 250,
+            chainId: '529375',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'LAYER_K',
+          },
+          '0x8173': {
+            blockTime: 250,
+            chainId: '33139',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'APECHAIN',
+          },
+          '0x82': {
+            blockTime: 2000,
+            chainId: '130',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'UNICHAIN',
+          },
+          '0x8274f': {
+            blockTime: 4667,
+            chainId: '534351',
+            countMax: 10,
+            intervalMs: 3000,
+            name: 'SCROLL_SEPOLIA',
+          },
+          '0x82750': {
+            blockTime: 3000,
+            chainId: '534352',
+            countMax: 10,
+            intervalMs: 2000,
+            name: 'SCROLL',
+          },
+          '0x8279': {
+            blockTime: 250,
+            chainId: '33401',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'SLINGSHOTDAO',
+          },
+          '0x868b': {
+            blockTime: 2000,
+            chainId: '34443',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'MODE',
+          },
+          '0x88b': {
+            blockTime: 250,
+            chainId: '2187',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'GAME7',
+          },
+          '0x88bb0': {
+            blockTime: 12000,
+            chainId: '560048',
+            countMax: 10,
+            intervalMs: 3000,
+            name: 'HOODI',
+          },
+          '0x89': {
+            blockTime: 2000,
+            chainId: '137',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'POLYGON',
+          },
+          '0x8f': {
+            blockTime: 500,
+            chainId: '143',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'MONAD',
+          },
+          '0x974': {
+            blockTime: 250,
+            chainId: '2420',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'DOGELON',
+          },
+          '0x98967f': {
+            blockTime: 250,
+            chainId: '9999999',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'FLUENCE',
+          },
+          '0x99797f': {
+            blockTime: 250,
+            chainId: '10058111',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'SPOTLIGHT',
+          },
+          '0x9c4400': {
+            blockTime: 250,
+            chainId: '10241024',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'ALIENX',
           },
           '0x9c4401': {
+            blockTime: 250,
             chainId: '10241025',
             countMax: 15,
             intervalMs: 500,
             name: 'ALIENX_TESTNET',
+          },
+          '0x9dd': {
             blockTime: 250,
+            chainId: '2525',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'INEVM',
+          },
+          '0xa': {
+            blockTime: 2000,
+            chainId: '10',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'OPTIMISM',
+          },
+          '0xa0c71fd': {
+            blockTime: 2000,
+            chainId: '168587773',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'BLAST_SEPOLIA',
+          },
+          '0xa1337': {
+            blockTime: 250,
+            chainId: '660279',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'XAI',
+          },
+          '0xa1ef': {
+            blockTime: 250,
+            chainId: '41455',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'ALEPH_ZERO',
           },
           '0xa33fc': {
             blockTime: 250,
@@ -3296,28 +3120,248 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
             intervalMs: 500,
             name: 'CONWAI',
           },
-          '0xe34': {
+          '0xa3c3': {
+            blockTime: 250,
+            chainId: '41923',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'EDUCHAIN',
+          },
+          '0xa4b1': {
+            blockTime: 250,
+            chainId: '42161',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'ARBITRUM_ONE',
+          },
+          '0xa4ba': {
+            blockTime: 250,
+            chainId: '42170',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'ARBITRUM_NOVA',
+          },
+          '0xa6': {
+            blockTime: 1667,
+            chainId: '166',
+            countMax: 10,
+            intervalMs: 1100,
+            name: 'OMNI',
+          },
+          '0xa867': {
+            blockTime: 1200,
+            chainId: '43111',
+            countMax: 10,
+            intervalMs: 800,
+            name: 'HEMI',
+          },
+          '0xa86a': {
+            blockTime: 1000,
+            chainId: '43114',
+            countMax: 10,
+            intervalMs: 700,
+            name: 'AVALANCHE',
+          },
+          '0xa9': {
+            blockTime: 2000,
+            chainId: '169',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'MANTA',
+          },
+          '0xaa36a7': {
+            blockTime: 12000,
+            chainId: '11155111',
+            countMax: 10,
             intervalMs: 3000,
-            name: 'BOTANIX_TESTNET',
+            name: 'ETHEREUM_SEPOLIA',
+          },
+          '0xaa37dc': {
+            blockTime: 2000,
+            chainId: '11155420',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'OPTIMISM_SEPOLIA',
+          },
+          '0xab5': {
+            blockTime: 1000,
+            chainId: '2741',
+            countMax: 10,
+            intervalMs: 700,
+            name: 'ABSTRACT',
+          },
+          '0xb1c9': {
+            blockTime: 250,
+            chainId: '45513',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'BLESSNET',
+          },
+          '0xb5f': {
+            blockTime: 250,
+            chainId: '2911',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'HYTOPIA',
+          },
+          '0xb67d2': {
+            blockTime: 1000,
+            chainId: '747474',
+            countMax: 10,
+            intervalMs: 700,
+            name: 'KATANA',
+          },
+          '0xb9': {
+            blockTime: 2000,
+            chainId: '185',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'MINT',
+          },
+          '0xbde31': {
+            blockTime: 250,
+            chainId: '777777',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'WINR',
+          },
+          '0xc350': {
+            blockTime: 250,
+            chainId: '50000',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'CITRONUS',
+          },
+          '0xca74': {
+            blockTime: 250,
+            chainId: '51828',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'CHAINBOUNTY',
+          },
+          '0xcc': {
+            blockTime: 1000,
+            chainId: '204',
+            countMax: 10,
+            intervalMs: 700,
+            name: 'OPBNB',
+          },
+          '0xd0d0': {
+            blockTime: 250,
+            chainId: '53456',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'DODO',
+          },
+          '0xd7cc': {
+            blockTime: 250,
+            chainId: '55244',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'SUPERPOSITION',
+          },
+          '0xe34': {
             blockTime: 6000,
             chainId: '3636',
             countMax: 10,
+            intervalMs: 3000,
+            name: 'BOTANIX_TESTNET',
           },
-          '0x7c5': {
+          '0xe35': {
+            blockTime: 4333,
+            chainId: '3637',
+            countMax: 10,
+            intervalMs: 2900,
+            name: 'BOTANIX',
+          },
+          '0xe4': {
+            blockTime: 250,
+            chainId: '228',
             countMax: 15,
             intervalMs: 500,
-            name: 'LYDIA',
+            name: 'MIND',
+          },
+          '0xe49b1': {
             blockTime: 250,
-            chainId: '1989',
+            chainId: '936369',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'LOGX',
+          },
+          '0xe705': {
+            blockTime: 2000,
+            chainId: '59141',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'LINEA_SEPOLIA',
+          },
+          '0xe708': {
+            blockTime: 2000,
+            chainId: '59144',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'LINEA',
+          },
+          '0xe8': {
+            blockTime: 48333,
+            chainId: '232',
+            countMax: 10,
+            intervalMs: 3000,
+            name: 'LENS',
+          },
+          '0xf4290': {
+            blockTime: 250,
+            chainId: '1000080',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'SCOREKOUNT',
+          },
+          '0xfa': {
+            blockTime: 4000,
+            chainId: '250',
+            countMax: 10,
+            intervalMs: 2700,
+            name: 'FANTOM',
+          },
+          '0xfc': {
+            blockTime: 2000,
+            chainId: '252',
+            countMax: 10,
+            intervalMs: 1300,
+            name: 'FRAXTAL',
+          },
+          '0xfee': {
+            blockTime: 250,
+            chainId: '4078',
+            countMax: 15,
+            intervalMs: 500,
+            name: 'COMETH',
           },
         },
       },
       batchSizeLimit: 10,
       gasEstimateFallback: {
         perChainConfig: {
+          '0x1237': {
+            fixed: 25000000,
+          },
           '0x279f': {
             fixed: 1000000,
           },
+        },
+      },
+      gasFeeRandomisation: {
+        randomisedGasFeeDigits: {
+          '0x2105': 5,
+        },
+      },
+      timeoutAttempts: {
+        default: 30,
+        perChainConfig: {
+          '0x2105': 100,
+          '0x38': 300,
+          '0x3e7': 240,
+          '0xa4b1': 800,
         },
       },
     },
@@ -5381,34 +5425,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     inProd: true,
     productionDefault: {
       versions: {
-        '8.0.0': {
-          payStrategies: {
-            relay: {
-              gaslessEnabled: true,
-            },
-          },
-          depositLimit: {
-            moneyAccountDeposit: 100000,
-          },
-          prefilledAmount: {
-            default: {
-              enabled: false,
-            },
-            overrides: {
-              moneyAccountDeposit: {
-                enabled: true,
-              },
-            },
-          },
-          enableDepositWalletWithdraw: true,
-          enableMoneyAccountTransactions: {
-            predictDeposit: true,
-            predictWithdraw: false,
-            perpsDeposit: true,
-            perpsWithdraw: false,
-          },
-          excludeChainIdsFromInfura: ['0x8f'],
-        },
         '0.0.0': {
           enableDepositWalletWithdraw: false,
           payStrategies: {
@@ -5425,6 +5441,108 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
             },
           },
         },
+        '8.0.0': {
+          depositLimit: {
+            moneyAccountDeposit: 500000,
+          },
+          enableDepositWalletWithdraw: true,
+          enableMoneyAccountTransactions: {
+            perpsDeposit: true,
+            perpsWithdraw: false,
+            predictDeposit: true,
+            predictWithdraw: false,
+          },
+          excludeChainIdsFromInfura: ['0x8f'],
+          payStrategies: {
+            relay: {
+              gaslessEnabled: true,
+            },
+          },
+        },
+        '8.7.0': {
+          defaultPaySelectedSection: {
+            perpsWithdraw: 'money-account',
+            predictWithdraw: 'money-account',
+          },
+          depositLimit: {
+            moneyAccountDeposit: 500000,
+          },
+          enableDepositWalletWithdraw: true,
+          enableMoneyAccountTransactions: {
+            perpsDeposit: true,
+            perpsWithdraw: true,
+            predictDeposit: true,
+            predictWithdraw: true,
+          },
+          excludeChainIdsFromInfura: ['0x8f'],
+          payStrategies: {
+            relay: {
+              gaslessEnabled: true,
+            },
+          },
+        },
+        '8.8.0': {
+          defaultPaySelectedSection: {
+            perpsWithdraw: 'money-account',
+            predictWithdraw: 'money-account',
+          },
+          depositLimit: {
+            moneyAccountDeposit: 500000,
+          },
+          enableDepositWalletWithdraw: true,
+          enableMoneyAccountTransactions: {
+            perpsDeposit: true,
+            perpsWithdraw: true,
+            predictDeposit: true,
+            predictWithdraw: true,
+          },
+          excludeChainIdsFromInfura: ['0x8f'],
+          payStrategies: {
+            relay: {
+              gaslessEnabled: true,
+              validationEnabled: {
+                default: true,
+                transactionTypes: {},
+              },
+            },
+          },
+        },
+        '8.9.0': {
+          defaultPaySelectedSection: {
+            perpsWithdraw: 'money-account',
+            predictWithdraw: 'money-account',
+          },
+          depositLimit: {
+            moneyAccountDeposit: 500000,
+          },
+          enableDepositWalletWithdraw: true,
+          enableMoneyAccountTransactions: {
+            perpsDeposit: true,
+            perpsWithdraw: true,
+            predictDeposit: true,
+            predictWithdraw: true,
+          },
+          excludeChainIdsFromInfura: ['0x8f'],
+          payStrategies: {
+            relay: {
+              gaslessEnabled: true,
+              validationEnabled: {
+                default: true,
+                transactionTypes: {},
+              },
+            },
+          },
+          prefilledAmount: {
+            default: {
+              enabled: false,
+            },
+            overrides: {
+              moneyAccountDeposit: {
+                enabled: true,
+              },
+            },
+          },
+        },
       },
     },
     status: FeatureFlagStatus.Active,
@@ -5435,24 +5553,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      versions: {
-        '0.0.0': {
-          enabled: false,
-        },
-        '8.9.0': {
-          default: {
-            enabled: false,
-          },
-          overrides: {
-            musdConversion: {
-              enabled: false,
-            },
-            moneyAccountDeposit: {
-              enabled: false,
-            },
-          },
-        },
-      },
+      enabled: false,
     },
     status: FeatureFlagStatus.Active,
   },

--- a/tests/page-objects/Confirmation/TransactionPayConfirmation.ts
+++ b/tests/page-objects/Confirmation/TransactionPayConfirmation.ts
@@ -115,6 +115,16 @@ class TransactionPayConfirmation {
     return Matchers.getElementByID(ConfirmationRowComponentIDs.TRANSACTION_FEE);
   }
 
+  get paidByMetaMask(): Promise<AppiumElement> {
+    return Matchers.getElementByID(
+      ConfirmationRowComponentIDs.PAID_BY_METAMASK,
+    );
+  }
+
+  get bridgeFeeRow(): Promise<AppiumElement> {
+    return Matchers.getElementByID('bridge-fee-row');
+  }
+
   get payWithTokenList(): Promise<AppiumElement> {
     return Matchers.getElementByID(
       TransactionPayComponentIDs.PAY_WITH_TOKEN_LIST,
@@ -405,10 +415,25 @@ class TransactionPayConfirmation {
   }
 
   async verifyTransactionFeeVisible(): Promise<void> {
-    await Assertions.expectElementToBeVisible(this.transactionFee, {
-      description: 'Transaction fee row should be visible',
+    await Assertions.expectElementToBeVisible(this.bridgeFeeRow, {
+      description: 'Bridge fee row should be visible',
       timeout: 15000,
     });
+
+    // Prod pay configs may sponsor gas (Paid by MetaMask) instead of showing a
+    // fiat `transaction-fee` value — either means the quote/fee row resolved.
+    try {
+      await Assertions.expectElementToBeVisible(this.transactionFee, {
+        description: 'Transaction fee value should be visible',
+        timeout: 5000,
+      });
+    } catch {
+      await Assertions.expectElementToBeVisible(this.paidByMetaMask, {
+        description:
+          'Paid by MetaMask label should be visible when fee value is sponsored',
+        timeout: 5000,
+      });
+    }
   }
 
   async verifyCustomAmount(amount: string, description: string): Promise<void> {

--- a/tests/page-objects/Confirmation/TransactionPayConfirmation.ts
+++ b/tests/page-objects/Confirmation/TransactionPayConfirmation.ts
@@ -422,18 +422,18 @@ class TransactionPayConfirmation {
 
     // Prod pay configs may sponsor gas (Paid by MetaMask) instead of showing a
     // fiat `transaction-fee` value — either means the quote/fee row resolved.
-    try {
-      await Assertions.expectElementToBeVisible(this.transactionFee, {
-        description: 'Transaction fee value should be visible',
-        timeout: 5000,
-      });
-    } catch {
-      await Assertions.expectElementToBeVisible(this.paidByMetaMask, {
-        description:
-          'Paid by MetaMask label should be visible when fee value is sponsored',
-        timeout: 5000,
-      });
-    }
+    await Utilities.waitUntil(
+      async () => {
+        const feeExisting = await (await this.transactionFee)
+          .unwrap()
+          .isExisting();
+        if (feeExisting) {
+          return true;
+        }
+        return (await this.paidByMetaMask).unwrap().isExisting();
+      },
+      { interval: 300, timeout: 15000 },
+    );
   }
 
   async verifyCustomAmount(amount: string, description: string): Promise<void> {


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

First focused slice of the feature-flag registry sync from [#35861](https://github.com/MetaMask/metamask-mobile/pull/35861).

Updates only `confirmations_*` `productionDefault` values in `tests/feature-flags/feature-flag-registry.ts` to match the 2026-09-08 prod sync, so E2E fixtures use the same confirmations defaults as production.

Flags updated:
- `confirmations_eip_7702`
- `confirmations_gas_buffer`
- `confirmations_pay_extended`
- `confirmations_pay_hardware`
- `confirmations_pay_post_quote`
- `confirmations_pay_tokens`
- `confirmations_relay_fixed_spread`
- `confirmations_transactions`

No app production code changes. Follow-up team PRs will peel other domains from #35861 the same way.

**Required CO:** `@MetaMask/confirmations` (+ `@MetaMask/qa` for registry)

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/metamask-mobile/pull/35861

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

1. Confirm CI Appium `confirmations` smoke (iOS + Android) passes with the updated registry defaults.
2. N/A for manual device testing beyond CI smoke for this registry-only change.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — E2E registry defaults only; no UI code changes in this PR.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches confirmations pay and transaction remote-config defaults and mock merge semantics; wrong values or merge behavior could skew Pay confirmation E2E without changing app code.
> 
> **Overview**
> Syncs **`confirmations_*`** remote flag **`productionDefault`** values in `feature-flag-registry.ts` to the latest prod client-config snapshot (EIP-7702 chains, gas buffers, pay extended version ladder through **8.9.0**, pay tokens/blocked lists, relay fixed-spread routes, transaction polling/timeouts, simplified **`confirmations_pay_hardware`**, etc.) so E2E mocks match production confirmations behavior.
> 
> **`createRemoteFeatureFlagsMock`** no longer deep-merges when either side has a **`versions`** key—it **replaces** the flag so flat pay smoke overrides (e.g. `confirmations_pay_extended`) are not polluted by newer registry version entries. A unit test locks that behavior.
> 
> **`TransactionPayConfirmation`** fee checks now require the **bridge fee** row and treat either a fiat **transaction fee** or **Paid by MetaMask** (gasless) as success, matching updated prod pay configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a71a6124db29d98042e57157f5105323ad507566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->