### PR TITLE
fix(content): correct market hours tooltip grammar

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2541,13 +2541,13 @@
       "market_hours": {
         "title": "Market hours",
         "closes_in": "Closes in {{time}}",
-        "content": "You're trading within regular market hours (9:30 am to 4 pm EST). When markets are closed, there's risk for wider spreads, price moves, and higher funding rates."
+        "content": "You're trading within regular market hours (9:30 am to 4 pm EST). When markets are closed, there's a risk of wider spreads, price moves, and higher funding rates."
       },
       "after_hours_trading": {
         "title": "After-hours trading",
         "reopens_in": "Reopens in {{time}}",
         "reopens_in_label": "Reopens in",
-        "content": "You're trading outside of regular market hours (9:30 am to 4 pm EST). When markets are closed, there's risk for wider spreads, price moves, and higher funding rates."
+        "content": "You're trading outside of regular market hours (9:30 am to 4 pm EST). When markets are closed, there's a risk of wider spreads, price moves, and higher funding rates."
       },
       "spread": {
         "title": "Spread",


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

The regular-hours and after-hours Perps tooltips said “there’s risk for wider spreads.” Both live variants now use the grammatical phrase “there’s a risk of wider spreads.” Their hours, meaning, and rendering structure are unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed grammar in Perps market hours tooltips

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps market hours tooltip

  Scenario: a user reviews market-hours information
    Given the market is inside or outside regular hours
    When the tooltip is displayed
    Then it describes a risk of wider spreads
```

Automated verification: `yarn jest app/components/UI/Perps/components/PerpsBottomSheetTooltip/content/MarketHoursContent.test.tsx --runInBand --coverage=false`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — copy-only correction with no component, styling, or layout changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR.
- [ ] I confirm that this PR addresses the described content issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only English locale edits with no logic, layout, or behavioral changes.
> 
> **Overview**
> Updates English copy for the Perps **market hours** and **after-hours trading** tooltips in `locales/languages/en.json`.
> 
> Both strings now say “there’s **a risk of** wider spreads…” instead of “there’s risk **for** wider spreads…”. Hours, meaning, and UI wiring are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 060bb707b1cefc06524dc2c80e873e66a1dd3817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->