### PR TITLE
fix: match asset label typography on the activity details screen

### DIFF
--- a/app/components/Views/ActivityDetails/components/ActivityDetailsAmountHeader.tsx
+++ b/app/components/Views/ActivityDetails/components/ActivityDetailsAmountHeader.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   AvatarTokenSize,
   Box,
+  FontWeight,
   Text,
   TextColor,
   TextVariant,
@@ -79,7 +80,11 @@ function AssetLine({ label, token }: { label: string; token: TokenAmount }) {
 
   return (
     <Box twClassName="gap-1">
-      <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
+        color={TextColor.TextAlternative}
+      >
         {label}
       </Text>
       <Box twClassName="flex-row items-center gap-3">


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

On the activity details screen, the **"You sent"** / **"You received"** labels rendered as `BodySm` at regular weight, while every metadata row label a few pixels below them — **Status**, **Date**, **Account**, **Network**, **Transaction ID** — renders as `BodyMd` at `FontWeight.Medium` through `ActivityDetailRow`. Two groups of labels of the same kind, on the same screen, were set in two different styles.

This aligns the asset labels with the metadata row labels. Both groups were already `TextColor.TextAlternative`, so only size and weight changed.

- `app/components/Views/ActivityDetails/components/ActivityDetailsAmountHeader.tsx` — the `AssetLine` label goes from `BodySm` (regular) to `BodyMd` + `FontWeight.Medium`

Verified at native 3x resolution: the labels grow from 30px to 34px tall, which matches **Date** and **Account** exactly. **Status** measures 36px, but that is the optical overshoot of its leading round `S` rather than a size difference.

`AssetLine` also backs the bridge details template, so bridge activity details pick up the same correction.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed the "You sent" and "You received" labels on the activity details screen so they match the other labels on the screen

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: UI polish — no linked GitHub issue

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Activity details asset label typography

  Scenario: user sees consistent label typography on the activity details screen
    Given I am logged into MetaMask Mobile
    And I have a completed or failed swap in my activity list

    When I open the Activity tab
    And I tap the swap to open its details screen
    Then the "You sent" and "You received" labels render at the same size and weight as the "Status", "Date" and "Account" labels
    And all of those labels keep the alternative text colour
    And the amounts, avatars and metadata rows are otherwise unchanged
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

"You sent" and "You received" were noticeably smaller and lighter than "Status", "Date" and "Account".

<img width="360" alt="Before: asset labels smaller and lighter than the metadata row labels" src="https://github.com/user-attachments/assets/b089b2a3-53b5-40f2-bbfa-9478bbd1291a" />

### **After**

All labels on the screen now share one style.

<img width="360" alt="After: asset labels match the metadata row labels" src="https://github.com/user-attachments/assets/84dc444c-7904-4e02-af61-3ad70561260d" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only typography tweak in one component; no logic, data, or security impact.
> 
> **Overview**
> Aligns **"You sent"** / **"You received"** label typography on activity details with the metadata row labels (**Status**, **Date**, **Account**, etc.).
> 
> In `AssetLine` inside `ActivityDetailsAmountHeader.tsx`, those labels change from `TextVariant.BodySm` (regular weight) to **`BodyMd`** with **`FontWeight.Medium`**, keeping `TextColor.TextAlternative`. Amounts, avatars, and other layout are unchanged. The same `AssetLine` is used by the dual-amount header (swaps/bridges), so bridge activity details get the same fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ad746e2562d0c7a693a472bd182af9561b1cfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->