### PR TITLE
test: sync FF defaults for perps

### DIFF
--- a/tests/feature-flags/feature-flag-registry.test.ts
+++ b/tests/feature-flags/feature-flag-registry.test.ts
@@ -12,10 +12,10 @@ import {
 
 describe('Feature Flag Registry', () => {
   describe('FEATURE_FLAG_REGISTRY', () => {
-    it('registers Chase as version-gated and default-off', () => {
+    it('registers Chase as in-prod, version-gated and default-off', () => {
       expect(FEATURE_FLAG_REGISTRY.perpsMobileChase).toMatchObject({
         name: 'perpsMobileChase',
-        inProd: false,
+        inProd: true,
         productionDefault: {
           enabled: false,
           minimumVersion: '8.10.0',
@@ -58,7 +58,7 @@ describe('Feature Flag Registry', () => {
       expect(FEATURE_FLAG_REGISTRY.perpsMobileScale).toMatchObject({
         name: 'perpsMobileScale',
         type: FeatureFlagType.Remote,
-        inProd: false,
+        inProd: true,
         productionDefault: {
           enabled: false,
           minimumVersion: '8.10.0',
@@ -67,13 +67,13 @@ describe('Feature Flag Registry', () => {
       });
     });
 
-    it('registers the Pro position-modify margin preview as version-gated and default-off', () => {
+    it('registers the Pro position-modify margin preview as in-prod, version-gated and default-off', () => {
       expect(
         FEATURE_FLAG_REGISTRY.perpsPositionModifyPreviewEnabled,
       ).toMatchObject({
         name: 'perpsPositionModifyPreviewEnabled',
         type: FeatureFlagType.Remote,
-        inProd: false,
+        inProd: true,
         productionDefault: {
           enabled: false,
           minimumVersion: '8.11.0',

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -109,8 +109,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
+      enabled: true,
       minimumVersion: '8.1.0',
-      enabled: false,
     },
     status: FeatureFlagStatus.Active,
   },
@@ -5774,22 +5774,9 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'homeTMCU725AbtestHomepagePerpsPillsEmptyState',
     type: FeatureFlagType.Remote,
     inProd: true,
-    productionDefault: [
-      {
-        scope: {
-          value: 1,
-          type: 'percentage_rollout',
-        },
-        name: 'control',
-      },
-      {
-        name: 'treatment',
-        scope: {
-          type: 'percentage_rollout',
-          value: 0,
-        },
-      },
-    ],
+    productionDefault: {
+      enabled: false,
+    },
     status: FeatureFlagStatus.Active,
   },
 

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -170,6 +170,44 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  perpsAbtestButtonColor: {
+    name: 'perpsAbtestButtonColor',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: 'monochrome',
+    status: FeatureFlagStatus.Active,
+  },
+
+  perpsLighterProviderEnabled: {
+    name: 'perpsLighterProviderEnabled',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '8.10.0',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  perpsMarketAboutEnabled: {
+    name: 'perpsMarketAboutEnabled',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '7.0.0',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  perpsTAT3597AbtestPerpsSectionPriority: {
+    name: 'perpsTAT3597AbtestPerpsSectionPriority',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [],
+    status: FeatureFlagStatus.Active,
+  },
+
   socialAiTSA531AbtestWhatsHappeningExplore: {
     name: 'socialAiTSA531AbtestWhatsHappeningExplore',
     type: FeatureFlagType.Remote,
@@ -4124,7 +4162,30 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'perpsTAT1937AbtestButtonColor',
     type: FeatureFlagType.Remote,
     inProd: true,
-    productionDefault: 'control',
+    productionDefault: {
+      versions: {
+        '8.3.0': [
+          {
+            scope: {
+              type: 'threshold',
+              value: 1,
+            },
+            thresholdName: 'control (white) — 50%',
+            thresholdVersion: 2,
+            value: 'control',
+          },
+          {
+            scope: {
+              type: 'threshold',
+              value: 0,
+            },
+            thresholdName: 'colors (green/red) — 50%',
+            thresholdVersion: 2,
+            value: 'colors',
+          },
+        ],
+      },
+    },
     status: FeatureFlagStatus.Active,
   },
 
@@ -4164,10 +4225,10 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   perpsProModeEnabled: {
     name: 'perpsProModeEnabled',
     type: FeatureFlagType.Remote,
-    inProd: false,
+    inProd: true,
     productionDefault: {
-      enabled: false,
-      minimumVersion: '7.0.0',
+      enabled: true,
+      minimumVersion: '8.8.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -4175,10 +4236,10 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   perpsProTriggeredOrdersEnabled: {
     name: 'perpsProTriggeredOrdersEnabled',
     type: FeatureFlagType.Remote,
-    inProd: false,
+    inProd: true,
     productionDefault: {
       enabled: false,
-      minimumVersion: '8.8.0',
+      minimumVersion: '8.3.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -4186,7 +4247,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   perpsMobileScale: {
     name: 'perpsMobileScale',
     type: FeatureFlagType.Remote,
-    inProd: false,
+    inProd: true,
     productionDefault: {
       enabled: false,
       minimumVersion: '8.10.0',
@@ -4197,7 +4258,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   perpsPositionModifyPreviewEnabled: {
     name: 'perpsPositionModifyPreviewEnabled',
     type: FeatureFlagType.Remote,
-    inProd: false,
+    inProd: true,
     productionDefault: {
       enabled: false,
       minimumVersion: '8.11.0',
@@ -4208,7 +4269,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   perpsMobileTwap: {
     name: 'perpsMobileTwap',
     type: FeatureFlagType.Remote,
-    inProd: false,
+    inProd: true,
     productionDefault: {
       enabled: false,
       minimumVersion: '8.10.0',
@@ -4219,7 +4280,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   perpsMobileChase: {
     name: 'perpsMobileChase',
     type: FeatureFlagType.Remote,
-    inProd: false,
+    inProd: true,
     productionDefault: {
       enabled: false,
       minimumVersion: '8.10.0',
@@ -4279,10 +4340,10 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   perpsShowFullAssetNames: {
     name: 'perpsShowFullAssetNames',
     type: FeatureFlagType.Remote,
-    inProd: false,
+    inProd: true,
     productionDefault: {
-      enabled: false,
-      minimumVersion: '8.2.0',
+      enabled: true,
+      minimumVersion: '8.3.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -6578,8 +6639,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      minimumVersion: '7.0.0',
-      enabled: false,
+      enabled: true,
+      minimumVersion: '8.3.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -6633,8 +6694,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      enabled: false,
-      minimumVersion: '7.0.0',
+      enabled: true,
+      minimumVersion: '8.3.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -6642,10 +6703,10 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   perpsRecentlyAddedEnabled: {
     name: 'perpsRecentlyAddedEnabled',
     type: FeatureFlagType.Remote,
-    inProd: false,
+    inProd: true,
     productionDefault: {
-      enabled: false,
-      minimumVersion: '8.3.0',
+      enabled: true,
+      minimumVersion: '8.5.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -6653,10 +6714,10 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   perpsRecentlyViewedEnabled: {
     name: 'perpsRecentlyViewedEnabled',
     type: FeatureFlagType.Remote,
-    inProd: false,
+    inProd: true,
     productionDefault: {
-      enabled: false,
-      minimumVersion: '8.4.0',
+      enabled: true,
+      minimumVersion: '8.10.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -6664,9 +6725,9 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   perpsClosePositionLimitOrderEnabled: {
     name: 'perpsClosePositionLimitOrderEnabled',
     type: FeatureFlagType.Remote,
-    inProd: false,
+    inProd: true,
     productionDefault: {
-      enabled: false,
+      enabled: true,
       minimumVersion: '8.3.0',
     },
     status: FeatureFlagStatus.Active,


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Third focused slice of the feature-flag registry sync from [#35861](https://github.com/MetaMask/metamask-mobile/pull/35861).

Updates perps-related defaults in `tests/feature-flags/feature-flag-registry.ts` to match the 2026-09-08 prod sync.

**Changed (15):** `perpsAdvancedChartEnabledV2`, `perpsClosePositionLimitOrderEnabled`, `perpsMobileChase`, `perpsMobileScale`, `perpsMobileTwap`, `perpsPositionModifyPreviewEnabled`, `perpsProModeEnabled`, `perpsProTriggeredOrdersEnabled`, `perpsRecentlyAddedEnabled`, `perpsRecentlyViewedEnabled`, `perpsShowFullAssetNames`, `perpsTAT1937AbtestButtonColor`, `perpsTerminalBackendEnabled`, `aiSocialLeaderboardPerpsEnabled`, `homeTMCU725AbtestHomepagePerpsPillsEmptyState`

**Added (4):** `perpsAbtestButtonColor`, `perpsLighterProviderEnabled`, `perpsMarketAboutEnabled`, `perpsTAT3597AbtestPerpsSectionPriority`

Follows PR-2 ([#35966](https://github.com/MetaMask/metamask-mobile/pull/35966)).

**Required CO:** `@MetaMask/perps` (+ `@MetaMask/qa` for registry). Also includes `aiSocialLeaderboardPerpsEnabled` and `homeTMCU725AbtestHomepagePerpsPillsEmptyState` so the full perps-related catalog delta lands with this slice.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/metamask-mobile/pull/35861

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

1. Confirm CI Appium `perps` smoke (iOS + Android) passes with the updated registry defaults.
2. N/A for manual device testing beyond CI smoke for this registry-only change.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — E2E registry defaults only; no UI code changes in this PR.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only changes that affect E2E mock flag responses; mis-synced values could skew Appium perps smoke tests but do not change shipped app logic.
> 
> **Overview**
> Syncs the E2E **feature flag registry** (`tests/feature-flags/feature-flag-registry.ts`) with the 2026-09-08 production client-config snapshot for perps-related remote flags. No application runtime code changes—only registry metadata and unit test expectations.
> 
> **Adds four** in-prod remote flags: `perpsAbtestButtonColor`, `perpsLighterProviderEnabled`, `perpsMarketAboutEnabled`, and `perpsTAT3597AbtestPerpsSectionPriority`.
> 
> **Updates ~15 existing entries**, mainly flipping `inProd` to `true` and aligning `productionDefault` / `minimumVersion` with prod (e.g. `perpsProModeEnabled` on at 8.8.0, recently added/viewed, advanced chart v2, terminal backend, close-position limit orders, full asset names). Several mobile order types (Chase, Scale, TWAP, position-modify preview) stay **default-off** but are marked in-prod. `perpsTAT1937AbtestButtonColor` moves from a scalar to a **versioned threshold rollout**; `homeTMCU725AbtestHomepagePerpsPillsEmptyState` collapses from percentage rollout to `{ enabled: false }`. Also enables `aiSocialLeaderboardPerpsEnabled` by default.
> 
> Registry tests now assert **`inProd: true`** for Chase, Scale, and position-modify preview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6aa17575c1d216db17b908e146251de6456a5dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->