### PR TITLE
fix(content): correct gas sponsorship reserve balance grammar

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -149,7 +149,7 @@
       "message": "The recipient address may not support direct token transfers, which could result in fund loss. Only continue if you're certain this contract can receive your transfer."
     },
     "gas_sponsorship_reserve_balance": {
-      "message": "This specific network requires to maintain a reserve of {{minBalance}} {{nativeTokenSymbol}} in your account.",
+      "message": "This specific network requires you to maintain a reserve of {{minBalance}} {{nativeTokenSymbol}} in your account.",
       "title": "Reserve balance is required"
     },
     "token_trust_signal": {


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

The Monad gas-sponsorship warning used the ungrammatical phrase “requires to maintain.” This changes it to “requires you to maintain” while preserving both interpolation placeholders exactly. The alert is live in transaction confirmations; the wording change does not alter alert behavior or typesetting structure.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed grammar in the gas sponsorship reserve balance warning

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: gas sponsorship reserve warning

  Scenario: a sponsored transaction requires a reserve balance
    Given gas sponsorship fails because the Monad reserve is too low
    When the estimated fee alert is shown
    Then the message says the network requires you to maintain the displayed reserve
```

Automated verification: `yarn jest app/components/Views/confirmations/hooks/alerts/useGasSponsorshipWarningAlert.test.ts --runInBand --coverage=false`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — copy-only correction with no component, styling, or layout changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR.
- [ ] I confirm that this PR addresses the described content issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single English locale string change with no logic, layout, or interpolation changes.
> 
> **Overview**
> Fixes English copy for the **gas sponsorship reserve balance** confirmation alert: the message now reads “requires **you to** maintain” instead of the ungrammatical “requires to maintain.” `{{minBalance}}` and `{{nativeTokenSymbol}}` are unchanged; only `locales/languages/en.json` is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c65d2d81aea9bd020c42e0bf0b4381549b51b2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->