### PR TITLE
fix(content): add missing article in Arc usage notice

### DIFF
--- a/app/components/Views/Wallet/hooks/useArcUsageNoticeToast.test.ts
+++ b/app/components/Views/Wallet/hooks/useArcUsageNoticeToast.test.ts
@@ -86,7 +86,7 @@ describe('useArcUsageNoticeToast', () => {
     const options = showToast.mock.calls[0][0];
     expect(options.labelOptions[0].label).toBe('Notice');
     expect(options.descriptionOptions.description).toBe(
-      'Welcome to Arc! To facilitate and verify your usage of Arc chain, we may share information with Arc team.',
+      'Welcome to Arc! To facilitate and verify your usage of Arc chain, we may share information with the Arc team.',
     );
   });
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -28,7 +28,7 @@
   },
   "arc_usage_notice": {
     "title": "Notice",
-    "description": "Welcome to Arc! To facilitate and verify your usage of Arc chain, we may share information with Arc team."
+    "description": "Welcome to Arc! To facilitate and verify your usage of Arc chain, we may share information with the Arc team."
   },
   "storage": {
     "device_full_alert": "Your device is low on storage. Free up space so MetaMask can save your wallet data."


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

The one-time Arc usage notice said MetaMask may share information “with Arc team.” This adds the missing definite article so it reads “with the Arc team” and updates the exact-string toast test. The toast structure and timing are unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed grammar in the Arc usage notice

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Arc usage notice

  Scenario: an eligible user opens the wallet on Arc
    Given the Arc usage notice has not been shown
    When the wallet screen receives focus
    Then the toast says information may be shared with the Arc team
```

Automated verification: `yarn jest app/components/Views/Wallet/hooks/useArcUsageNoticeToast.test.ts --runInBand --coverage=false`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — copy-only correction with no component, styling, or layout changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR.
- [ ] I confirm that this PR addresses the described content issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing copy and a single test expectation only; no logic or security impact.
> 
> **Overview**
> Corrects grammar in the one-time **Arc usage notice** toast: the English copy now says information may be shared “with **the** Arc team” instead of “with Arc team.”
> 
> Updates `locales/languages/en.json` (`arc_usage_notice.description`) and the expected string in `useArcUsageNoticeToast.test.ts`. Toast behavior, analytics, and display options are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b13b3e7351e464ed1c8ad5fc3a0e37c06e34a31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->