### PR TITLE
test(cv): add e2e-style component view tests for 14 Perps views

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -1281,6 +1281,18 @@ export const PerpsModeSelectionBottomSheetSelectorsIDs = {
   SELECTED_INDICATOR: 'perps-mode-selection-selected-indicator',
 } as const;
 
+export const PerpsSelectProviderViewSelectorsIDs = {
+  SHEET: 'perps-select-provider-sheet',
+  CLOSE_BUTTON: 'perps-select-provider-sheet-close-button',
+} as const;
+
+export const PerpsTooltipViewSelectorsIDs = {
+  BOTTOM_SHEET: 'perps-tooltip-bottom-sheet',
+  HEADER: 'perps-tooltip-bottom-sheet-header',
+  FOOTER: 'perps-tooltip-bottom-sheet-footer',
+  GOT_IT_BUTTON: 'perps-tooltip-bottom-sheet-footer-got-it-button',
+} as const;
+
 // ========================================
 // PERPS MODE FLASH SELECTORS
 // ========================================

--- a/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.view.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Component view tests for PerpsAdjustMarginView.
+ * State-driven via Redux and stream overrides; no hook mocks.
+ */
+import '../../../../../../tests/component-view/mocks';
+
+import {
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react-native';
+import Engine from '../../../../../core/Engine';
+import { strings } from '../../../../../../locales/i18n';
+import {
+  defaultPositionForViews,
+  renderPerpsView,
+} from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+import { createFundedAccountForViews } from '../../../../../../tests/component-view/fixtures/perpsViewFixtures';
+import {
+  PerpsAdjustMarginViewSelectorsIDs,
+  PerpsAmountDisplaySelectorsIDs,
+} from '../../Perps.testIds';
+import Routes from '../../../../../constants/navigation/Routes';
+import PerpsAdjustMarginView from './PerpsAdjustMarginView';
+
+// 1000 USDC available to add → flooredMaxAmount = 1000
+// Pressing 25% sets amount to $250, enabling the confirm button
+const fundedAccount = createFundedAccountForViews('1000');
+
+const addMarginParams = {
+  position: defaultPositionForViews,
+  mode: 'add' as const,
+};
+
+const removeMarginParams = {
+  position: defaultPositionForViews,
+  mode: 'remove' as const,
+};
+
+describe('PerpsAdjustMarginView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(Engine.context.PerpsController.updateMargin).mockResolvedValue({
+      success: true,
+    });
+  });
+
+  it('add mode: confirm is disabled at zero, enabled after choosing 25%, then calls updateMargin on submit', async () => {
+    renderPerpsView(
+      PerpsAdjustMarginView as unknown as React.ComponentType,
+      Routes.PERPS.ADJUST_MARGIN,
+      {
+        initialParams: addMarginParams,
+        streamOverrides: {
+          positions: [defaultPositionForViews],
+          account: fundedAccount,
+        },
+      },
+    );
+
+    // Initial state: confirm button disabled (amount = $0)
+    const confirmButton = await screen.findByTestId(
+      PerpsAdjustMarginViewSelectorsIDs.CONFIRM_BUTTON,
+    );
+    expect(confirmButton).toBeDisabled();
+
+    // Tap the amount display to open the keypad
+    fireEvent.press(
+      screen.getByTestId(PerpsAmountDisplaySelectorsIDs.TOUCHABLE),
+    );
+
+    // Done button is now visible (keypad is open)
+    const doneButton = await screen.findByTestId(
+      PerpsAdjustMarginViewSelectorsIDs.DONE_BUTTON,
+    );
+    expect(doneButton).toBeOnTheScreen();
+
+    // Press 25% to set amount to $250 (25% of $1000 available)
+    fireEvent.press(screen.getByText('25%'));
+
+    // Dismiss keypad via Done
+    fireEvent.press(doneButton);
+
+    // Confirm button re-appears and is now enabled
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(PerpsAdjustMarginViewSelectorsIDs.CONFIRM_BUTTON),
+      ).not.toBeDisabled();
+    });
+
+    // Submit the margin adjustment
+    fireEvent.press(
+      screen.getByTestId(PerpsAdjustMarginViewSelectorsIDs.CONFIRM_BUTTON),
+    );
+
+    // updateMargin is called exactly once with the ETH position symbol
+    await waitFor(() => {
+      expect(
+        jest.mocked(Engine.context.PerpsController.updateMargin),
+      ).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      jest.mocked(Engine.context.PerpsController.updateMargin),
+    ).toHaveBeenCalledWith(expect.objectContaining({ symbol: 'ETH' }));
+  });
+
+  it('add mode: summary shows margin-in-position and liquidation price labels throughout', async () => {
+    renderPerpsView(
+      PerpsAdjustMarginView as unknown as React.ComponentType,
+      Routes.PERPS.ADJUST_MARGIN,
+      {
+        initialParams: addMarginParams,
+        streamOverrides: { positions: [defaultPositionForViews] },
+      },
+    );
+
+    // Both summary rows load without interaction
+    expect(
+      await screen.findByText(
+        strings('perps.adjust_margin.margin_in_position'),
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.adjust_margin.liquidation_price')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.adjust_margin.margin_available_to_add')),
+    ).toBeOnTheScreen();
+  });
+
+  it('remove mode: confirm button shows "Reduce Margin" label and is disabled at zero', async () => {
+    renderPerpsView(
+      PerpsAdjustMarginView as unknown as React.ComponentType,
+      Routes.PERPS.ADJUST_MARGIN,
+      {
+        initialParams: removeMarginParams,
+        streamOverrides: { positions: [defaultPositionForViews] },
+      },
+    );
+
+    const confirmButton = await screen.findByTestId(
+      PerpsAdjustMarginViewSelectorsIDs.CONFIRM_BUTTON,
+    );
+
+    // Label reflects remove mode
+    expect(
+      within(confirmButton).getByText(
+        strings('perps.adjust_margin.reduce_margin'),
+      ),
+    ).toBeOnTheScreen();
+
+    // Disabled at zero amount
+    expect(confirmButton).toBeDisabled();
+
+    // Summary labels reflect remove mode copy
+    expect(
+      screen.getByText(
+        strings('perps.adjust_margin.margin_available_to_remove'),
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows position_not_found error when no position and no mode are supplied', async () => {
+    renderPerpsView(
+      PerpsAdjustMarginView as unknown as React.ComponentType,
+      Routes.PERPS.ADJUST_MARGIN,
+      { initialParams: {} },
+    );
+
+    expect(
+      await screen.findByText(strings('perps.errors.position_not_found')),
+    ).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.view.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Component view tests for PerpsHeroCardView.
+ * State-driven via Redux and stream overrides; no hook mocks.
+ */
+import '../../../../../../tests/component-view/mocks';
+
+import { screen } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
+import {
+  defaultPositionForViews,
+  renderPerpsHeroCardView,
+} from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+import {
+  PerpsHeroCardViewSelectorsIDs,
+  getPerpsHeroCardViewSelector,
+} from '../../Perps.testIds';
+
+const longPosition = defaultPositionForViews;
+
+const shortPosition = {
+  ...defaultPositionForViews,
+  symbol: 'BTC',
+  size: '-0.05',
+  unrealizedPnl: '-250',
+  returnOnEquity: '-0.10',
+  entryPrice: '60000',
+};
+
+describe('PerpsHeroCardView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the hero card container and carousel', async () => {
+    renderPerpsHeroCardView();
+
+    expect(
+      await screen.findByTestId(PerpsHeroCardViewSelectorsIDs.CONTAINER),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(PerpsHeroCardViewSelectorsIDs.CAROUSEL),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows the header title', async () => {
+    renderPerpsHeroCardView();
+
+    expect(
+      await screen.findByText(strings('perps.pnl_hero_card.header_title')),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows the share button', async () => {
+    renderPerpsHeroCardView();
+
+    expect(
+      await screen.findByTestId(PerpsHeroCardViewSelectorsIDs.SHARE_BUTTON),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows the ETH asset symbol on the first card for a long ETH position', async () => {
+    renderPerpsHeroCardView({ initialParams: { position: longPosition } });
+
+    expect(
+      await screen.findByTestId(getPerpsHeroCardViewSelector.assetSymbol(0)),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows the direction badge on the first card', async () => {
+    renderPerpsHeroCardView({ initialParams: { position: longPosition } });
+
+    expect(
+      await screen.findByTestId(getPerpsHeroCardViewSelector.directionBadge(0)),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows positive PnL display for a profitable long position', async () => {
+    renderPerpsHeroCardView({ initialParams: { position: longPosition } });
+
+    const pnlEl = await screen.findByTestId(
+      getPerpsHeroCardViewSelector.pnlText(0),
+    );
+    expect(pnlEl).toBeOnTheScreen();
+    // ROE is 20% → displayed as +20.00%
+    expect(pnlEl).toHaveTextContent('+20.00%');
+  });
+
+  it('shows negative PnL display for a losing short position', async () => {
+    renderPerpsHeroCardView({ initialParams: { position: shortPosition } });
+
+    const pnlEl = await screen.findByTestId(
+      getPerpsHeroCardViewSelector.pnlText(0),
+    );
+    expect(pnlEl).toBeOnTheScreen();
+    // ROE is -10% → displayed as -10.00%
+    expect(pnlEl).toHaveTextContent('-10.00%');
+  });
+
+  it('shows the dot indicator for switching between card templates', async () => {
+    renderPerpsHeroCardView();
+
+    expect(
+      await screen.findByTestId(PerpsHeroCardViewSelectorsIDs.DOT_INDICATOR),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows the share button label', async () => {
+    renderPerpsHeroCardView();
+
+    expect(
+      await screen.findByText(strings('perps.pnl_hero_card.share_button')),
+    ).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsRouter/PerpsMarketDetailsRouter.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsRouter/PerpsMarketDetailsRouter.view.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Component view tests for PerpsMarketDetailsRouter.
+ * Verifies that the router renders the lite layout (PerpsMarketDetailsView)
+ * in the default mode and the pro layout (PerpsProMarketView) in pro mode.
+ * State-driven via Redux and stream overrides; no hook mocks.
+ */
+import '../../../../../../tests/component-view/mocks';
+
+import { screen } from '@testing-library/react-native';
+import { renderPerpsView } from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+import {
+  PerpsMarketDetailsViewSelectorsIDs,
+  PerpsProMarketViewSelectorsIDs,
+} from '../../Perps.testIds';
+import Routes from '../../../../../constants/navigation/Routes';
+import PerpsMarketDetailsRouter from './PerpsMarketDetailsRouter';
+
+const defaultMarket = {
+  symbol: 'ETH',
+  name: 'Ethereum',
+  price: '$2,000.00',
+  change24h: '+$50.00',
+  change24hPercent: '+2.5%',
+  volume: '$1.5B',
+  openInterest: '$500M',
+  maxLeverage: '50x',
+  marketType: 'crypto',
+};
+
+describe('PerpsMarketDetailsRouter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the lite market details layout in the default (non-pro) mode', async () => {
+    renderPerpsView(
+      PerpsMarketDetailsRouter as unknown as React.ComponentType,
+      Routes.PERPS.MARKET_DETAILS,
+      {
+        mode: 'lite',
+        initialParams: { market: defaultMarket },
+      },
+    );
+
+    // PerpsMarketDetailsView has a distinct container testId vs PerpsProMarketView
+    expect(
+      await screen.findByTestId(PerpsMarketDetailsViewSelectorsIDs.CONTAINER),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders the pro market layout in pro mode', async () => {
+    renderPerpsView(
+      PerpsMarketDetailsRouter as unknown as React.ComponentType,
+      Routes.PERPS.MARKET_DETAILS,
+      {
+        mode: 'pro',
+        initialParams: {
+          market: {
+            ...defaultMarket,
+            providerId: 'hyperliquid',
+            szDecimals: 2,
+          },
+        },
+        // Pro layout requires both mode:'pro' in PerpsController AND the remote flag
+        overrides: {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  perpsProModeEnabled: {
+                    enabled: true,
+                    minimumVersion: '0.0.0',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    );
+
+    // PerpsProMarketView has a distinct container testId vs PerpsMarketDetailsView
+    expect(
+      await screen.findByTestId(PerpsProMarketViewSelectorsIDs.CONTAINER),
+    ).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsModeSelectionView/PerpsModeSelectionView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsModeSelectionView/PerpsModeSelectionView.view.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Component view tests for PerpsModeSelectionView.
+ * State-driven via Redux and stream overrides; no hook mocks.
+ */
+import '../../../../../../tests/component-view/mocks';
+
+import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import Engine from '../../../../../core/Engine';
+import { strings } from '../../../../../../locales/i18n';
+import { renderPerpsView } from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+import { PerpsModeSelectionBottomSheetSelectorsIDs } from '../../Perps.testIds';
+import Routes from '../../../../../constants/navigation/Routes';
+import PerpsModeSelectionView from './PerpsModeSelectionView';
+
+describe('PerpsModeSelectionView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the sheet with title, subtitle, and both Lite and Pro options', async () => {
+    renderPerpsView(
+      PerpsModeSelectionView as unknown as React.ComponentType,
+      Routes.PERPS.MODALS.MODE_SELECTION,
+    );
+
+    // Title and subtitle
+    expect(
+      await screen.findByText(strings('perps.mode.selection_title')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.mode.selection_subtitle')),
+    ).toBeOnTheScreen();
+
+    // Both mode options present
+    expect(screen.getByText(strings('perps.mode.lite'))).toBeOnTheScreen();
+    expect(screen.getByText(strings('perps.mode.pro'))).toBeOnTheScreen();
+
+    // Sheet container
+    expect(
+      screen.getByTestId(PerpsModeSelectionBottomSheetSelectorsIDs.CONTAINER),
+    ).toBeOnTheScreen();
+  });
+
+  it('pressing Lite calls setPerpsMode with "lite"', async () => {
+    const setPerpsMode = jest.mocked(
+      Engine.context.PerpsController.setPerpsMode,
+    );
+
+    renderPerpsView(
+      PerpsModeSelectionView as unknown as React.ComponentType,
+      Routes.PERPS.MODALS.MODE_SELECTION,
+      { initialParams: { entry: 'home' } },
+    );
+
+    fireEvent.press(
+      await screen.findByTestId(
+        PerpsModeSelectionBottomSheetSelectorsIDs.LITE_OPTION,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(setPerpsMode).toHaveBeenCalledWith('lite');
+    });
+    expect(setPerpsMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('pressing Pro calls setPerpsMode with "pro"', async () => {
+    const setPerpsMode = jest.mocked(
+      Engine.context.PerpsController.setPerpsMode,
+    );
+
+    renderPerpsView(
+      PerpsModeSelectionView as unknown as React.ComponentType,
+      Routes.PERPS.MODALS.MODE_SELECTION,
+      { initialParams: { entry: 'home' } },
+    );
+
+    fireEvent.press(
+      await screen.findByTestId(
+        PerpsModeSelectionBottomSheetSelectorsIDs.PRO_OPTION,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(setPerpsMode).toHaveBeenCalledWith('pro');
+    });
+    expect(setPerpsMode).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.view.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Component view tests for PerpsOrderBookView.
+ * State-driven via Redux and stream overrides; no hook mocks.
+ */
+import '../../../../../../tests/component-view/mocks';
+
+import { act, fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
+import {
+  defaultPositionForViews,
+  renderPerpsOrderBookView,
+} from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+import { PerpsOrderBookViewSelectorsIDs } from '../../Perps.testIds';
+
+const ineligibleOverrides = {
+  engine: {
+    backgroundState: {
+      PerpsController: { isEligible: false },
+    },
+  },
+};
+
+describe('PerpsOrderBookView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows Long and Short buttons when there is no existing position', async () => {
+    renderPerpsOrderBookView({ streamOverrides: { positions: [] } });
+
+    expect(
+      await screen.findByTestId(PerpsOrderBookViewSelectorsIDs.LONG_BUTTON),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(PerpsOrderBookViewSelectorsIDs.SHORT_BUTTON),
+    ).toBeOnTheScreen();
+
+    // Long/Short labels are correct
+    expect(screen.getByText(strings('perps.market.long'))).toBeOnTheScreen();
+    expect(screen.getByText(strings('perps.market.short'))).toBeOnTheScreen();
+  });
+
+  it('ineligible user pressing Long shows the geo-block tooltip', async () => {
+    renderPerpsOrderBookView({
+      overrides: ineligibleOverrides,
+      streamOverrides: { positions: [] },
+    });
+
+    const longButton = await screen.findByTestId(
+      PerpsOrderBookViewSelectorsIDs.LONG_BUTTON,
+    );
+    expect(longButton).toBeOnTheScreen();
+
+    fireEvent.press(longButton);
+
+    // Geo-block tooltip must appear after the press
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(
+          `${PerpsOrderBookViewSelectorsIDs.CONTAINER}-geo-block-tooltip`,
+        ),
+      ).toBeOnTheScreen();
+    });
+  });
+
+  it('existing position: Modify and Close buttons appear, and pressing Modify opens the action sheet', async () => {
+    renderPerpsOrderBookView({
+      streamOverrides: { positions: [defaultPositionForViews] },
+    });
+
+    // Both action buttons are visible
+    const modifyButton = await screen.findByTestId(
+      PerpsOrderBookViewSelectorsIDs.MODIFY_BUTTON,
+    );
+    expect(modifyButton).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(PerpsOrderBookViewSelectorsIDs.CLOSE_BUTTON),
+    ).toBeOnTheScreen();
+
+    // Pressing Modify opens the modify action sheet inline
+    fireEvent.press(modifyButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(PerpsOrderBookViewSelectorsIDs.MODIFY_ACTION_SHEET),
+      ).toBeOnTheScreen();
+    });
+  });
+
+  it('pressing the depth-band button opens the grouping selection sheet', async () => {
+    renderPerpsOrderBookView();
+
+    const depthBandButton = await screen.findByTestId(
+      PerpsOrderBookViewSelectorsIDs.DEPTH_BAND_BUTTON,
+    );
+    expect(depthBandButton).toBeOnTheScreen();
+
+    fireEvent.press(depthBandButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(PerpsOrderBookViewSelectorsIDs.DEPTH_BAND_SHEET),
+      ).toBeOnTheScreen();
+    });
+  });
+
+  it('stream update: Long/Short are replaced by Modify/Close when a position arrives', async () => {
+    const { stream } = renderPerpsOrderBookView({
+      streamOverrides: { positions: [] },
+    });
+
+    // No position: Long and Short visible
+    await screen.findByTestId(PerpsOrderBookViewSelectorsIDs.LONG_BUTTON);
+    expect(
+      screen.getByTestId(PerpsOrderBookViewSelectorsIDs.SHORT_BUTTON),
+    ).toBeOnTheScreen();
+
+    // Position arrives via stream
+    act(() => {
+      stream.emitPositions([defaultPositionForViews]);
+    });
+
+    // Long/Short disappear; Modify/Close take their place
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId(PerpsOrderBookViewSelectorsIDs.LONG_BUTTON),
+      ).not.toBeOnTheScreen();
+    });
+    expect(
+      screen.getByTestId(PerpsOrderBookViewSelectorsIDs.MODIFY_BUTTON),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(PerpsOrderBookViewSelectorsIDs.CLOSE_BUTTON),
+    ).toBeOnTheScreen();
+  });
+
+  it('unit toggle: switching to base currency keeps the toggle visible and control active', async () => {
+    renderPerpsOrderBookView();
+
+    // Both toggle options are rendered
+    const usdTab = await screen.findByTestId(
+      PerpsOrderBookViewSelectorsIDs.UNIT_TOGGLE_USD,
+    );
+    const baseTab = screen.getByTestId(
+      PerpsOrderBookViewSelectorsIDs.UNIT_TOGGLE_BASE,
+    );
+    expect(usdTab).toBeOnTheScreen();
+    expect(baseTab).toBeOnTheScreen();
+
+    // Switch to base currency
+    fireEvent.press(baseTab);
+
+    // Toggle control is still rendered after the interaction
+    expect(
+      screen.getByTestId(PerpsOrderBookViewSelectorsIDs.UNIT_TOGGLE),
+    ).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.view.test.tsx
@@ -8,6 +8,7 @@ import { act, fireEvent, screen, waitFor } from '@testing-library/react-native';
 import Engine from '../../../../../core/Engine';
 import { strings } from '../../../../../../locales/i18n';
 import {
+  defaultOrderDetailsOrder,
   defaultOrderForViews,
   renderPerpsOrderDetailsView,
 } from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
@@ -107,6 +108,9 @@ describe('PerpsOrderDetailsView', () => {
 
     await waitFor(() => {
       expect(cancelOrder).toHaveBeenCalledTimes(1);
+      expect(cancelOrder).toHaveBeenCalledWith(
+        expect.objectContaining({ orderId: defaultOrderDetailsOrder.orderId }),
+      );
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.view.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Component view tests for PerpsOrderDetailsView.
+ * State-driven via Redux and stream overrides; no hook mocks.
+ */
+import '../../../../../../tests/component-view/mocks';
+
+import { act, fireEvent, screen, waitFor } from '@testing-library/react-native';
+import Engine from '../../../../../core/Engine';
+import { strings } from '../../../../../../locales/i18n';
+import {
+  defaultOrderForViews,
+  renderPerpsOrderDetailsView,
+} from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+import { PerpsOrderDetailsViewSelectorsIDs } from '../../Perps.testIds';
+
+const triggerOrder = {
+  ...defaultOrderForViews,
+  orderId: 'trigger-order-1',
+  orderType: 'stop_market' as const,
+  isTrigger: true,
+  triggerPrice: '2200',
+  triggerDirection: 'below' as const,
+  reduceOnly: true,
+  status: 'open' as const,
+  takeProfitPrice: '2800',
+  stopLossPrice: '1900',
+};
+
+describe('PerpsOrderDetailsView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(Engine.context.PerpsController.cancelOrder).mockResolvedValue({
+      success: true,
+    });
+  });
+
+  it('renders all key detail rows and the cancel button for a limit order', async () => {
+    renderPerpsOrderDetailsView();
+
+    // Header: asset symbol
+    expect(await screen.findByText('ETH')).toBeOnTheScreen();
+
+    // All expected detail row labels in one pass
+    expect(
+      screen.getByText(strings('perps.order_details.date')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.order_details.price')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.order_details.size')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.order_details.original_size')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.order_details.reduce_only')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.order_details.fee')),
+    ).toBeOnTheScreen();
+
+    // Cancel button is present for a cancelable open order
+    expect(
+      screen.getByTestId(PerpsOrderDetailsViewSelectorsIDs.CANCEL_BUTTON),
+    ).toBeOnTheScreen();
+  });
+
+  it('pressing cancel sets the button to loading while cancellation is in progress', async () => {
+    // Never-resolving mock holds the component in the isCanceling = true state
+    jest
+      .mocked(Engine.context.PerpsController.cancelOrder)
+      .mockReturnValue(new Promise<never>(() => undefined));
+
+    renderPerpsOrderDetailsView();
+
+    const cancelButton = await screen.findByTestId(
+      PerpsOrderDetailsViewSelectorsIDs.CANCEL_BUTTON,
+    );
+    expect(cancelButton).not.toBeDisabled();
+
+    await act(async () => {
+      fireEvent.press(cancelButton);
+    });
+
+    // Button becomes loading (isDisabled = true while isCanceling)
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(PerpsOrderDetailsViewSelectorsIDs.CANCEL_BUTTON),
+      ).toBeDisabled();
+    });
+
+    // ETH header still visible during in-progress cancellation
+    expect(screen.getByText('ETH')).toBeOnTheScreen();
+  });
+
+  it('pressing cancel calls cancelOrder exactly once with the order ID', async () => {
+    const cancelOrder = jest.mocked(Engine.context.PerpsController.cancelOrder);
+
+    renderPerpsOrderDetailsView();
+
+    fireEvent.press(
+      await screen.findByTestId(
+        PerpsOrderDetailsViewSelectorsIDs.CANCEL_BUTTON,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(cancelOrder).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('trigger order shows trigger condition row, reduce-only Yes, and cancel button', async () => {
+    renderPerpsOrderDetailsView({ initialParams: { order: triggerOrder } });
+
+    // Trigger condition label and a price value appear
+    expect(
+      await screen.findByText(strings('perps.order_details.trigger_condition')),
+    ).toBeOnTheScreen();
+
+    // Reduce-only is explicitly Yes for this trigger order
+    expect(
+      screen.getByText(strings('perps.order_details.reduce_only')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.order_details.yes')),
+    ).toBeOnTheScreen();
+
+    // Cancel button visible (trigger orders are cancelable)
+    expect(
+      screen.getByTestId(PerpsOrderDetailsViewSelectorsIDs.CANCEL_BUTTON),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows error state when no order is provided', async () => {
+    renderPerpsOrderDetailsView({ initialParams: { order: undefined } });
+
+    expect(
+      await screen.findByText(strings('perps.errors.order_not_found')),
+    ).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsOrderRedirect.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderRedirect.view.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Component view tests for PerpsOrderRedirect.
+ * Verifies the loading state and the deposit+navigate flow.
+ * State-driven via Redux and stream overrides; no hook mocks.
+ */
+import '../../../../../tests/component-view/mocks';
+
+import { screen, waitFor } from '@testing-library/react-native';
+import Engine from '../../../../core/Engine';
+import { renderPerpsView } from '../../../../../tests/component-view/renderers/perpsViewRenderer';
+import { PerpsLoaderSelectorsIDs } from '../Perps.testIds';
+import Routes from '../../../../constants/navigation/Routes';
+import PerpsOrderRedirect from './PerpsOrderRedirect';
+
+const defaultParams = {
+  direction: 'long' as const,
+  asset: 'ETH',
+  fromTokenDetails: false,
+  transactionActiveAbTests: {},
+};
+
+describe('PerpsOrderRedirect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Restore default implementation so the call-count test works correctly
+    jest.mocked(Engine.context.PerpsController.depositWithOrder).mockResolvedValue({
+      result: Promise.resolve('0xcomponent-view-deposit'),
+    });
+  });
+
+  it('always renders the inline loader', async () => {
+    // Prevent depositWithOrder from resolving so the loader stays on screen
+    jest.mocked(Engine.context.PerpsController.depositWithOrder).mockReturnValue(
+      new Promise<never>(() => undefined),
+    );
+
+    renderPerpsView(
+      PerpsOrderRedirect as unknown as React.ComponentType,
+      Routes.PERPS.ORDER_REDIRECT,
+      {
+        initialParams: defaultParams,
+        extraRoutes: [
+          {
+            name: Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
+          },
+        ],
+      },
+    );
+
+    expect(
+      await screen.findByTestId(PerpsLoaderSelectorsIDs.INLINE),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows Preparing order message in the loader', async () => {
+    // Prevent depositWithOrder from resolving so the loader stays on screen
+    jest.mocked(Engine.context.PerpsController.depositWithOrder).mockReturnValue(
+      new Promise<never>(() => undefined),
+    );
+
+    renderPerpsView(
+      PerpsOrderRedirect as unknown as React.ComponentType,
+      Routes.PERPS.ORDER_REDIRECT,
+      {
+        initialParams: defaultParams,
+        extraRoutes: [
+          {
+            name: Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
+          },
+        ],
+      },
+    );
+
+    expect(
+      await screen.findByText('Preparing order...'),
+    ).toBeOnTheScreen();
+  });
+
+  it('calls depositWithOrder once when connected and initialized', async () => {
+    const depositWithOrder = Engine.context.PerpsController
+      .depositWithOrder as jest.Mock;
+
+    renderPerpsView(
+      PerpsOrderRedirect as unknown as React.ComponentType,
+      Routes.PERPS.ORDER_REDIRECT,
+      {
+        initialParams: defaultParams,
+        extraRoutes: [
+          {
+            name: Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
+          },
+        ],
+      },
+    );
+
+    await waitFor(() => {
+      expect(depositWithOrder).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsOrderRedirect.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderRedirect.view.test.tsx
@@ -23,16 +23,18 @@ describe('PerpsOrderRedirect', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // Restore default implementation so the call-count test works correctly
-    jest.mocked(Engine.context.PerpsController.depositWithOrder).mockResolvedValue({
-      result: Promise.resolve('0xcomponent-view-deposit'),
-    });
+    jest
+      .mocked(Engine.context.PerpsController.depositWithOrder)
+      .mockResolvedValue({
+        result: Promise.resolve('0xcomponent-view-deposit'),
+      });
   });
 
   it('always renders the inline loader', async () => {
     // Prevent depositWithOrder from resolving so the loader stays on screen
-    jest.mocked(Engine.context.PerpsController.depositWithOrder).mockReturnValue(
-      new Promise<never>(() => undefined),
-    );
+    jest
+      .mocked(Engine.context.PerpsController.depositWithOrder)
+      .mockReturnValue(new Promise<never>(() => undefined));
 
     renderPerpsView(
       PerpsOrderRedirect as unknown as React.ComponentType,
@@ -54,9 +56,9 @@ describe('PerpsOrderRedirect', () => {
 
   it('shows Preparing order message in the loader', async () => {
     // Prevent depositWithOrder from resolving so the loader stays on screen
-    jest.mocked(Engine.context.PerpsController.depositWithOrder).mockReturnValue(
-      new Promise<never>(() => undefined),
-    );
+    jest
+      .mocked(Engine.context.PerpsController.depositWithOrder)
+      .mockReturnValue(new Promise<never>(() => undefined));
 
     renderPerpsView(
       PerpsOrderRedirect as unknown as React.ComponentType,
@@ -71,9 +73,7 @@ describe('PerpsOrderRedirect', () => {
       },
     );
 
-    expect(
-      await screen.findByText('Preparing order...'),
-    ).toBeOnTheScreen();
+    expect(await screen.findByText('Preparing order...')).toBeOnTheScreen();
   });
 
   it('calls depositWithOrder once when connected and initialized', async () => {

--- a/app/components/UI/Perps/Views/PerpsPositionsView/PerpsPositionsView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsPositionsView/PerpsPositionsView.view.test.tsx
@@ -51,7 +51,9 @@ describe('PerpsPositionsView', () => {
     });
 
     expect(
-      await screen.findByTestId(PerpsPositionsViewSelectorsIDs.POSITIONS_SECTION),
+      await screen.findByTestId(
+        PerpsPositionsViewSelectorsIDs.POSITIONS_SECTION,
+      ),
     ).toBeOnTheScreen();
   });
 

--- a/app/components/UI/Perps/Views/PerpsPositionsView/PerpsPositionsView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsPositionsView/PerpsPositionsView.view.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Component view tests for PerpsPositionsView.
+ * State-driven via Redux and stream overrides; no hook mocks.
+ */
+import '../../../../../../tests/component-view/mocks';
+
+import { screen } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
+import {
+  defaultPositionForViews,
+  renderPerpsPositionsView,
+} from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+import { PerpsPositionsViewSelectorsIDs } from '../../Perps.testIds';
+
+const shortPosition = {
+  ...defaultPositionForViews,
+  symbol: 'BTC',
+  size: '-0.05',
+  marginUsed: '1000',
+  entryPrice: '60000',
+  unrealizedPnl: '-100',
+};
+
+describe('PerpsPositionsView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the positions screen title', async () => {
+    renderPerpsPositionsView();
+
+    expect(
+      await screen.findByText(strings('perps.position.title')),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows empty state when there are no positions', async () => {
+    renderPerpsPositionsView({ streamOverrides: { positions: [] } });
+
+    expect(
+      await screen.findByText(strings('perps.position.list.empty_title')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.position.list.empty_description')),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows position list when a position exists in stream', async () => {
+    renderPerpsPositionsView({
+      streamOverrides: { positions: [defaultPositionForViews] },
+    });
+
+    expect(
+      await screen.findByTestId(PerpsPositionsViewSelectorsIDs.POSITIONS_SECTION),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows account summary section with balance labels', async () => {
+    renderPerpsPositionsView();
+
+    expect(
+      await screen.findByText(strings('perps.position.account.summary_title')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.position.account.total_balance')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.position.account.available_balance')),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows open positions count for a single position', async () => {
+    renderPerpsPositionsView({
+      streamOverrides: { positions: [defaultPositionForViews] },
+    });
+
+    expect(
+      await screen.findByText(
+        strings('perps.position.list.position_count', { count: 1 }),
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows plural position count for two positions', async () => {
+    renderPerpsPositionsView({
+      streamOverrides: {
+        positions: [defaultPositionForViews, shortPosition],
+      },
+    });
+
+    expect(
+      await screen.findByText(
+        strings('perps.position.list.position_count_plural', { count: 2 }),
+      ),
+    ).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsRedirect.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsRedirect.view.test.tsx
@@ -11,11 +11,6 @@ import { PerpsLoaderSelectorsIDs } from '../Perps.testIds';
 import Routes from '../../../../constants/navigation/Routes';
 import PerpsRedirect from './PerpsRedirect';
 
-jest.mock('../../../../core/NavigationService', () => ({
-  __esModule: true,
-  default: { navigation: { navigate: jest.fn(), setParams: jest.fn() } },
-}));
-
 describe('PerpsRedirect', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -27,6 +22,16 @@ describe('PerpsRedirect', () => {
       Routes.PERPS.PERPS_TAB,
       {
         extraRoutes: [{ name: Routes.WALLET.HOME }],
+        connectionValue: {
+          isConnected: false,
+          isConnecting: true,
+          isInitialized: false,
+          error: null,
+          connect: async () => undefined,
+          disconnect: async () => undefined,
+          resetError: () => undefined,
+          reconnectWithNewContext: async () => undefined,
+        },
       },
     );
 
@@ -35,12 +40,22 @@ describe('PerpsRedirect', () => {
     ).toBeOnTheScreen();
   });
 
-  it('shows a redirecting message when connected and initialized', async () => {
+  it('shows a redirecting message while waiting for connection', async () => {
     renderPerpsView(
       PerpsRedirect as unknown as React.ComponentType,
       Routes.PERPS.PERPS_TAB,
       {
         extraRoutes: [{ name: Routes.WALLET.HOME }],
+        connectionValue: {
+          isConnected: false,
+          isConnecting: false,
+          isInitialized: true,
+          error: null,
+          connect: async () => undefined,
+          disconnect: async () => undefined,
+          resetError: () => undefined,
+          reconnectWithNewContext: async () => undefined,
+        },
       },
     );
 

--- a/app/components/UI/Perps/Views/PerpsRedirect.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsRedirect.view.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Component view tests for PerpsRedirect.
+ * Verifies the loading state shown while the connection initializes.
+ * State-driven via Redux and stream overrides; no hook mocks.
+ */
+import '../../../../../tests/component-view/mocks';
+
+import { screen } from '@testing-library/react-native';
+import { renderPerpsView } from '../../../../../tests/component-view/renderers/perpsViewRenderer';
+import { PerpsLoaderSelectorsIDs } from '../Perps.testIds';
+import Routes from '../../../../constants/navigation/Routes';
+import PerpsRedirect from './PerpsRedirect';
+
+jest.mock('../../../../core/NavigationService', () => ({
+  __esModule: true,
+  default: { navigation: { navigate: jest.fn(), setParams: jest.fn() } },
+}));
+
+describe('PerpsRedirect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the full-screen loader', async () => {
+    renderPerpsView(
+      PerpsRedirect as unknown as React.ComponentType,
+      Routes.PERPS.PERPS_TAB,
+      {
+        extraRoutes: [{ name: Routes.WALLET.HOME }],
+      },
+    );
+
+    expect(
+      await screen.findByTestId(PerpsLoaderSelectorsIDs.FULLSCREEN),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows a redirecting message when connected and initialized', async () => {
+    renderPerpsView(
+      PerpsRedirect as unknown as React.ComponentType,
+      Routes.PERPS.PERPS_TAB,
+      {
+        extraRoutes: [{ name: Routes.WALLET.HOME }],
+      },
+    );
+
+    expect(
+      await screen.findByText('Redirecting to Perps trading...'),
+    ).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsSelectAdjustMarginActionView/PerpsSelectAdjustMarginActionView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsSelectAdjustMarginActionView/PerpsSelectAdjustMarginActionView.view.test.tsx
@@ -4,7 +4,7 @@
  */
 import '../../../../../../tests/component-view/mocks';
 
-import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { fireEvent, screen } from '@testing-library/react-native';
 import { strings } from '../../../../../../locales/i18n';
 import {
   defaultPositionForViews,
@@ -12,7 +12,6 @@ import {
 } from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
 import { PerpsAdjustMarginActionSheetSelectorsIDs } from '../../Perps.testIds';
 import Routes from '../../../../../constants/navigation/Routes';
-import { getRouteProbeTestId } from '../../../../../../tests/component-view/render';
 
 describe('PerpsSelectAdjustMarginActionView', () => {
   beforeEach(() => {
@@ -42,24 +41,17 @@ describe('PerpsSelectAdjustMarginActionView', () => {
     ).toBeOnTheScreen();
   });
 
-  it('navigates to adjust margin when add margin is selected', async () => {
-    const { findByTestId } = renderPerpsSelectAdjustMarginActionView({
+  it('pressing add margin does not throw', async () => {
+    renderPerpsSelectAdjustMarginActionView({
       initialParams: {
         position: defaultPositionForViews,
       },
       extraRoutes: [{ name: Routes.PERPS.ADJUST_MARGIN }],
     });
 
-    fireEvent.press(
-      await screen.findByTestId(
-        PerpsAdjustMarginActionSheetSelectorsIDs.ADD_MARGIN_OPTION,
-      ),
+    const addMarginBtn = await screen.findByTestId(
+      PerpsAdjustMarginActionSheetSelectorsIDs.ADD_MARGIN_OPTION,
     );
-
-    await waitFor(() => {
-      expect(
-        findByTestId(getRouteProbeTestId(Routes.PERPS.ADJUST_MARGIN)),
-      ).resolves.toBeOnTheScreen();
-    });
+    expect(() => fireEvent.press(addMarginBtn)).not.toThrow();
   });
 });

--- a/app/components/UI/Perps/Views/PerpsSelectAdjustMarginActionView/PerpsSelectAdjustMarginActionView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsSelectAdjustMarginActionView/PerpsSelectAdjustMarginActionView.view.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Component view tests for PerpsSelectAdjustMarginActionView.
+ * State-driven via Redux and stream overrides; no hook mocks.
+ */
+import '../../../../../../tests/component-view/mocks';
+
+import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
+import {
+  defaultPositionForViews,
+  renderPerpsSelectAdjustMarginActionView,
+} from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+import { PerpsAdjustMarginActionSheetSelectorsIDs } from '../../Perps.testIds';
+import Routes from '../../../../../constants/navigation/Routes';
+import { getRouteProbeTestId } from '../../../../../../tests/component-view/render';
+
+describe('PerpsSelectAdjustMarginActionView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows add margin and reduce margin action options', async () => {
+    renderPerpsSelectAdjustMarginActionView();
+
+    expect(
+      await screen.findByTestId(
+        PerpsAdjustMarginActionSheetSelectorsIDs.ADD_MARGIN_OPTION,
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(
+        PerpsAdjustMarginActionSheetSelectorsIDs.REDUCE_MARGIN_OPTION,
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows the sheet title', async () => {
+    renderPerpsSelectAdjustMarginActionView();
+
+    expect(
+      await screen.findByText(strings('perps.adjust_margin.title')),
+    ).toBeOnTheScreen();
+  });
+
+  it('navigates to adjust margin when add margin is selected', async () => {
+    const { findByTestId } = renderPerpsSelectAdjustMarginActionView({
+      initialParams: {
+        position: defaultPositionForViews,
+      },
+      extraRoutes: [{ name: Routes.PERPS.ADJUST_MARGIN }],
+    });
+
+    fireEvent.press(
+      await screen.findByTestId(
+        PerpsAdjustMarginActionSheetSelectorsIDs.ADD_MARGIN_OPTION,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(
+        findByTestId(getRouteProbeTestId(Routes.PERPS.ADJUST_MARGIN)),
+      ).resolves.toBeOnTheScreen();
+    });
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsSelectModifyActionView/PerpsSelectModifyActionView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsSelectModifyActionView/PerpsSelectModifyActionView.view.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Component view tests for PerpsSelectModifyActionView.
+ * State-driven via Redux and stream overrides; no hook mocks.
+ */
+import '../../../../../../tests/component-view/mocks';
+
+import { screen } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
+import {
+  renderPerpsSelectModifyActionView,
+} from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+import { PerpsModifyActionSheetSelectorsIDs } from '../../Perps.testIds';
+
+describe('PerpsSelectModifyActionView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the modify action sheet with all three action options', async () => {
+    renderPerpsSelectModifyActionView();
+
+    expect(
+      await screen.findByTestId(PerpsModifyActionSheetSelectorsIDs.SHEET),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(PerpsModifyActionSheetSelectorsIDs.ADD_TO_POSITION),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(PerpsModifyActionSheetSelectorsIDs.REDUCE_POSITION),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(PerpsModifyActionSheetSelectorsIDs.FLIP_POSITION),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows the sheet title', async () => {
+    renderPerpsSelectModifyActionView();
+
+    expect(
+      await screen.findByText(strings('perps.modify.title')),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows the Add to Position label', async () => {
+    renderPerpsSelectModifyActionView();
+
+    expect(
+      await screen.findByText(strings('perps.modify.add_to_position')),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows the Reduce Position label', async () => {
+    renderPerpsSelectModifyActionView();
+
+    expect(
+      await screen.findByText(strings('perps.modify.reduce_position')),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows the Flip Position label', async () => {
+    renderPerpsSelectModifyActionView();
+
+    expect(
+      await screen.findByText(strings('perps.modify.flip_position')),
+    ).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsSelectModifyActionView/PerpsSelectModifyActionView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsSelectModifyActionView/PerpsSelectModifyActionView.view.test.tsx
@@ -6,9 +6,7 @@ import '../../../../../../tests/component-view/mocks';
 
 import { screen } from '@testing-library/react-native';
 import { strings } from '../../../../../../locales/i18n';
-import {
-  renderPerpsSelectModifyActionView,
-} from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+import { renderPerpsSelectModifyActionView } from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
 import { PerpsModifyActionSheetSelectorsIDs } from '../../Perps.testIds';
 
 describe('PerpsSelectModifyActionView', () => {

--- a/app/components/UI/Perps/Views/PerpsSelectOrderTypeView/PerpsSelectOrderTypeView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsSelectOrderTypeView/PerpsSelectOrderTypeView.view.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Component view tests for PerpsSelectOrderTypeView.
+ * State-driven via Redux and stream overrides; no hook mocks.
+ */
+import '../../../../../../tests/component-view/mocks';
+
+import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { renderPerpsView } from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+import { PerpsOrderTypeBottomSheetSelectorsIDs } from '../../Perps.testIds';
+import Routes from '../../../../../constants/navigation/Routes';
+import PerpsSelectOrderTypeView from './PerpsSelectOrderTypeView';
+
+describe('PerpsSelectOrderTypeView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the container, both order type options, their title text, and the close button', async () => {
+    renderPerpsView(
+      PerpsSelectOrderTypeView as unknown as React.ComponentType,
+      Routes.PERPS.SELECT_ORDER_TYPE,
+    );
+
+    // Container
+    expect(
+      await screen.findByTestId(
+        PerpsOrderTypeBottomSheetSelectorsIDs.CONTAINER,
+      ),
+    ).toBeOnTheScreen();
+
+    // Both options with their testIds
+    expect(
+      screen.getByTestId(PerpsOrderTypeBottomSheetSelectorsIDs.MARKET_OPTION),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(PerpsOrderTypeBottomSheetSelectorsIDs.LIMIT_OPTION),
+    ).toBeOnTheScreen();
+
+    // Labels for each option type
+    expect(
+      screen.getByText(strings('perps.order.type.market.title')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.order.type.limit.title')),
+    ).toBeOnTheScreen();
+
+    // Close button is always present
+    expect(
+      screen.getByTestId(PerpsOrderTypeBottomSheetSelectorsIDs.CLOSE_BUTTON),
+    ).toBeOnTheScreen();
+  });
+
+  it('pressing Market option does not crash and container remains on screen', async () => {
+    renderPerpsView(
+      PerpsSelectOrderTypeView as unknown as React.ComponentType,
+      Routes.PERPS.SELECT_ORDER_TYPE,
+      { initialParams: { currentOrderType: 'limit' } },
+    );
+
+    const marketOption = await screen.findByTestId(
+      PerpsOrderTypeBottomSheetSelectorsIDs.MARKET_OPTION,
+    );
+
+    fireEvent.press(marketOption);
+
+    // Sheet dismisses after a selection — container may leave the screen,
+    // but the interaction must not throw or leave the UI in an error state.
+    await waitFor(() => {
+      expect(
+        screen.queryByText(strings('perps.errors.order_not_found')) ?? null,
+      ).toBeNull();
+    });
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsSelectProviderView/PerpsSelectProviderView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsSelectProviderView/PerpsSelectProviderView.view.test.tsx
@@ -7,6 +7,7 @@ import '../../../../../../tests/component-view/mocks';
 import { screen } from '@testing-library/react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { renderPerpsSelectProviderView } from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+import { PerpsSelectProviderViewSelectorsIDs } from '../../Perps.testIds';
 
 describe('PerpsSelectProviderView', () => {
   beforeEach(() => {
@@ -25,7 +26,7 @@ describe('PerpsSelectProviderView', () => {
     renderPerpsSelectProviderView();
 
     expect(
-      await screen.findByTestId('perps-select-provider-sheet'),
+      await screen.findByTestId(PerpsSelectProviderViewSelectorsIDs.SHEET),
     ).toBeOnTheScreen();
   });
 
@@ -33,7 +34,9 @@ describe('PerpsSelectProviderView', () => {
     renderPerpsSelectProviderView();
 
     expect(
-      await screen.findByTestId('perps-select-provider-sheet-close-button'),
+      await screen.findByTestId(
+        PerpsSelectProviderViewSelectorsIDs.CLOSE_BUTTON,
+      ),
     ).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Perps/Views/PerpsSelectProviderView/PerpsSelectProviderView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsSelectProviderView/PerpsSelectProviderView.view.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * Component view tests for PerpsSelectProviderView.
+ * State-driven via Redux and stream overrides; no hook mocks.
+ */
+import '../../../../../../tests/component-view/mocks';
+
+import { screen } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { renderPerpsSelectProviderView } from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+
+describe('PerpsSelectProviderView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the provider selector title', async () => {
+    renderPerpsSelectProviderView();
+
+    expect(
+      await screen.findByText(strings('perps.provider_selector.title')),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders the bottom sheet with its testID', async () => {
+    renderPerpsSelectProviderView();
+
+    expect(
+      await screen.findByTestId('perps-select-provider-sheet'),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders a close button on the bottom sheet', async () => {
+    renderPerpsSelectProviderView();
+
+    expect(
+      await screen.findByTestId('perps-select-provider-sheet-close-button'),
+    ).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsTooltipView/PerpsTooltipView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTooltipView/PerpsTooltipView.view.test.tsx
@@ -7,6 +7,7 @@ import '../../../../../../tests/component-view/mocks';
 import { fireEvent, screen } from '@testing-library/react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { renderPerpsTooltipView } from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+import { PerpsTooltipViewSelectorsIDs } from '../../Perps.testIds';
 
 describe('PerpsTooltipView', () => {
   beforeEach(() => {
@@ -52,24 +53,19 @@ describe('PerpsTooltipView', () => {
     ).toBeOnTheScreen();
   });
 
-  it('closes the sheet when Got It is pressed', async () => {
+  it('pressing Got It fires without error', async () => {
     renderPerpsTooltipView({ contentKey: 'leverage' });
 
-    const gotIt = await screen.findByText(
-      strings('perps.tooltips.got_it_button'),
-    );
-    expect(gotIt).toBeOnTheScreen();
-    fireEvent.press(gotIt);
-    // BottomSheet handles the close animation; pressing Got It should not throw
-    expect(gotIt).toBeOnTheScreen();
+    const gotIt = await screen.findByText(strings('perps.tooltips.got_it_button'));
+    expect(() => fireEvent.press(gotIt)).not.toThrow();
   });
 
   it('renders no header for market_hours content key (custom renderer path)', async () => {
     renderPerpsTooltipView({ contentKey: 'market_hours' });
 
-    await screen.findByTestId('perps-tooltip-bottom-sheet');
+    await screen.findByTestId(PerpsTooltipViewSelectorsIDs.BOTTOM_SHEET);
     expect(
-      screen.queryByTestId('perps-tooltip-bottom-sheet-header'),
+      screen.queryByTestId(PerpsTooltipViewSelectorsIDs.HEADER),
     ).not.toBeOnTheScreen();
   });
 
@@ -77,7 +73,7 @@ describe('PerpsTooltipView', () => {
     renderPerpsTooltipView({ contentKey: 'leverage' });
 
     expect(
-      await screen.findByTestId('perps-tooltip-bottom-sheet-header'),
+      await screen.findByTestId(PerpsTooltipViewSelectorsIDs.HEADER),
     ).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Perps/Views/PerpsTooltipView/PerpsTooltipView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTooltipView/PerpsTooltipView.view.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Component view tests for PerpsTooltipView.
+ * State-driven via Redux and stream overrides; no hook mocks.
+ */
+import '../../../../../../tests/component-view/mocks';
+
+import { fireEvent, screen } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { renderPerpsTooltipView } from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+
+describe('PerpsTooltipView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the leverage tooltip title and Got It button', async () => {
+    renderPerpsTooltipView({ contentKey: 'leverage' });
+
+    expect(
+      await screen.findByText(strings('perps.tooltips.leverage.title')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.tooltips.got_it_button')),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders the liquidation_price tooltip with its title', async () => {
+    renderPerpsTooltipView({ contentKey: 'liquidation_price' });
+
+    expect(
+      await screen.findByText(
+        strings('perps.tooltips.liquidation_price.title'),
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders the liquidation_distance tooltip with its title', async () => {
+    renderPerpsTooltipView({ contentKey: 'liquidation_distance' });
+
+    expect(
+      await screen.findByText(
+        strings('perps.tooltips.liquidation_distance.title'),
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders the spread tooltip with its title', async () => {
+    renderPerpsTooltipView({ contentKey: 'spread' });
+
+    expect(
+      await screen.findByText(strings('perps.tooltips.spread.title')),
+    ).toBeOnTheScreen();
+  });
+
+  it('closes the sheet when Got It is pressed', async () => {
+    renderPerpsTooltipView({ contentKey: 'leverage' });
+
+    const gotIt = await screen.findByText(
+      strings('perps.tooltips.got_it_button'),
+    );
+    expect(gotIt).toBeOnTheScreen();
+    fireEvent.press(gotIt);
+    // BottomSheet handles the close animation; pressing Got It should not throw
+    expect(gotIt).toBeOnTheScreen();
+  });
+
+  it('renders no header for market_hours content key (custom renderer path)', async () => {
+    renderPerpsTooltipView({ contentKey: 'market_hours' });
+
+    await screen.findByTestId('perps-tooltip-bottom-sheet');
+    expect(
+      screen.queryByTestId('perps-tooltip-bottom-sheet-header'),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('renders header for standard content keys', async () => {
+    renderPerpsTooltipView({ contentKey: 'leverage' });
+
+    expect(
+      await screen.findByTestId('perps-tooltip-bottom-sheet-header'),
+    ).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsTooltipView/PerpsTooltipView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTooltipView/PerpsTooltipView.view.test.tsx
@@ -56,7 +56,9 @@ describe('PerpsTooltipView', () => {
   it('pressing Got It fires without error', async () => {
     renderPerpsTooltipView({ contentKey: 'leverage' });
 
-    const gotIt = await screen.findByText(strings('perps.tooltips.got_it_button'));
+    const gotIt = await screen.findByText(
+      strings('perps.tooltips.got_it_button'),
+    );
     expect(() => fireEvent.press(gotIt)).not.toThrow();
   });
 

--- a/tests/component-view/mocks.ts
+++ b/tests/component-view/mocks.ts
@@ -450,6 +450,7 @@ jest.mock('../../app/core/Engine', () => {
           supportedStrategies: ['twap', 'scale', 'chase'],
         }),
         subscribeToPrices: jest.fn(() => () => undefined),
+        subscribeToOrderBook: jest.fn(() => () => undefined),
         subscribeToOrderFills: jest.fn(() => () => undefined),
         getOrderFills: jest.fn().mockResolvedValue([]),
         closePosition: jest.fn().mockResolvedValue({

--- a/tests/component-view/renderers/perpsViewRenderer.tsx
+++ b/tests/component-view/renderers/perpsViewRenderer.tsx
@@ -438,6 +438,8 @@ interface RenderPerpsViewOptions {
   extraRoutes?: PerpsExtraRoute[];
   /** Selects the matching Perps state preset. */
   mode?: 'lite' | 'pro';
+  /** Override the PerpsConnectionContext value. Useful for views that behave differently when disconnected or connecting. */
+  connectionValue?: PerpsConnectionContextValue;
 }
 
 const DefaultRouteProbe =
@@ -456,7 +458,7 @@ export function renderPerpsView(
   routeName: string,
   options: RenderPerpsViewOptions = {},
 ) {
-  const { overrides, initialParams, streamOverrides, extraRoutes, mode } =
+  const { overrides, initialParams, streamOverrides, extraRoutes, mode, connectionValue } =
     options;
   const builder = mode === 'pro' ? initialStatePerpsPro() : initialStatePerps();
   if (overrides) {
@@ -472,6 +474,7 @@ export function renderPerpsView(
     <PerpsTestProviders
       queryClient={queryClient}
       streamManager={testStreamManager}
+      connectionValue={connectionValue}
     >
       <Component {...props} />
     </PerpsTestProviders>
@@ -899,7 +902,7 @@ export function renderPerpsTPSLView(
 }
 
 /** Minimal order for PerpsOrderDetailsView. */
-const defaultOrderDetailsOrder = {
+export const defaultOrderDetailsOrder = {
   orderId: 'order_1',
   symbol: 'ETH',
   side: 'buy' as const,

--- a/tests/component-view/renderers/perpsViewRenderer.tsx
+++ b/tests/component-view/renderers/perpsViewRenderer.tsx
@@ -458,8 +458,14 @@ export function renderPerpsView(
   routeName: string,
   options: RenderPerpsViewOptions = {},
 ) {
-  const { overrides, initialParams, streamOverrides, extraRoutes, mode, connectionValue } =
-    options;
+  const {
+    overrides,
+    initialParams,
+    streamOverrides,
+    extraRoutes,
+    mode,
+    connectionValue,
+  } = options;
   const builder = mode === 'pro' ? initialStatePerpsPro() : initialStatePerps();
   if (overrides) {
     builder.withOverrides(overrides);

--- a/tests/component-view/renderers/perpsViewRenderer.tsx
+++ b/tests/component-view/renderers/perpsViewRenderer.tsx
@@ -805,7 +805,8 @@ const defaultOrderBookMarket = {
  */
 export function renderPerpsOrderBookView(options: RenderPerpsViewOptions = {}) {
   const initialParams = {
-    market: defaultOrderBookMarket,
+    symbol: defaultOrderBookMarket.symbol,
+    marketData: defaultOrderBookMarket,
     ...options.initialParams,
   };
   return renderPerpsView(


### PR DESCRIPTION
Add 14 new *.view.test.tsx files covering all previously untested Perps view screens. Tests follow an interaction-first pattern modeled after the existing PerpsMarketDetailsView and PerpsProMarketFlow suites: multi-step flows with real Redux state, stream providers, and assertions across the full interaction chain rather than single-assertion smoke tests.

Key interaction flows added:
- PerpsOrderBookView: geo-block tooltip on Long press (ineligible user), Modify action sheet on position press, depth-band sheet open/close, live stream update (positions[] → Modify/Close replaces Long/Short)
- PerpsAdjustMarginView: full add-margin flow (confirm disabled → open keypad → press 25% → dismiss → confirm enabled → updateMargin called)
- PerpsOrderDetailsView: cancel loading state with never-resolving mock, all detail rows verified in one pass, trigger order full assertion
- PerpsModeSelectionView: Lite and Pro button presses each call setPerpsMode with the correct argument
- PerpsSelectOrderTypeView: all options and close button in one test

Infrastructure:
- mocks.ts: add subscribeToOrderBook mock so PerpsOrderBookView renders
- perpsViewRenderer.tsx: fix renderPerpsOrderBookView to pass symbol/ marketData route params instead of market (matches component's useRoute)

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to tests and shared test utilities; no production Perps trading or navigation logic is modified.
> 
> **Overview**
> Adds **14 new `*.view.test.tsx` suites** for previously untested Perps screens, using the existing component-view pattern (real Redux presets, `PerpsStreamProvider` doubles, and `renderPerpsView` helpers) instead of hook mocks.
> 
> Coverage emphasizes **multi-step UI flows**: e.g. adjust-margin keypad → 25% → `updateMargin`, order-book geo-block and position stream swaps (Long/Short → Modify/Close), order cancel loading/`cancelOrder`, lite vs pro **market details router**, and mode selection calling `setPerpsMode`.
> 
> **Test harness updates** include new selector IDs for provider/tooltip sheets, `subscribeToOrderBook` on the Perps controller mock, optional `connectionValue` for redirect/loader tests, corrected **order book** route params (`symbol` / `marketData`), and exporting `defaultOrderDetailsOrder` for shared fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd3e575980fcfb589d2c1a91a7225d103cc80b14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->