### PR TITLE
test: sync FF defaults for swaps and bridge

### DIFF
--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -382,20 +382,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      quoteRequestOverrides: {
-        perps: {
-          noFee: true,
-        },
-      },
-      refreshRate: 30000,
       bip44DefaultPairs: {
-        tron: {
-          other: {},
-          standard: {
-            'tron:72812642/slip44:195':
-              'tron:72812642/token:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
-          },
-        },
         bip122: {
           other: {},
           standard: {
@@ -411,21 +398,32 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
           },
         },
         solana: {
+          other: {},
           standard: {
             'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501':
               'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
           },
+        },
+        tron: {
           other: {},
+          standard: {
+            'tron:72812642/slip44:195':
+              'tron:72812642/token:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+          },
         },
       },
       chainRanking: [
         {
-          name: 'Ethereum',
           chainId: 'eip155:1',
+          name: 'Ethereum',
         },
         {
-          name: 'BNB',
           chainId: 'eip155:56',
+          name: 'BNB',
+        },
+        {
+          chainId: 'eip155:4663',
+          name: 'Robinhood',
         },
         {
           chainId: 'bip122:000000000019d6689c085ae165831e93',
@@ -448,54 +446,44 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
           name: 'Arbitrum',
         },
         {
-          name: 'Linea',
           chainId: 'eip155:59144',
+          name: 'Linea',
         },
         {
           chainId: 'eip155:137',
           name: 'Polygon',
         },
         {
-          name: 'Avalanche',
           chainId: 'eip155:43114',
+          name: 'Avalanche',
         },
         {
           chainId: 'eip155:10',
           name: 'Optimism',
         },
         {
-          name: 'Monad',
           chainId: 'eip155:143',
+          name: 'Monad',
         },
         {
-          name: 'Sei',
           chainId: 'eip155:1329',
+          name: 'Sei',
         },
         {
           chainId: 'eip155:4326',
           name: 'MegaETH',
         },
         {
-          name: 'HyperEVM',
           chainId: 'eip155:999',
+          name: 'HyperEVM',
         },
         {
-          name: 'zkSync',
           chainId: 'eip155:324',
+          name: 'zkSync',
         },
       ],
-      priceImpactThreshold: {
-        normal: 0.05,
-        gasless: 0.2,
-      },
       chains: {
         '1': {
-          isUnifiedUIEnabled: true,
-          noFeeAssets: [],
-          topAssets: [
-            '0xaca92e438df0b2401ff60da7e4337b687a2435da',
-            '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-          ],
           batchSellDestStablecoins: [
             'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
             'eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7',
@@ -503,20 +491,26 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
           isActiveDest: true,
           isActiveSrc: true,
           isGaslessSwapEnabled: true,
+          isUnifiedUIEnabled: true,
+          noFeeAssets: [],
+          topAssets: [
+            '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+            '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          ],
         },
         '10': {
+          isActiveDest: true,
           isActiveSrc: true,
           isUnifiedUIEnabled: true,
-          isActiveDest: true,
         },
         '56': {
-          isActiveSrc: true,
-          isGaslessSwapEnabled: true,
-          isUnifiedUIEnabled: true,
           batchSellDestStablecoins: [
             'eip155:56/erc20:0x55d398326f99059ff775485246999027b3197955',
           ],
           isActiveDest: true,
+          isActiveSrc: true,
+          isGaslessSwapEnabled: true,
+          isUnifiedUIEnabled: true,
         },
         '137': {
           batchSellDestStablecoins: [
@@ -537,25 +531,33 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
           isUnifiedUIEnabled: true,
         },
         '1329': {
-          isUnifiedUIEnabled: true,
           isActiveDest: true,
           isActiveSrc: true,
+          isUnifiedUIEnabled: true,
+        },
+        '4663': {
+          isActiveDest: true,
+          isActiveSrc: true,
+          topAssets: [
+            '0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34',
+            '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168',
+          ],
         },
         '8453': {
-          isUnifiedUIEnabled: true,
           batchSellDestStablecoins: [
             'eip155:8453/erc20:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
           ],
           isActiveDest: true,
           isActiveSrc: true,
+          isUnifiedUIEnabled: true,
         },
         '42161': {
-          isUnifiedUIEnabled: true,
           batchSellDestStablecoins: [
             'eip155:42161/erc20:0xaf88d065e77c8cc2239327c5edb3a432268e5831',
           ],
           isActiveDest: true,
           isActiveSrc: true,
+          isUnifiedUIEnabled: true,
         },
         '43114': {
           isActiveDest: true,
@@ -563,6 +565,9 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
           isUnifiedUIEnabled: true,
         },
         '59144': {
+          batchSellDestStablecoins: [
+            'eip155:59144/erc20:0xaca92e438df0b2401ff60da7e4337b687a2435da',
+          ],
           isActiveDest: true,
           isActiveSrc: true,
           isUnifiedUIEnabled: true,
@@ -571,16 +576,16 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
             '0xaca92e438df0b2401ff60da7e4337b687a2435da',
             '0x176211869ca2b568f2a7d4ee941e073a821ee1ff',
           ],
-          batchSellDestStablecoins: [
-            'eip155:59144/erc20:0xaca92e438df0b2401ff60da7e4337b687a2435da',
-          ],
         },
         '728126428': {
+          isActiveDest: true,
           isActiveSrc: true,
           isUnifiedUIEnabled: true,
-          isActiveDest: true,
         },
         '1151111081099710': {
+          isActiveDest: true,
+          isActiveSrc: true,
+          isUnifiedUIEnabled: true,
           refreshRate: 10000,
           topAssets: [
             'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
@@ -594,9 +599,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
             '21AErpiB8uSb94oQKRcwuHqyHF93njAxBSbdUrpupump',
             'pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn',
           ],
-          isActiveDest: true,
-          isActiveSrc: true,
-          isUnifiedUIEnabled: true,
         },
         '20000000000001': {
           isActiveDest: true,
@@ -604,13 +606,23 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
           isUnifiedUIEnabled: true,
         },
       },
-      support: true,
       maxRefreshCount: 5,
       minimumVersion: '7.46.0',
+      priceImpactThreshold: {
+        gasless: 0.2,
+        normal: 0.05,
+      },
+      quoteRequestOverrides: {
+        perps: {
+          noFee: true,
+        },
+      },
+      refreshRate: 30000,
       sse: {
         enabled: true,
         minimumVersion: '7.59.0',
       },
+      support: true,
     },
     status: FeatureFlagStatus.Active,
   },
@@ -4859,6 +4871,145 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  swapsLimitOrder: {
+    name: 'swapsLimitOrder',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      versions: {},
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  swapsRecurringBuy: {
+    name: 'swapsRecurringBuy',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      versions: {},
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  swapsSWAPS4135AbtestNumpadQuickAmounts: {
+    name: 'swapsSWAPS4135AbtestNumpadQuickAmounts',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [],
+    status: FeatureFlagStatus.Active,
+  },
+
+  swapsSWAPS4242AbtestTokenSelectorBalanceLayout: {
+    name: 'swapsSWAPS4242AbtestTokenSelectorBalanceLayout',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [
+      {
+        name: 'control',
+        scope: {
+          type: 'percentage_rollout',
+          value: 1,
+        },
+      },
+      {
+        name: 'treatment',
+        scope: {
+          type: 'percentage_rollout',
+          value: 0,
+        },
+      },
+    ],
+    status: FeatureFlagStatus.Active,
+  },
+
+  swapsSWAPS4543AbtestPostTradeModal: {
+    name: 'swapsSWAPS4543AbtestPostTradeModal',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      versions: {
+        '8.1.0': [
+          {
+            name: 'control',
+            scope: {
+              type: 'percentage_rollout',
+              value: 1,
+            },
+          },
+          {
+            name: 'treatment',
+            scope: {
+              type: 'percentage_rollout',
+              value: 0,
+            },
+          },
+        ],
+      },
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  swapsSWAPS4666AbtestDiscoveryFeedRevamp: {
+    name: 'swapsSWAPS4666AbtestDiscoveryFeedRevamp',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [
+      {
+        name: 'control',
+        scope: {
+          type: 'percentage_rollout',
+          value: 1,
+        },
+      },
+      {
+        name: 'discovery_feed',
+        scope: {
+          type: 'percentage_rollout',
+          value: 0,
+        },
+      },
+      {
+        name: 'empty',
+        scope: {
+          type: 'percentage_rollout',
+          value: 0,
+        },
+      },
+    ],
+    status: FeatureFlagStatus.Active,
+  },
+
+  swapsSWAPS4780AbtestSwapHaptics: {
+    name: 'swapsSWAPS4780AbtestSwapHaptics',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [
+      {
+        name: 'control',
+        scope: {
+          type: 'percentage_rollout',
+          value: 1,
+        },
+      },
+      {
+        name: 'treatment',
+        scope: {
+          type: 'percentage_rollout',
+          value: 0,
+        },
+      },
+    ],
+    status: FeatureFlagStatus.Active,
+  },
+
+  swapsSWAPS4784AbtestCTAButtonColor: {
+    name: 'swapsSWAPS4784AbtestCTAButtonColor',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [],
+    status: FeatureFlagStatus.Active,
+  },
+
   telegram_login_enabled: {
     name: 'telegram_login_enabled',
     type: FeatureFlagType.Remote,
@@ -4882,12 +5033,41 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
+      '0x1': {
+        expectedDeadline: 45,
+        gaslessBridgeWith7702Enabled: false,
+        maxDeadline: 160,
+        mobileActive: true,
+        mobileActiveAndroid: true,
+        mobileActiveIOS: true,
+        sentinelUrl: 'https://tx-sentinel-ethereum-mainnet.api.cx.metamask.io',
+      },
+      '0x1237': {
+        gaslessBridgeWith7702Enabled: false,
+        mobileActive: true,
+        mobileActiveAndroid: true,
+        mobileActiveIOS: true,
+        sentinelUrl: 'https://tx-sentinel-robinhood-mainnet.api.cx.metamask.io',
+      },
+      '0x144': {
+        sentinelUrl: 'https://tx-sentinel-zksync-mainnet.api.cx.metamask.io',
+      },
       '0x2105': {
+        gaslessBridgeWith7702Enabled: true,
+        mobileActive: true,
         mobileActiveAndroid: true,
         mobileActiveIOS: true,
         sentinelUrl: 'https://tx-sentinel-base-mainnet.api.cx.metamask.io',
-        gaslessBridgeWith7702Enabled: true,
+      },
+      '0x38': {
+        gaslessBridgeWith7702Enabled: false,
         mobileActive: true,
+        mobileActiveAndroid: true,
+        mobileActiveIOS: true,
+        sentinelUrl: 'https://tx-sentinel-bsc-mainnet.api.cx.metamask.io',
+      },
+      '0x531': {
+        sentinelUrl: 'https://tx-sentinel-sei-mainnet.api.cx.metamask.io',
       },
       '0x89': {
         gaslessBridgeWith7702Enabled: true,
@@ -4896,45 +5076,31 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
         mobileActiveIOS: true,
         sentinelUrl: 'https://tx-sentinel-polygon-mainnet.api.cx.metamask.io',
       },
-      '0xa86a': {
-        sentinelUrl: 'https://tx-sentinel-avalanche-mainnet.api.cx.metamask.io',
-      },
-      '0x531': {
-        sentinelUrl: 'https://tx-sentinel-sei-mainnet.api.cx.metamask.io',
+      '0x8f': {
+        sentinelUrl: 'https://tx-sentinel-monad-mainnet.api.cx.metamask.io',
       },
       '0xa': {
         sentinelUrl: 'https://tx-sentinel-optimism-mainnet.api.cx.metamask.io',
       },
       '0xa4b1': {
-        sentinelUrl: 'https://tx-sentinel-arbitrum-mainnet.api.cx.metamask.io',
         gaslessBridgeWith7702Enabled: true,
         mobileActive: true,
         mobileActiveAndroid: true,
         mobileActiveIOS: true,
+        sentinelUrl: 'https://tx-sentinel-arbitrum-mainnet.api.cx.metamask.io',
       },
-      '0x1': {
-        mobileActiveAndroid: true,
-        mobileActiveIOS: true,
-        sentinelUrl: 'https://tx-sentinel-ethereum-mainnet.api.cx.metamask.io',
-        expectedDeadline: 45,
-        gaslessBridgeWith7702Enabled: false,
-        maxDeadline: 160,
-        mobileActive: true,
+      '0xa86a': {
+        sentinelUrl: 'https://tx-sentinel-avalanche-mainnet.api.cx.metamask.io',
       },
       '0xe708': {
+        gaslessBridgeWith7702Enabled: false,
+        mobileActive: true,
         mobileActiveAndroid: true,
         mobileActiveIOS: true,
         sentinelUrl: 'https://tx-sentinel-linea-mainnet.api.cx.metamask.io',
-        gaslessBridgeWith7702Enabled: false,
-        mobileActive: true,
-      },
-      '0x8f': {
-        sentinelUrl: 'https://tx-sentinel-monad-mainnet.api.cx.metamask.io',
-      },
-      '0x144': {
-        sentinelUrl: 'https://tx-sentinel-zksync-mainnet.api.cx.metamask.io',
       },
       default: {
+        batchStatusPollingInterval: 1000,
         expectedDeadline: 45,
         gaslessBridgeWith7702Enabled: false,
         maxDeadline: 150,
@@ -4942,14 +5108,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
         mobileActiveAndroid: false,
         mobileActiveIOS: false,
         mobileReturnTxHashAsap: true,
-        batchStatusPollingInterval: 1000,
-      },
-      '0x38': {
-        mobileActive: true,
-        mobileActiveAndroid: true,
-        mobileActiveIOS: true,
-        sentinelUrl: 'https://tx-sentinel-bsc-mainnet.api.cx.metamask.io',
-        gaslessBridgeWith7702Enabled: false,
       },
     },
     status: FeatureFlagStatus.Active,
@@ -5317,22 +5475,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'swapsSWAPS4825AbtestChainValueOrder',
     type: FeatureFlagType.Remote,
     inProd: true,
-    productionDefault: [
-      {
-        name: 'control',
-        scope: {
-          value: 1,
-          type: 'percentage_rollout',
-        },
-      },
-      {
-        name: 'treatment',
-        scope: {
-          type: 'percentage_rollout',
-          value: 0,
-        },
-      },
-    ],
+    productionDefault: [],
     status: FeatureFlagStatus.Active,
   },
 
@@ -6095,11 +6238,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     productionDefault: [
       {
         name: 'control',
-        scope: { type: 'percentage_rollout', value: 1 },
+        scope: {
+          type: 'percentage_rollout',
+          value: 1,
+        },
       },
       {
         name: 'treatment',
-        scope: { type: 'percentage_rollout', value: 0 },
+        scope: {
+          type: 'percentage_rollout',
+          value: 0,
+        },
       },
     ],
     status: FeatureFlagStatus.Active,
@@ -6197,7 +6346,26 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'swapsSWAPS4635AbtestVerified2',
     type: FeatureFlagType.Remote,
     inProd: true,
-    productionDefault: [],
+    productionDefault: {
+      versions: {
+        '8.2.0': [
+          {
+            name: 'control',
+            scope: {
+              type: 'percentage_rollout',
+              value: 1,
+            },
+          },
+          {
+            name: 'treatment',
+            scope: {
+              type: 'percentage_rollout',
+              value: 0,
+            },
+          },
+        ],
+      },
+    },
     status: FeatureFlagStatus.Active,
   },
 


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Second focused slice of the feature-flag registry sync from [#35861](https://github.com/MetaMask/metamask-mobile/pull/35861).

Updates only swaps/bridge-related defaults in `tests/feature-flags/feature-flag-registry.ts` to match the 2026-09-08 prod sync.

**Changed:** `bridgeConfigV2`, `smartTransactionsNetworks`, `tradeTO880AbtestOnboardingInterestQuestion`, `swapsSWAPS4635AbtestVerified2`, `swapsSWAPS4825AbtestChainValueOrder`

**Added:** `swapsLimitOrder`, `swapsRecurringBuy`, `swapsSWAPS4135AbtestNumpadQuickAmounts`, `swapsSWAPS4242AbtestTokenSelectorBalanceLayout`, `swapsSWAPS4543AbtestPostTradeModal`, `swapsSWAPS4666AbtestDiscoveryFeedRevamp`, `swapsSWAPS4780AbtestSwapHaptics`, `swapsSWAPS4784AbtestCTAButtonColor`

Follows PR-1 ([#35954](https://github.com/MetaMask/metamask-mobile/pull/35954)). A/B scopes remain control-pinned where applicable.

**Required CO:** `@MetaMask/swaps-engineers` (+ `@MetaMask/qa` for registry)

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/metamask-mobile/pull/35861

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

1. Confirm CI Appium `swap` smoke (iOS + Android) passes with the updated registry defaults.
2. N/A for manual device testing beyond CI smoke for this registry-only change.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — E2E registry defaults only; no UI code changes in this PR.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only E2E mock data; no app runtime changes, though updated bridge/STX defaults could shift CI swap smoke behavior if tests depend on old flag shapes.
> 
> **Overview**
> Syncs **E2E feature-flag registry** defaults in `tests/feature-flags/feature-flag-registry.ts` with prod (2026-09-08), so Appium swap/bridge smokes see the same remote config as production.
> 
> **`bridgeConfigV2`** gains **Robinhood** in `chainRanking` and chain `4663` (active src/dest + `topAssets`); mostly key reordering with the same underlying values.
> 
> **`smartTransactionsNetworks`** adds **Robinhood** (`0x1237`) sentinel/mobile settings and refreshes per-network field ordering; BSC (`0x38`) keeps full mobile + sentinel entries.
> 
> **New swaps/bridge flags** are registered with prod-shaped defaults: `swapsLimitOrder`, `swapsRecurringBuy`, and several `swapsSWAPS*` A/B flags (mostly control-pinned rollouts or empty/versioned configs).
> 
> **A/B default tweaks:** `swapsSWAPS4825AbtestChainValueOrder` → empty array (was control/treatment rollout); `swapsSWAPS4635AbtestVerified2` → versioned `8.2.0` control/treatment rollout (was `[]`). `tradeTO880AbtestOnboardingInterestQuestion` is formatting-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffda025e722cde158869cc55ebaca3d5d13d0972. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->