### PR TITLE
fix(content): remove extra “to” from inaccurate fee alert

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.test.ts
@@ -97,7 +97,7 @@ describe('useGasEstimateFailedAlert', () => {
     );
 
     expect(result.current[0].message).toBe(
-      "We're unable to provide an accurate fee and this estimate might be high. We suggest you to input a custom gas limit, but there's a risk the transaction will still fail.",
+      "We're unable to provide an accurate fee and this estimate might be high. We suggest you input a custom gas limit, but there's a risk the transaction will still fail.",
     );
   });
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -64,7 +64,7 @@
     },
     "gas_estimate_failed": {
       "title": "Inaccurate fee",
-      "message": "We're unable to provide an accurate fee and this estimate might be high. We suggest you to input a custom gas limit, but there's a risk the transaction will still fail."
+      "message": "We're unable to provide an accurate fee and this estimate might be high. We suggest you input a custom gas limit, but there's a risk the transaction will still fail."
     },
     "insufficient_balance": {
       "title": "Insufficient funds",


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

The live inaccurate-fee warning said “We suggest you to input,” which is ungrammatical. This removes the extra “to” and updates the exact-string unit assertion. No interpolation, styling, or component behavior changes.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed grammar in the inaccurate network fee warning

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: inaccurate fee warning

  Scenario: fee estimation fails
    Given transaction simulation cannot estimate the fee
    When the estimated fee alert is shown
    Then the message says “We suggest you input a custom gas limit”
```

Automated verification: `yarn jest app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.test.ts --runInBand --coverage=false`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — copy-only correction with no component, styling, or layout changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR.
- [ ] I confirm that this PR addresses the described content issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to English locale text and a matching test string; no runtime or security impact.
> 
> **Overview**
> Fixes grammar in the **inaccurate fee** warning shown when gas estimation fails: the copy now reads “We suggest **you input**” instead of “We suggest **you to input**.”
> 
> The change is in `locales/languages/en.json` under `alert_system.gas_estimate_failed.message`, which `useGasEstimateFailedAlert` already loads via `strings()`. The unit test expectation in `useGasEstimateFailedAlert.test.ts` is updated to match. No alert logic, UI, or interpolation changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6098cd9f8299fbb5edaf0fd9c75dcc7f94b7d053. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->