### PR TITLE
perf: add cold-start stage instrumentation readable on release builds

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -274,3 +274,17 @@ export REACT_COMPILER_LOG_FAILURES='false'
 # Metro (yarn install:ios:dev:device). Only needed if auto-detection picks the wrong
 # network interface (e.g. when on a VPN).
 # export METRO_HOST="192.168.1.12"
+
+# Optional: emit cold-start stage timings to the platform log (logcat / NSLog) so
+# startup can be measured on a release build without Sentry or metrics consent.
+# Read them with: adb logcat -s ReactNativeJS | grep MM_STARTUP
+# Leave unset for normal builds — the value is inlined at build time, so the
+# instrumentation is dead code when this is not "true".
+# See docs/performance/startup-instrumentation.md
+# export MM_STARTUP_TIMELINE="true"
+
+# Optional: record a Hermes sampling profile across cold start, written to the
+# device's Downloads folder. Separate from MM_STARTUP_TIMELINE because sampling
+# overhead inflates the stage marks — use a profiled run for attribution and an
+# unprofiled run for absolute numbers.
+# export MM_STARTUP_PROFILE="true"

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useRef } from 'react';
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { FullWindowOverlay } from 'react-native-screens';
 import { useRoute } from '@react-navigation/native';
 import {
@@ -134,7 +134,14 @@ import TooltipModal from '../../Views/TooltipModal';
 import OptionsSheet from '../../UI/SelectOptionSheet/OptionsSheet';
 import FoxLoader from '../../UI/FoxLoader';
 import MultiRpcModal from '../../Views/MultiRpcModal/MultiRpcModal';
-import { endTrace, TraceName } from '../../../util/trace';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../util/trace';
+import { startupMark } from '../../../core/Performance/StartupTimeline';
+import getUIStartupSpan from '../../../core/Performance/UIStartup';
 import { selectExistingUser } from '../../../reducers/user/selectors';
 import { Performance } from '../../../core/Performance';
 import { queueColdHomepageReadyTrace } from '../../../core/Performance/HomepageReady';
@@ -1164,12 +1171,50 @@ const ModalSwitchAccountType = () => (
   </NativeStack.Navigator>
 );
 
+/**
+ * Guards the first-render span below. Module scope, not a ref, so a remount
+ * cannot restart the measurement — the module-evaluation burst it measures can
+ * only ever happen once per JS context.
+ */
+let hasMeasuredRootNavigatorRender = false;
+
 const AppFlow = () => {
   const { colors, themeAppearance } = useTheme();
   const onboardingCanvasColor =
     themeAppearance === 'dark'
       ? importedColors.gettingStartedTextColor
       : importedColors.gettingStartedPageBackgroundColorLightMode;
+
+  // Opens on the first render, before the JSX below is constructed. Every
+  // `component={Screen}` reference in this navigator is an inline `require()`,
+  // so building that element tree synchronously evaluates the screen graph —
+  // this span is what separates that cost from Engine initialisation.
+  //
+  // A lazy `useState` initialiser is used rather than a ref write during
+  // render because this directory is compiled by the React Compiler (see
+  // `babel.config.js` `pathsToInclude`); NavigationProvider uses the same
+  // pattern for `NavInit`.
+  useState(() => {
+    if (hasMeasuredRootNavigatorRender) {
+      return false;
+    }
+    startupMark('root_navigator_render_start');
+    trace({
+      name: TraceName.RootNavigatorFirstRender,
+      op: TraceOperation.UIStartup,
+      parentContext: getUIStartupSpan(),
+    });
+    return true;
+  });
+
+  useEffect(() => {
+    if (hasMeasuredRootNavigatorRender) {
+      return;
+    }
+    hasMeasuredRootNavigatorRender = true;
+    startupMark('root_navigator_render_end');
+    endTrace({ name: TraceName.RootNavigatorFirstRender });
+  }, []);
 
   return (
     <NativeStack.Navigator

--- a/app/components/Nav/ControllersGate/ControllersGate.tsx
+++ b/app/components/Nav/ControllersGate/ControllersGate.tsx
@@ -4,6 +4,17 @@ import { ControllersGateProps } from './types';
 import { useSelector } from 'react-redux';
 import { selectAppServicesReady } from '../../../reducers/user/selectors';
 import FoxLoader from '../../UI/FoxLoader';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../util/trace';
+import {
+  flushNativeStartupMarks,
+  flushStartupTimeline,
+  startupMark,
+} from '../../../core/Performance/StartupTimeline';
 /**
  * A higher order component that gate keeps the children until the app services are finished loaded
  * and the splash animation has completed.
@@ -25,8 +36,34 @@ const ControllersGate: React.FC<ControllersGateProps> = ({
       toValue: 0,
       duration: 300,
       useNativeDriver: true,
-    }).start(() => setLoaderDone(true));
+    }).start(() => {
+      // Closes the reveal-tax span: children have been rendering underneath
+      // since `appServicesReady` flipped, so everything between that moment and
+      // here is perceived latency the user pays with nothing to show for it.
+      startupMark('splash_loader_done');
+      endTrace({ name: TraceName.SplashRevealTax });
+      flushStartupTimeline('cold_start');
+      // Flushed here rather than earlier so late markers (contentAppeared,
+      // attachMeasuredRootViews*) have already been recorded.
+      flushNativeStartupMarks();
+      setLoaderDone(true);
+    });
   }, [loaderOpacity]);
+
+  // Open the reveal-tax span the moment the gate unblocks. Neither `UIStartup`
+  // (ends at App's first render) nor Sentry's `app_start_cold` (ends at root
+  // mount) covers this window, so without an explicit span the fixed
+  // 800ms + 250ms + 300ms below is invisible to every shipped metric.
+  useEffect(() => {
+    if (!appServicesReady) {
+      return;
+    }
+    startupMark('app_services_ready');
+    trace({
+      name: TraceName.SplashRevealTax,
+      op: TraceOperation.UIStartup,
+    });
+  }, [appServicesReady]);
 
   // Only fade out once BOTH the animation is done AND app services are ready.
   // This prevents a blank screen when Rive fails or times out before services finish.

--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -54,6 +54,7 @@ import { containsErrorMessage } from '../../../util/errorHandling';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { LoginViewSelectors } from './LoginView.testIds';
 import trackErrorAsAnalytics from '../../../util/metrics/TrackError/trackErrorAsAnalytics';
+import { startupMark } from '../../../core/Performance/StartupTimeline';
 import { trackVaultCorruption } from '../../../util/analytics/vaultCorruptionTracking';
 import { downloadStateLogs } from '../../../util/logs';
 import {
@@ -145,6 +146,11 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
   const fieldRef = useRef<TextInput | null>(null);
   const lastSubmittedPasswordRef = useRef('');
   const isProcessingForgotPassword = useRef(false);
+
+  /** Cold start -> unlock interactive. See the `onLayout` call site below. */
+  const markUnlockInteractive = useCallback(() => {
+    startupMark('unlock_interactive');
+  }, []);
 
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
@@ -615,6 +621,13 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
                 inputRef={fieldRef}
                 onChangeText={handlePasswordChange}
                 value={password}
+                // Fires on the password field's NATIVE layout — the first
+                // moment the user can actually type. A React mount or effect
+                // would fire earlier and measure ~zero, which is why the mark
+                // is anchored here (see docs/performance/startup-instrumentation.md).
+                // `startupMark` keeps only the first occurrence, so repeated
+                // layouts are harmless.
+                onLayout={markUnlockInteractive}
                 endAccessory={
                   capabilities ? (
                     <DeviceAuthenticationButton

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -18,6 +18,7 @@ import {
 import { getTraceTags } from '../../util/sentry/tags';
 import { trace, endTrace, TraceName, TraceOperation } from '../../util/trace';
 import getUIStartupSpan from '../Performance/UIStartup';
+import { startupMark } from '../Performance/StartupTimeline';
 
 import ReduxService from '../redux';
 import NavigationService from '../NavigationService';
@@ -145,7 +146,19 @@ export class EngineService {
    */
   start = async () => {
     const reduxState = ReduxService.store.getState();
+    // Separately spanned because this is ~70 filesystem reads + JSON.parse
+    // before a single controller can be constructed, and it needs to be
+    // attributable independently of Engine.init() to know whether startup is
+    // I/O-bound or CPU-bound here.
+    startupMark('controller_rehydrate_start');
+    trace({
+      name: TraceName.ControllerStateRehydration,
+      op: TraceOperation.StorageRehydration,
+      parentContext: getUIStartupSpan(),
+    });
     const persistedState = await ControllerStorage.getAllPersistedState();
+    endTrace({ name: TraceName.ControllerStateRehydration });
+    startupMark('controller_rehydrate_end');
 
     if (reduxState?.user?.existingUser) {
       Logger.log(
@@ -177,7 +190,9 @@ export class EngineService {
       // Passing it to engine ensures all controllers are initialized with the same analyticsId.
       // The persisted controller copy is passed as a recovery source for MMKV loss.
       const analyticsId = await getAnalyticsId(getPersistedAnalyticsId(state));
+      startupMark('engine_init_start');
       Engine.init(analyticsId, state);
+      startupMark('engine_init_end');
       // `Engine.init()` call mutates `typeof UntypedEngine` to `TypedEngine`
       // Pass state to detect controllers that changed during init
       this.initializeControllers(

--- a/app/core/Performance/HomepageReady.ts
+++ b/app/core/Performance/HomepageReady.ts
@@ -5,6 +5,7 @@ import {
   TraceOperation,
   TRACES_CLEANUP_INTERVAL,
 } from '../../util/trace';
+import { startupMark, stopStartupProfile } from './StartupTimeline';
 
 export type HomepageReadyContentState = 'filled' | 'empty' | 'error';
 export type HomepageReadyStartSource = 'app_open' | 'unlock';
@@ -124,6 +125,13 @@ export const endHomepageReadyTrace = ({
       content_state: contentState,
     },
   });
+  // Mirrors the CUF end onto the local startup timeline so cold-start ->
+  // homepage can be read over adb without metrics consent.
+  startupMark('homepage_ready');
+  // Cold start ends HERE, so the CPU profile stops immediately after the mark.
+  // Anything added between the two would land inside the profiled window and
+  // be attributed to startup.
+  stopStartupProfile();
   startedAt = null;
   activeTraceToken = null;
 };

--- a/app/core/Performance/StartupTimeline.test.ts
+++ b/app/core/Performance/StartupTimeline.test.ts
@@ -1,0 +1,68 @@
+import {
+  ENABLED,
+  flushStartupTimeline,
+  getStartupTimeline,
+  resetStartupTimelineForTesting,
+  startupMark,
+} from './StartupTimeline';
+
+interface GlobalWithLoggingHook {
+  nativeLoggingHook?: (message: string, logLevel: number) => void;
+}
+
+const getGlobal = () => globalThis as typeof globalThis & GlobalWithLoggingHook;
+
+describe('StartupTimeline', () => {
+  let logSpy: jest.Mock<void, [string, number]>;
+  let originalHook: GlobalWithLoggingHook['nativeLoggingHook'];
+
+  beforeEach(() => {
+    resetStartupTimelineForTesting();
+    logSpy = jest.fn();
+    originalHook = getGlobal().nativeLoggingHook;
+    getGlobal().nativeLoggingHook = logSpy;
+  });
+
+  afterEach(() => {
+    getGlobal().nativeLoggingHook = originalHook;
+  });
+
+  // The module is gated on a build-time env var that is inlined by
+  // `transform-inline-environment-variables`. Under Jest it is unset, so the
+  // disabled path is what the suite can exercise directly.
+  it('is disabled unless MM_STARTUP_TIMELINE is set at build time', () => {
+    expect(ENABLED).toBe(false);
+  });
+
+  describe('when disabled', () => {
+    it('records nothing and never touches the platform log', () => {
+      startupMark('js_bundle_evaluated');
+      startupMark('app_services_ready');
+
+      expect(getStartupTimeline()).toEqual([]);
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not emit a timeline on flush', () => {
+      flushStartupTimeline('cold_start');
+
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resetStartupTimelineForTesting', () => {
+    it('clears recorded marks', () => {
+      startupMark('js_bundle_evaluated');
+      resetStartupTimelineForTesting();
+
+      expect(getStartupTimeline()).toEqual([]);
+    });
+  });
+
+  it('tolerates a missing nativeLoggingHook', () => {
+    delete getGlobal().nativeLoggingHook;
+
+    expect(() => startupMark('app_services_ready')).not.toThrow();
+    expect(() => flushStartupTimeline('cold_start')).not.toThrow();
+  });
+});

--- a/app/core/Performance/StartupTimeline.test.ts
+++ b/app/core/Performance/StartupTimeline.test.ts
@@ -12,6 +12,34 @@ interface GlobalWithLoggingHook {
 
 const getGlobal = () => globalThis as typeof globalThis & GlobalWithLoggingHook;
 
+/** The module's own public surface, for use with isolated re-requires. */
+type StartupTimelineModule = typeof import('./StartupTimeline');
+
+/**
+ * Load a fresh copy of the module with the build-time flags forced.
+ *
+ * The flags cannot be driven through `process.env` here:
+ * `transform-inline-environment-variables` replaces those lookups with literals
+ * when Babel transforms the file, long before a test runs. Mocking
+ * `StartupTimelineFlags` is what makes the enabled paths reachable at all.
+ *
+ * @param flags - Flag values to force for this load.
+ * @param run - Receives the freshly loaded module.
+ */
+const withFlags = (
+  flags: { timeline?: boolean; profile?: boolean },
+  run: (startupTimeline: StartupTimelineModule) => void,
+) => {
+  jest.isolateModules(() => {
+    jest.doMock('./StartupTimelineFlags', () => ({
+      TIMELINE_ENABLED: flags.timeline ?? false,
+      PROFILE_ENABLED: flags.profile ?? false,
+    }));
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    run(require('./StartupTimeline') as StartupTimelineModule);
+  });
+};
+
 describe('StartupTimeline', () => {
   let logSpy: jest.Mock<void, [string, number]>;
   let originalHook: GlobalWithLoggingHook['nativeLoggingHook'];
@@ -29,7 +57,7 @@ describe('StartupTimeline', () => {
 
   // The module is gated on a build-time env var that is inlined by
   // `transform-inline-environment-variables`. Under Jest it is unset, so the
-  // disabled path is what the suite can exercise directly.
+  // statically imported module above is the disabled variant.
   it('is disabled unless MM_STARTUP_TIMELINE is set at build time', () => {
     expect(ENABLED).toBe(false);
   });
@@ -48,6 +76,247 @@ describe('StartupTimeline', () => {
 
       expect(logSpy).not.toHaveBeenCalled();
     });
+
+    it('does not emit ad-hoc lines or native marks', () => {
+      withFlags({ timeline: false }, (startupTimeline) => {
+        startupTimeline.emitStartupLine('anything');
+        startupTimeline.flushNativeStartupMarks();
+
+        expect(logSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when enabled', () => {
+    const enabled = { timeline: true };
+
+    it('records a mark and emits it with epoch and elapsed time', () => {
+      withFlags(enabled, (startupTimeline) => {
+        startupTimeline.startupMark('js_bundle_evaluated');
+
+        const [entry] = startupTimeline.getStartupTimeline();
+        expect(entry.mark).toBe('js_bundle_evaluated');
+        expect(entry.sinceFirstMs).toBe(0);
+        expect(entry.epochMs).toBeGreaterThan(0);
+        expect(logSpy).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /^MM_STARTUP js_bundle_evaluated epoch=\d+ since_first=0ms$/u,
+          ),
+          3,
+        );
+      });
+    });
+
+    it('keeps only the first occurrence of a repeated mark', () => {
+      withFlags(enabled, (startupTimeline) => {
+        startupTimeline.startupMark('unlock_interactive');
+        startupTimeline.startupMark('unlock_interactive');
+        startupTimeline.startupMark('unlock_interactive');
+
+        expect(startupTimeline.getStartupTimeline()).toHaveLength(1);
+      });
+    });
+
+    it('measures each mark relative to the first one', () => {
+      withFlags(enabled, (startupTimeline) => {
+        const nowSpy = jest
+          .spyOn(Date, 'now')
+          .mockReturnValueOnce(1_000)
+          .mockReturnValueOnce(1_250);
+
+        startupTimeline.startupMark('engine_init_start');
+        startupTimeline.startupMark('engine_init_end');
+
+        const [first, second] = startupTimeline.getStartupTimeline();
+        expect(first.sinceFirstMs).toBe(0);
+        expect(second.sinceFirstMs).toBe(250);
+        nowSpy.mockRestore();
+      });
+    });
+
+    it('emits the whole timeline as one parseable JSON line', () => {
+      withFlags(enabled, (startupTimeline) => {
+        startupTimeline.startupMark('js_bundle_evaluated');
+        startupTimeline.startupMark('homepage_ready');
+        logSpy.mockClear();
+
+        startupTimeline.flushStartupTimeline('cold_start');
+
+        expect(logSpy).toHaveBeenCalledTimes(1);
+        const [line] = logSpy.mock.calls[0];
+        const payload = JSON.parse(line.replace('MM_STARTUP_TIMELINE ', ''));
+        expect(payload.label).toBe('cold_start');
+        expect(payload.entries.map((e: { mark: string }) => e.mark)).toEqual([
+          'js_bundle_evaluated',
+          'homepage_ready',
+        ]);
+      });
+    });
+
+    it('does not emit a timeline when no marks were recorded', () => {
+      withFlags(enabled, (startupTimeline) => {
+        startupTimeline.flushStartupTimeline('cold_start');
+
+        expect(logSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    it('emits ad-hoc lines on the same prefixed channel', () => {
+      withFlags(enabled, (startupTimeline) => {
+        startupTimeline.emitStartupLine('CUSTOM key=value');
+
+        expect(logSpy).toHaveBeenCalledWith('MM_STARTUP CUSTOM key=value', 3);
+      });
+    });
+  });
+
+  describe('native startup marks', () => {
+    it('emits an anchor, every mark in time order, and a count', () => {
+      withFlags({ timeline: true }, (startupTimeline) => {
+        jest.doMock('react-native-performance', () => ({
+          __esModule: true,
+          default: {
+            timeOrigin: 1_000,
+            now: () => 2_000,
+            getEntriesByType: () => [
+              { name: 'runJsBundleEnd', startTime: 1_930.4 },
+              { name: 'nativeLaunchStart', startTime: 0 },
+            ],
+          },
+        }));
+
+        startupTimeline.flushNativeStartupMarks();
+
+        const lines = logSpy.mock.calls.map(([line]) => line);
+        expect(lines[0]).toContain(
+          'MM_STARTUP_NATIVE _anchor time_origin=1000',
+        );
+        // Unsorted input, sorted output.
+        expect(lines[1]).toBe('MM_STARTUP_NATIVE nativeLaunchStart t=0');
+        expect(lines[2]).toBe('MM_STARTUP_NATIVE runJsBundleEnd t=1930');
+        expect(lines[3]).toBe('MM_STARTUP_NATIVE _count 2');
+      });
+    });
+
+    it('reports a failure line instead of throwing when the bridge is unavailable', () => {
+      withFlags({ timeline: true }, (startupTimeline) => {
+        jest.doMock('react-native-performance', () => {
+          throw new Error('no native module');
+        });
+
+        expect(() => startupTimeline.flushNativeStartupMarks()).not.toThrow();
+        expect(logSpy).toHaveBeenCalledWith(
+          expect.stringContaining('MM_STARTUP_NATIVE _failed'),
+          3,
+        );
+      });
+    });
+  });
+
+  describe('startup CPU profile', () => {
+    const profiling = { timeline: true, profile: true };
+
+    it('is inert unless MM_STARTUP_PROFILE is set, even with the timeline on', () => {
+      withFlags({ timeline: true, profile: false }, (startupTimeline) => {
+        const startProfiling = jest.fn();
+        jest.doMock('react-native-release-profiler', () => ({
+          startProfiling,
+          stopProfiling: jest.fn(),
+        }));
+
+        startupTimeline.startStartupProfile();
+
+        expect(startProfiling).not.toHaveBeenCalled();
+        expect(logSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    it('starts once and reports it', () => {
+      withFlags(profiling, (startupTimeline) => {
+        const startProfiling = jest.fn();
+        jest.doMock('react-native-release-profiler', () => ({
+          startProfiling,
+          stopProfiling: jest.fn(),
+        }));
+
+        startupTimeline.startStartupProfile();
+        startupTimeline.startStartupProfile();
+
+        expect(startProfiling).toHaveBeenCalledTimes(1);
+        expect(logSpy).toHaveBeenCalledWith('MM_STARTUP profile_started', 3);
+      });
+    });
+
+    it('reports a failure instead of throwing when the profiler cannot start', () => {
+      withFlags(profiling, (startupTimeline) => {
+        jest.doMock('react-native-release-profiler', () => ({
+          startProfiling: () => {
+            throw new Error('profiler unavailable');
+          },
+          stopProfiling: jest.fn(),
+        }));
+
+        expect(() => startupTimeline.startStartupProfile()).not.toThrow();
+        expect(logSpy).toHaveBeenCalledWith(
+          expect.stringContaining('MM_STARTUP profile_start_failed'),
+          3,
+        );
+      });
+    });
+
+    it('stops the profile and logs where the trace was written', async () => {
+      let pending: Promise<void> = Promise.resolve();
+
+      withFlags(profiling, (startupTimeline) => {
+        const stopProfiling = jest.fn().mockResolvedValue('/sdcard/trace.json');
+        jest.doMock('react-native-release-profiler', () => ({
+          startProfiling: jest.fn(),
+          stopProfiling,
+        }));
+
+        startupTimeline.startStartupProfile();
+        pending = startupTimeline.stopStartupProfile().then(() => {
+          expect(stopProfiling).toHaveBeenCalledWith(true);
+          expect(logSpy).toHaveBeenCalledWith(
+            'MM_STARTUP profile_saved /sdcard/trace.json',
+            3,
+          );
+        });
+      });
+
+      await pending;
+    });
+
+    it('does nothing when stopped without having started', async () => {
+      let pending: Promise<void> = Promise.resolve();
+
+      withFlags(profiling, (startupTimeline) => {
+        pending = startupTimeline.stopStartupProfile();
+      });
+
+      await pending;
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('reports a failure instead of rejecting when the profile cannot be written', async () => {
+      let pending: Promise<void> = Promise.resolve();
+
+      withFlags(profiling, (startupTimeline) => {
+        jest.doMock('react-native-release-profiler', () => ({
+          startProfiling: jest.fn(),
+          stopProfiling: jest.fn().mockRejectedValue(new Error('disk full')),
+        }));
+
+        startupTimeline.startStartupProfile();
+        pending = startupTimeline.stopStartupProfile();
+      });
+
+      await expect(pending).resolves.toBeUndefined();
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('MM_STARTUP profile_stop_failed'),
+        3,
+      );
+    });
   });
 
   describe('resetStartupTimelineForTesting', () => {
@@ -56,6 +325,16 @@ describe('StartupTimeline', () => {
       resetStartupTimelineForTesting();
 
       expect(getStartupTimeline()).toEqual([]);
+    });
+
+    it('allows a mark to be recorded again after a reset', () => {
+      withFlags({ timeline: true }, (startupTimeline) => {
+        startupTimeline.startupMark('homepage_ready');
+        startupTimeline.resetStartupTimelineForTesting();
+        startupTimeline.startupMark('homepage_ready');
+
+        expect(startupTimeline.getStartupTimeline()).toHaveLength(1);
+      });
     });
   });
 

--- a/app/core/Performance/StartupTimeline.ts
+++ b/app/core/Performance/StartupTimeline.ts
@@ -1,0 +1,287 @@
+/**
+ * Local startup-stage timeline for measurement builds.
+ *
+ * ## Why this exists alongside `trace()`
+ *
+ * `trace()` is the right production instrumentation, but it cannot be read on a
+ * measurement device: spans buffer until the user grants metrics consent, and
+ * they flush to Sentry, which needs `MM_SENTRY_DSN`. Neither holds on a freshly
+ * onboarded test wallet, so startup numbers are invisible exactly when we most
+ * need them. This module is the local counterpart — same seams, readable over
+ * `adb logcat`, no consent and no network.
+ *
+ * ## Why `nativeLoggingHook` and not `console`
+ *
+ * `babel.config.js` applies `transform-remove-console` in the `production` babel
+ * env, so every `console.*` call is stripped from release builds — the only
+ * builds whose startup timings are worth measuring. `global.nativeLoggingHook`
+ * writes straight to logcat/NSLog and is a plain global call, so the plugin
+ * leaves it alone.
+ *
+ * ## Cost when disabled
+ *
+ * `process.env.MM_STARTUP_TIMELINE` is inlined at build time by
+ * `transform-inline-environment-variables`, so in a normal build `ENABLED` is a
+ * literal `false` and every function below collapses to an empty body that a
+ * minifier can drop.
+ *
+ * Read the output with `adb logcat -s ReactNativeJS | grep MM_STARTUP`.
+ */
+
+/** Log level passed to `nativeLoggingHook`; 3 === error, which is never filtered out. */
+const LOG_LEVEL_ERROR = 3;
+
+const LOG_PREFIX = 'MM_STARTUP';
+
+export const ENABLED = process.env.MM_STARTUP_TIMELINE === 'true';
+
+/**
+ * Records a Hermes sampling profile across cold start, stopped at
+ * `splash_loader_done`.
+ *
+ * Separate from {@link ENABLED} because the sampling profiler has real
+ * overhead: stage marks from a profiled run are **inflated** and must not be
+ * used as headline timings. Use a profiled build for *attribution* (which
+ * modules dominate the navigator module-evaluation burst) and an unprofiled
+ * build for absolute numbers.
+ *
+ * One exception: the splash reveal tax is driven by `setTimeout` durations
+ * (800 + 250 + 300 ms), which are wall-clock and therefore unaffected by
+ * profiler overhead. That number stays trustworthy in a profiled run.
+ *
+ * `ProfilerManager` cannot serve this purpose — it is shake-to-open and
+ * manual, so by the time its UI exists startup is already over, and it is
+ * gated to `rc`/`exp` only.
+ *
+ * Android writes the trace to the Downloads folder; pull it with
+ * `adb pull /sdcard/Download/<name>.cpuprofile`, then symbolicate via
+ * `npx react-native-release-profiler --local <trace>`.
+ */
+export const PROFILE_ENABLED = process.env.MM_STARTUP_PROFILE === 'true';
+
+let profileStarted = false;
+
+/**
+ * Begin the startup CPU profile. Called as early as possible in the entry
+ * module. The profiler package is required lazily so that a build without
+ * `MM_STARTUP_PROFILE` never pulls it onto the startup path.
+ */
+export function startStartupProfile(): void {
+  if (!PROFILE_ENABLED || profileStarted) {
+    return;
+  }
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { startProfiling } = require('react-native-release-profiler');
+    startProfiling();
+    profileStarted = true;
+    emit(`${LOG_PREFIX} profile_started`);
+  } catch (error) {
+    emit(`${LOG_PREFIX} profile_start_failed ${String(error)}`);
+  }
+}
+
+/**
+ * Stop the startup CPU profile and write it to disk, logging the path so it can
+ * be pulled without opening the app.
+ */
+export async function stopStartupProfile(): Promise<void> {
+  if (!PROFILE_ENABLED || !profileStarted) {
+    return;
+  }
+  profileStarted = false;
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { stopProfiling } = require('react-native-release-profiler');
+    const path: unknown = await stopProfiling(true);
+    emit(`${LOG_PREFIX} profile_saved ${String(path)}`);
+  } catch (error) {
+    emit(`${LOG_PREFIX} profile_stop_failed ${String(error)}`);
+  }
+}
+
+/**
+ * Startup seams, in the order a cold launch passes through them.
+ *
+ * Names are snake_case because they are consumed by log-scraping scripts, not
+ * by TypeScript callers.
+ */
+export type StartupMark =
+  /** End of `index.js` — bundle prelude + entry evaluation is done. */
+  | 'js_bundle_evaluated'
+  /** redux-persist rehydration finished (`onPersistComplete`). */
+  | 'store_persist_complete'
+  /** Reading every `persist:<Controller>` blob — start. */
+  | 'controller_rehydrate_start'
+  /** Reading every `persist:<Controller>` blob — done. */
+  | 'controller_rehydrate_end'
+  /** `Engine.init()` — synchronous construction of all controllers. */
+  | 'engine_init_start'
+  | 'engine_init_end'
+  /** `setAppServicesReady()` — the gate that unblocks the whole UI. */
+  | 'app_services_ready'
+  /** `AppFlow`'s first render — the navigator module-evaluation burst. */
+  | 'root_navigator_render_start'
+  | 'root_navigator_render_end'
+  /** Splash overlay fully removed (end of the fixed reveal tax). */
+  | 'splash_loader_done'
+  /** Unlock screen genuinely accepts input. */
+  | 'unlock_interactive'
+  /** Homepage rendered a usable state. */
+  | 'homepage_ready';
+
+interface TimelineEntry {
+  mark: StartupMark;
+  /** Absolute epoch milliseconds, for aligning against native launch. */
+  epochMs: number;
+  /** Milliseconds since the first recorded mark. */
+  sinceFirstMs: number;
+}
+
+let entries: TimelineEntry[] = [];
+let firstEpochMs: number | null = null;
+const recorded = new Set<StartupMark>();
+
+/**
+ * Emit one line to the platform log. Guarded because `nativeLoggingHook` is a
+ * React Native global that is absent under Jest and in bare JS contexts.
+ */
+function emit(line: string): void {
+  const hook = (
+    globalThis as typeof globalThis & {
+      nativeLoggingHook?: (message: string, logLevel: number) => void;
+    }
+  ).nativeLoggingHook;
+
+  hook?.(line, LOG_LEVEL_ERROR);
+}
+
+/**
+ * Emit a prefixed line on the startup log channel. Exposed so sibling
+ * measurement probes share one channel and one `MM_STARTUP` grep.
+ *
+ * @param line - Text appended after the `MM_STARTUP` prefix.
+ */
+export function emitStartupLine(line: string): void {
+  if (!ENABLED) {
+    return;
+  }
+  emit(`${LOG_PREFIX} ${line}`);
+}
+
+/**
+ * Record a startup seam and emit it to the platform log.
+ *
+ * No-ops unless the build set `MM_STARTUP_TIMELINE=true`. Safe to call from
+ * render paths: it does no I/O and allocates one small object.
+ *
+ * @param mark - The seam being recorded.
+ */
+export function startupMark(mark: StartupMark): void {
+  if (!ENABLED) {
+    return;
+  }
+
+  // Each seam is recorded once per launch. Some call sites fire repeatedly by
+  // nature (e.g. a view's `onLayout`), and a startup timeline wants the first
+  // occurrence — the moment the seam was reached — not every re-entry.
+  if (recorded.has(mark)) {
+    return;
+  }
+  recorded.add(mark);
+
+  const epochMs = Date.now();
+  if (firstEpochMs === null) {
+    firstEpochMs = epochMs;
+  }
+
+  const entry: TimelineEntry = {
+    mark,
+    epochMs,
+    sinceFirstMs: epochMs - firstEpochMs,
+  };
+  entries.push(entry);
+
+  emit(
+    `${LOG_PREFIX} ${mark} epoch=${epochMs} since_first=${entry.sinceFirstMs}ms`,
+  );
+}
+
+/**
+ * Emit the full timeline as one line of JSON, so a single logcat grep yields a
+ * parseable record rather than requiring the reader to stitch marks together.
+ *
+ * @param label - Free-form tag identifying this launch (e.g. the flow measured).
+ */
+export function flushStartupTimeline(label: string): void {
+  if (!ENABLED || entries.length === 0) {
+    return;
+  }
+
+  emit(`${LOG_PREFIX}_TIMELINE ${JSON.stringify({ label, entries })}`);
+}
+
+/**
+ * Emit the native startup markers React Native already produces, so the phases
+ * *before* JavaScript runs are visible.
+ *
+ * `react-native-performance`'s Android module bridges ~30 `ReactMarker`
+ * constants into buffered `react-native-mark` performance entries —
+ * `nativeLaunchStart/End`, `loadReactNativeSoFileStart/End`, `vmInit`,
+ * `createReactContextStart/End`, `processCoreReactPackageStart/End`,
+ * `createViewManagersStart/End`, `buildNativeModuleRegistryStart/End`,
+ * `runJsBundleStart/End`, `setupReactContextStart/End`, `contentAppeared`.
+ * They are recorded on every build but never surfaced in release, because the
+ * only consumer logs them through `console.info`, which
+ * `transform-remove-console` strips.
+ *
+ * Timebase: entry `startTime` is relative to `performance.timeOrigin`, which
+ * the library anchors at native launch. `performance.now()` is emitted
+ * alongside so the JS marks above (wall-clock `Date.now()`) can be aligned onto
+ * the same axis in post-processing.
+ *
+ * Not all markers fire under bridgeless/New Architecture — several are
+ * legacy-bridge concepts. Whatever is present is emitted; nothing is assumed.
+ */
+export function flushNativeStartupMarks(): void {
+  if (!ENABLED) {
+    return;
+  }
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { default: perf } = require('react-native-performance');
+    const nativeMarks: { name: string; startTime: number }[] =
+      perf.getEntriesByType('react-native-mark');
+
+    emit(
+      `${LOG_PREFIX}_NATIVE _anchor time_origin=${perf.timeOrigin} now=${perf.now()} epoch=${Date.now()}`,
+    );
+    for (const entry of [...nativeMarks].sort(
+      (a, b) => a.startTime - b.startTime,
+    )) {
+      emit(
+        `${LOG_PREFIX}_NATIVE ${entry.name} t=${Math.round(entry.startTime)}`,
+      );
+    }
+    emit(`${LOG_PREFIX}_NATIVE _count ${nativeMarks.length}`);
+  } catch (error) {
+    emit(`${LOG_PREFIX}_NATIVE _failed ${String(error)}`);
+  }
+}
+
+/**
+ * The marks recorded so far. Exposed for tests and for in-app debug surfaces.
+ */
+export function getStartupTimeline(): readonly TimelineEntry[] {
+  return entries;
+}
+
+/** @internal Reset module state between tests. Do not call in production code. */
+export function resetStartupTimelineForTesting(): void {
+  entries = [];
+  firstEpochMs = null;
+  recorded.clear();
+}

--- a/app/core/Performance/StartupTimeline.ts
+++ b/app/core/Performance/StartupTimeline.ts
@@ -21,19 +21,26 @@
  * ## Cost when disabled
  *
  * `process.env.MM_STARTUP_TIMELINE` is inlined at build time by
- * `transform-inline-environment-variables`, so in a normal build `ENABLED` is a
+ * `transform-inline-environment-variables` (see {@link ./StartupTimelineFlags},
+ * which exists so the flag stays inlinable *and* mockable in tests), so in a
+ * normal build `ENABLED` is a
  * literal `false` and every function below collapses to an empty body that a
  * minifier can drop.
  *
  * Read the output with `adb logcat -s ReactNativeJS | grep MM_STARTUP`.
  */
 
+import {
+  PROFILE_ENABLED as PROFILE_ENABLED_FLAG,
+  TIMELINE_ENABLED,
+} from './StartupTimelineFlags';
+
 /** Log level passed to `nativeLoggingHook`; 3 === error, which is never filtered out. */
 const LOG_LEVEL_ERROR = 3;
 
 const LOG_PREFIX = 'MM_STARTUP';
 
-export const ENABLED = process.env.MM_STARTUP_TIMELINE === 'true';
+export const ENABLED = TIMELINE_ENABLED;
 
 /**
  * Records a Hermes sampling profile across cold start, stopped at
@@ -57,7 +64,7 @@ export const ENABLED = process.env.MM_STARTUP_TIMELINE === 'true';
  * `adb pull /sdcard/Download/<name>.cpuprofile`, then symbolicate via
  * `npx react-native-release-profiler --local <trace>`.
  */
-export const PROFILE_ENABLED = process.env.MM_STARTUP_PROFILE === 'true';
+export const PROFILE_ENABLED = PROFILE_ENABLED_FLAG;
 
 let profileStarted = false;
 

--- a/app/core/Performance/StartupTimelineFlags.ts
+++ b/app/core/Performance/StartupTimelineFlags.ts
@@ -1,0 +1,35 @@
+/**
+ * Build-time switches for the startup instrumentation.
+ *
+ * These live in their own module for two reasons.
+ *
+ * **Release builds.** `babel.config.js` applies
+ * `transform-inline-environment-variables` in every babel env, so each
+ * `process.env` lookup below is replaced by a literal at transform time. In a
+ * normal build both constants become `false`, every guard in
+ * {@link ./StartupTimeline} collapses to an immediate return, and a minifier
+ * can drop the rest.
+ *
+ * **Tests.** Because the values are inlined, they cannot be changed at runtime —
+ * setting `process.env.MM_STARTUP_TIMELINE` inside a test has no effect, since
+ * the transform already ran. Keeping them in a separate module means a test can
+ * exercise the enabled paths by mocking this module instead, which is otherwise
+ * impossible to reach.
+ */
+
+/**
+ * Emit cold-start stage marks to the platform log.
+ *
+ * See `docs/performance/startup-instrumentation.md`.
+ */
+export const TIMELINE_ENABLED = process.env.MM_STARTUP_TIMELINE === 'true';
+
+/**
+ * Record a Hermes sampling profile across cold start.
+ *
+ * Deliberately separate from {@link TIMELINE_ENABLED} because the sampling
+ * profiler has real overhead: stage marks from a profiled run are **inflated**
+ * and must not be used as headline timings. Use a profiled build for
+ * *attribution* and an unprofiled build for absolute numbers.
+ */
+export const PROFILE_ENABLED = process.env.MM_STARTUP_PROFILE === 'true';

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -39,6 +39,25 @@ export enum TraceName {
   EngineInitialization = 'Engine Initialization',
   UIStartup = 'UI Startup',
   HomepageReady = 'Homepage Ready',
+  /**
+   * Process start -> the unlock screen genuinely accepts input. The app's
+   * most-executed cold path, previously untracked in production: `UIStartup`
+   * ends at `App`'s first render, before the splash reveal and unlock paint.
+   */
+  AppStartToUnlockInteractive = 'App Start To Unlock Interactive',
+  /**
+   * `appServicesReady` -> splash overlay removed. Fixed animation cost paid
+   * after the UI is already rendered underneath, so it is pure perceived
+   * latency. Should trend to zero.
+   */
+  SplashRevealTax = 'Splash Reveal Tax',
+  /**
+   * `AppFlow`'s first render — the synchronous navigator module-evaluation
+   * burst. Splits "engine init" from "screen graph evaluation" inside startup.
+   */
+  RootNavigatorFirstRender = 'Root Navigator First Render',
+  /** Reading and parsing every `persist:<Controller>` blob before Engine init. */
+  ControllerStateRehydration = 'Controller State Rehydration',
   UiSlotsLoad = 'UI Slots Load',
   DeeplinkProcessed = 'Deeplink Processed',
   DeeplinkNavigated = 'Deeplink Navigated',

--- a/index.js
+++ b/index.js
@@ -34,6 +34,9 @@ import Root from './app/components/Views/Root';
 import { name } from './app.config.js';
 import { hasTestOverrides } from './app/util/test/utils.js';
 import { Performance } from './app/core/Performance';
+// The cold-start CPU profile is started from shim.js, which runs before this
+// module, so that the bundle prelude is inside the trace.
+import { startupMark } from './app/core/Performance/StartupTimeline';
 import {
   handleCustomError,
   setReactNativeDefaultHandler,
@@ -124,6 +127,11 @@ AppRegistry.registerComponent(name, () =>
   // Disable Sentry for E2E tests
   hasTestOverrides ? Root : Sentry.wrap(Root),
 );
+
+// Last statement of the entry module: everything above (SES lockdown, shim.js
+// polyfills, Nitro setup, Sentry, the store IIFE) has now been evaluated, so
+// this mark closes out bundle-prelude time.
+startupMark('js_bundle_evaluated');
 
 function setupGlobalErrorHandler() {
   const reactNativeDefaultHandler = global.ErrorUtils.getGlobalHandler();

--- a/shim.js
+++ b/shim.js
@@ -1,4 +1,16 @@
 /* eslint-disable import-x/no-nodejs-modules */
+// Earliest reachable point in application code — before this module's own
+// polyfills and before index.js runs. Starting the cold-start CPU profile here
+// (rather than in index.js, which is the END of the prelude) is what makes the
+// ~1.3s `runJsBundle` phase attributable. No-op unless MM_STARTUP_PROFILE=true.
+//
+// Note this still cannot see SES `hardenIntrinsics()`: lockdown is injected by
+// the Metro serializer and runs before any app module, so that portion of
+// runJsBundle needs a Perfetto/native trace instead.
+import { startStartupProfile } from './app/core/Performance/StartupTimeline';
+
+startStartupProfile();
+
 import { BackHandler, Platform, Settings } from 'react-native';
 
 // RN 0.74+ removed `BackHandler.removeEventListener`. Some third-party


### PR DESCRIPTION
## **Description**

Cold-start timings are effectively **unmeasurable on the builds that matter**, which is why startup work has been hard to justify or verify:

- `trace()` spans buffer until the user grants metrics consent, then flush to Sentry, which needs `MM_SENTRY_DSN`. Neither holds on a freshly onboarded test wallet.
- `console.*` is stripped from release builds by `transform-remove-console` — and release is the only build whose startup timing is meaningful.
- The one shipped metric, `am start -W` TTID, stops at `runJsBundleEnd`. Measured against the full path to a usable wallet, that is roughly the first quarter.

### What this adds

`app/core/Performance/StartupTimeline.ts` — stage marks emitted through `global.nativeLoggingHook`, which survives console stripping and needs no consent, DSN or network:

```bash
adb logcat -s ReactNativeJS | grep MM_STARTUP
```

Marks: bundle evaluation → controller rehydration → `Engine.init` → `appServicesReady` → navigator first render → splash removal → unlock interactive → homepage ready.

Two details worth reviewing:

- **`unlock_interactive` is anchored to the password field's native `onLayout`**, not a React mount or effect. Mount/effect fire before the field can actually accept input and measure near zero — the mark would look great and mean nothing.
- **`stopStartupProfile()` runs immediately after `startupMark('homepage_ready')`.** Anything inserted between them lands inside the profiled window and gets attributed to startup. This bit me while investigating: measurement scaffolding placed after the profile stop was initially measured *as* startup and accounted for 99.5% of the window.

It also surfaces the **~30 native `ReactMarker` stages that React Native already records** and `react-native-performance` already bridges. They were invisible in release only because the sole consumer logged them through `console.info`. No new native code was required. (Only ~11 fire under bridgeless; the rest are legacy-bridge concepts, so sizing the full pre-JS window still needs a Perfetto capture.)

Four `TraceName`s cover the same seams on the production Sentry channel, including **`AppStartToUnlockInteractive`** — the app's most-executed cold path, previously untracked, because `UIStartup` ends at `App`'s first render, before the splash reveal and unlock paint.

### Cost when disabled

Everything is gated on `MM_STARTUP_TIMELINE`, which `transform-inline-environment-variables` inlines at build time. In a normal build the flag is a literal `false`, so every function collapses to an empty body a minifier can drop. `MM_STARTUP_PROFILE` (Hermes sampling profile) is a deliberately separate switch, because sampling overhead inflates the marks and a profiled run must not be used for headline numbers.

### What it found

For context on why this is worth landing — measured with this instrumentation on a Galaxy A14 5G (Android 15, `production` release, populated wallet, n=5 medians), icon tap → usable wallet was **~9.7 s**, distributed as:

| Stage | Time |
|---|---:|
| Native launch | 53 ms |
| RN host/context setup (no marker under bridgeless) | 589 ms |
| `runJsBundle` | 1,288 ms |
| Bundle eval → rehydrate | 200 ms |
| Controller rehydration | 88 ms |
| `Engine.init` | 778 ms |
| Post-init gap | 1,102 ms |
| Navigator module-eval | 24 ms |
| Splash reveal tax | 1,752 ms |
| Unlock → homepage | 3,846 ms |

`am start -W` reports ~400 ms for the same launch. That gap is the point of this PR.

It also disproved two plausible-sounding hypotheses before anyone spent time on them: the navigator module-evaluation burst is **24 ms** (not worth a 340-screen `getComponent` codemod), and controller rehydration across ~70 persisted blobs is **88 ms**.

### Reviewer notes

- Two comments (`.js.env.example`, `Login/index.tsx`) point at `docs/performance/startup-instrumentation.md`, which lands in #35984. If these merge out of order the reference is briefly stale — it is a comment, not a link.
- `App.tsx` uses a lazy `useState` initializer for the first-render span so it stays React Compiler compatible (that directory is opted in).
- The marks are first-occurrence-only, so call sites that fire repeatedly by nature (`onLayout`) are safe.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #35984

## **Manual testing steps**

```gherkin
Feature: Cold-start stage instrumentation

  Scenario: instrumentation is inert in a normal build
    Given MM_STARTUP_TIMELINE is unset in .js.env
    And a production release build is installed

    When user launches the app and unlocks the wallet
    Then startup behaves exactly as before
    And no MM_STARTUP lines appear in logcat

  Scenario: developer measures a cold start
    Given MM_STARTUP_TIMELINE="true" in .js.env
    And a production release build is installed on an Android device
    And the app has been force-stopped

    When user launches the app and unlocks the wallet
    Then logcat shows MM_STARTUP marks in launch order
    And a MM_STARTUP_TIMELINE JSON line summarises the run
    And MM_STARTUP_NATIVE lines report the native ReactMarker stages
```

## **Screenshots/Recordings**

### **Before**

N/A — no UI change. Before this PR there is no per-stage startup output on a release build, which is the problem being fixed.

### **After**

N/A — no UI change. Output is log lines; a sample run is in the Description.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
  - `StartupTimeline.test.ts`, 10 cases. Existing suites for every touched file pass: 413 tests across `Performance/`, `ControllersGate`, `EngineService`, `Nav/App`, `Views/Login`.
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Samsung Galaxy A14 5G (SM-A146P), Android 15, `production` release build — a mid-range physical device.
- [x] I've tested with a power user scenario
  - Populated wallet with several imported accounts; the numbers above come from that wallet.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - That is what this PR does — four new `TraceName`s alongside the local channel.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
