### PR TITLE
fix(perps): perps confirm loader trap cp-8.11.0

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithPerpsSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithPerpsSection.test.tsx
@@ -348,6 +348,16 @@ describe('usePayWithPerpsSection', () => {
     });
   });
 
+  it('recreates the order immediately when the deposit fails', async () => {
+    depositWithConfirmationMock.mockRejectedValueOnce(new Error('user-cancel'));
+
+    const { result } = renderHook(() => usePayWithPerpsSection());
+
+    await pressAdd(result);
+
+    expect(depositWithOrderMock).toHaveBeenCalledTimes(1);
+  });
+
   it('does not navigate when deposit confirmation rejects', async () => {
     depositWithConfirmationMock.mockRejectedValueOnce(new Error('user-cancel'));
 

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithPerpsSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithPerpsSection.test.tsx
@@ -18,6 +18,9 @@ jest.mock('react-redux', () => ({
 }));
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
+  // Not a jest.fn: `resetAllMocks` would strip the implementation and silently
+  // turn this into a no-op.
+  useFocusEffect: (callback: () => void) => callback(),
 }));
 jest.mock('../../../../../../../locales/i18n', () => ({
   strings: (key: string, params?: { balance?: string }) => {
@@ -53,6 +56,7 @@ describe('usePayWithPerpsSection', () => {
 
   const navigateMock = jest.fn();
   const goBackMock = jest.fn();
+  const depositWithOrderMock = jest.fn();
   const onPaymentTokenChangeMock = jest.fn();
   const depositWithConfirmationMock = jest.fn();
   const onRejectMock = jest.fn();
@@ -94,6 +98,9 @@ describe('usePayWithPerpsSection', () => {
 
     usePerpsTradingMock.mockReturnValue({
       depositWithConfirmation: depositWithConfirmationMock.mockResolvedValue({
+        result: Promise.resolve('ok'),
+      }),
+      depositWithOrder: depositWithOrderMock.mockResolvedValue({
         result: Promise.resolve('ok'),
       }),
     } as never);
@@ -195,9 +202,9 @@ describe('usePayWithPerpsSection', () => {
     expect(goBackMock).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects approval, triggers deposit confirmation, and navigates with perps header when Add is pressed', async () => {
-    const { result } = renderHook(() => usePayWithPerpsSection());
-
+  const pressAdd = async (result: {
+    current: ReturnType<typeof usePayWithPerpsSection>;
+  }) => {
     const trailing = result.current?.rows[0].trailingElement as
       | { props: { onPress: () => Promise<void> } }
       | undefined;
@@ -205,6 +212,12 @@ describe('usePayWithPerpsSection', () => {
     await act(async () => {
       await trailing?.props.onPress();
     });
+  };
+
+  it('rejects approval, triggers deposit confirmation, and navigates with perps header when Add is pressed', async () => {
+    const { result } = renderHook(() => usePayWithPerpsSection());
+
+    await pressAdd(result);
 
     expect(onRejectMock).toHaveBeenCalledTimes(1);
     expect(depositWithConfirmationMock).toHaveBeenCalledTimes(1);
@@ -212,6 +225,77 @@ describe('usePayWithPerpsSection', () => {
       Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
       { showPerpsHeader: true },
     );
+  });
+
+  it('recreates the rejected order when the sheet regains focus after Add', async () => {
+    const { result, rerender } = renderHook(() => usePayWithPerpsSection());
+
+    await pressAdd(result);
+
+    useTransactionMetadataRequestMock.mockReturnValue(undefined as never);
+
+    await act(async () => {
+      rerender();
+    });
+
+    expect(depositWithOrderMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not recreate the order when the sheet is opened without pressing Add', async () => {
+    useTransactionMetadataRequestMock.mockReturnValue(undefined as never);
+
+    const { rerender } = renderHook(() => usePayWithPerpsSection());
+
+    await act(async () => {
+      rerender();
+    });
+
+    expect(depositWithOrderMock).not.toHaveBeenCalled();
+  });
+
+  it('does not recreate the order while a transaction is still pending', async () => {
+    const { result, rerender } = renderHook(() => usePayWithPerpsSection());
+
+    await pressAdd(result);
+
+    await act(async () => {
+      rerender();
+    });
+
+    expect(depositWithOrderMock).not.toHaveBeenCalled();
+  });
+
+  it('recreates the order only once across repeated focus events', async () => {
+    const { result, rerender } = renderHook(() => usePayWithPerpsSection());
+
+    await pressAdd(result);
+
+    useTransactionMetadataRequestMock.mockReturnValue(undefined as never);
+
+    await act(async () => {
+      rerender();
+    });
+    await act(async () => {
+      rerender();
+    });
+
+    expect(depositWithOrderMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a failure to recreate the order', async () => {
+    depositWithOrderMock.mockRejectedValueOnce(new Error('no-connection'));
+
+    const { result, rerender } = renderHook(() => usePayWithPerpsSection());
+
+    await pressAdd(result);
+
+    useTransactionMetadataRequestMock.mockReturnValue(undefined as never);
+
+    await act(async () => {
+      rerender();
+    });
+
+    expect(depositWithOrderMock).toHaveBeenCalledTimes(1);
   });
 
   it('does not navigate when deposit confirmation rejects', async () => {

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithPerpsSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithPerpsSection.test.tsx
@@ -298,6 +298,56 @@ describe('usePayWithPerpsSection', () => {
     expect(depositWithOrderMock).toHaveBeenCalledTimes(1);
   });
 
+  it('retries on the next focus when recreating the order failed', async () => {
+    depositWithOrderMock.mockRejectedValueOnce(new Error('no-connection'));
+
+    const { result, rerender } = renderHook(() => usePayWithPerpsSection());
+
+    await pressAdd(result);
+
+    useTransactionMetadataRequestMock.mockReturnValue(undefined as never);
+
+    await act(async () => {
+      rerender();
+    });
+    await act(async () => {
+      rerender();
+    });
+
+    expect(depositWithOrderMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not recreate the order while the deposit is still in flight', async () => {
+    let resolveDeposit: (value: unknown) => void = () => undefined;
+    depositWithConfirmationMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveDeposit = resolve;
+      }),
+    );
+
+    const { result, rerender } = renderHook(() => usePayWithPerpsSection());
+
+    const trailing = result.current?.rows[0].trailingElement as
+      | { props: { onPress: () => Promise<void> } }
+      | undefined;
+
+    act(() => {
+      trailing?.props.onPress();
+    });
+
+    useTransactionMetadataRequestMock.mockReturnValue(undefined as never);
+
+    await act(async () => {
+      rerender();
+    });
+
+    expect(depositWithOrderMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveDeposit({ result: Promise.resolve('ok') });
+    });
+  });
+
   it('does not navigate when deposit confirmation rejects', async () => {
     depositWithConfirmationMock.mockRejectedValueOnce(new Error('user-cancel'));
 

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithPerpsSection.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithPerpsSection.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useMemo } from 'react';
-import { useNavigation } from '@react-navigation/native';
+import React, { useCallback, useMemo, useRef } from 'react';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../../core/NavigationService/types';
 import { useSelector } from 'react-redux';
 import {
@@ -45,8 +45,10 @@ export function usePayWithPerpsSection(): PayWithSectionConfig | null {
   const perpsAccount = useSelector(selectPerpsAccountState);
   const { onPaymentTokenChange } = usePerpsPaymentToken();
   const isPerpsBalanceSelected = useIsPerpsBalanceSelected();
-  const { depositWithConfirmation } = usePerpsTrading();
+  const { depositWithConfirmation, depositWithOrder } = usePerpsTrading();
   const { onReject } = useApprovalRequest();
+  const hasLeftForDeposit = useRef(false);
+  const isRestoringOrder = useRef(false);
 
   const isPerpsDepositAndOrder = hasTransactionType(transactionMeta, [
     TransactionType.perpsDepositAndOrder,
@@ -70,6 +72,7 @@ export function usePayWithPerpsSection(): PayWithSectionConfig | null {
 
   const handleAdd = useCallback(async () => {
     onReject();
+    hasLeftForDeposit.current = true;
     try {
       await depositWithConfirmation();
       navigation.navigate(
@@ -80,6 +83,32 @@ export function usePayWithPerpsSection(): PayWithSectionConfig | null {
       // Deposit flow handles errors (e.g. user rejection or missing network).
     }
   }, [depositWithConfirmation, navigation, onReject]);
+
+  // Only one approval can be pending, so `handleAdd` rejects the order to make
+  // room for the deposit. Put it back on the way out, or the confirmation
+  // still mounted beneath this sheet has nothing left to render.
+  useFocusEffect(
+    useCallback(() => {
+      if (
+        !hasLeftForDeposit.current ||
+        isRestoringOrder.current ||
+        transactionMeta
+      ) {
+        return;
+      }
+
+      isRestoringOrder.current = true;
+
+      depositWithOrder()
+        .catch(() => {
+          // The deposit flow surfaces its own errors.
+        })
+        .finally(() => {
+          hasLeftForDeposit.current = false;
+          isRestoringOrder.current = false;
+        });
+    }, [depositWithOrder, transactionMeta]),
+  );
 
   return useMemo(() => {
     if (!isPerpsDepositAndOrder) {

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithPerpsSection.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithPerpsSection.tsx
@@ -72,15 +72,15 @@ export function usePayWithPerpsSection(): PayWithSectionConfig | null {
 
   const handleAdd = useCallback(async () => {
     onReject();
-    hasLeftForDeposit.current = true;
     try {
       await depositWithConfirmation();
+      hasLeftForDeposit.current = true;
       navigation.navigate(
         Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
         { showPerpsHeader: true },
       );
     } catch {
-      // Deposit flow handles errors (e.g. user rejection or missing network).
+      hasLeftForDeposit.current = true;
     }
   }, [depositWithConfirmation, navigation, onReject]);
 
@@ -100,11 +100,11 @@ export function usePayWithPerpsSection(): PayWithSectionConfig | null {
       isRestoringOrder.current = true;
 
       depositWithOrder()
-        .catch(() => {
-          // The deposit flow surfaces its own errors.
-        })
-        .finally(() => {
+        .then(() => {
           hasLeftForDeposit.current = false;
+        })
+        .catch(() => undefined)
+        .finally(() => {
           isRestoringOrder.current = false;
         });
     }, [depositWithOrder, transactionMeta]),

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithPerpsSection.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithPerpsSection.tsx
@@ -70,6 +70,23 @@ export function usePayWithPerpsSection(): PayWithSectionConfig | null {
     navigation.goBack();
   }, [clearPaymentOverride, navigation, onPaymentTokenChange]);
 
+  const restoreOrder = useCallback(() => {
+    if (isRestoringOrder.current) {
+      return;
+    }
+
+    isRestoringOrder.current = true;
+
+    depositWithOrder()
+      .then(() => {
+        hasLeftForDeposit.current = false;
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        isRestoringOrder.current = false;
+      });
+  }, [depositWithOrder]);
+
   const handleAdd = useCallback(async () => {
     onReject();
     try {
@@ -81,33 +98,18 @@ export function usePayWithPerpsSection(): PayWithSectionConfig | null {
       );
     } catch {
       hasLeftForDeposit.current = true;
+      restoreOrder();
     }
-  }, [depositWithConfirmation, navigation, onReject]);
+  }, [depositWithConfirmation, navigation, onReject, restoreOrder]);
 
-  // Only one approval can be pending, so `handleAdd` rejects the order to make
-  // room for the deposit. Put it back on the way out, or the confirmation
-  // still mounted beneath this sheet has nothing left to render.
   useFocusEffect(
     useCallback(() => {
-      if (
-        !hasLeftForDeposit.current ||
-        isRestoringOrder.current ||
-        transactionMeta
-      ) {
+      if (!hasLeftForDeposit.current || transactionMeta) {
         return;
       }
 
-      isRestoringOrder.current = true;
-
-      depositWithOrder()
-        .then(() => {
-          hasLeftForDeposit.current = false;
-        })
-        .catch(() => undefined)
-        .finally(() => {
-          isRestoringOrder.current = false;
-        });
-    }, [depositWithOrder, transactionMeta]),
+      restoreOrder();
+    }, [restoreOrder, transactionMeta]),
   );
 
   return useMemo(() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

  <!-- mms-check: type=text required=true -->

  Backing out of the Perps "Add funds" confirmation reached from the Pay With sheet leaves the user on a spinner that never resolves, with no header, hardware back swallowed and the back gesture disabled. The flow is dead and the pending order is lost; swiping back to the wallet home is the only recovery. Reproducible on 8.11 and 8.12.

**Root cause.** `Confirm` does not own an approval request: `useApprovalRequest` returns `Object.values(pendingApprovals)[0]`, whichever request happens to be first in the approval controller. Only one confirmation can be live at a time, so `usePayWithPerpsSection.handleAdd` has to `onReject()` the order to free the slot before `depositWithConfirmation()` can create the deposit request.

That reject is correct and is unchanged here. What was missing is the other half — nothing ever put the order back. Its screen stayed on the navigation stack with its transaction gone, and once the deposit request was rejected on the way out there were zero pending approvals left, so that screen fell through to `if (!approvalRequest) return <Loader />` with every exit disabled.

Confirmed on device with the navigator state logged at each step:

  ```
  13:53:19.983  handleAdd → onReject()                     order request rejected, its screen stays mounted
  13:53:22.192  stack: [PerpsMarketDetails, RedesignedConfirmations, PayWithBottomSheet, RedesignedConfirmations]
  13:53:26.840  beforeRemove {"type":"GO_BACK"}            deposit request rejected on the way out
  13:53:27.022  approvalRequest → ABSENT                   no requests left; the screen below renders a Loader
  ```

**Fix.** A `useFocusEffect` in `usePayWithPerpsSection` recreates the order when the Pay With sheet regains focus after an Add, via `depositWithOrder()` — the same no-argument call `usePerpsNavigation.navigateToOrder` and `PerpsOrderRedirect` already use to create it, with the order details held in controller state. Guarded to run only once the deposit request exists, only when no transaction is pending, and only once at a time; arming any earlier would race
  a second request into the same approval slot while the deposit is still in flight. Navigation is unchanged.

  ## **Changelog**

  <!-- mms-check: type=changelog required=true blocking=true -->

  <!--
  If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
  1. Write `CHANGELOG entry: null`
  2. Label with `no-changelog`

  If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
  `CHANGELOG entry: Added a new tab for users to see their NFTs`
  `CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

  (This helps the Release Engineer do their job more quickly and accurately)
  -->

  CHANGELOG entry: Fixed a bug where backing out of the Perps add-funds screen could leave the app stuck on a loading spinner

  ## **Related issues**

  <!-- mms-check: type=issue-link required=true -->

  Fixes: https://consensys.slack.com/archives/C092T3GPHQD/p1788972993964219

  ## **Manual testing steps**

  <!-- mms-check: type=manual-testing required=true -->

  ```gherkin
  Feature: Adding funds to the Perps balance from the Pay With sheet

    Scenario: user backs out of the add-funds confirmation
      Given the user is on the order confirmation for a Perps deposit-and-order
      And the user has opened the "Pay with" bottom sheet

      When user taps "Add" on the Perps balance row
      And user taps back from the add-funds confirmation
      Then the order confirmation is shown with the "Pay with" sheet still open
      And the app is responsive with no loading spinner

    Scenario: user completes the order after returning
      Given the user has backed out of the add-funds confirmation

      When user selects a payment method and submits the order
      Then the order is placed as normal
  ```

  ## **Screenshots/Recordings**

  <!-- mms-check: type=screenshot required=true -->

  <!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

  ### **Before**
https://github.com/user-attachments/assets/1eda5160-10e5-4de7-bdcd-95432590ded6
  <!-- [screenshots/recordings] -->

  ### **After**
 https://www.loom.com/share/7b1e831910e34f63ac08dad474a42ecc
  <!-- [screenshots/recordings] -->

  ## **Pre-merge author checklist**

  <!-- mms-check: type=checklist required=true -->

  <!--
  Every checklist item must be consciously assessed before marking this PR as
  "Ready for review". A checked box means you deliberately considered that
  responsibility, not that you literally performed every action listed.

  Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
  a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
  semantics.
  -->

  - [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
  - [x] I've completed the PR template to the best of my ability
  - [x] I've included tests if applicable
  - [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

  #### Performance checks (if applicable)

  - [x] I've tested on Android
    - Ideally on a mid-range device; emulator is acceptable
  - [x] I've tested with a power user scenario
    - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
  - [x] I've instrumented key operations with Sentry traces for production performance metrics
    - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

  For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

  ## **Pre-merge reviewer checklist**

  <!--
  Reviewer checklist items follow the same semantics as the author checklist: an
  unchecked box is ambiguous, a checked box means the reviewer consciously
  assessed that responsibility. See `docs/readme/ready-for-review.md`.
  -->

  - [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
  - [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Perps confirmation and approval-slot timing; behavior is guarded but incorrect guards could duplicate orders or leave users stuck again.
> 
> **Overview**
> Fixes a **dead-end loader** when users tap **Add** on the Perps balance in the Pay With sheet, reject the deposit confirmation, and return—the original order approval was rejected to free the slot and was never recreated.
> 
> **`usePayWithPerpsSection`** now tracks when the user left for the deposit flow and calls **`depositWithOrder()`** via a guarded **`restoreOrder`** helper: on **focus** when there is no pending transaction metadata (after deposit completes or is dismissed), and **immediately** if **`depositWithConfirmation`** fails. Refs prevent duplicate restores, races while the deposit is in flight, and allow **retry** after a failed restore.
> 
> Tests add a stable **`useFocusEffect`** mock, **`depositWithOrder`** expectations, and cases for focus-only restore, no restore without Add, in-flight deposit, single-fire across focus, error swallow/retry, and immediate restore on deposit cancel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81fa30031e39e6f84243f957d77c56884f9c63bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->