### PR TITLE
fix(rewards): perps campaign deeplink, banner scoping and prize-pool follow-ups

### DIFF
--- a/app/components/UI/Perps/components/PerpsCompetitionBanner/PerpsCompetitionBanner.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCompetitionBanner/PerpsCompetitionBanner.test.tsx
@@ -210,6 +210,33 @@ describe('PerpsCompetitionBanner', () => {
     });
   });
 
+  it('shows the banner for a new campaign after dismissing a different one', async () => {
+    // Dismissing campaign 1 must not suppress campaign 2's banner when the
+    // campaign list swaps under the component mid-session.
+    setupSelector(true, [buildCampaign({ id: 'perps-campaign-1' })]);
+
+    const { getByTestId, queryByTestId, rerender } = render(
+      <PerpsCompetitionBanner />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('perps-competition-banner')).toBeOnTheScreen();
+    });
+
+    fireEvent.press(getByTestId('perps-competition-banner-close'));
+
+    await waitFor(() => {
+      expect(queryByTestId('perps-competition-banner')).not.toBeOnTheScreen();
+    });
+
+    setupSelector(true, [buildCampaign({ id: 'perps-campaign-2' })]);
+    rerender(<PerpsCompetitionBanner />);
+
+    await waitFor(() => {
+      expect(getByTestId('perps-competition-banner')).toBeOnTheScreen();
+    });
+  });
+
   it('ignores a late read under the previous key when the campaign resolves', async () => {
     // Mount unresolved, then let campaigns land. The ':unknown' read is made to
     // resolve LAST and report a dismissal; without a cancellation guard it

--- a/app/components/UI/Perps/components/PerpsCompetitionBanner/PerpsCompetitionBanner.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCompetitionBanner/PerpsCompetitionBanner.test.tsx
@@ -210,6 +210,43 @@ describe('PerpsCompetitionBanner', () => {
     });
   });
 
+  it('ignores a late read under the previous key when the campaign resolves', async () => {
+    // Mount unresolved, then let campaigns land. The ':unknown' read is made to
+    // resolve LAST and report a dismissal; without a cancellation guard it
+    // would clobber the resolved key's result and hide the banner.
+    const unknownKey = perpsCompetitionBannerDismissedKey('unknown');
+    const resolvedKey = perpsCompetitionBannerDismissedKey('perps-campaign-9');
+    let releaseUnknownRead: (value: string | null) => void = () => undefined;
+
+    (StorageWrapper.getItem as jest.Mock).mockImplementation(
+      async (key: string) => {
+        if (key === unknownKey) {
+          return new Promise<string | null>((resolve) => {
+            releaseUnknownRead = resolve;
+          });
+        }
+        return null;
+      },
+    );
+
+    setupSelector(true, []);
+    const { getByTestId, rerender } = render(<PerpsCompetitionBanner />);
+
+    setupSelector(true, [buildCampaign({ id: 'perps-campaign-9' })]);
+    rerender(<PerpsCompetitionBanner />);
+
+    await waitFor(() => {
+      expect(StorageWrapper.getItem).toHaveBeenCalledWith(resolvedKey);
+    });
+
+    // The stale read now resolves with a dismissal for the old key.
+    releaseUnknownRead('true');
+
+    await waitFor(() => {
+      expect(getByTestId('perps-competition-banner')).toBeOnTheScreen();
+    });
+  });
+
   it('ignores a completed perps campaign when building the storage key', async () => {
     setupSelector(true, [
       buildCampaign({

--- a/app/components/UI/Perps/components/PerpsCompetitionBanner/PerpsCompetitionBanner.tsx
+++ b/app/components/UI/Perps/components/PerpsCompetitionBanner/PerpsCompetitionBanner.tsx
@@ -45,6 +45,9 @@ import type { PerpsCompetitionBannerProps } from './PerpsCompetitionBanner.types
 // are keyed separately rather than against a real campaign id, so they can never
 // suppress the banner for a later campaign.
 const UNRESOLVED_CAMPAIGN_KEY = 'unknown';
+const UNRESOLVED_STORAGE_KEY = perpsCompetitionBannerDismissedKey(
+  UNRESOLVED_CAMPAIGN_KEY,
+);
 
 // Pending addition to PERPS_EVENT_VALUE.BUTTON_CLICKED in @metamask/perps-controller
 const COMPETITION_BANNER_BUTTON = {
@@ -92,7 +95,9 @@ const PerpsCompetitionBanner: React.FC<PerpsCompetitionBannerProps> = ({
   const dispatch = useDispatch();
   const { track } = usePerpsEventTracking();
   const [isDismissed, setIsDismissed] = useState<boolean | null>(null);
-  const dismissedThisSessionRef = useRef(false);
+  // The storage key a dismissal was made against this session, not a bare
+  // boolean: a dismissal must not carry across to a different campaign.
+  const dismissedKeyRef = useRef<string | null>(null);
   const campaigns = useSelector(selectCampaigns);
 
   const dismissedStorageKey = useMemo(() => {
@@ -106,11 +111,16 @@ const PerpsCompetitionBanner: React.FC<PerpsCompetitionBannerProps> = ({
   }, [campaigns]);
 
   useEffect(() => {
-    // Campaigns can land in Redux after this mounts, which switches the key from
-    // the unresolved one to a real campaign id. Re-reading then would bring the
-    // banner back after the user had already closed it, so a dismissal in this
-    // session wins over whatever the new key holds.
-    if (dismissedThisSessionRef.current) {
+    // A dismissal made before the campaign was known was aimed at whatever the
+    // banner was advertising, so it carries forward once the id resolves —
+    // otherwise the banner would reappear the moment campaigns land. A
+    // dismissal made against a real campaign id applies only to that campaign,
+    // so a second campaign still gets its own banner.
+    const dismissedKey = dismissedKeyRef.current;
+    if (
+      dismissedKey === dismissedStorageKey ||
+      dismissedKey === UNRESOLVED_STORAGE_KEY
+    ) {
       return;
     }
     // The key changes under this effect when campaigns land in Redux, leaving
@@ -146,7 +156,7 @@ const PerpsCompetitionBanner: React.FC<PerpsCompetitionBannerProps> = ({
       [PERPS_EVENT_PROPERTY.LOCATION]:
         PERPS_EVENT_VALUE.BUTTON_LOCATION.PERPS_HOME,
     });
-    dismissedThisSessionRef.current = true;
+    dismissedKeyRef.current = dismissedStorageKey;
     setIsDismissed(true);
     try {
       await StorageWrapper.setItem(dismissedStorageKey, 'true');

--- a/app/components/UI/Perps/components/PerpsCompetitionBanner/PerpsCompetitionBanner.tsx
+++ b/app/components/UI/Perps/components/PerpsCompetitionBanner/PerpsCompetitionBanner.tsx
@@ -113,15 +113,29 @@ const PerpsCompetitionBanner: React.FC<PerpsCompetitionBannerProps> = ({
     if (dismissedThisSessionRef.current) {
       return;
     }
+    // The key changes under this effect when campaigns land in Redux, leaving
+    // two storage reads racing. Storage gives no ordering guarantee, so without
+    // this guard a late read under the previous key can overwrite the newer
+    // key's result and hide a banner the user never dismissed.
+    let cancelled = false;
     const checkDismissed = async () => {
       try {
         const value = await StorageWrapper.getItem(dismissedStorageKey);
+        if (cancelled) {
+          return;
+        }
         setIsDismissed(value === 'true');
       } catch {
+        if (cancelled) {
+          return;
+        }
         setIsDismissed(false);
       }
     };
     checkDismissed();
+    return () => {
+      cancelled = true;
+    };
   }, [dismissedStorageKey]);
 
   const handleDismiss = useCallback(async () => {

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
@@ -567,7 +567,9 @@ describe('OndoCampaignDetailsView', () => {
       refetch: jest.fn(),
     });
     mockUseGetOndoCampaignDeposits.mockReturnValue({
-      deposits: null,
+      // The prize pool section is hidden when there is no deposits total and
+      // nothing in flight, so tests asserting it renders need a real value.
+      deposits: { totalUsdDeposited: '1250000.000000' },
       isLoading: false,
       hasError: false,
       refetch: jest.fn(),

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -44,6 +44,7 @@ import OndoCampaignEndedStats from '../components/Campaigns/OndoCampaignEndedSta
 import OndoNotEligibleSheet from '../components/Campaigns/OndoNotEligibleSheet';
 import OndoCampaignStatsSummary from '../components/Campaigns/OndoCampaignStatsSummary';
 import OndoPrizePool from '../components/Campaigns/OndoPrizePool';
+import { hasPrizePoolContent } from '../utils/prizePoolUtils';
 import { getCampaignStatus } from '../components/Campaigns/CampaignTile.utils';
 import RewardsErrorBanner from '../components/RewardsErrorBanner';
 import { useGetCampaignParticipantStatus } from '../hooks/useGetCampaignParticipantStatus';
@@ -480,22 +481,27 @@ const OndoCampaignDetailsView: React.FC = () => {
                 </>
               )}
 
-              {getCampaignStatus(campaign) !== 'upcoming' && (
-                <>
-                  <Box twClassName="my-1 border-b border-border-muted" />
-                  <Box twClassName="p-4">
-                    <Text variant={TextVariant.HeadingMd} twClassName="mb-1">
-                      {strings('rewards.campaign_prize_pool.title')}
-                    </Text>
-                    <OndoPrizePool
-                      totalUsdDeposited={deposits?.totalUsdDeposited ?? null}
-                      isLoading={isDepositsLoading}
-                      hasError={hasDepositsError}
-                      refetch={refetchDeposits}
-                    />
-                  </Box>
-                </>
-              )}
+              {getCampaignStatus(campaign) !== 'upcoming' &&
+                hasPrizePoolContent({
+                  hasData: deposits?.totalUsdDeposited != null,
+                  isLoading: isDepositsLoading,
+                  hasError: hasDepositsError,
+                }) && (
+                  <>
+                    <Box twClassName="my-1 border-b border-border-muted" />
+                    <Box twClassName="p-4">
+                      <Text variant={TextVariant.HeadingMd} twClassName="mb-1">
+                        {strings('rewards.campaign_prize_pool.title')}
+                      </Text>
+                      <OndoPrizePool
+                        totalUsdDeposited={deposits?.totalUsdDeposited ?? null}
+                        isLoading={isDepositsLoading}
+                        hasError={hasDepositsError}
+                        refetch={refetchDeposits}
+                      />
+                    </Box>
+                  </>
+                )}
 
               {showLeaderboardSection && (
                 <>

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -44,7 +44,6 @@ import OndoCampaignEndedStats from '../components/Campaigns/OndoCampaignEndedSta
 import OndoNotEligibleSheet from '../components/Campaigns/OndoNotEligibleSheet';
 import OndoCampaignStatsSummary from '../components/Campaigns/OndoCampaignStatsSummary';
 import OndoPrizePool from '../components/Campaigns/OndoPrizePool';
-import { hasPrizePoolContent } from '../utils/prizePoolUtils';
 import { getCampaignStatus } from '../components/Campaigns/CampaignTile.utils';
 import RewardsErrorBanner from '../components/RewardsErrorBanner';
 import { useGetCampaignParticipantStatus } from '../hooks/useGetCampaignParticipantStatus';
@@ -481,27 +480,14 @@ const OndoCampaignDetailsView: React.FC = () => {
                 </>
               )}
 
-              {getCampaignStatus(campaign) !== 'upcoming' &&
-                hasPrizePoolContent({
-                  hasData: deposits?.totalUsdDeposited != null,
-                  isLoading: isDepositsLoading,
-                  hasError: hasDepositsError,
-                }) && (
-                  <>
-                    <Box twClassName="my-1 border-b border-border-muted" />
-                    <Box twClassName="p-4">
-                      <Text variant={TextVariant.HeadingMd} twClassName="mb-1">
-                        {strings('rewards.campaign_prize_pool.title')}
-                      </Text>
-                      <OndoPrizePool
-                        totalUsdDeposited={deposits?.totalUsdDeposited ?? null}
-                        isLoading={isDepositsLoading}
-                        hasError={hasDepositsError}
-                        refetch={refetchDeposits}
-                      />
-                    </Box>
-                  </>
-                )}
+              {getCampaignStatus(campaign) !== 'upcoming' && (
+                <OndoPrizePool
+                  totalUsdDeposited={deposits?.totalUsdDeposited ?? null}
+                  isLoading={isDepositsLoading}
+                  hasError={hasDepositsError}
+                  refetch={refetchDeposits}
+                />
+              )}
 
               {showLeaderboardSection && (
                 <>

--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.test.tsx
@@ -441,7 +441,15 @@ function setupHooks(
   } as ReturnType<typeof useGetPerpsTradingCampaignLeaderboardPosition>);
 
   mockUseGetPerpsTradingCampaignPrizePool.mockReturnValue({
-    prizePool: null,
+    // The section is hidden when there is no data and nothing in flight, so
+    // tests asserting it renders need an actual prize pool here.
+    prizePool: {
+      totalVolumeUsd: 7_500_000,
+      unlockedPoolUsd: 15_000,
+      thresholdsUsd: [0, 5_000_000],
+      poolScheduleUsd: [10_000, 15_000],
+      computedAt: '2026-07-15T00:00:00.000Z',
+    },
     isLoading: false,
     hasError: false,
     refetch: jest.fn(),
@@ -887,6 +895,40 @@ describe('PerpsTradingCampaignDetailsView', () => {
       Routes.REWARDS_CAMPAIGN_MECHANICS,
       { campaignId: 'resolved-by-type' },
     );
+  });
+
+  it('hides the prize pool heading when there is no prize pool to show', () => {
+    // The heading lives in this view, outside the prize pool component, so it
+    // has to be dropped alongside it — a lone "Prize pool" title above empty
+    // space is worse than no section.
+    setupHooks({});
+    mockUseGetPerpsTradingCampaignPrizePool.mockReturnValue({
+      prizePool: null,
+      isLoading: false,
+      hasError: false,
+      refetch: jest.fn(),
+    } as ReturnType<typeof useGetPerpsTradingCampaignPrizePool>);
+
+    const { queryByText, queryByTestId } = render(
+      <PerpsTradingCampaignDetailsView />,
+    );
+
+    expect(queryByTestId('perps-prize-pool')).toBeNull();
+    expect(queryByText('rewards.campaign_prize_pool.title')).toBeNull();
+  });
+
+  it('shows the prize pool heading while the prize pool is loading', () => {
+    setupHooks({});
+    mockUseGetPerpsTradingCampaignPrizePool.mockReturnValue({
+      prizePool: null,
+      isLoading: true,
+      hasError: false,
+      refetch: jest.fn(),
+    } as ReturnType<typeof useGetPerpsTradingCampaignPrizePool>);
+
+    const { getByTestId } = render(<PerpsTradingCampaignDetailsView />);
+
+    expect(getByTestId('perps-prize-pool')).toBeOnTheScreen();
   });
 
   it('prefers the active campaign over a completed one when route has no campaignId', () => {

--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.tsx
@@ -31,7 +31,7 @@ import CampaignHowItWorks from '../components/Campaigns/CampaignHowItWorks';
 import PerpsTradingCampaignLeaderboard, {
   PERPS_CAMPAIGN_LEADERBOARD_TEST_IDS,
 } from '../components/Campaigns/PerpsTradingCampaignLeaderboard';
-import CampaignPrizePool from '../components/Campaigns/CampaignPrizePool';
+import CampaignPrizePoolSection from '../components/Campaigns/CampaignPrizePoolSection';
 import PerpsTradingCampaignCTA from '../components/Campaigns/PerpsTradingCampaignCTA';
 import PerpsCampaignStatsSummary from '../components/Campaigns/PerpsCampaignStatsSummary';
 import PerpsTradingCampaignEndedStats from '../components/Campaigns/PerpsTradingCampaignEndedStats';
@@ -54,7 +54,6 @@ import {
 } from '../../../../core/Engine/controllers/rewards-controller/types';
 import { selectReferralCode } from '../../../../reducers/rewards/selectors';
 import { getCampaignMechanicsButtonProps } from '../utils/campaignHeaderUtils';
-import { hasPrizePoolContent } from '../utils/prizePoolUtils';
 import RewardsErrorBanner from '../components/RewardsErrorBanner';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -360,31 +359,14 @@ const PerpsTradingCampaignDetailsView: React.FC = () => {
                 </Box>
               )}
 
-              {showPrizePoolSection &&
-                hasPrizePoolContent({
-                  hasData: prizePool != null,
-                  isLoading: isPrizePoolLoading,
-                  hasError: hasPrizePoolError,
-                }) && (
-                  <>
-                    <Box twClassName="my-1 border-b border-border-muted" />
-                    <Box twClassName="p-4">
-                      <Text
-                        variant={TextVariant.HeadingMd}
-                        fontWeight={FontWeight.Bold}
-                        twClassName="mb-1"
-                      >
-                        {strings('rewards.campaign_prize_pool.title')}
-                      </Text>
-                      <CampaignPrizePool
-                        prizePool={prizePool}
-                        isLoading={isPrizePoolLoading}
-                        hasError={hasPrizePoolError}
-                        refetch={refetchPrizePool}
-                      />
-                    </Box>
-                  </>
-                )}
+              {showPrizePoolSection && (
+                <CampaignPrizePoolSection
+                  prizePool={prizePool}
+                  isLoading={isPrizePoolLoading}
+                  hasError={hasPrizePoolError}
+                  refetch={refetchPrizePool}
+                />
+              )}
 
               {showLeaderboardSection && (
                 <>

--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.tsx
@@ -434,6 +434,7 @@ const PerpsTradingCampaignDetailsView: React.FC = () => {
                       maxEntries={5}
                       campaignId={effectiveCampaignId}
                       isCampaignComplete={isComplete}
+                      numberOfWinners={leaderboard?.numberOfWinners}
                     />
                   </Box>
                 </>

--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.tsx
@@ -54,6 +54,7 @@ import {
 } from '../../../../core/Engine/controllers/rewards-controller/types';
 import { selectReferralCode } from '../../../../reducers/rewards/selectors';
 import { getCampaignMechanicsButtonProps } from '../utils/campaignHeaderUtils';
+import { hasPrizePoolContent } from '../utils/prizePoolUtils';
 import RewardsErrorBanner from '../components/RewardsErrorBanner';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -359,26 +360,31 @@ const PerpsTradingCampaignDetailsView: React.FC = () => {
                 </Box>
               )}
 
-              {showPrizePoolSection && (
-                <>
-                  <Box twClassName="my-1 border-b border-border-muted" />
-                  <Box twClassName="p-4">
-                    <Text
-                      variant={TextVariant.HeadingMd}
-                      fontWeight={FontWeight.Bold}
-                      twClassName="mb-1"
-                    >
-                      {strings('rewards.campaign_prize_pool.title')}
-                    </Text>
-                    <CampaignPrizePool
-                      prizePool={prizePool}
-                      isLoading={isPrizePoolLoading}
-                      hasError={hasPrizePoolError}
-                      refetch={refetchPrizePool}
-                    />
-                  </Box>
-                </>
-              )}
+              {showPrizePoolSection &&
+                hasPrizePoolContent({
+                  hasData: prizePool != null,
+                  isLoading: isPrizePoolLoading,
+                  hasError: hasPrizePoolError,
+                }) && (
+                  <>
+                    <Box twClassName="my-1 border-b border-border-muted" />
+                    <Box twClassName="p-4">
+                      <Text
+                        variant={TextVariant.HeadingMd}
+                        fontWeight={FontWeight.Bold}
+                        twClassName="mb-1"
+                      >
+                        {strings('rewards.campaign_prize_pool.title')}
+                      </Text>
+                      <CampaignPrizePool
+                        prizePool={prizePool}
+                        isLoading={isPrizePoolLoading}
+                        hasError={hasPrizePoolError}
+                        refetch={refetchPrizePool}
+                      />
+                    </Box>
+                  </>
+                )}
 
               {showLeaderboardSection && (
                 <>

--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignLeaderboardView.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignLeaderboardView.tsx
@@ -134,6 +134,7 @@ const PerpsTradingCampaignLeaderboardView: React.FC = () => {
               userPosition={leaderboardUserPosition}
               campaignId={campaignId}
               isCampaignComplete={isCampaignComplete}
+              numberOfWinners={leaderboard?.numberOfWinners}
             />
           </Box>
         </ScrollView>

--- a/app/components/UI/Rewards/Views/PredictThePitchCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/PredictThePitchCampaignDetailsView.tsx
@@ -48,6 +48,7 @@ import { useGetPredictThePitchPrizePool } from '../hooks/useGetPredictThePitchPr
 import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
 import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 import { getCampaignMechanicsButtonProps } from '../utils/campaignHeaderUtils';
+import { hasPrizePoolContent } from '../utils/prizePoolUtils';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 import {
@@ -493,26 +494,31 @@ const PredictThePitchCampaignDetailsView: React.FC = () => {
                 </Box>
               )}
 
-              {showPrizePoolSection && (
-                <>
-                  <Box twClassName="my-1 border-b border-border-muted" />
-                  <Box twClassName="p-4">
-                    <Text
-                      variant={TextVariant.HeadingMd}
-                      fontWeight={FontWeight.Bold}
-                      twClassName="mb-1"
-                    >
-                      {strings('rewards.campaign_prize_pool.title')}
-                    </Text>
-                    <CampaignPrizePool
-                      prizePool={prizePool}
-                      isLoading={isPrizePoolLoading}
-                      hasError={hasPrizePoolError}
-                      refetch={refetchPrizePool}
-                    />
-                  </Box>
-                </>
-              )}
+              {showPrizePoolSection &&
+                hasPrizePoolContent({
+                  hasData: prizePool != null,
+                  isLoading: isPrizePoolLoading,
+                  hasError: hasPrizePoolError,
+                }) && (
+                  <>
+                    <Box twClassName="my-1 border-b border-border-muted" />
+                    <Box twClassName="p-4">
+                      <Text
+                        variant={TextVariant.HeadingMd}
+                        fontWeight={FontWeight.Bold}
+                        twClassName="mb-1"
+                      >
+                        {strings('rewards.campaign_prize_pool.title')}
+                      </Text>
+                      <CampaignPrizePool
+                        prizePool={prizePool}
+                        isLoading={isPrizePoolLoading}
+                        hasError={hasPrizePoolError}
+                        refetch={refetchPrizePool}
+                      />
+                    </Box>
+                  </>
+                )}
 
               {showLeaderboardSection && (
                 <>

--- a/app/components/UI/Rewards/Views/PredictThePitchCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/PredictThePitchCampaignDetailsView.tsx
@@ -35,7 +35,7 @@ import PredictThePitchLeaderboard, {
   PREDICT_THE_PITCH_LEADERBOARD_TEST_IDS,
 } from '../components/Campaigns/PredictThePitchLeaderboard';
 import PredictThePitchPortfolio from '../components/Campaigns/PredictThePitchPortfolio';
-import CampaignPrizePool from '../components/Campaigns/CampaignPrizePool';
+import CampaignPrizePoolSection from '../components/Campaigns/CampaignPrizePoolSection';
 import PredictThePitchStatsSummary from '../components/Campaigns/PredictThePitchStatsSummary';
 import { getCampaignStatus } from '../components/Campaigns/CampaignTile.utils';
 import RewardsErrorBanner from '../components/RewardsErrorBanner';
@@ -48,7 +48,6 @@ import { useGetPredictThePitchPrizePool } from '../hooks/useGetPredictThePitchPr
 import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
 import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 import { getCampaignMechanicsButtonProps } from '../utils/campaignHeaderUtils';
-import { hasPrizePoolContent } from '../utils/prizePoolUtils';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 import {
@@ -494,31 +493,14 @@ const PredictThePitchCampaignDetailsView: React.FC = () => {
                 </Box>
               )}
 
-              {showPrizePoolSection &&
-                hasPrizePoolContent({
-                  hasData: prizePool != null,
-                  isLoading: isPrizePoolLoading,
-                  hasError: hasPrizePoolError,
-                }) && (
-                  <>
-                    <Box twClassName="my-1 border-b border-border-muted" />
-                    <Box twClassName="p-4">
-                      <Text
-                        variant={TextVariant.HeadingMd}
-                        fontWeight={FontWeight.Bold}
-                        twClassName="mb-1"
-                      >
-                        {strings('rewards.campaign_prize_pool.title')}
-                      </Text>
-                      <CampaignPrizePool
-                        prizePool={prizePool}
-                        isLoading={isPrizePoolLoading}
-                        hasError={hasPrizePoolError}
-                        refetch={refetchPrizePool}
-                      />
-                    </Box>
-                  </>
-                )}
+              {showPrizePoolSection && (
+                <CampaignPrizePoolSection
+                  prizePool={prizePool}
+                  isLoading={isPrizePoolLoading}
+                  hasError={hasPrizePoolError}
+                  refetch={refetchPrizePool}
+                />
+              )}
 
               {showLeaderboardSection && (
                 <>

--- a/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
@@ -55,6 +55,7 @@ jest.mock('../../../../reducers/rewards/selectors', () => ({
   selectHideCurrentAccountNotOptedInBannerArray: jest.fn(),
   selectHideUnlinkedAccountsBanner: jest.fn(),
   selectPendingDeeplink: jest.fn(),
+  selectCampaignsFetching: jest.fn(),
 }));
 
 jest.mock('../../../../selectors/rewards', () => ({
@@ -81,6 +82,7 @@ import {
   selectHideUnlinkedAccountsBanner,
   selectHideCurrentAccountNotOptedInBannerArray,
   selectPendingDeeplink,
+  selectCampaignsFetching,
 } from '../../../../reducers/rewards/selectors';
 // Real action creator (the rewards reducer module is intentionally not mocked),
 // so the deeplink tests can assert the exact clear action dispatched.
@@ -829,13 +831,21 @@ describe('RewardsDashboard', () => {
     // REWARDS_FLOW host, so mockNavigate receives that wrapper shape.
     const renderWithPendingDeeplink = (
       pendingDeeplink: Record<string, unknown> | null,
+      selectorOverrides: {
+        subscriptionId?: string | null;
+        campaignsFetching?: boolean;
+      } = {},
     ) => {
       mockUseSelector.mockImplementation((selector) => {
         if (selector === selectPendingDeeplink) return pendingDeeplink;
+        if (selector === selectCampaignsFetching)
+          return selectorOverrides.campaignsFetching ?? false;
         if (selector === selectActiveTab)
           return defaultSelectorValues.activeTab;
         if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
+          return 'subscriptionId' in selectorOverrides
+            ? selectorOverrides.subscriptionId
+            : defaultSelectorValues.subscriptionId;
         if (selector === selectIsCurrentSubscriptionVipEnabled)
           return defaultSelectorValues.isVipEnabled;
         if (selector === selectHideUnlinkedAccountsBanner)
@@ -1019,6 +1029,41 @@ describe('RewardsDashboard', () => {
         mockCampaigns([], { hasError: true });
 
         renderWithPendingDeeplink({ campaign: 'perps-comp' });
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockDispatch).not.toHaveBeenCalledWith(setPendingDeeplink(null));
+      });
+
+      it('keeps the deeplink pending when there is no subscription yet', () => {
+        // fetchCampaigns short-circuits to an empty list without a
+        // subscription, and still marks campaigns loaded — so an empty list
+        // here means "not signed in", not "no campaigns exist".
+        mockCampaigns([]);
+
+        renderWithPendingDeeplink(
+          { campaign: 'perps-comp' },
+          { subscriptionId: null },
+        );
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockDispatch).not.toHaveBeenCalledWith(setPendingDeeplink(null));
+      });
+
+      it('keeps the deeplink pending while a refresh runs over a stale list', () => {
+        // campaignsLoading is suppressed once campaigns exist, so only the
+        // fetching flag catches a refresh that may add the active campaign.
+        mockCampaigns([
+          buildPerpsCampaign({
+            id: 'perps-past',
+            startDate: '2020-01-01T00:00:00.000Z',
+            endDate: '2020-02-01T00:00:00.000Z',
+          }),
+        ]);
+
+        renderWithPendingDeeplink(
+          { campaign: 'perps-comp' },
+          { campaignsFetching: true },
+        );
 
         expect(mockNavigate).not.toHaveBeenCalled();
         expect(mockDispatch).not.toHaveBeenCalledWith(setPendingDeeplink(null));

--- a/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
@@ -829,12 +829,14 @@ describe('RewardsDashboard', () => {
     // into the corresponding rewards sub-page, then clears it so it does not
     // re-fire. navigateToRewardsRoute (not mocked) forwards through the
     // REWARDS_FLOW host, so mockNavigate receives that wrapper shape.
-    const renderWithPendingDeeplink = (
+    interface DeeplinkSelectorOverrides {
+      subscriptionId?: string | null;
+      campaignsFetching?: boolean;
+    }
+
+    const setDeeplinkSelectors = (
       pendingDeeplink: Record<string, unknown> | null,
-      selectorOverrides: {
-        subscriptionId?: string | null;
-        campaignsFetching?: boolean;
-      } = {},
+      selectorOverrides: DeeplinkSelectorOverrides = {},
     ) => {
       mockUseSelector.mockImplementation((selector) => {
         if (selector === selectPendingDeeplink) return pendingDeeplink;
@@ -857,7 +859,36 @@ describe('RewardsDashboard', () => {
         if (selector === mockHasAcceptedVipInviteSelector) return false;
         return undefined;
       });
+    };
+
+    const renderWithPendingDeeplink = (
+      pendingDeeplink: Record<string, unknown> | null,
+      selectorOverrides: DeeplinkSelectorOverrides = {},
+    ) => {
+      setDeeplinkSelectors(pendingDeeplink, selectorOverrides);
       return render(<RewardsDashboard />);
+    };
+
+    /**
+     * Renders through the real fetch sequence: the focus effect starts a
+     * campaigns fetch, then it settles. Deeplink resolution deliberately waits
+     * for a fetch to have been observed, so a single static render can never
+     * resolve one — a plain render only ever reproduces the pre-fetch commit.
+     */
+    const renderAfterSettledFetch = (
+      pendingDeeplink: Record<string, unknown> | null,
+      selectorOverrides: DeeplinkSelectorOverrides = {},
+    ) => {
+      const view = renderWithPendingDeeplink(pendingDeeplink, {
+        ...selectorOverrides,
+        campaignsFetching: true,
+      });
+      setDeeplinkSelectors(pendingDeeplink, {
+        ...selectorOverrides,
+        campaignsFetching: false,
+      });
+      view.rerender(<RewardsDashboard />);
+      return view;
     };
 
     const activeMoneyCampaign: CampaignDto = {
@@ -977,7 +1008,7 @@ describe('RewardsDashboard', () => {
           buildPerpsCampaign({ id: 'perps-active' }),
         ]);
 
-        renderWithPendingDeeplink({ campaign: 'perps-comp' });
+        renderAfterSettledFetch({ campaign: 'perps-comp' });
 
         expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_FLOW, {
           screen: Routes.REWARDS_PERPS_TRADING_CAMPAIGN_DETAILS_VIEW,
@@ -995,7 +1026,7 @@ describe('RewardsDashboard', () => {
           }),
         ]);
 
-        renderWithPendingDeeplink({ campaign: 'perps-comp' });
+        renderAfterSettledFetch({ campaign: 'perps-comp' });
 
         expect(mockNavigate).not.toHaveBeenCalled();
         expect(mockDispatch).toHaveBeenCalledWith(setPendingDeeplink(null));
@@ -1010,7 +1041,7 @@ describe('RewardsDashboard', () => {
           }),
         ]);
 
-        renderWithPendingDeeplink({ campaign: 'perps-comp' });
+        renderAfterSettledFetch({ campaign: 'perps-comp' });
 
         expect(mockNavigate).not.toHaveBeenCalled();
         expect(mockDispatch).toHaveBeenCalledWith(setPendingDeeplink(null));
@@ -1029,6 +1060,28 @@ describe('RewardsDashboard', () => {
         mockCampaigns([], { hasError: true });
 
         renderWithPendingDeeplink({ campaign: 'perps-comp' });
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockDispatch).not.toHaveBeenCalledWith(setPendingDeeplink(null));
+      });
+
+      it('keeps the deeplink pending on the commit before a fetch starts', () => {
+        // The focus effect dispatches campaignsFetching, so it is not readable
+        // until the next render. On the first commit after a remount the
+        // campaigns list in Redux is whatever the previous fetch left behind —
+        // resolving against it here would drop the deeplink for good.
+        mockCampaigns([
+          buildPerpsCampaign({
+            id: 'perps-past',
+            startDate: '2020-01-01T00:00:00.000Z',
+            endDate: '2020-02-01T00:00:00.000Z',
+          }),
+        ]);
+
+        renderWithPendingDeeplink(
+          { campaign: 'perps-comp' },
+          { campaignsFetching: false },
+        );
 
         expect(mockNavigate).not.toHaveBeenCalled();
         expect(mockDispatch).not.toHaveBeenCalledWith(setPendingDeeplink(null));

--- a/app/components/UI/Rewards/Views/RewardsDashboard.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.tsx
@@ -25,6 +25,7 @@ import {
   selectHideUnlinkedAccountsBanner,
   selectHideCurrentAccountNotOptedInBannerArray,
   selectPendingDeeplink,
+  selectCampaignsFetching,
 } from '../../../../reducers/rewards/selectors';
 import { setPendingDeeplink } from '../../../../reducers/rewards';
 import {
@@ -94,6 +95,7 @@ const RewardsDashboard: React.FC = () => {
     hasError: campaignsHasError,
     isLoading: isCampaignsLoading,
   } = useRewardCampaigns();
+  const isCampaignsFetching = useSelector(selectCampaignsFetching);
   const moneyAccountSeries = useMoneyAccountSweepstakesSeries();
   const {
     optedInAny: moneyAccountOptedInAny,
@@ -140,10 +142,19 @@ const RewardsDashboard: React.FC = () => {
       );
     } else if (pendingDeeplink.campaign === 'perps-comp') {
       // The deeplink carries no campaign id, so it has to be resolved against
-      // the campaign list. Failed and in-flight fetches also flip
-      // campaignsHasLoaded, so an empty list is only trustworthy once a
-      // successful fetch has settled.
+      // the campaign list — and resolving against a list that is not yet
+      // authoritative would drop the deeplink for good, because a null result
+      // still counts as handled. The list is only authoritative once every one
+      // of these is false:
+      //  - no subscription yet: fetchCampaigns short-circuits to an empty list
+      //    and still marks it loaded, so "no campaigns" means "not signed in",
+      //    not "no campaigns exist".
+      //  - a fetch is in flight: campaignsLoading is suppressed once campaigns
+      //    exist, so only campaignsFetching catches a refresh over a stale list.
+      //  - never loaded, or failed/in-flight with nothing cached.
       const waitingForCampaigns =
+        !subscriptionId ||
+        isCampaignsFetching ||
         !campaignsHasLoaded ||
         (campaigns.length === 0 && (campaignsHasError || isCampaignsLoading));
 
@@ -226,10 +237,12 @@ const RewardsDashboard: React.FC = () => {
     navigation,
     dispatch,
     pendingDeeplink,
+    subscriptionId,
     campaigns,
     campaignsHasLoaded,
     campaignsHasError,
     isCampaignsLoading,
+    isCampaignsFetching,
     moneyAccountSeries,
     moneyAccountOptedInAny,
     isMoneyAccountParticipationLoading,

--- a/app/components/UI/Rewards/Views/RewardsDashboard.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.tsx
@@ -96,6 +96,17 @@ const RewardsDashboard: React.FC = () => {
     isLoading: isCampaignsLoading,
   } = useRewardCampaigns();
   const isCampaignsFetching = useSelector(selectCampaignsFetching);
+  // `campaignsFetching` is dispatched by the focus effect, so it only becomes
+  // readable one render later — on the first commit after a (re)mount the
+  // deeplink effect below always sees `false`, even though a fetch is already
+  // under way. Waiting until a fetch has actually been *observed* closes that
+  // window without depending on the order the two effects happen to run in.
+  const hasObservedCampaignsFetchRef = useRef(false);
+  useEffect(() => {
+    if (isCampaignsFetching) {
+      hasObservedCampaignsFetchRef.current = true;
+    }
+  }, [isCampaignsFetching]);
   const moneyAccountSeries = useMoneyAccountSweepstakesSeries();
   const {
     optedInAny: moneyAccountOptedInAny,
@@ -149,11 +160,15 @@ const RewardsDashboard: React.FC = () => {
       //  - no subscription yet: fetchCampaigns short-circuits to an empty list
       //    and still marks it loaded, so "no campaigns" means "not signed in",
       //    not "no campaigns exist".
+      //  - no fetch observed yet this mount: the list in Redux survives the
+      //    tab unmounting, so it can be a previous fetch's result that the
+      //    in-flight refresh has not replaced yet.
       //  - a fetch is in flight: campaignsLoading is suppressed once campaigns
       //    exist, so only campaignsFetching catches a refresh over a stale list.
       //  - never loaded, or failed/in-flight with nothing cached.
       const waitingForCampaigns =
         !subscriptionId ||
+        !hasObservedCampaignsFetchRef.current ||
         isCampaignsFetching ||
         !campaignsHasLoaded ||
         (campaigns.length === 0 && (campaignsHasError || isCampaignsLoading));

--- a/app/components/UI/Rewards/components/Campaigns/CampaignPrizePool.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignPrizePool.test.tsx
@@ -292,12 +292,24 @@ describe('CampaignPrizePool', () => {
     expect(getByTestId(CAMPAIGN_PRIZE_POOL_TEST_IDS.MAX_BADGE)).toBeDefined();
   });
 
-  it('renders an empty ladder when no prize pool is available', () => {
-    const { getByText, getByTestId } = render(
+  it('renders nothing when there is no prize pool and no request in flight', () => {
+    // A zeroed ladder would assert a $0 prize pool rather than an absent one.
+    const { queryByTestId } = render(
       <CampaignPrizePool {...baseProps} prizePool={null} />,
     );
 
-    expect(getByText('$0.00')).toBeDefined();
-    expect(getByTestId(CAMPAIGN_PRIZE_POOL_TEST_IDS.MAX_BADGE)).toBeDefined();
+    expect(queryByTestId(CAMPAIGN_PRIZE_POOL_TEST_IDS.CONTAINER)).toBeNull();
+    expect(queryByTestId(CAMPAIGN_PRIZE_POOL_TEST_IDS.PROGRESS_BAR)).toBeNull();
+    expect(queryByTestId(CAMPAIGN_PRIZE_POOL_TEST_IDS.MAX_BADGE)).toBeNull();
+  });
+
+  it('prefers existing data over a loading state (stale-while-revalidate)', () => {
+    const { getByTestId } = render(
+      <CampaignPrizePool {...baseProps} isLoading hasError />,
+    );
+
+    expect(
+      getByTestId(CAMPAIGN_PRIZE_POOL_TEST_IDS.PROGRESS_BAR),
+    ).toBeDefined();
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/CampaignPrizePool.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignPrizePool.test.tsx
@@ -4,6 +4,7 @@ import CampaignPrizePool, {
   CAMPAIGN_PRIZE_POOL_TEST_IDS,
   type CampaignPrizePoolSchedule,
 } from './CampaignPrizePool';
+import { hasPrizePoolContent } from '../../utils/prizePoolUtils';
 
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
@@ -301,6 +302,70 @@ describe('CampaignPrizePool', () => {
     expect(queryByTestId(CAMPAIGN_PRIZE_POOL_TEST_IDS.CONTAINER)).toBeNull();
     expect(queryByTestId(CAMPAIGN_PRIZE_POOL_TEST_IDS.PROGRESS_BAR)).toBeNull();
     expect(queryByTestId(CAMPAIGN_PRIZE_POOL_TEST_IDS.MAX_BADGE)).toBeNull();
+  });
+
+  describe('hasPrizePoolContent', () => {
+    it('reports content whenever data, a load, or an error is present', () => {
+      expect(
+        hasPrizePoolContent({
+          hasData: true,
+          isLoading: false,
+          hasError: false,
+        }),
+      ).toBe(true);
+      expect(
+        hasPrizePoolContent({
+          hasData: false,
+          isLoading: true,
+          hasError: false,
+        }),
+      ).toBe(true);
+      expect(
+        hasPrizePoolContent({
+          hasData: false,
+          isLoading: false,
+          hasError: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('reports no content only when there is nothing to show or await', () => {
+      expect(
+        hasPrizePoolContent({
+          hasData: false,
+          isLoading: false,
+          hasError: false,
+        }),
+      ).toBe(false);
+    });
+
+    it('agrees with what the component actually renders', () => {
+      // The predicate exists so parents can drop their section heading in step
+      // with the component; they must not be able to disagree.
+      const cases = [
+        { prizePool, isLoading: false, hasError: false },
+        { prizePool: null, isLoading: true, hasError: false },
+        { prizePool: null, isLoading: false, hasError: true },
+        { prizePool: null, isLoading: false, hasError: false },
+      ];
+
+      cases.forEach((props) => {
+        const { queryByTestId, unmount } = render(
+          <CampaignPrizePool {...props} refetch={mockRefetch} />,
+        );
+        const rendered =
+          queryByTestId(CAMPAIGN_PRIZE_POOL_TEST_IDS.CONTAINER) !== null;
+
+        expect(rendered).toBe(
+          hasPrizePoolContent({
+            hasData: props.prizePool != null,
+            isLoading: props.isLoading,
+            hasError: props.hasError,
+          }),
+        );
+        unmount();
+      });
+    });
   });
 
   it('prefers existing data over a loading state (stale-while-revalidate)', () => {

--- a/app/components/UI/Rewards/components/Campaigns/CampaignPrizePool.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignPrizePool.tsx
@@ -125,6 +125,13 @@ const CampaignPrizePool: React.FC<CampaignPrizePoolProps> = ({
     );
   }
 
+  // No data, and nothing in flight or failed to explain its absence. Rendering
+  // the ladder here would state a $0 prize pool as fact, which is a claim about
+  // the campaign rather than a missing value.
+  if (prizePool == null) {
+    return null;
+  }
+
   return (
     <Box
       twClassName="gap-2 mt-2"

--- a/app/components/UI/Rewards/components/Campaigns/CampaignPrizePool.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignPrizePool.tsx
@@ -14,7 +14,10 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../locales/i18n';
 import RewardsErrorBanner from '../RewardsErrorBanner';
 import { formatCompactUsd, formatUsd } from '../../utils/formatUtils';
-import { computePrizePoolProgress } from '../../utils/prizePoolUtils';
+import {
+  computePrizePoolProgress,
+  hasPrizePoolContent,
+} from '../../utils/prizePoolUtils';
 
 export const CAMPAIGN_PRIZE_POOL_TEST_IDS = {
   CONTAINER: 'campaign-prize-pool-container',
@@ -128,7 +131,9 @@ const CampaignPrizePool: React.FC<CampaignPrizePoolProps> = ({
   // No data, and nothing in flight or failed to explain its absence. Rendering
   // the ladder here would state a $0 prize pool as fact, which is a claim about
   // the campaign rather than a missing value.
-  if (prizePool == null) {
+  if (
+    !hasPrizePoolContent({ hasData: prizePool != null, isLoading, hasError })
+  ) {
     return null;
   }
 

--- a/app/components/UI/Rewards/components/Campaigns/CampaignPrizePoolSection.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignPrizePoolSection.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import CampaignPrizePoolSection, {
+  CAMPAIGN_PRIZE_POOL_SECTION_TEST_IDS,
+} from './CampaignPrizePoolSection';
+import {
+  CAMPAIGN_PRIZE_POOL_TEST_IDS,
+  type CampaignPrizePoolSchedule,
+} from './CampaignPrizePool';
+
+jest.mock('@metamask/design-system-twrnc-preset', () => {
+  const tw = (..._args: unknown[]) => ({});
+  tw.style = jest.fn(() => ({}));
+  return { useTailwind: () => tw };
+});
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: (key: string) =>
+    key === 'rewards.campaign_prize_pool.title' ? 'Prize pool' : key,
+  default: { locale: 'en-US' },
+}));
+
+jest.mock('./CampaignPrizePool', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    CAMPAIGN_PRIZE_POOL_TEST_IDS: {
+      CONTAINER: 'campaign-prize-pool-container',
+    },
+    default: () =>
+      ReactActual.createElement(View, {
+        testID: 'campaign-prize-pool-container',
+      }),
+  };
+});
+
+const prizePool: CampaignPrizePoolSchedule = {
+  totalVolumeUsd: 150,
+  unlockedPoolUsd: 20_000,
+  thresholdsUsd: [0, 100],
+  poolScheduleUsd: [10_000, 20_000],
+};
+
+const baseProps = {
+  prizePool: prizePool as CampaignPrizePoolSchedule | null,
+  isLoading: false,
+  hasError: false,
+  refetch: jest.fn(),
+};
+
+describe('CampaignPrizePoolSection', () => {
+  it('renders the heading and the ladder when data is present', () => {
+    const { getByTestId, getByText } = render(
+      <CampaignPrizePoolSection {...baseProps} />,
+    );
+
+    expect(
+      getByTestId(CAMPAIGN_PRIZE_POOL_SECTION_TEST_IDS.CONTAINER),
+    ).toBeDefined();
+    expect(getByText('Prize pool')).toBeDefined();
+    expect(getByTestId(CAMPAIGN_PRIZE_POOL_TEST_IDS.CONTAINER)).toBeDefined();
+  });
+
+  it('renders the heading while loading with no data yet', () => {
+    const { getByTestId } = render(
+      <CampaignPrizePoolSection {...baseProps} prizePool={null} isLoading />,
+    );
+
+    expect(
+      getByTestId(CAMPAIGN_PRIZE_POOL_SECTION_TEST_IDS.HEADING),
+    ).toBeDefined();
+  });
+
+  it('renders the heading on error with no data', () => {
+    const { getByTestId } = render(
+      <CampaignPrizePoolSection {...baseProps} prizePool={null} hasError />,
+    );
+
+    expect(
+      getByTestId(CAMPAIGN_PRIZE_POOL_SECTION_TEST_IDS.HEADING),
+    ).toBeDefined();
+  });
+
+  it('renders nothing at all with no data, no load and no error', () => {
+    // The heading has to go with the ladder — a lone "Prize pool" title above
+    // empty space reads worse than having no section.
+    const { queryByTestId, queryByText } = render(
+      <CampaignPrizePoolSection {...baseProps} prizePool={null} />,
+    );
+
+    expect(
+      queryByTestId(CAMPAIGN_PRIZE_POOL_SECTION_TEST_IDS.CONTAINER),
+    ).toBeNull();
+    expect(
+      queryByTestId(CAMPAIGN_PRIZE_POOL_SECTION_TEST_IDS.HEADING),
+    ).toBeNull();
+    expect(queryByText('Prize pool')).toBeNull();
+    expect(queryByTestId(CAMPAIGN_PRIZE_POOL_TEST_IDS.CONTAINER)).toBeNull();
+  });
+
+  it('keeps the section while a refresh over existing data fails', () => {
+    const { getByTestId } = render(
+      <CampaignPrizePoolSection {...baseProps} isLoading hasError />,
+    );
+
+    expect(getByTestId(CAMPAIGN_PRIZE_POOL_TEST_IDS.CONTAINER)).toBeDefined();
+  });
+});

--- a/app/components/UI/Rewards/components/Campaigns/CampaignPrizePoolSection.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignPrizePoolSection.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {
+  Box,
+  FontWeight,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { hasPrizePoolContent } from '../../utils/prizePoolUtils';
+import CampaignPrizePool, {
+  type CampaignPrizePoolSchedule,
+} from './CampaignPrizePool';
+
+export const CAMPAIGN_PRIZE_POOL_SECTION_TEST_IDS = {
+  CONTAINER: 'campaign-prize-pool-section',
+  HEADING: 'campaign-prize-pool-section-heading',
+} as const;
+
+interface CampaignPrizePoolSectionProps {
+  prizePool: CampaignPrizePoolSchedule | null;
+  isLoading: boolean;
+  hasError: boolean;
+  refetch: () => void;
+}
+
+/**
+ * A campaign's whole prize pool section: the divider and heading chrome, the
+ * ladder itself, and the decision about whether any of it appears.
+ *
+ * The heading has to share that decision. When there is no data and nothing in
+ * flight the ladder renders nothing, and a lone "Prize pool" title above empty
+ * space reads worse than no section at all — so a campaign cannot show one
+ * without the other.
+ */
+const CampaignPrizePoolSection: React.FC<CampaignPrizePoolSectionProps> = ({
+  prizePool,
+  isLoading,
+  hasError,
+  refetch,
+}) => {
+  if (
+    !hasPrizePoolContent({ hasData: prizePool != null, isLoading, hasError })
+  ) {
+    return null;
+  }
+
+  return (
+    <>
+      <Box twClassName="my-1 border-b border-border-muted" />
+      <Box
+        twClassName="p-4"
+        testID={CAMPAIGN_PRIZE_POOL_SECTION_TEST_IDS.CONTAINER}
+      >
+        <Text
+          variant={TextVariant.HeadingMd}
+          fontWeight={FontWeight.Bold}
+          twClassName="mb-1"
+          testID={CAMPAIGN_PRIZE_POOL_SECTION_TEST_IDS.HEADING}
+        >
+          {strings('rewards.campaign_prize_pool.title')}
+        </Text>
+        <CampaignPrizePool
+          prizePool={prizePool}
+          isLoading={isLoading}
+          hasError={hasError}
+          refetch={refetch}
+        />
+      </Box>
+    </>
+  );
+};
+
+export default CampaignPrizePoolSection;

--- a/app/components/UI/Rewards/components/Campaigns/OndoPrizePool.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPrizePool.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from 'react';
-import CampaignPrizePool, {
+import {
   CAMPAIGN_PRIZE_POOL_TEST_IDS,
   type CampaignPrizePoolSchedule,
 } from './CampaignPrizePool';
+import CampaignPrizePoolSection from './CampaignPrizePoolSection';
 
 export const ONDO_PRIZE_POOL_TEST_IDS = CAMPAIGN_PRIZE_POOL_TEST_IDS;
 
@@ -47,7 +48,7 @@ const OndoPrizePool: React.FC<OndoPrizePoolProps> = ({
   );
 
   return (
-    <CampaignPrizePool
+    <CampaignPrizePoolSection
       prizePool={prizePool}
       isLoading={isLoading}
       hasError={hasError}

--- a/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.test.tsx
@@ -151,6 +151,45 @@ describe('PerpsTradingCampaignLeaderboard', () => {
     expect(UNSAFE_queryAllByProps({ name: 'crown' })).toHaveLength(1);
   });
 
+  it('crowns only up to numberOfWinners from the API, not the local default', () => {
+    const entries = [
+      createPerpsEntry({ rank: 1, referralCode: 'AAA111' }),
+      createPerpsEntry({ rank: 2, referralCode: 'BBB222' }),
+      createPerpsEntry({ rank: 3, referralCode: 'CCC333' }),
+    ];
+    const { UNSAFE_queryAllByProps } = render(
+      <PerpsTradingCampaignLeaderboard
+        {...defaultProps}
+        entries={entries}
+        numberOfWinners={2}
+      />,
+    );
+
+    expect(UNSAFE_queryAllByProps({ name: 'crown' })).toHaveLength(2);
+  });
+
+  it('falls back to the local default when the API omits numberOfWinners', () => {
+    const entries = [
+      createPerpsEntry({
+        rank: PERPS_TRADING_MAX_WINNERS,
+        referralCode: 'WINNER',
+      }),
+      createPerpsEntry({
+        rank: PERPS_TRADING_MAX_WINNERS + 1,
+        referralCode: 'NEXT',
+      }),
+    ];
+    const { UNSAFE_queryAllByProps } = render(
+      <PerpsTradingCampaignLeaderboard
+        {...defaultProps}
+        entries={entries}
+        numberOfWinners={undefined}
+      />,
+    );
+
+    expect(UNSAFE_queryAllByProps({ name: 'crown' })).toHaveLength(1);
+  });
+
   it('hides crown in preview mode for perps winner ranks', () => {
     const entries = [
       createPerpsEntry({ rank: 1, referralCode: 'AAA111' }),

--- a/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.tsx
@@ -58,6 +58,11 @@ export interface PerpsTradingCampaignLeaderboardProps {
   userPosition?: UserPosition | null;
   campaignId?: string;
   isCampaignComplete?: boolean;
+  /**
+   * Number of prize-winning ranks for this campaign, from the leaderboard API.
+   * Falls back to PERPS_TRADING_MAX_WINNERS when the backend does not send it.
+   */
+  numberOfWinners?: number;
 }
 
 const PerpsTradingCampaignLeaderboard: React.FC<
@@ -72,6 +77,7 @@ const PerpsTradingCampaignLeaderboard: React.FC<
   maxEntries,
   userPosition,
   isCampaignComplete = false,
+  numberOfWinners = PERPS_TRADING_MAX_WINNERS,
 }) => {
   const navigation = useNavigation<AppNavigationProp>();
   const { colors } = useTheme();
@@ -167,7 +173,7 @@ const PerpsTradingCampaignLeaderboard: React.FC<
             key={`${entry.rank}-${entry.referralCode}`}
             entry={{ ...entry, qualified: true }}
             isCurrentUser={isCurrentUser(entry)}
-            showCrown={!isPreview && entry.rank <= PERPS_TRADING_MAX_WINNERS}
+            showCrown={!isPreview && entry.rank <= numberOfWinners}
             isCampaignComplete={isCampaignComplete}
             formatPrimaryMetric={(e) => formatSignedUsd(e.pnl)}
             isPositivePrimaryMetric={(e) => e.pnl >= 0}
@@ -181,9 +187,7 @@ const PerpsTradingCampaignLeaderboard: React.FC<
                 key={`neighbor-${entry.rank}-${entry.referralCode}`}
                 entry={{ ...entry, qualified: true }}
                 isCurrentUser={isCurrentUser(entry)}
-                showCrown={
-                  !isPreview && entry.rank <= PERPS_TRADING_MAX_WINNERS
-                }
+                showCrown={!isPreview && entry.rank <= numberOfWinners}
                 isCampaignComplete={isCampaignComplete}
                 formatPrimaryMetric={(e) => formatSignedUsd(e.pnl)}
                 isPositivePrimaryMetric={(e) => e.pnl >= 0}

--- a/app/components/UI/Rewards/hooks/useRewardCampaigns.test.ts
+++ b/app/components/UI/Rewards/hooks/useRewardCampaigns.test.ts
@@ -7,6 +7,7 @@ import {
   setCampaigns,
   setCampaignsLoading,
   setCampaignsError,
+  setCampaignsFetching,
 } from '../../../../reducers/rewards';
 import {
   selectCampaigns,
@@ -37,6 +38,7 @@ jest.mock('../../../../reducers/rewards', () => ({
   setCampaigns: jest.fn(),
   setCampaignsLoading: jest.fn(),
   setCampaignsError: jest.fn(),
+  setCampaignsFetching: jest.fn(),
 }));
 
 jest.mock('../../../../reducers/rewards/selectors', () => ({
@@ -114,6 +116,9 @@ describe('useRewardCampaigns', () => {
   const mockSetCampaignsError = setCampaignsError as jest.MockedFunction<
     typeof setCampaignsError
   >;
+  const mockSetCampaignsFetching = setCampaignsFetching as jest.MockedFunction<
+    typeof setCampaignsFetching
+  >;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -128,6 +133,10 @@ describe('useRewardCampaigns', () => {
     });
     mockSetCampaignsError.mockReturnValue({
       type: 'rewards/setCampaignsError',
+      payload: false,
+    });
+    mockSetCampaignsFetching.mockReturnValue({
+      type: 'rewards/setCampaignsFetching',
       payload: false,
     });
     mockUseFocusEffect.mockClear();
@@ -289,6 +298,35 @@ describe('useRewardCampaigns', () => {
       expect(mockSetCampaignsLoading).not.toHaveBeenCalledWith(true);
     });
 
+    it('dispatches setCampaignsFetching(true) even when campaigns were already loaded', async () => {
+      // setCampaignsLoading(true) is suppressed once campaigns exist, so the
+      // fetching flag is the only signal that a refresh is in flight.
+      setupSelectorMocks({ hasLoaded: true });
+      mockEngineCall.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useRewardCampaigns());
+
+      await act(async () => {
+        await result.current.fetchCampaigns();
+      });
+
+      expect(mockSetCampaignsFetching).toHaveBeenCalledWith(true);
+      expect(mockSetCampaignsFetching).toHaveBeenCalledWith(false);
+    });
+
+    it('clears setCampaignsFetching when the fetch fails', async () => {
+      setupSelectorMocks({ hasLoaded: true });
+      mockEngineCall.mockRejectedValueOnce(new Error('network'));
+
+      const { result } = renderHook(() => useRewardCampaigns());
+
+      await act(async () => {
+        await result.current.fetchCampaigns();
+      });
+
+      expect(mockSetCampaignsFetching).toHaveBeenLastCalledWith(false);
+    });
+
     it('does not fetch when subscriptionId is null', async () => {
       setupSelectorMocks({ subscriptionId: null });
 
@@ -302,6 +340,7 @@ describe('useRewardCampaigns', () => {
       expect(mockDispatch).toHaveBeenCalledWith(mockSetCampaigns([]));
       expect(mockDispatch).toHaveBeenCalledWith(mockSetCampaignsLoading(false));
       expect(mockDispatch).toHaveBeenCalledWith(mockSetCampaignsError(false));
+      expect(mockSetCampaignsFetching).toHaveBeenCalledWith(false);
     });
   });
 

--- a/app/components/UI/Rewards/hooks/useRewardCampaigns.ts
+++ b/app/components/UI/Rewards/hooks/useRewardCampaigns.ts
@@ -6,6 +6,7 @@ import {
   setCampaigns,
   setCampaignsLoading,
   setCampaignsError,
+  setCampaignsFetching,
 } from '../../../../reducers/rewards';
 import {
   selectCampaigns,
@@ -66,6 +67,7 @@ export const useRewardCampaigns = (): UseRewardCampaignsReturn => {
       dispatch(setCampaigns([]));
       dispatch(setCampaignsLoading(false));
       dispatch(setCampaignsError(false));
+      dispatch(setCampaignsFetching(false));
       return;
     }
 
@@ -75,6 +77,7 @@ export const useRewardCampaigns = (): UseRewardCampaignsReturn => {
 
     try {
       isLoadingRef.current = true;
+      dispatch(setCampaignsFetching(true));
       if (!hasLoadedRef.current) {
         dispatch(setCampaignsLoading(true));
       }
@@ -89,6 +92,7 @@ export const useRewardCampaigns = (): UseRewardCampaignsReturn => {
     } finally {
       isLoadingRef.current = false;
       dispatch(setCampaignsLoading(false));
+      dispatch(setCampaignsFetching(false));
     }
   }, [dispatch, subscriptionId]);
 

--- a/app/components/UI/Rewards/utils/prizePoolUtils.ts
+++ b/app/components/UI/Rewards/utils/prizePoolUtils.ts
@@ -47,3 +47,30 @@ export function computePrizePoolProgress<T extends { prize: number }>(
     isMaxTier: false,
   };
 }
+
+/**
+ * Whether a prize pool section has anything to say — data to show, a load in
+ * progress, or an error to report.
+ *
+ * Parent views use this to drop their section heading in step with the prize
+ * pool itself: a lone "Prize pool" title above an empty space is worse than no
+ * section at all. It lives here rather than on the component so a view can ask
+ * without importing (and having to mock) the component itself.
+ *
+ * @param params - Whether data is present, plus the loading and error flags.
+ * @param params.hasData - Whether prize pool data has been resolved.
+ * @param params.isLoading - Whether a fetch is in flight.
+ * @param params.hasError - Whether the last fetch failed.
+ * @returns Whether the prize pool section will render anything.
+ */
+export function hasPrizePoolContent({
+  hasData,
+  isLoading,
+  hasError,
+}: {
+  hasData: boolean;
+  isLoading: boolean;
+  hasError: boolean;
+}): boolean {
+  return hasData || isLoading || hasError;
+}

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -38,6 +38,7 @@ import rewardsReducer, {
   setCampaigns,
   setCampaignsLoading,
   setCampaignsError,
+  setCampaignsFetching,
   setCampaignParticipantStatus,
   setPendingMasSeriesOptIn,
   clearPendingMasSeriesOptIn,
@@ -2141,6 +2142,7 @@ describe('rewardsReducer', () => {
         campaignsLoading: false,
         campaignsError: false,
         campaignsHasLoaded: false,
+        campaignsFetching: false,
         campaignParticipantStatuses: {},
         ondoCampaignLeaderboards: {},
         ondoCampaignLeaderboardPositions: {},
@@ -2293,6 +2295,7 @@ describe('rewardsReducer', () => {
         campaignsLoading: false,
         campaignsError: false,
         campaignsHasLoaded: false,
+        campaignsFetching: false,
         campaignParticipantStatuses: {},
         ondoCampaignLeaderboards: {},
         ondoCampaignLeaderboardPositions: {},
@@ -5362,6 +5365,44 @@ describe('setCampaignsError', () => {
     currentState = rewardsReducer(currentState, action);
     expect(currentState.campaignsError).toBe(true);
     expect(currentState.campaignsHasLoaded).toBe(true);
+  });
+});
+
+describe('setCampaignsFetching', () => {
+  it('should set campaignsFetching to true even when campaigns already exist', () => {
+    const stateWithCampaigns: RewardsState = {
+      ...initialState,
+      campaigns: [mockCampaign],
+      campaignsHasLoaded: true,
+    };
+
+    const state = rewardsReducer(
+      stateWithCampaigns,
+      setCampaignsFetching(true),
+    );
+
+    expect(state.campaignsFetching).toBe(true);
+  });
+
+  it('should set campaignsFetching to false', () => {
+    const stateWithFetching: RewardsState = {
+      ...initialState,
+      campaignsFetching: true,
+    };
+
+    const state = rewardsReducer(
+      stateWithFetching,
+      setCampaignsFetching(false),
+    );
+
+    expect(state.campaignsFetching).toBe(false);
+  });
+
+  it('should not affect campaignsLoading or campaignsHasLoaded', () => {
+    const state = rewardsReducer(initialState, setCampaignsFetching(true));
+
+    expect(state.campaignsLoading).toBe(false);
+    expect(state.campaignsHasLoaded).toBe(false);
   });
 });
 

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -211,6 +211,14 @@ export interface RewardsState {
   campaignsLoading: boolean;
   campaignsError: boolean;
   campaignsHasLoaded: boolean;
+  /**
+   * True while a campaigns fetch is in flight, including a refresh over an
+   * already-populated list. Distinct from `campaignsLoading`, which is
+   * suppressed once campaigns exist so the list UI does not flash a skeleton on
+   * every refocus. Callers that must not act on a stale list — deeplink
+   * resolution in particular — need this signal instead.
+   */
+  campaignsFetching: boolean;
 
   // Campaign participant status (keyed by `${subscriptionId}:${campaignId}`)
   campaignParticipantStatuses: Record<string, CampaignParticipantStatusDto>;
@@ -414,6 +422,7 @@ export const initialState: RewardsState = {
   campaignsLoading: false,
   campaignsError: false,
   campaignsHasLoaded: false,
+  campaignsFetching: false,
 
   // Campaign participant statuses initial state
   campaignParticipantStatuses: {},
@@ -758,6 +767,9 @@ const rewardsSlice = createSlice({
       if (action.payload) {
         state.campaignsHasLoaded = true;
       }
+    },
+    setCampaignsFetching: (state, action: PayloadAction<boolean>) => {
+      state.campaignsFetching = action.payload;
     },
 
     setCampaignParticipantStatus: (
@@ -1721,6 +1733,7 @@ export const {
   setCampaigns,
   setCampaignsLoading,
   setCampaignsError,
+  setCampaignsFetching,
   setCampaignParticipantStatus,
   setPendingMasSeriesOptIn,
   clearPendingMasSeriesOptIn,

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -4,6 +4,7 @@ import {
   selectActiveTab,
   selectReferralCode,
   selectBalanceTotal,
+  selectCampaignsFetching,
   selectReferralCount,
   selectReferredByCode,
   selectIsVipReferee,
@@ -1436,6 +1437,25 @@ describe('Rewards selectors', () => {
       it('returns correct active tab directly', () => {
         const state = createMockRootState({ activeTab: 'activity' });
         expect(selectActiveTab(state)).toBe('activity');
+      });
+    });
+
+    describe('selectCampaignsFetching direct calls', () => {
+      it('returns true while a campaigns fetch is in flight', () => {
+        const state = createMockRootState({ campaignsFetching: true });
+        expect(selectCampaignsFetching(state)).toBe(true);
+      });
+
+      it('returns false when no fetch is in flight', () => {
+        const state = createMockRootState({ campaignsFetching: false });
+        expect(selectCampaignsFetching(state)).toBe(false);
+      });
+
+      it('defaults to false when the flag is absent from persisted state', () => {
+        const state = createMockRootState({});
+        // @ts-expect-error deliberately simulating pre-upgrade state
+        delete state.rewards.campaignsFetching;
+        expect(selectCampaignsFetching(state)).toBe(false);
       });
     });
 

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -250,6 +250,9 @@ export const selectCampaignsError = (state: RootState) =>
 export const selectCampaignsHasLoaded = (state: RootState) =>
   state.rewards.campaignsHasLoaded;
 
+export const selectCampaignsFetching = (state: RootState) =>
+  state.rewards.campaignsFetching ?? false;
+
 // Campaign participant status selectors
 export const selectCampaignParticipantStatuses = (state: RootState) =>
   state.rewards.campaignParticipantStatuses;

--- a/tests/framework/fixtures/json/default-fixture.json
+++ b/tests/framework/fixtures/json/default-fixture.json
@@ -898,6 +898,7 @@
       "campaignParticipantStatuses": {},
       "campaigns": [],
       "campaignsError": false,
+      "campaignsFetching": false,
       "campaignsHasLoaded": false,
       "campaignsLoading": false,
       "candidateSubscriptionId": "pending",


### PR DESCRIPTION
## **Description**

Three follow-up fixes for issues found while reviewing #35759 (now merged). All three are in code that PR introduced and that has not shipped yet, so none of this changes released behaviour.

**1. The `perps-comp` deeplink could be dropped and never retried.** The deeplink carries no campaign id, so it resolves against the campaign list — and a `null` result still counted as handled, which cleared the pending deeplink for good. Two cases produced a `null` result from a list that was not yet trustworthy:

- **No subscription yet.** `fetchCampaigns` short-circuits to `setCampaigns([])` when there is no subscription id, and `setCampaigns` marks campaigns loaded. So "no campaigns" really meant "not signed in", and a deeplink opened during that window was thrown away before the real list arrived.
- **A refresh over an existing list.** `setCampaignsLoading(true)` is deliberately suppressed once campaigns exist, so nothing signalled that a fetch was in flight. A second deeplink in the same session resolved against the previous fetch's array and could miss a campaign added since.

Adds a `campaignsFetching` flag that tracks every fetch including refreshes, and gates the deeplink branch on it plus the subscription id. `campaignsLoading` is untouched, so the campaigns list UI still does not flash a skeleton on refocus.

**2. Banner dismissal was leaking across campaigns, and the storage read could race itself.** The session-dismissal ref was a bare boolean that short-circuited the storage read for the rest of the component's life. That was meant to cover the unresolved-key → real-id transition, but it also covered real-id → *different* real-id, so dismissing campaign 1 suppressed campaign 2's banner for the session. The ref now records the key the dismissal was made against: a dismissal under the unresolved key still carries forward once the id resolves, while a dismissal under a real campaign id applies only to that campaign.

Separately, the dismissal effect re-runs when the storage key changes, leaving two reads racing with no ordering guarantee. A late read under the old key could overwrite the newer key's result and hide a banner the user never dismissed. Added a cancellation guard.

**3. Winner count and prize-pool empty state.** The leaderboard hardcoded `PERPS_TRADING_MAX_WINNERS` for crown highlighting while the ended-stats tile directly above it reads `numberOfWinners` from the API — so a campaign configured with a different winner count showed two contradictory answers on one screen. The leaderboard now takes `numberOfWinners` from the same DTO, keeping the local constant as the fallback.

The shared prize pool rendered a single `$0.00` tier with a "Max" badge when it had no data and nothing was in flight — asserting that the prize pool *is* zero and fully unlocked, rather than that the value is unknown. This matters most for the perps campaign, whose ladder used to come from a hardcoded constant, so moving it onto the API left this as its only fallback. State precedence is now explicit: existing data always wins (including while a background refresh is loading or has failed), otherwise loading shows the skeleton, an error shows the retry banner, and no data at all renders nothing.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A

## **Manual testing steps**

1. **Deeplink before sign-in** — sign out / clear the rewards subscription, then open the `?campaign=perps-comp` deeplink. The app should wait rather than silently landing on the dashboard, and should open the active perps campaign once the subscription and campaign list resolve.
2. **Deeplink twice in one session** — open the Rewards tab (populating the campaign list), navigate away, then fire the `perps-comp` deeplink. It should still resolve to the active campaign rather than against the earlier list.
3. **Deeplink with no active campaign** — with only a completed perps campaign present, the same deeplink lands on the Rewards dashboard and stays there.
4. **Banner is per campaign** — dismiss the competition banner on Perps home, then point the app at an environment whose active perps campaign has a different id. The banner should appear again for the new campaign.
5. **Banner dismissal before campaigns load** — dismiss the banner immediately on Perps home before opening the Rewards tab, then open Rewards. The banner should stay dismissed rather than reappearing when the campaign id resolves.
6. **Crown count** — against a backend serving a campaign with `numberOfWinners` below 20, open the full leaderboard: crowns stop at that rank, matching the "Total winners" tile.
7. **Prize pool with no data** — against an environment where the prize-pool endpoint returns nothing and no request is in flight, the prize pool section renders nothing rather than a `$0.00` ladder. With a request in flight it shows the skeleton; on error it shows the retry banner; with data already loaded it keeps showing it through a failed refresh.

## **Screenshots/Recordings**

### **Before**

N/A — the only rendered difference is the prize pool section no longer showing a `$0.00 / Max` ladder when it has no data, and crowns stopping at the configured winner count. The remaining changes are to deeplink resolution and an AsyncStorage key, which produce no visual difference.

### **After**

N/A — as above.

### Note: shared prize pool section

The three campaign detail views each carried their own copy of the prize pool section — divider, padded box, heading, ladder. Editing inside those regions pulled long-standing duplicate blocks into SonarCloud's new-code window and failed the duplication gate, so this PR extracts the section into a shared `CampaignPrizePoolSection` rather than leaving the duplication in place.

The component owns the chrome, the ladder, and the decision about whether the section appears at all. That last part is why the heading moved in with it: the ladder renders nothing when there is no data and nothing in flight, and a heading stranded above empty space reads worse than no section, so neither can appear without the other now.

One intentional visual change: Ondo's prize pool heading was not bold while the other two campaigns' were. Sharing the component settles that in favour of bold, matching perps and Predict the Pitch.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deeplink gating and AsyncStorage dismissal keys for the perps banner; incorrect timing could mis-route deeplinks or show banners users dismissed, but scope is rewards UI rather than auth or funds.
> 
> **Overview**
> Fixes three follow-ups around perps rewards: deeplink handling, competition banner dismissals, and prize-pool / leaderboard presentation.
> 
> **`perps-comp` deeplink** no longer clears when the campaign list is not trustworthy. Redux gains **`campaignsFetching`** (set on every fetch, including refresh while a list is already cached). Resolution waits for a subscription, an observed fetch this mount, no in-flight fetch, and the existing loaded/error rules so empty or stale lists do not consume the pending deeplink.
> 
> **Perps competition banner** tracks dismissals by **storage key** instead of a session boolean: pre-resolve dismissals still apply to the first resolved campaign only; dismissing one campaign does not hide another. Async **`getItem`** races when the key changes are ignored via an effect **cancellation** guard.
> 
> **Prize pool** uses **`hasPrizePoolContent`** so the ladder (and shared **`CampaignPrizePoolSection`** heading/chrome) render only when there is data, loading, or error—not a misleading **$0 / Max** empty state. **Perps leaderboard** crowns use API **`numberOfWinners`** with the previous constant as fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47a8dc515fad7713af9b136b5204d700a7b24d0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


