### PR TITLE
fix(content): remove trailing space from notification empty state

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6463,7 +6463,7 @@
     "network_fee_not_available": "Network fee not available",
     "empty": {
       "title": "Nothing to see here",
-      "message": "This is where you can find notifications once there’s activity in your wallet. "
+      "message": "This is where you can find notifications once there’s activity in your wallet."
     },
     "disabled": {
       "title": "Turn on notifications",


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

The notification empty-state message contained a trailing space. The string is rendered as a standalone Text value with no adjacent fragment or link, so the space is not intentional typesetting. This removes it without changing visible copy or layout.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Removed unintended whitespace from the notification empty state

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: notification empty state

  Scenario: a user has no notifications
    Given the notifications list is empty
    When the empty state is displayed
    Then its message has no trailing whitespace
```

Automated verification: `yarn jest app/components/UI/Notification/Empty/index.test.tsx --runInBand --coverage=false`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — copy-only correction with no component, styling, or layout changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR.
- [ ] I confirm that this PR addresses the described content issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single locale string edit with no logic, styling, or behavior changes.
> 
> **Overview**
> Removes an **unintended trailing space** from the English notification empty-state message in `locales/languages/en.json` (`…in your wallet.` with no space after the period).
> 
> Visible copy and UI layout are unchanged; this is a string hygiene fix for standalone text that does not need trailing whitespace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08eb44b7fe82f896edd0d64107a02988ffc85c69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->