### PR TITLE
fix(content): replace “in order to” with “to” (batch 3 of 3)

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9746,12 +9746,12 @@
       },
       "verifying_veriff_kyc": {
         "title": "Awaiting approval",
-        "description": "Our partner needs to verify your identity in order to approve your application.",
+        "description": "Our partner needs to verify your identity to approve your application.",
         "helper_text": "This usually takes a few seconds. Please do not close the app."
       },
       "immersve_kyc_processing": {
         "title": "Awaiting approval",
-        "description": "Our partner needs to verify your identity in order to approve your application.",
+        "description": "Our partner needs to verify your identity to approve your application.",
         "helper_text": "This usually takes a few seconds. Please do not close the app.",
         "incomplete_title": "Finish verifying your identity",
         "incomplete_description": "You closed identity verification before it was complete. Continue to finish.",
@@ -9795,7 +9795,7 @@
       },
       "kyc_pending": {
         "title": "Awaiting approval",
-        "description": "Our partner needs to verify your identity in order to approve your application.",
+        "description": "Our partner needs to verify your identity to approve your application.",
         "footer_text": "Approvals usually take around 12 hours.\nWe'll notify you when a decision is made.",
         "got_it_button": "Got it"
       },


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Uses direct plain language in three live MetaMask Card KYC states by changing “needs to verify your identity in order to approve” to “needs to verify your identity to approve.” All three states share the same copy, so this keeps them consistent without changing behavior or layout structure.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Clarified identity verification copy in MetaMask Card onboarding

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: MetaMask Card identity verification

  Scenario: an application is awaiting identity verification
    Given the Card application is pending partner approval
    When the KYC status is displayed
    Then the description says verification is needed to approve the application
```

Automated verification: `yarn jest app/components/UI/Card/components/Onboarding/VerifyingVeriffKYC.test.tsx app/components/UI/Card/components/Onboarding/KYCPending.test.tsx --runInBand --coverage=false`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — copy-only correction with no component, styling, or layout changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR.
- [ ] I confirm that this PR addresses the described content issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing English copy only; no behavioral, security, or layout changes.
> 
> **Overview**
> **Copy-only** update to English strings for three MetaMask Card onboarding states that share the same awaiting-approval message: `verifying_veriff_kyc`, `immersve_kyc_processing`, and `kyc_pending`.
> 
> Each **description** now reads “needs to verify your identity **to** approve your application” instead of “…in order to approve…”. Wording is aligned across those screens; no UI structure, logic, or other locale keys change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f80f52a919a80fc679c0055ccf07ca0538db793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->