### PR TITLE
fix(content): replace “in order to” with “to” (batch 2 of 3)

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -952,7 +952,7 @@
     "additional_verification": {
       "title": "Additional verification",
       "paragraph_1": "For larger deposits, you’ll need a valid ID (like a driver’s license) and a real-time selfie.",
-      "paragraph_2": "In order to complete your verification, you’ll need to enable access to your camera.",
+      "paragraph_2": "To complete your verification, you’ll need to enable access to your camera.",
       "button": "Continue"
     },
     "basic_info": {
@@ -3764,7 +3764,7 @@
     "private_key_detected": "Private key detected",
     "do_you_want_to_import_this_account": "Do you want to import this account?",
     "error": "Error",
-    "logout_to_import_seed": "You need to log out first in order to import a Secret Recovery Phrase.",
+    "logout_to_import_seed": "You need to log out first to import a Secret Recovery Phrase.",
     "ready_to_explore": "Ready to start exploring blockchain applications?",
     "unable_to_load": "Unable to load balance",
     "unable_to_find_conversion_rate": "no conversion rate",
@@ -3973,7 +3973,7 @@
     "toast_action_button": "Close",
     "toast_read_more": "Read more",
     "pna25_title": "Privacy and product updates",
-    "pna25_description": "To better serve you, we’re updating our analytics so publicly available data like wallet addresses and related on-chain activity can be associated with actions you take in MetaMask. This helps us improve MetaMask's performance, security, and features in order to make a better, safer wallet.",
+    "pna25_description": "To better serve you, we’re updating our analytics so publicly available data like wallet addresses and related on-chain activity can be associated with actions you take in MetaMask. This helps us improve MetaMask's performance, security, and features to make a better, safer wallet.",
     "pna25_description_2": "We take privacy seriously. We do not use this information for advertising or sell your data to third parties. You can opt out anytime in Settings.",
     "pna25_description_3": "You can read more about what we collect, how we protect it, and why we're making this change in our latest",
     "pna25_blog_post_link": "blog post",
@@ -5315,7 +5315,7 @@
     "cancel": "Cancel",
     "error": "Error",
     "attempting_to_scan_with_wallet_locked": "Looks like you're trying to scan a QR code, you need to unlock your wallet to be able to use it.",
-    "attempting_sync_from_wallet_error": "Looks like you're trying to sync with the extension. In order to do so, you will need to erase your current wallet. \n\nOnce you've erased or reinstalled a fresh version of the app, select the option to \"Sync with MetaMask Extension\". Important! Before erasing your wallet, make sure you've backed up your Secret Recovery Phrase.",
+    "attempting_sync_from_wallet_error": "Looks like you're trying to sync with the extension. To do so, you will need to erase your current wallet. \n\nOnce you've erased or reinstalled a fresh version of the app, select the option to \"Sync with MetaMask Extension\". Important! Before erasing your wallet, make sure you've backed up your Secret Recovery Phrase.",
     "not_allowed_error_title": "Turn on camera access",
     "not_allowed_error_desc": "To scan a QR code, you'll need to give MetaMask camera access from your device's settings menu.",
     "unrecognized_address_qr_code_title": "Unrecognized QR code",


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Uses direct plain language in four live workflow strings by replacing “in order to” with “to.” The affected copy appears in additional deposit verification, wallet import, the privacy update sheet, and extension-sync guidance. Existing paragraph breaks, capitalization, and quoted labels are preserved.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Clarified instructions across deposit, import, privacy, and sync flows

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: workflow guidance copy

  Scenario: a user sees workflow instructions
    Given a deposit, import, privacy, or extension-sync instruction is displayed
    When the guidance is rendered
    Then it uses concise “to” wording without changing the instruction
```

Automated verification: `yarn jest app/components/UI/Ramp/Views/NativeFlow/AdditionalVerification.test.tsx app/components/Views/Pna25BottomSheet/Pna25BottomSheet.test.tsx app/components/Views/ImportPrivateKey/index.test.tsx --runInBand --coverage=false`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — copy-only correction with no component, styling, or layout changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR.
- [ ] I confirm that this PR addresses the described content issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> English string edits only; no logic, routing, or security behavior changes.
> 
> **Overview**
> **Copy-only plain-language pass** in English locale strings: replaces **“in order to”** with **“to”** (and tightens one privacy blurb from “in order to make” → “to make”) across four user-facing flows.
> 
> Affected keys: deposit **additional verification** camera guidance, **wallet import** logout message, **PNA25 privacy** sheet description, and **QR scanner** extension-sync error text. Meaning, line breaks, and quoted UI labels are unchanged; no component or layout updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e762b73e611e95a6bf75a50aa7801584cd3e51c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->