### PR TITLE
fix(predict): set overwriteUpgrade on Predict MM Pay batches

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -4693,6 +4693,7 @@ describe('PredictController', () => {
             disableHook: true,
             disableSequential: true,
             gasFeeToken: MATIC_CONTRACTS_V2.collateral,
+            overwriteUpgrade: true,
           }),
         );
       });
@@ -5659,6 +5660,7 @@ describe('PredictController', () => {
           networkClientId: 'polygon-mainnet',
           disableHook: true,
           disableSequential: true,
+          overwriteUpgrade: true,
           skipInitialGasEstimate: true,
           transactions: mockTransactions,
         });
@@ -9266,6 +9268,7 @@ describe('PredictController', () => {
             networkClientId: expect.any(String),
             disableHook: true,
             disableSequential: true,
+            overwriteUpgrade: true,
             requireApproval: true,
             transactions: [mockWithdrawResponse.transaction],
           }),

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -1593,7 +1593,10 @@ export class PredictController extends BaseController<
     missingBatchIdError: string;
   }): Promise<string> {
     try {
-      const batchResult = await addTransactionBatch(params);
+      const batchResult = await addTransactionBatch({
+        ...params,
+        overwriteUpgrade: true,
+      });
 
       if (!batchResult?.batchId) {
         throw new Error(missingBatchIdError);

--- a/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.test.tsx
+++ b/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.test.tsx
@@ -203,6 +203,120 @@ describe('ConfirmationsDeveloperOptions', () => {
     });
   });
 
+  describe('Predict developer options', () => {
+    it('adds overwriteUpgrade for the Predict Deposit batch', async () => {
+      const { getByText } = render(<ConfirmationsDeveloperOptions />);
+
+      await act(async () => {
+        fireEvent.press(getByText('Deposit'));
+      });
+
+      expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
+        loader: ConfirmationLoader.CustomAmount,
+        stack: Routes.PREDICT.ROOT,
+      });
+      expect(mockAddTransactionBatch).toHaveBeenCalledWith({
+        from: MOCK_ACCOUNT,
+        origin: ORIGIN_METAMASK,
+        networkClientId: MOCK_NETWORK_CLIENT_ID,
+        disableHook: true,
+        disableSequential: true,
+        overwriteUpgrade: true,
+        transactions: [
+          {
+            params: {
+              to: MOCK_PROXY_ADDRESS,
+              data: '0x',
+              value: '0x1',
+            },
+          },
+          {
+            params: {
+              to: MOCK_POLYGON_USDCE,
+              data: MOCK_TRANSFER_DATA,
+            },
+            type: TransactionType.predictDeposit,
+          },
+        ],
+      });
+    });
+
+    it('adds overwriteUpgrade for the Predict Claim batch', async () => {
+      const { getByText } = render(<ConfirmationsDeveloperOptions />);
+
+      await act(async () => {
+        fireEvent.press(getByText('Claim'));
+      });
+
+      expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
+        headerShown: false,
+        loader: ConfirmationLoader.PredictClaim,
+        stack: Routes.PREDICT.ROOT,
+      });
+      expect(mockAddTransactionBatch).toHaveBeenCalledWith({
+        from: MOCK_ACCOUNT,
+        origin: ORIGIN_METAMASK,
+        networkClientId: MOCK_NETWORK_CLIENT_ID,
+        disableHook: true,
+        disableSequential: true,
+        overwriteUpgrade: true,
+        transactions: [
+          {
+            params: {
+              to: MOCK_PROXY_ADDRESS,
+              data: '0x',
+              value: '0x1',
+            },
+          },
+          {
+            params: {
+              to: MOCK_POLYGON_USDCE,
+              data: MOCK_TRANSFER_DATA,
+            },
+            type: TransactionType.predictClaim,
+          },
+        ],
+      });
+    });
+
+    it('adds overwriteUpgrade for the Predict Withdraw batch', async () => {
+      const { getAllByText } = render(<ConfirmationsDeveloperOptions />);
+
+      await act(async () => {
+        fireEvent.press(getAllByText('Withdraw')[0]);
+      });
+
+      expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
+        loader: ConfirmationLoader.CustomAmount,
+        stack: Routes.PREDICT.ROOT,
+      });
+      expect(mockAddTransactionBatch).toHaveBeenCalledWith({
+        from: MOCK_ACCOUNT,
+        origin: ORIGIN_METAMASK,
+        networkClientId: MOCK_NETWORK_CLIENT_ID,
+        disableHook: true,
+        disableSequential: true,
+        overwriteUpgrade: true,
+        transactions: [
+          {
+            params: {
+              to: MOCK_PROXY_ADDRESS,
+              data: '0x',
+              value: '0x1',
+            },
+          },
+          {
+            params: {
+              to: MOCK_POLYGON_USDCE,
+              data: MOCK_TRANSFER_DATA,
+            },
+            type: TransactionType.predictWithdraw,
+          },
+        ],
+      });
+    });
+  });
+
   describe('Money Account Deposit', () => {
     it('renders when moneyAccountDepositEnabled flag is true', () => {
       mockSelectMoneyAccountDepositEnabledFlag.mockReturnValue(true);

--- a/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
+++ b/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
@@ -236,12 +236,19 @@ function useAddTransactionBatch() {
         stack: Routes.PREDICT.ROOT,
       });
 
+      const overwriteUpgrade =
+        transactionType === TransactionType.predictDeposit ||
+        transactionType === TransactionType.predictDepositAndOrder ||
+        transactionType === TransactionType.predictClaim ||
+        transactionType === TransactionType.predictWithdraw;
+
       addTransactionBatch({
         from: selectedAccount as Hex,
         origin: ORIGIN_METAMASK,
         networkClientId,
         disableHook: true,
         disableSequential: true,
+        ...(overwriteUpgrade ? { overwriteUpgrade: true } : {}),
         transactions: [
           {
             params: {


### PR DESCRIPTION
## **Description**

This extends the EIP-7702 batch overwrite fix from [#34250](https://github.com/MetaMask/metamask-mobile/pull/34250) to Predict MM Pay. Predict deposit, deposit+order, claim, and withdraw batches now go through `overwriteUpgrade: true` in `PredictController`, and the Predict developer-options helper mirrors the same behavior for debug buttons. Money Account batches remain unchanged and still use `disableUpgrade: true`.

## **Changelog**

CHANGELOG entry: Fixed Predict MM Pay batches for externally delegated EOA accounts

## **Related issues**

Fixes: [CONF-1951](https://consensyssoftware.atlassian.net/browse/CONF-1951)
Refs: [#34250](https://github.com/MetaMask/metamask-mobile/pull/34250)

## **Manual testing steps**

```gherkin
Feature: Predict MM Pay batch submission

  Scenario: submit Predict batches from an externally delegated EOA
    Given a selected EOA that is already delegated to a non-MetaMask EIP-7702 contract
    And the account has a Predict deposit, claim, or withdraw action available

    When the user submits a Predict batch flow
    Then the batch is created with `overwriteUpgrade: true`
    And the transaction is submitted successfully
```

## **Screenshots/Recordings**

N/A — this change updates transaction batch parameters only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[CONF-1951]: https://consensyssoftware.atlassian.net/browse/CONF-1951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction batch EIP-7702 upgrade handling for Predict flows; misconfiguration could affect batch submission for delegated accounts, though it mirrors an existing Perps fix pattern.
> 
> **Overview**
> Extends the EIP-7702 **overwrite upgrade** behavior to Predict MM Pay so deposit, deposit+order, claim, and withdraw batches work when the EOA is already delegated to a non–MetaMask contract.
> 
> `PredictController.submitPredictTransactionBatch` now always passes **`overwriteUpgrade: true`** into `addTransactionBatch`, so every Predict batch that goes through that helper gets the flag. The Predict paths in **confirmations developer options** set the same flag for those transaction types on debug flows. Tests were updated in `PredictController` and new coverage was added for deposit, claim, and withdraw developer buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cabb08b834b8087ff5eada24edc076d3eebf554. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->