### PR TITLE
fix(swaps): record no quote outcomes

### DIFF
--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 import {
   selectBridgeControllerState,
   selectBridgeQuotes,
+  selectQuoteStreamComplete,
   selectSlippage,
   selectSourceToken,
 } from '../../../../../core/redux/slices/bridge';
@@ -47,6 +48,7 @@ export const useBridgeQuoteEvents = ({
   const { quoteFetchError, quotesRefreshCount } = useSelector(
     selectBridgeControllerState,
   );
+  const quoteStreamComplete = useSelector(selectQuoteStreamComplete);
   const { activeQuote, recommendedQuote, isLoading } =
     useSelector(selectBridgeQuotes);
   const isFirstQuoteUsable =
@@ -130,16 +132,21 @@ export const useBridgeQuoteEvents = ({
     }
   }, [firstUsableQuoteRequestId]);
 
+  // The stream's complete event drives the empty-state UI before close updates
+  // loading status and refresh count. Finish on that same explicit signal.
   useEffect(() => {
-    if (
-      !isLoading &&
-      quotesRefreshCount > 0 &&
-      !quoteFetchError &&
-      hasNoQuotesAvailable
-    ) {
-      swapQuoteFetchTrace.finish('no_quotes');
+    if (!quoteFetchError && quoteStreamComplete?.hasQuotes === false) {
+      swapQuoteFetchTrace.finish(
+        'no_quotes',
+        undefined,
+        quoteStreamComplete?.reason,
+      );
     }
-  }, [hasNoQuotesAvailable, isLoading, quoteFetchError, quotesRefreshCount]);
+  }, [
+    quoteFetchError,
+    quoteStreamComplete?.hasQuotes,
+    quoteStreamComplete?.reason,
+  ]);
 
   useEffect(() => {
     if (quoteFetchError) {

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
@@ -3,7 +3,11 @@ import { useBridgeQuoteEvents } from '.';
 import Engine from '../../../../../core/Engine';
 import { createBridgeTestState } from '../../testUtils';
 import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
-import { RequestStatus, toQuoteResponseV2 } from '@metamask/bridge-controller';
+import {
+  QuoteStreamCompleteReason,
+  RequestStatus,
+  toQuoteResponseV2,
+} from '@metamask/bridge-controller';
 import {
   selectBridgeQuotes,
   selectControllerFields,
@@ -231,13 +235,21 @@ describe('useBridgeQuoteEvents', () => {
     );
   });
 
-  it('ends the quote trace when a completed request has no quotes', () => {
+  it.each([
+    { quotesLoadingStatus: null, quotesRefreshCount: 1 },
+    { quotesLoadingStatus: RequestStatus.LOADING, quotesRefreshCount: 0 },
+    { quotesLoadingStatus: RequestStatus.FETCHED, quotesRefreshCount: 0 },
+  ])('ends the empty-stream trace with controller state %s', (fetchState) => {
     const testState = createBridgeTestState({
       bridgeControllerOverrides: {
-        quotesLoadingStatus: null,
+        ...fetchState,
         quoteFetchError: null,
         quotes: [],
-        quotesRefreshCount: 1,
+        quoteStreamComplete: {
+          quoteCount: 0,
+          hasQuotes: false,
+          reason: QuoteStreamCompleteReason.AMOUNT_TOO_LOW,
+        },
       },
     });
 
@@ -257,7 +269,11 @@ describe('useBridgeQuoteEvents', () => {
       { state: testState },
     );
 
-    expect(mockFinishQuoteTrace).toHaveBeenCalledWith('no_quotes');
+    expect(mockFinishQuoteTrace).toHaveBeenCalledWith(
+      'no_quotes',
+      undefined,
+      QuoteStreamCompleteReason.AMOUNT_TOO_LOW,
+    );
   });
 
   it('ends the quote trace when quote fetching fails', () => {

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -46,7 +46,7 @@ interface UpdateQuoteParamsOptions {
 export const useBridgeQuoteRequest = (
   options: UseBridgeQuoteRequestOptions = {},
 ) => {
-  const ownedTraceId = useRef<string>();
+  const ownedTraceId = useRef<string | undefined>(undefined);
   const cancelOwnedTrace = useCallback(() => {
     if (ownedTraceId.current) {
       swapQuoteFetchTrace.finish('cancelled', ownedTraceId.current);
@@ -216,8 +216,9 @@ export const useBridgeQuoteRequest = (
 
       if (!traceId) {
         cancelOwnedTrace();
+      } else {
+        ownedTraceId.current = traceId;
       }
-      ownedTraceId.current = traceId;
 
       debounced({
         ...requestOptions,

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import Engine from '../../../../../core/Engine';
 import {
   formatAddressToCaipReference,
@@ -46,6 +46,16 @@ interface UpdateQuoteParamsOptions {
 export const useBridgeQuoteRequest = (
   options: UseBridgeQuoteRequestOptions = {},
 ) => {
+  const ownedTraceId = useRef<string>();
+  const cancelOwnedTrace = useCallback(() => {
+    if (ownedTraceId.current) {
+      swapQuoteFetchTrace.finish('cancelled', ownedTraceId.current);
+      ownedTraceId.current = undefined;
+    }
+  }, []);
+
+  useEffect(() => cancelOwnedTrace, [cancelOwnedTrace]);
+
   const sourceAmount = useSelector(selectSourceAmount);
   const sourceToken = useSelector(selectSourceToken);
   const destToken = useSelector(selectDestToken);
@@ -171,7 +181,12 @@ export const useBridgeQuoteRequest = (
 
   // Start the trace when the user commits a request, before the debounce timer.
   const debouncedUpdateQuoteParams = useMemo(() => {
-    const debounced = debounce(updateQuoteParams, DEBOUNCE_WAIT);
+    let traceId: string | undefined;
+    let requestDispatched = false;
+    const debounced = debounce((requestOptions: UpdateQuoteParamsOptions) => {
+      requestDispatched = true;
+      return updateQuoteParams(requestOptions);
+    }, DEBOUNCE_WAIT);
 
     const debouncedWithTrace = ((
       requestOptions: UpdateQuoteParamsOptions = {},
@@ -184,11 +199,12 @@ export const useBridgeQuoteRequest = (
         !walletAddress
       ) {
         debounced.cancel();
-        swapQuoteFetchTrace.finish('cancelled');
+        cancelOwnedTrace();
+        traceId = undefined;
         return;
       }
 
-      const traceId =
+      traceId =
         sourceAmount && sourceAmount !== '.'
           ? swapQuoteFetchTrace.start({
               srcChainId: sourceToken?.chainId,
@@ -196,10 +212,12 @@ export const useBridgeQuoteRequest = (
               isRefresh: requestOptions.isRefresh ?? false,
             })
           : undefined;
+      requestDispatched = false;
 
       if (!traceId) {
-        swapQuoteFetchTrace.finish('cancelled');
+        cancelOwnedTrace();
       }
+      ownedTraceId.current = traceId;
 
       debounced({
         ...requestOptions,
@@ -209,12 +227,16 @@ export const useBridgeQuoteRequest = (
 
     debouncedWithTrace.cancel = () => {
       debounced.cancel();
-      swapQuoteFetchTrace.finish('cancelled');
+      if (!requestDispatched && traceId) {
+        swapQuoteFetchTrace.finish('cancelled', traceId);
+      }
+      traceId = undefined;
     };
     debouncedWithTrace.flush = () => debounced.flush();
 
     return debouncedWithTrace;
   }, [
+    cancelOwnedTrace,
     destToken,
     destChainId,
     sourceAmount,

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/runQuoteRequestCases.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/runQuoteRequestCases.ts
@@ -274,88 +274,85 @@ export const runQuoteRequestCases = ({
       });
     });
 
-    if (name === 'useBridgeQuoteRequest') {
-      it('preserves a no-quote result when an unused hook instance unmounts', async () => {
-        const owner = renderUseBridgeQuoteRequest();
-        const unused = renderUseBridgeQuoteRequest();
+    it('preserves a no-quote result when an unused hook instance unmounts', async () => {
+      const owner = renderUseBridgeQuoteRequest();
+      const unused = renderUseBridgeQuoteRequest();
 
-        await act(async () => {
-          owner.result.current();
-          await owner.result.current.flush?.();
-        });
-        const startedTraceId = mockTrace.mock.calls[0][0].id;
-        unused.unmount();
-        swapQuoteFetchTrace.finish(
-          'no_quotes',
-          undefined,
-          QuoteStreamCompleteReason.AMOUNT_TOO_LOW,
-        );
+      await act(async () => {
+        owner.result.current();
+        await owner.result.current.flush?.();
+      });
+      const startedTraceId = mockTrace.mock.calls[0][0].id;
+      unused.unmount();
+      swapQuoteFetchTrace.finish(
+        'no_quotes',
+        undefined,
+        QuoteStreamCompleteReason.AMOUNT_TOO_LOW,
+      );
 
-        expect(mockEndTrace).toHaveBeenCalledTimes(1);
-        expect(mockEndTrace).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: startedTraceId,
-            data: {
-              result: 'no_quotes',
-              no_quote_reason: QuoteStreamCompleteReason.AMOUNT_TOO_LOW,
-            },
-          }),
-        );
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: startedTraceId,
+          data: {
+            result: 'no_quotes',
+            no_quote_reason: QuoteStreamCompleteReason.AMOUNT_TOO_LOW,
+          },
+        }),
+      );
+    });
+
+    it('cancels a dispatched quote trace when its owner unmounts', async () => {
+      const { result, unmount } = renderUseBridgeQuoteRequest();
+
+      await act(async () => {
+        result.current();
+        await result.current.flush?.();
       });
 
-      it('cancels a dispatched quote trace when its owner unmounts', async () => {
-        const { result, unmount } = renderUseBridgeQuoteRequest();
+      const startedTraceId = mockTrace.mock.calls[0][0].id;
+      mockEndTrace.mockClear();
+      unmount();
 
-        await act(async () => {
-          result.current();
-          await result.current.flush?.();
-        });
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: startedTraceId,
+          data: { result: 'cancelled' },
+        }),
+      );
+    });
 
-        const startedTraceId = mockTrace.mock.calls[0][0].id;
-        mockEndTrace.mockClear();
-        unmount();
-
-        expect(mockEndTrace).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: startedTraceId,
-            data: { result: 'cancelled' },
-          }),
-        );
+    it('preserves a dispatched trace across callback recreation and caller cleanup', async () => {
+      const { result, rerender } = renderUseBridgeQuoteRequest();
+      const previousRequest = result.current;
+      await act(async () => {
+        result.current();
+        await result.current.flush?.();
       });
+      const startedTraceId = mockTrace.mock.calls[0][0].id;
 
-      it('preserves a dispatched trace across callback recreation and caller cleanup', async () => {
-        const { result, rerender } = renderUseBridgeQuoteRequest();
-        const previousRequest = result.current;
-        await act(async () => {
-          result.current();
-          await result.current.flush?.();
-        });
-        const startedTraceId = mockTrace.mock.calls[0][0].id;
+      jest.spyOn(bridgeSlice, 'selectSlippage').mockReturnValue('2');
+      rerender?.(undefined);
+      // BridgeMarketView also cancels the previous callback in effect cleanup.
+      previousRequest.cancel?.();
+      swapQuoteFetchTrace.finish(
+        'no_quotes',
+        undefined,
+        QuoteStreamCompleteReason.SLIPPAGE_TOO_LOW,
+      );
 
-        jest.spyOn(bridgeSlice, 'selectSlippage').mockReturnValue('2');
-        rerender?.(undefined);
-        // BridgeMarketView also cancels the previous callback in effect cleanup.
-        previousRequest.cancel?.();
-        swapQuoteFetchTrace.finish(
-          'no_quotes',
-          undefined,
-          QuoteStreamCompleteReason.SLIPPAGE_TOO_LOW,
-        );
-
-        expect(result.current).not.toBe(previousRequest);
-        expect(mockEndTrace).toHaveBeenCalledTimes(1);
-        expect(mockEndTrace).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: startedTraceId,
-            data: {
-              result: 'no_quotes',
-              no_quote_reason: QuoteStreamCompleteReason.SLIPPAGE_TOO_LOW,
-            },
-          }),
-        );
-      });
-    }
-
+      expect(result.current).not.toBe(previousRequest);
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: startedTraceId,
+          data: {
+            result: 'no_quotes',
+            no_quote_reason: QuoteStreamCompleteReason.SLIPPAGE_TOO_LOW,
+          },
+        }),
+      );
+    });
     it('marks manually requested quote refreshes in the quote trace', async () => {
       const { result } = renderUseBridgeQuoteRequest();
 
@@ -574,16 +571,7 @@ export const runQuoteRequestCases = ({
 
       expect(spyUpdateBridgeQuoteRequestParams).not.toHaveBeenCalled();
       expect(mockTrace).toHaveBeenCalledTimes(1);
-      if (name === 'useBridgeQuoteRequest') {
-        expect(mockEndTrace).not.toHaveBeenCalled();
-      } else {
-        expect(mockEndTrace).toHaveBeenCalledWith({
-          name: TraceName.SwapQuoteFetch,
-          id: leftoverTraceId,
-          timestamp: cancelledAt,
-          data: { result: 'cancelled' },
-        });
-      }
+      expect(mockEndTrace).not.toHaveBeenCalled();
     });
 
     it('skips update when destination token is missing', async () => {
@@ -809,16 +797,7 @@ export const runQuoteRequestCases = ({
         1,
       );
       expect(mockTrace).toHaveBeenCalledTimes(1);
-      if (name === 'useBridgeQuoteRequest') {
-        expect(mockEndTrace).not.toHaveBeenCalled();
-      } else {
-        expect(mockEndTrace).toHaveBeenCalledWith({
-          name: TraceName.SwapQuoteFetch,
-          id: leftoverTraceId,
-          timestamp: cancelledAt,
-          data: { result: 'cancelled' },
-        });
-      }
+      expect(mockEndTrace).not.toHaveBeenCalled();
     });
 
     it('converts source amount to srcTokenAmount "0" when token decimals are missing', async () => {

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/runQuoteRequestCases.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/runQuoteRequestCases.ts
@@ -3,6 +3,7 @@ import { act } from '@testing-library/react-native';
 import {
   formatAddressToCaipReference,
   isSolanaChainId,
+  QuoteStreamCompleteReason,
 } from '@metamask/bridge-controller';
 import { getDecimalChainId } from '../../../../../util/networks';
 import { MultichainNetwork } from '@metamask/multichain-transactions-controller';
@@ -101,6 +102,7 @@ export const runQuoteRequestCases = ({
       };
     };
     unmount: () => void;
+    rerender?: (props: undefined) => void;
   };
   name: string;
 }) => {
@@ -272,6 +274,88 @@ export const runQuoteRequestCases = ({
       });
     });
 
+    if (name === 'useBridgeQuoteRequest') {
+      it('preserves a no-quote result when an unused hook instance unmounts', async () => {
+        const owner = renderUseBridgeQuoteRequest();
+        const unused = renderUseBridgeQuoteRequest();
+
+        await act(async () => {
+          owner.result.current();
+          await owner.result.current.flush?.();
+        });
+        const startedTraceId = mockTrace.mock.calls[0][0].id;
+        unused.unmount();
+        swapQuoteFetchTrace.finish(
+          'no_quotes',
+          undefined,
+          QuoteStreamCompleteReason.AMOUNT_TOO_LOW,
+        );
+
+        expect(mockEndTrace).toHaveBeenCalledTimes(1);
+        expect(mockEndTrace).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: startedTraceId,
+            data: {
+              result: 'no_quotes',
+              no_quote_reason: QuoteStreamCompleteReason.AMOUNT_TOO_LOW,
+            },
+          }),
+        );
+      });
+
+      it('cancels a dispatched quote trace when its owner unmounts', async () => {
+        const { result, unmount } = renderUseBridgeQuoteRequest();
+
+        await act(async () => {
+          result.current();
+          await result.current.flush?.();
+        });
+
+        const startedTraceId = mockTrace.mock.calls[0][0].id;
+        mockEndTrace.mockClear();
+        unmount();
+
+        expect(mockEndTrace).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: startedTraceId,
+            data: { result: 'cancelled' },
+          }),
+        );
+      });
+
+      it('preserves a dispatched trace across callback recreation and caller cleanup', async () => {
+        const { result, rerender } = renderUseBridgeQuoteRequest();
+        const previousRequest = result.current;
+        await act(async () => {
+          result.current();
+          await result.current.flush?.();
+        });
+        const startedTraceId = mockTrace.mock.calls[0][0].id;
+
+        jest.spyOn(bridgeSlice, 'selectSlippage').mockReturnValue('2');
+        rerender?.(undefined);
+        // BridgeMarketView also cancels the previous callback in effect cleanup.
+        previousRequest.cancel?.();
+        swapQuoteFetchTrace.finish(
+          'no_quotes',
+          undefined,
+          QuoteStreamCompleteReason.SLIPPAGE_TOO_LOW,
+        );
+
+        expect(result.current).not.toBe(previousRequest);
+        expect(mockEndTrace).toHaveBeenCalledTimes(1);
+        expect(mockEndTrace).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: startedTraceId,
+            data: {
+              result: 'no_quotes',
+              no_quote_reason: QuoteStreamCompleteReason.SLIPPAGE_TOO_LOW,
+            },
+          }),
+        );
+      });
+    }
+
     it('marks manually requested quote refreshes in the quote trace', async () => {
       const { result } = renderUseBridgeQuoteRequest();
 
@@ -334,7 +418,7 @@ export const runQuoteRequestCases = ({
         name: TraceName.SwapQuoteFetch,
         id: expect.any(String),
         timestamp: expect.any(Number),
-        data: { result: 'error' },
+        data: { result: 'error', no_quote_reason: 'generic_error' },
       });
     });
 
@@ -356,7 +440,7 @@ export const runQuoteRequestCases = ({
         name: TraceName.SwapQuoteFetch,
         id: expect.any(String),
         timestamp: expect.any(Number),
-        data: { result: 'error' },
+        data: { result: 'error', no_quote_reason: 'generic_error' },
       });
     });
 
@@ -490,12 +574,16 @@ export const runQuoteRequestCases = ({
 
       expect(spyUpdateBridgeQuoteRequestParams).not.toHaveBeenCalled();
       expect(mockTrace).toHaveBeenCalledTimes(1);
-      expect(mockEndTrace).toHaveBeenCalledWith({
-        name: TraceName.SwapQuoteFetch,
-        id: leftoverTraceId,
-        timestamp: cancelledAt,
-        data: { result: 'cancelled' },
-      });
+      if (name === 'useBridgeQuoteRequest') {
+        expect(mockEndTrace).not.toHaveBeenCalled();
+      } else {
+        expect(mockEndTrace).toHaveBeenCalledWith({
+          name: TraceName.SwapQuoteFetch,
+          id: leftoverTraceId,
+          timestamp: cancelledAt,
+          data: { result: 'cancelled' },
+        });
+      }
     });
 
     it('skips update when destination token is missing', async () => {
@@ -721,12 +809,16 @@ export const runQuoteRequestCases = ({
         1,
       );
       expect(mockTrace).toHaveBeenCalledTimes(1);
-      expect(mockEndTrace).toHaveBeenCalledWith({
-        name: TraceName.SwapQuoteFetch,
-        id: leftoverTraceId,
-        timestamp: cancelledAt,
-        data: { result: 'cancelled' },
-      });
+      if (name === 'useBridgeQuoteRequest') {
+        expect(mockEndTrace).not.toHaveBeenCalled();
+      } else {
+        expect(mockEndTrace).toHaveBeenCalledWith({
+          name: TraceName.SwapQuoteFetch,
+          id: leftoverTraceId,
+          timestamp: cancelledAt,
+          data: { result: 'cancelled' },
+        });
+      }
     });
 
     it('converts source amount to srcTokenAmount "0" when token decimals are missing', async () => {

--- a/app/components/UI/Bridge/hooks/useUpdateQuoteParams/index.ts
+++ b/app/components/UI/Bridge/hooks/useUpdateQuoteParams/index.ts
@@ -6,7 +6,7 @@ import {
   isValidQuoteRequest,
   type FeatureId,
 } from '@metamask/bridge-controller';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { useUnifiedSwapBridgeContext } from '../useUnifiedSwapBridgeContext';
 import { swapQuoteFetchTrace } from '../../utils/swapQuoteFetchTrace';
@@ -33,6 +33,16 @@ interface UpdateQuoteParamsOptions {
  * @returns A debounced function to update quote parameters
  */
 export const useUpdateQuoteParams = (params: UseDebouncedUpdateParams) => {
+  const ownedTraceId = useRef<string | undefined>(undefined);
+  const cancelOwnedTrace = useCallback(() => {
+    if (ownedTraceId.current) {
+      swapQuoteFetchTrace.finish('cancelled', ownedTraceId.current);
+      ownedTraceId.current = undefined;
+    }
+  }, []);
+
+  useEffect(() => cancelOwnedTrace, [cancelOwnedTrace]);
+
   const {
     genericQuoteRequest,
     featureId,
@@ -86,7 +96,12 @@ export const useUpdateQuoteParams = (params: UseDebouncedUpdateParams) => {
 
   // Start the trace when the user commits a request, before the debounce timer.
   const debouncedUpdateQuoteParams = useMemo(() => {
-    const debounced = debounce(updateQuoteParams, debounceWait);
+    let traceId: string | undefined;
+    let requestDispatched = false;
+    const debounced = debounce((requestOptions: UpdateQuoteParamsOptions) => {
+      requestDispatched = true;
+      return updateQuoteParams(requestOptions);
+    }, debounceWait);
 
     const debouncedWithTrace = (
       requestOptions: UpdateQuoteParamsOptions = {},
@@ -100,11 +115,12 @@ export const useUpdateQuoteParams = (params: UseDebouncedUpdateParams) => {
         !walletAddress
       ) {
         debounced.cancel();
-        swapQuoteFetchTrace.finish('cancelled');
+        cancelOwnedTrace();
+        traceId = undefined;
         return;
       }
 
-      const traceId =
+      traceId =
         srcAmount && srcAmount !== '.'
           ? swapQuoteFetchTrace.start({
               srcChainId,
@@ -112,9 +128,12 @@ export const useUpdateQuoteParams = (params: UseDebouncedUpdateParams) => {
               isRefresh: requestOptions.isRefresh ?? false,
             })
           : undefined;
+      requestDispatched = false;
 
       if (!traceId) {
-        swapQuoteFetchTrace.finish('cancelled');
+        cancelOwnedTrace();
+      } else {
+        ownedTraceId.current = traceId;
       }
 
       debounced({
@@ -125,12 +144,16 @@ export const useUpdateQuoteParams = (params: UseDebouncedUpdateParams) => {
 
     debouncedWithTrace.cancel = () => {
       debounced.cancel();
-      swapQuoteFetchTrace.finish('cancelled');
+      if (!requestDispatched && traceId) {
+        swapQuoteFetchTrace.finish('cancelled', traceId);
+      }
+      traceId = undefined;
     };
     debouncedWithTrace.flush = () => debounced.flush();
 
     return debouncedWithTrace;
   }, [
+    cancelOwnedTrace,
     destChainId,
     srcChainId,
     destTokenAddress,

--- a/app/components/UI/Bridge/utils/swapQuoteFetchTrace.test.ts
+++ b/app/components/UI/Bridge/utils/swapQuoteFetchTrace.test.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { QuoteStreamCompleteReason } from '@metamask/bridge-controller';
 import {
   endTrace,
   trace,
@@ -65,13 +66,54 @@ describe('swapQuoteFetchTrace', () => {
       isRefresh: false,
     });
 
-    swapQuoteFetchTrace.finish('no_quotes');
+    swapQuoteFetchTrace.finish(
+      'no_quotes',
+      undefined,
+      QuoteStreamCompleteReason.AMOUNT_TOO_LOW,
+    );
 
     expect(mockEndTrace).toHaveBeenCalledWith({
       name: TraceName.SwapQuoteFetch,
       id: 'quote-trace-id',
       timestamp: expect.any(Number),
-      data: { result: 'no_quotes' },
+      data: { result: 'no_quotes', no_quote_reason: 'AMOUNT_TOO_LOW' },
     });
   });
+
+  it('falls back to a generic reason for quote failures without a reason', () => {
+    swapQuoteFetchTrace.start({
+      srcChainId: sourceToken.chainId,
+      destChainId: sameChainDestinationToken.chainId,
+      isRefresh: false,
+    });
+
+    swapQuoteFetchTrace.finish('error');
+
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { result: 'error', no_quote_reason: 'generic_error' },
+      }),
+    );
+  });
+
+  it.each(['success', 'cancelled'] as const)(
+    'does not attach a no-quote reason to %s traces',
+    (result) => {
+      swapQuoteFetchTrace.start({
+        srcChainId: sourceToken.chainId,
+        destChainId: sameChainDestinationToken.chainId,
+        isRefresh: false,
+      });
+
+      swapQuoteFetchTrace.finish(
+        result,
+        undefined,
+        QuoteStreamCompleteReason.RETRY,
+      );
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { result } }),
+      );
+    },
+  );
 });

--- a/app/components/UI/Bridge/utils/swapQuoteFetchTrace.ts
+++ b/app/components/UI/Bridge/utils/swapQuoteFetchTrace.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   formatChainIdToCaip,
   type GenericQuoteRequest,
+  type QuoteStreamCompleteReason,
 } from '@metamask/bridge-controller';
 import {
   endTrace,
@@ -27,6 +28,7 @@ let activeTraceId: string | undefined;
 const finishTrace = (
   result: SwapQuoteFetchTraceResult,
   id: string | undefined = activeTraceId,
+  reason?: QuoteStreamCompleteReason,
 ): void => {
   if (!id || activeTraceId !== id) {
     return;
@@ -36,7 +38,12 @@ const finishTrace = (
     name: TraceName.SwapQuoteFetch,
     id,
     timestamp: Date.now(),
-    data: { result },
+    data: {
+      result,
+      ...(result === 'no_quotes' || result === 'error'
+        ? { no_quote_reason: reason ?? 'generic_error' }
+        : {}),
+    },
   });
   activeTraceId = undefined;
 };
@@ -84,7 +91,11 @@ export const swapQuoteFetchTrace = {
     return id;
   },
 
-  finish(result: SwapQuoteFetchTraceResult, id?: string): void {
-    finishTrace(result, id);
+  finish(
+    result: SwapQuoteFetchTraceResult,
+    id?: string,
+    reason?: QuoteStreamCompleteReason,
+  ): void {
+    finishTrace(result, id, reason);
   },
 };


### PR DESCRIPTION
## **Description**

Adds no-quote outcome telemetry to the existing `Swap Quote Fetch` Sentry span and fixes premature cancellation during quote-request lifecycle cleanup. Completed empty quote streams now record the raw controller reason, while request ownership prevents unrelated hook cleanup from ending active traces.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: SWAPS-5032

## **Manual testing steps**

```gherkin
Feature: No quote Sentry telemetry

  Scenario: completed quote stream with no quotes
    Given the swaps screen is open with valid quote inputs
    When the quote stream completes without a quote
    Then the Swap Quote Fetch span has result no_quotes and a no_quote_reason attribute

  Scenario: successful quote request
    Given the swaps screen is open with valid quote inputs
    When a quote is returned
    Then the Swap Quote Fetch span has result success
```

## **Screenshots/Recordings**

### **Before**

N/A — telemetry-only change.

### **After**

N/A — telemetry-only change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android — not applicable; telemetry-only change
- [x] I've tested with a power user scenario — not applicable; telemetry-only change
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry and trace lifecycle only; no swap execution or auth changes. Risk is mis-attributed spans if ownership logic regresses, which is covered by new tests.
> 
> **Overview**
> Improves **Swap Quote Fetch** Sentry spans by recording **`no_quote_reason`** on **`no_quotes`** and **`error`** outcomes (controller stream reason or **`generic_error`**), and by ending empty streams from **`selectQuoteStreamComplete`** instead of loading/refresh heuristics.
> 
> **`useBridgeQuoteRequest`** and **`useUpdateQuoteParams`** now **own** trace IDs so debounce **`cancel`**, rerenders, and extra hook instances do not wrongly finish an in-flight trace; only the owning instance cancels on unmount after a request is dispatched.
> 
> Tests cover stream-complete reasons, trace ownership across unmount/rerender, and updated cancel expectations when inputs are invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64c95d64ae12b5cb6ae129a1fa17cf5d83a65072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->