### PR TITLE
chore: limit recurring dest chains to source network

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/useRecurringBuySwapInputs.test.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/useRecurringBuySwapInputs.test.ts
@@ -327,7 +327,7 @@ describe('useRecurringBuySwapInputs', () => {
       );
     });
 
-    it('opens the destination picker scoped to the enabled chains and without RWAs', () => {
+    it("opens the destination picker scoped to the source token's chain and without RWAs", () => {
       const { result } = renderRecurringBuySwapInputsHook(
         {
           sourceToken: getNativeSourceToken('eip155:1'),
@@ -343,7 +343,53 @@ describe('useRecurringBuySwapInputs', () => {
         Routes.BRIDGE.TOKEN_SELECTOR,
         expect.objectContaining({
           type: TokenSelectorType.Dest,
-          enabledChainIds: ENABLED_CHAIN_IDS,
+          enabledChainIds: ['eip155:1'],
+          excludeRwaTokens: true,
+          featureId: FeatureId.RECURRING_BUY,
+        }),
+      );
+    });
+
+    it('scopes the destination picker to the CAIP form of a hex source chain id', () => {
+      const { result } = renderRecurringBuySwapInputsHook(
+        {
+          sourceToken: createMockToken({ chainId: '0x38' }),
+          destToken: undefined,
+          sourceAmount: undefined,
+        },
+        ENABLED_CHAIN_IDS,
+      );
+
+      result.current.handleDestTokenPress();
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.BRIDGE.TOKEN_SELECTOR,
+        expect.objectContaining({
+          type: TokenSelectorType.Dest,
+          enabledChainIds: ['eip155:56'],
+          excludeRwaTokens: true,
+          featureId: FeatureId.RECURRING_BUY,
+        }),
+      );
+    });
+
+    it('opens the destination picker with no enabled chains when there is no source token', () => {
+      const { result } = renderRecurringBuySwapInputsHook(
+        {
+          sourceToken: undefined,
+          destToken: undefined,
+          sourceAmount: undefined,
+        },
+        ENABLED_CHAIN_IDS,
+      );
+
+      result.current.handleDestTokenPress();
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.BRIDGE.TOKEN_SELECTOR,
+        expect.objectContaining({
+          type: TokenSelectorType.Dest,
+          enabledChainIds: [],
           excludeRwaTokens: true,
           featureId: FeatureId.RECURRING_BUY,
         }),

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/useRecurringBuySwapInputs.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/useRecurringBuySwapInputs.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
-import { FeatureId } from '@metamask/bridge-controller';
+import { FeatureId, formatChainIdToCaip } from '@metamask/bridge-controller';
 import type { AppNavigationProp } from '../../../../../../core/NavigationService/types';
 import Routes from '../../../../../../constants/navigation/Routes';
 import type { RootState } from '../../../../../../reducers';
@@ -182,11 +182,13 @@ export const useRecurringBuySwapInputs = ({
   const handleDestTokenPress = useCallback(() => {
     navigation.navigate(Routes.BRIDGE.TOKEN_SELECTOR, {
       type: TokenSelectorType.Dest,
-      enabledChainIds,
+      enabledChainIds: sourceToken?.chainId
+        ? [formatChainIdToCaip(sourceToken.chainId)]
+        : [],
       excludeRwaTokens: true,
       featureId: FeatureId.RECURRING_BUY,
     });
-  }, [enabledChainIds, navigation]);
+  }, [navigation, sourceToken?.chainId]);
 
   return {
     enabledChainIds,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Recurring swaps previously opened the destination token picker with every recurring-enabled network, allowing users to browse cross-chain destinations that recurring swaps do not support.

This change matches limit swaps by restricting the destination picker to the selected source token's network. It converts the source chain ID to CAIP format for the picker and exposes no destination networks when no source token is selected.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed recurring swaps to only show destination tokens on the selected source network

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: recurring swap destination token selection

  Scenario: select a destination token
    Given the user is creating a recurring swap
    And the source token is on Ethereum
    When the user opens the destination token picker
    Then only Ethereum destination tokens are available

  Scenario: change the source network
    Given the user selects a source token on BNB Chain
    When the user opens the destination token picker
    Then only BNB Chain destination tokens are available
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/6dc0ae95-fd46-4f6a-a22b-16220b6ac36d



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized navigation params for the recurring buy token picker; aligns with an established limit-order pattern and does not change signing, quotes, or backend swap execution.
> 
> **Overview**
> Recurring buy **destination token selection** no longer lists tokens across every recurring-enabled network. Opening the destination picker now passes **`enabledChainIds`** as a single CAIP chain derived from the selected source token (via `formatChainIdToCaip`), matching the existing **limit order** swap input behavior.
> 
> If no source token is selected, the destination picker is opened with **no enabled chains** so users cannot browse unsupported cross-chain destinations. Source token selection is unchanged and still uses the full recurring feature-flag chain list.
> 
> Tests were updated and extended to cover Ethereum source scoping, hex→CAIP conversion (e.g. BNB), and the empty-source case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cef587bcd36cf01cc7edba511b6394e65ad97983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->