### PR TITLE
fix: report app start over the full pre-JS window, not the larger phase

### DIFF
--- a/app/core/Performance/Performance.test.ts
+++ b/app/core/Performance/Performance.test.ts
@@ -17,6 +17,11 @@ jest.mock('react-native-performance', () => {
     default: {
       measure: jest.fn(),
       getEntriesByName: jest.fn(),
+      // `endTrace` reaches `getPerformanceTimestamp`, which reads both of
+      // these. Without them the observer callback throws before any assertion
+      // runs, and which test sees it depends on trace-buffer ordering.
+      now: jest.fn(() => 0),
+      timeOrigin: 0,
     },
     PerformanceObserver: jest.fn(),
   };
@@ -62,6 +67,7 @@ describe('Performance', () => {
       runJsBundleStart: [{ name: 'runJsBundleStart', duration: 0 }],
       nativeLaunch: [{ name: 'nativeLaunch', duration: 1500 }],
       runJsBundle: [{ name: 'runJsBundle', duration: 1000 }],
+      appStart: [{ name: 'appStart', duration: 3100 }],
     };
     mockedPerformance.getEntriesByName.mockImplementation(
       (name: string) => entriesByName[name] ?? [],
@@ -89,7 +95,44 @@ describe('Performance', () => {
     );
     expect(console.info).toHaveBeenCalledWith(
       expect.stringContaining(
-        `APP START TIME = MAX(NATIVE LAUNCH TIME, JS BUNDLE LOAD TIME) - 1500ms`,
+        `APP START TIME = nativeLaunchStart -> runJsBundleEnd - 3100ms`,
+      ),
+    );
+  });
+
+  it('spans nativeLaunchStart to runJsBundleEnd so the host-setup gap is counted', () => {
+    // Arrange: the two phases are sequential, not overlapping, and there is a
+    // further host/context-setup gap between them. `appStart` (3100ms) is
+    // therefore larger than either phase and larger than their max (1500ms) —
+    // taking the max would silently discard the gap.
+    console.info = jest.fn();
+    setupObserverWithEntries([{ name: 'runJsBundleEnd', duration: 1000 }]);
+    const entriesByName: Record<string, MockEntry[]> = {
+      runJsBundleStart: [{ name: 'runJsBundleStart', duration: 0 }],
+      nativeLaunch: [{ name: 'nativeLaunch', duration: 1500 }],
+      runJsBundle: [{ name: 'runJsBundle', duration: 1000 }],
+      appStart: [{ name: 'appStart', duration: 3100 }],
+    };
+    mockedPerformance.getEntriesByName.mockImplementation(
+      (name: string) => entriesByName[name] ?? [],
+    );
+
+    // Act
+    Performance.setupPerformanceObservers();
+
+    // Assert
+    expect(mockedPerformance.measure).toHaveBeenCalledWith(
+      'appStart',
+      'nativeLaunchStart',
+      'runJsBundleEnd',
+    );
+    expect(console.info).toHaveBeenCalledWith(
+      expect.stringContaining('APP START TIME'),
+    );
+    // The reported app start must be the full span, not the larger phase.
+    expect(console.info).not.toHaveBeenCalledWith(
+      expect.stringContaining(
+        'APP START TIME = nativeLaunchStart -> runJsBundleEnd - 1500ms',
       ),
     );
   });

--- a/app/core/Performance/Performance.ts
+++ b/app/core/Performance/Performance.ts
@@ -49,16 +49,25 @@ class Performance {
           'runJsBundleStart',
           'runJsBundleEnd',
         );
+        // Measure the whole pre-JS window in one span. `Math.max` of the two
+        // phases below was used here previously, on the assumption that native
+        // launch and JS bundle load overlap. They do not: measured on a
+        // Galaxy A14 (production release), `nativeLaunchEnd` precedes
+        // `runJsBundleStart` with 0 ms of overlap, and there is a further
+        // ~589 ms of React Native host/context setup between them that neither
+        // phase covers. Taking the max therefore under-reported app start by
+        // ~642 ms and made that gap permanently invisible.
+        performance.measure('appStart', 'nativeLaunchStart', 'runJsBundleEnd');
+
         // Retrieve the measurements
         const nativeLaunchEntry = performance.getEntriesByName('nativeLaunch');
         const runJsBundleEntry = performance.getEntriesByName('runJsBundle');
+        const appStartEntry = performance.getEntriesByName('appStart');
 
         // Get the duration
         const nativeLaunchDuration = nativeLaunchEntry[0].duration;
         const jsBundleDuration = runJsBundleEntry[0].duration;
-        // Assuming JS bundle loads in parallel with launch start
-        // the total app start time is then the maximum of the two durations
-        const appStartTime = Math.max(nativeLaunchDuration, jsBundleDuration);
+        const appStartTime = appStartEntry[0].duration;
 
         if (isTestEnvironment || isE2EOrExpEnvironment) {
           // eslint-disable-next-line no-console
@@ -74,7 +83,7 @@ class Performance {
           console.info(`NATIVE LAUNCH TIME - ${nativeLaunchDuration}ms`);
           console.info(`JS BUNDLE LOAD TIME - ${jsBundleDuration}ms`);
           console.info(
-            `APP START TIME = MAX(NATIVE LAUNCH TIME, JS BUNDLE LOAD TIME) - ${appStartTime}ms`,
+            `APP START TIME = nativeLaunchStart -> runJsBundleEnd - ${appStartTime}ms`,
           );
           console.info(
             `-------------------------------------------------------`,


### PR DESCRIPTION
## **Description**

`Performance.setupPerformanceObservers` derived app start as:

```js
// Assuming JS bundle loads in parallel with launch start
// the total app start time is then the maximum of the two durations
const appStartTime = Math.max(nativeLaunchDuration, jsBundleDuration);
```

**The two phases are not parallel.** Measured on a Samsung Galaxy A14 5G with a `production` release build, `nativeLaunchEnd` precedes `runJsBundleStart` with **0 ms of overlap** — and there is a further **~589 ms** of React Native host/context setup between them that *neither* phase covers.

So the reported figure was `max(53 ms, 1,288 ms) = 1,288 ms`, while the real span from `nativeLaunchStart` to `runJsBundleEnd` was **1,930 ms**. A **~642 ms under-report**, and the host-setup gap was permanently invisible because it belonged to no measured phase.

That value is not cosmetic. `appStartTime` feeds `appLaunchTime`, which is the **start timestamp** for the `UIStartup` parent span and for `LoadScripts`, so four production startup metrics inherited the error — every one of them started ~642 ms too late.

### The fix

Measure the real span directly:

```js
performance.measure('appStart', 'nativeLaunchStart', 'runJsBundleEnd');
```

This covers both phases *and* the gap between them. The individual `nativeLaunch` and `runJsBundle` measures are kept, since the dev console log still reports them separately and they remain useful.

### ⚠️ Expected dashboard effect

**Reported startup values will step up by roughly 640 ms on release.** That is the correction landing, not a regression. Anyone watching startup dashboards or alert thresholds should know the shift is coming, and thresholds derived from the old numbers will need rebasing.

This is also a prerequisite for any startup work being verifiable: while the span starts 642 ms late, improvements are measured against a baseline that was never correct.

### Reviewer notes

- The `isTestEnvironment` console block now prints `APP START TIME = nativeLaunchStart -> runJsBundleEnd` rather than `MAX(NATIVE LAUNCH TIME, JS BUNDLE LOAD TIME)`, so the log states what is actually measured.
- The existing hot-reload guard is untouched: RN 0.83 bridgeless drops `runJsBundleStart` while `runJsBundleEnd` still fires (facebook/react-native#56339), and the new `measure` call sits after that early return, so it cannot throw on a missing mark.
- While adding the test I extended the `react-native-performance` mock with `now`/`timeOrigin`. Without them `endTrace` → `getPerformanceTimestamp` throws inside the observer callback, and *which* test hit it depended on trace-buffer ordering — a latent flake in the existing suite.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #35984

## **Manual testing steps**

```gherkin
Feature: App start metric spans the full pre-JS window

  Scenario: developer inspects startup numbers in a dev build
    Given a build where isTestEnvironment or isE2EOrExpEnvironment is true
    And the app has been force-stopped

    When user cold-launches the app
    Then the console prints NATIVE LAUNCH TIME and JS BUNDLE LOAD TIME
    And it prints "APP START TIME = nativeLaunchStart -> runJsBundleEnd"
    And that value is greater than either individual phase

  Scenario: hot reload does not break startup telemetry
    Given a debug build with Metro attached

    When developer triggers a hot reload
    Then no error is thrown for a missing runJsBundleStart mark
    And no startup telemetry is emitted for that reload
```

## **Screenshots/Recordings**

### **Before**

N/A — no UI change. The affected value is a reported metric; before/after numbers are in the Description.

### **After**

N/A — no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
  - Added a case asserting the `appStart` span is measured and that the reported value is not the larger phase. 3/3 pass.
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - The 0 ms overlap and the ~589 ms host-setup gap were measured on a Samsung Galaxy A14 5G (SM-A146P), Android 15, `production` release build.
- [x] I've tested with a power user scenario
  - Populated wallet with several imported accounts. This stage is wallet-size independent, so account count does not affect it.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - This PR corrects the start timestamp of existing Sentry startup spans rather than adding new ones.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
