### PR TITLE
chore(perps): bump perps-controller to 16.2.0

### DIFF
--- a/app/components/UI/Perps/utils/translatePerpsError.ts
+++ b/app/components/UI/Perps/utils/translatePerpsError.ts
@@ -74,6 +74,14 @@ export const ERROR_CODE_TO_I18N_KEY: Record<PerpsErrorCode, string> = {
   [PERPS_ERROR_CODES.ORDER_SIZE_MIN]: 'perps.order.validation.minimum_amount',
   [PERPS_ERROR_CODES.ORDER_LEVERAGE_INVALID]:
     'perps.order.validation.invalid_leverage',
+  [PERPS_ERROR_CODES.ORDER_MARGIN_MODE_INVALID]:
+    'perps.errors.orderValidation.marginModeInvalid',
+  [PERPS_ERROR_CODES.ORDER_MARGIN_MODE_UNSUPPORTED]:
+    'perps.errors.orderValidation.marginModeUnsupported',
+  [PERPS_ERROR_CODES.ORDER_MARGIN_MODE_POSITION_OPEN]:
+    'perps.errors.orderValidation.marginModePositionOpen',
+  [PERPS_ERROR_CODES.ORDER_MARGIN_MODE_ORDER_OPEN]:
+    'perps.errors.orderValidation.marginModeOrderOpen',
   [PERPS_ERROR_CODES.ORDER_LEVERAGE_BELOW_POSITION]:
     'perps.order.validation.leverage_below_position',
   [PERPS_ERROR_CODES.ORDER_MAX_VALUE_EXCEEDED]:

--- a/app/components/UI/Perps/utils/translatePerpsErrorCoverage.test.ts
+++ b/app/components/UI/Perps/utils/translatePerpsErrorCoverage.test.ts
@@ -9,9 +9,9 @@ import enTranslations from '../../../../../locales/languages/en.json';
  * read the installed controller's full code list.
  *
  * A controller upgrade that widens `PerpsErrorCode` — as v11 did with the
- * trigger-order, TP/SL linkage and exchange codes, and v12 with strategy
- * placement codes — fails here rather than shipping an untranslated code to
- * users.
+ * trigger-order, TP/SL linkage and exchange codes, v12 with strategy
+ * placement codes, and v16.2 with margin-mode codes — fails here rather than
+ * shipping an untranslated code to users.
  */
 const resolveTranslation = (i18nKey: string): string | undefined => {
   let node: unknown = enTranslations;
@@ -96,6 +96,19 @@ describe('ERROR_CODE_TO_I18N_KEY', () => {
     ];
 
     const unmapped = v13Codes.filter((code) => !ERROR_CODE_TO_I18N_KEY[code]);
+
+    expect(unmapped).toStrictEqual([]);
+  });
+
+  it('maps the v16.2 margin-mode codes', () => {
+    const v16Codes = [
+      PERPS_ERROR_CODES.ORDER_MARGIN_MODE_INVALID,
+      PERPS_ERROR_CODES.ORDER_MARGIN_MODE_UNSUPPORTED,
+      PERPS_ERROR_CODES.ORDER_MARGIN_MODE_POSITION_OPEN,
+      PERPS_ERROR_CODES.ORDER_MARGIN_MODE_ORDER_OPEN,
+    ];
+
+    const unmapped = v16Codes.filter((code) => !ERROR_CODE_TO_I18N_KEY[code]);
 
     expect(unmapped).toStrictEqual([]);
   });

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2263,7 +2263,11 @@
         "chaseLimitReached": "Too many chase orders are already running",
         "chaseAbandoned": "Chase order was cancelled because the connection dropped",
         "chaseTouchUnavailable": "No market price is available to place this chase order",
-        "chaseMaxDistanceInvalid": "Max chase distance is outside the allowed range"
+        "chaseMaxDistanceInvalid": "Max chase distance is outside the allowed range",
+        "marginModeInvalid": "Margin mode is invalid",
+        "marginModeUnsupported": "This margin mode isn't available on this market",
+        "marginModePositionOpen": "Can't change margin mode while a position is open",
+        "marginModeOrderOpen": "Can't change margin mode while an order is open"
       },
       "networkToggleFailed": "Failed to toggle network: {{error}}",
       "accountBalanceFailed": "Failed to get account balance: {{error}}",

--- a/package.json
+++ b/package.json
@@ -361,7 +361,7 @@
     "@metamask/network-enablement-controller": "patch:@metamask/network-enablement-controller@npm%3A5.4.1#~/.yarn/patches/@metamask-network-enablement-controller-npm-5.4.1-020a82a308.patch",
     "@metamask/notification-services-controller": "^27.0.1",
     "@metamask/permission-controller": "^13.1.1",
-    "@metamask/perps-controller": "^16.1.0",
+    "@metamask/perps-controller": "^16.2.0",
     "@metamask/phishing-controller": "^17.3.1",
     "@metamask/post-message-stream": "^10.0.0",
     "@metamask/preferences-controller": "^23.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11310,9 +11310,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/perps-controller@npm:^16.1.0":
-  version: 16.1.0
-  resolution: "@metamask/perps-controller@npm:16.1.0"
+"@metamask/perps-controller@npm:^16.2.0":
+  version: 16.2.0
+  resolution: "@metamask/perps-controller@npm:16.2.0"
   dependencies:
     "@metamask/abi-utils": "npm:^2.0.3"
     "@metamask/base-controller": "npm:^9.1.0"
@@ -11324,7 +11324,7 @@ __metadata:
     bignumber.js: "npm:^9.1.2"
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/e28bc78339c140ae2d714f14c72480a782212e391be7f57bb5485d4528737c638f2d8dea6d16b90a0c599edf11c811815ebef397bd37a9e407e086633832f779
+  checksum: 10/ca1b4389e8ff92bed3fcdaa66272ebc96b5e554d987a30b47f964b2ac05ab31c957131161d7a03aada4dd7d638bfd37c48b14fa420740323e1883c135d929ed3
   languageName: node
   linkType: hard
 
@@ -39723,7 +39723,7 @@ __metadata:
     "@metamask/notification-services-controller": "npm:^27.0.1"
     "@metamask/object-multiplex": "npm:^1.1.0"
     "@metamask/permission-controller": "npm:^13.1.1"
-    "@metamask/perps-controller": "npm:^16.1.0"
+    "@metamask/perps-controller": "npm:^16.2.0"
     "@metamask/phishing-controller": "npm:^17.3.1"
     "@metamask/platform-api-docs": "npm:^0.1.0"
     "@metamask/post-message-stream": "npm:^10.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Bumps `@metamask/perps-controller` from 16.1.0 to 16.2.0 (Core release 1245.0.0).

16.2.0 adds optional HyperLiquid `OrderParams.marginMode`, four `ORDER_MARGIN_MODE_*` error codes, a TWAP terminal-record fix, and Lighter account/market fixes. Callers that omit `marginMode` stay on isolated.

Mobile maps `PerpsErrorCode` exhaustively, so this PR adds the four new codes to `ERROR_CODE_TO_I18N_KEY`, English copy, and `translatePerpsErrorCoverage.test.ts`. It does not ship Pro cross-margin UI (that is #35831).

### Recipe validation

Verdict: pass

Proved:
- AC1: lockfile resolves `@metamask/perps-controller@16.2.0`
- AC2: bundled `perps.smoke` opened Perps Testnet, read positions/orders (empty, no mutation), and `perps-market-list` was present

Gaps:
- iOS Runway only (`mm-1`). Android not run.
- First recipe run failed on Login/CDP after restart; relaunch + fixtures recovered. Passing run is the proof.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Added Perps error messages for invalid, unsupported, and occupied-position/order margin modes

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/core/pull/10136
Jira: https://consensyssoftware.atlassian.net/browse/TAT-3519

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps controller 16.2.0 smoke

  Scenario: Perps market list still loads after the bump
    Given a Runway iOS build on mm-1 with the wallet fixture unlocked
    And @metamask/perps-controller is 16.2.0

    When the bundled perps.smoke recipe runs
    Then the wallet unlocks if needed
    And the Perps market list is present
    And live positions and orders can be read without placing or cancelling anything
```

Platform: iOS simulator `mm-1`. Build: Runway expo-dev-client. Fixture: existing 4-entry wallet. Perps testnet enabled.

## **Screenshots/Recordings**

<table>
<tr><td colspan="2"><strong>Recipe visual evidence</strong><br/>Screenshots are grouped for quick reviewer comparison.</td></tr>
<tr>
<td align="center" width="50%"><strong>Perps Testnet home after 16.2.0 smoke</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/dev-update-perps-controller-smoke-2221/01-ui-screenshot-screenshot.png" alt="Perps Testnet home after 16.2.0 smoke" width="400" /></td>
<td width="50%"></td>
</tr>
</table>

### **Before**

N/A. Dependency bump, no UI redesign.

### **After**

Perps Testnet home after the 16.2.0 smoke (recipe-backed).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Considered; iOS Runway only for this bump
- [x] I've tested with a power user scenario
  - Considered; not applicable (fixture wallet, non-mutating smoke)
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Considered; not applicable (no new product operations)

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
