### PR TITLE
fix: tighten top spacing above the Select Quote info text

### DIFF
--- a/app/components/UI/Bridge/components/QuoteSelectorView/index.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/index.tsx
@@ -141,7 +141,7 @@ export const QuoteSelectorView = () => {
         includesTopInset
       />
       <ScreenView safeAreaEdges={[]}>
-        <Box padding={4}>
+        <Box padding={4} paddingTop={0}>
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {strings('bridge.select_quote_info')}
           </Text>


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

On the Swaps/Bridge **Select Quote** screen, the sort explainer ("Quotes are sorted by the estimated total cost…") sat **16pt** below the header. `HeaderStandard` renders a fixed 56pt (`h-14`) row with its title vertically centred, so roughly 20pt of empty header already sits between the title and whatever follows it. Stacking another 16pt on top of that read as an oversized gap under the title.

This drops the explainer container's top padding to 0 while keeping 16pt on the other three sides, so the explainer and the quote list below it move up by 16pt.

- `app/components/UI/Bridge/components/QuoteSelectorView/index.tsx`: `<Box padding={4}>` → `<Box padding={4} paddingTop={0}>`

`Box` emits `pt-0` after `p-4` in its generated class list, so the override wins over the shorthand rather than competing with it.

Verified at native 3x resolution: the header/title band is pixel-identical between the two captures below, and the explainer's first line moves from 140pt to 124pt — exactly 16pt — with the quote rows following.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Reduced the empty space above the sort explainer on the Swaps Select Quote screen

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: UI polish — no linked GitHub issue

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Select Quote sort explainer spacing

  Scenario: user sees the sort explainer sitting close under the header
    Given I am logged into MetaMask Mobile
    And I have a funded account on a network with multiple swap providers

    When I open Swaps and enter an amount that returns more than one quote
    And I tap the quote to open the "Select Quote" screen
    Then the "Quotes are sorted by the estimated total cost…" text sits directly below the header with no extra padding above it
    And the text keeps 16pt of spacing on its left, right and bottom sides
    And the quote rows below it remain unchanged apart from moving up by the same 16pt
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

The explainer sat 16pt below a header that already ends with ~20pt of its own empty space.

<img width="360" alt="Before: extra gap between the Select Quote header and the sort explainer" src="https://github.com/user-attachments/assets/1fbcdbb4-43fd-4686-8185-abe700c681a4" />

### **After**

The explainer sits directly under the header row.

<img width="360" alt="After: sort explainer sits directly below the Select Quote header" src="https://github.com/user-attachments/assets/2fccad09-cd0f-433c-aa61-b35f45fdf8fd" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single layout tweak on the Bridge Select Quote screen with no logic, auth, or data changes.
> 
> **Overview**
> On the Bridge **Select Quote** screen, the sort explainer text had **16pt top padding** on top of the header’s own bottom whitespace, which looked like an oversized gap under the title.
> 
> The explainer wrapper now uses **`paddingTop={0}`** while keeping **`padding={4}`** on the other sides, so the info line and quote list shift up by 16pt without changing horizontal or bottom spacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a96df5e9d207a2769fc04aaf8d1f6c9f5a3b9d7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->