### PR TITLE
fix(content): clarify token transfer warning copy

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -146,7 +146,7 @@
     },
     "token_contract_warning": {
       "title": "Token contract warning",
-      "message": "The recipient address may not support direct token transfers, which could result in fund loss. Only continue if you're certain this contract can receive your transfer."
+      "message": "The recipient address may not support direct token transfers, which could result in a loss of funds. Only continue if you're certain this contract can receive your transfer."
     },
     "gas_sponsorship_reserve_balance": {
       "message": "This specific network requires to maintain a reserve of {{minBalance}} {{nativeTokenSymbol}} in your account.",
@@ -785,7 +785,7 @@
     "entered_malicious": "The Address You Entered",
     "known_safe_address": "Known Address",
     "smart_contract_address": "Smart contract address",
-    "smart_contract_address_warning": "The recipient address may not support direct token transfers, which could result in fund loss. Only continue if you're certain this contract can receive your transfer.",
+    "smart_contract_address_warning": "The recipient address may not support direct token transfers, which could result in a loss of funds. Only continue if you're certain this contract can receive your transfer.",
     "unavailable_network_connection": "Unavailable network connection",
     "unavailable_network_connection_description": "The connection with {{network}} is unreliable. Update network connectivity details before continuing or try again later.",
     "update": "Update",


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

The token-contract warnings used the awkward phrase “result in fund loss.” Both live warning paths now say “result in a loss of funds.” The duplicate strings remain aligned, with no interpolation or behavior changes.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Clarified the token contract transfer warning

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: token contract warning

  Scenario: a recipient might not accept a direct token transfer
    Given MetaMask detects a token contract recipient
    When the warning is displayed
    Then it explains that the transfer could result in a loss of funds
```

Automated verification: `yarn jest app/components/Views/confirmations/hooks/alerts/useTokenContractAlert.test.ts app/components/Views/confirmations/hooks/send/alerts/useTokenContractSendAlert.test.ts --runInBand --coverage=false`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — copy-only correction with no component, styling, or layout changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR.
- [ ] I confirm that this PR addresses the described content issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> English locale string edits only; no application logic or security behavior changes.
> 
> **Overview**
> Updates English user-facing copy for **token contract / smart contract recipient** warnings so both strings use **“result in a loss of funds”** instead of **“result in fund loss.”**
> 
> The change is applied in two aligned locale entries: the confirmation alert `token_contract_warning.message` and the send-flow `smart_contract_address_warning`. No interpolation, keys, or runtime behavior change—only wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39057db94c5660bf035fc4bc1c4844e034a8b3d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->