### PR TITLE
fix: MUSD-1329, MUSD-1330 Fixing Money onboarding regressions introduced by nitro-rive upgrade cp-8.11.0

### DIFF
--- a/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.test.tsx
@@ -133,7 +133,9 @@ jest.mock('react-native-reanimated', () => {
 // Local wrapper around the global Nitro Rive mock so the RiveView `onError`
 // prop is observable; triggers/setters are driven via the global mock helpers.
 const mockRiveViewProps: {
-  current?: { onError?: (error: RiveError) => void };
+  current?: {
+    onError?: (error: RiveError) => void;
+  };
 } = {};
 
 jest.mock('@rive-app/react-native', () => {
@@ -151,6 +153,9 @@ jest.mock('@rive-app/react-native', () => {
 });
 
 const STEP_TRANSITION_MS = 300;
+const FORWARD_NAVIGATION_INPUT_LOCK_MS = 3200;
+const BACKWARD_NAVIGATION_INPUT_LOCK_MS = 1600;
+const FINAL_STEP_ANIMATION_MS = 3200;
 
 // Steps are reconstructed from `continue`/`back` view-model triggers (no
 // `onStateChanged` in Nitro): fire a trigger, then settle the transition timer.
@@ -169,16 +174,21 @@ const settleTransition = () => {
 const advanceStep = () => {
   fireTrigger('continue');
   settleTransition();
+  act(() => {
+    jest.advanceTimersByTime(
+      FORWARD_NAVIGATION_INPUT_LOCK_MS - STEP_TRANSITION_MS,
+    );
+  });
 };
 
 /** Fires `continue` up to the final step and settles the last transition. */
 const completeOnboarding = async () => {
-  fireTrigger('continue');
-  fireTrigger('continue');
-  fireTrigger('continue');
+  advanceStep();
+  advanceStep();
+  advanceStep();
   fireTrigger('continue');
   await act(async () => {
-    jest.advanceTimersByTime(STEP_TRANSITION_MS);
+    jest.advanceTimersByTime(STEP_TRANSITION_MS + FINAL_STEP_ANIMATION_MS);
   });
 };
 
@@ -387,6 +397,52 @@ describe('MoneyOnboardingView', () => {
       expect(mockTrackOnboardingEvent).not.toHaveBeenCalled();
     });
 
+    it('keeps Rive input disabled until the navigation lock expires', () => {
+      const { getByTestId } = renderMoneyOnboardingView();
+      const getRiveInputContainer = () =>
+        getByTestId(MoneyOnboardingViewTestIds.RIVE_INPUT_CONTAINER);
+
+      expect(getRiveInputContainer()?.props.pointerEvents).toBe('auto');
+
+      fireTrigger('continue');
+
+      expect(getRiveInputContainer()?.props.pointerEvents).toBe('none');
+
+      act(() => {
+        jest.advanceTimersByTime(FORWARD_NAVIGATION_INPUT_LOCK_MS - 1);
+      });
+
+      expect(getRiveInputContainer()?.props.pointerEvents).toBe('none');
+
+      act(() => {
+        jest.advanceTimersByTime(1);
+      });
+
+      expect(getRiveInputContainer()?.props.pointerEvents).toBe('auto');
+    });
+
+    it('uses the shorter lock for backward navigation', () => {
+      const { getByTestId } = renderMoneyOnboardingView();
+      const getRiveInputContainer = () =>
+        getByTestId(MoneyOnboardingViewTestIds.RIVE_INPUT_CONTAINER);
+      advanceStep();
+      advanceStep();
+
+      fireTrigger('back');
+
+      act(() => {
+        jest.advanceTimersByTime(BACKWARD_NAVIGATION_INPUT_LOCK_MS - 1);
+      });
+
+      expect(getRiveInputContainer()?.props.pointerEvents).toBe('none');
+
+      act(() => {
+        jest.advanceTimersByTime(1);
+      });
+
+      expect(getRiveInputContainer()?.props.pointerEvents).toBe('auto');
+    });
+
     it('tracks the previous step again when the back trigger settles', () => {
       renderMoneyOnboardingView();
       advanceStep();
@@ -468,6 +524,50 @@ describe('MoneyOnboardingView', () => {
         },
         { pop: true },
       );
+    });
+
+    it('waits for the final animation before completing onboarding', () => {
+      renderMoneyOnboardingView();
+      advanceStep();
+      advanceStep();
+      advanceStep();
+      mockTrackOnboardingEvent.mockClear();
+
+      fireTrigger('continue');
+      settleTransition();
+
+      expect(mockTrackOnboardingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          step: 5,
+          step_action: MONEY_ONBOARDING_STEP_ACTIONS.VIEWED,
+        }),
+      );
+      expect(mockTrackOnboardingEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          step_action: MONEY_ONBOARDING_STEP_ACTIONS.COMPLETED,
+        }),
+      );
+      expect(mockNavigate).not.toHaveBeenCalled();
+
+      act(() => {
+        jest.advanceTimersByTime(
+          FINAL_STEP_ANIMATION_MS - STEP_TRANSITION_MS - 1,
+        );
+      });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+
+      act(() => {
+        jest.advanceTimersByTime(1);
+      });
+
+      expect(mockTrackOnboardingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          step: 5,
+          step_action: MONEY_ONBOARDING_STEP_ACTIONS.COMPLETED,
+        }),
+      );
+      expect(mockNavigate).toHaveBeenCalled();
     });
 
     it('dispatches setMoneyOnboardingSeen when the final step settles', async () => {

--- a/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.testIds.ts
+++ b/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.testIds.ts
@@ -1,4 +1,5 @@
 export const MoneyOnboardingViewTestIds = {
+  RIVE_INPUT_CONTAINER: 'money-onboarding-rive-input-container',
   RIVE_ANIMATION: 'money-onboarding-rive-animation',
   OVERLAY_TITLE: 'money-onboarding-overlay-title',
   OVERLAY_CONTENT: 'money-onboarding-overlay-content',

--- a/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
+++ b/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
@@ -101,11 +101,24 @@ const TOTAL_ONBOARDING_STEPS = FINAL_STEP_INDEX + 1;
  * authored transition instead.
  */
 const STEP_TRANSITION_MS = 300;
+/**
+ * The authored Coins-to-Fox transition is 188 frames at 60 fps (~3.13 s).
+ * Round up slightly and keep completion timing separate so Money Home is not
+ * shown before the final animation has finished.
+ */
+const FINAL_STEP_ANIMATION_MS = 3200;
+/**
+ * Keep Rive input disabled until each transition is complete because Nitro
+ * does not expose a transition-complete callback. Backward transitions are
+ * authored at roughly half the duration of forward transitions.
+ */
+const FORWARD_NAVIGATION_INPUT_LOCK_MS = 3200;
+const BACKWARD_NAVIGATION_INPUT_LOCK_MS = 1600;
 const OVERLAY_FADE_DURATION_MS = 200;
 const SMALL_OVERLAY_DEVICE_MAX_WIDTH = 375;
 const SMALL_OVERLAY_DEVICE_MAX_HEIGHT = 700;
 const HEADER_TOP_OFFSET = 60;
-const FOOTER_BOTTOM_OFFSET = 100;
+const FOOTER_BOTTOM_OFFSET = 75;
 const OVERLAY_TEXT_PRESETS = {
   small: {
     title: { fontSize: 18, lineHeight: 25, paddingHorizontal: 42 },
@@ -153,6 +166,7 @@ const styles = StyleSheet.create({
   footer: {
     opacity: 0.7,
     paddingHorizontal: 16,
+    paddingTop: 16,
     textAlign: 'center',
   },
 });
@@ -271,8 +285,31 @@ const MoneyOnboardingView = () => {
   });
 
   const stepRef = useRef(0);
+  const stepTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const finalStepAnimationTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const navigationLockTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const isTransitioningRef = useRef(false);
+  const [isRiveInputDisabled, setIsRiveInputDisabled] = useState(false);
   const [overlayStep, setOverlayStep] = useState(0);
   const overlayOpacity = useSharedValue(0);
+
+  const clearStepTimers = useCallback(() => {
+    if (stepTimerRef.current) {
+      clearTimeout(stepTimerRef.current);
+      stepTimerRef.current = null;
+    }
+    if (finalStepAnimationTimerRef.current) {
+      clearTimeout(finalStepAnimationTimerRef.current);
+      finalStepAnimationTimerRef.current = null;
+    }
+    if (navigationLockTimerRef.current) {
+      clearTimeout(navigationLockTimerRef.current);
+      navigationLockTimerRef.current = null;
+    }
+    isTransitioningRef.current = false;
+  }, []);
+
+  useEffect(() => clearStepTimers, [clearStepTimers]);
 
   const { setValue: setButtonText } = useRiveString('button', instance);
   const { setValue: setTransitionSpeed } = useRiveNumber(
@@ -400,6 +437,8 @@ const MoneyOnboardingView = () => {
 
   const handleClose = useCallback(
     async (stepIndex: number) => {
+      clearStepTimers();
+      setIsRiveInputDisabled(false);
       playImpact(ImpactMoment.PageNavigation);
       trackOnboardingEvent({
         step: stepIndex + 1, // Use 1-based index for event tracking to match total_steps count.
@@ -413,9 +452,11 @@ const MoneyOnboardingView = () => {
       await navigateToPostOnboardingDestination();
     },
     [
+      clearStepTimers,
       dispatch,
       navigateToPostOnboardingDestination,
       postOnboardingRedirectTarget,
+      setIsRiveInputDisabled,
       stepTitlesEnglish,
       trackOnboardingEvent,
     ],
@@ -471,25 +512,38 @@ const MoneyOnboardingView = () => {
   // index. The overlay fades out immediately (as the authored transition
   // starts) and the copy swap / VIEWED tracking / completion fire once the
   // transition has had time to finish.
-  const stepTimerRef = useRef<NodeJS.Timeout | null>(null);
-  useEffect(
-    () => () => {
-      if (stepTimerRef.current) clearTimeout(stepTimerRef.current);
-    },
-    [],
-  );
-
   const goToStep = useCallback(
     (nextStep: number) => {
+      if (isTransitioningRef.current) return;
+
+      clearStepTimers();
+      isTransitioningRef.current = true;
+      setIsRiveInputDisabled(true);
+      const isForwardNavigation = nextStep > stepRef.current;
+      const navigationInputLockMs = isForwardNavigation
+        ? FORWARD_NAVIGATION_INPUT_LOCK_MS
+        : BACKWARD_NAVIGATION_INPUT_LOCK_MS;
       stepRef.current = nextStep;
+      navigationLockTimerRef.current = setTimeout(() => {
+        navigationLockTimerRef.current = null;
+        isTransitioningRef.current = false;
+        setIsRiveInputDisabled(false);
+      }, navigationInputLockMs);
       playImpact(ImpactMoment.PageNavigation);
       overlayOpacity.set(
         withTiming(0, {
           duration: OVERLAY_FADE_DURATION_MS,
         }),
       );
-      if (stepTimerRef.current) clearTimeout(stepTimerRef.current);
+      if (nextStep === FINAL_STEP_INDEX) {
+        finalStepAnimationTimerRef.current = setTimeout(() => {
+          finalStepAnimationTimerRef.current = null;
+          handleComplete(nextStep);
+        }, FINAL_STEP_ANIMATION_MS);
+      }
+
       stepTimerRef.current = setTimeout(() => {
+        stepTimerRef.current = null;
         if (stepContent[nextStep]) {
           setOverlayStep(nextStep);
           overlayOpacity.set(
@@ -500,13 +554,16 @@ const MoneyOnboardingView = () => {
         }
 
         handleStepViewed(nextStep);
-
-        if (nextStep === FINAL_STEP_INDEX) {
-          handleComplete(nextStep);
-        }
       }, STEP_TRANSITION_MS);
     },
-    [handleStepViewed, handleComplete, overlayOpacity, stepContent],
+    [
+      clearStepTimers,
+      handleStepViewed,
+      handleComplete,
+      overlayOpacity,
+      setIsRiveInputDisabled,
+      stepContent,
+    ],
   );
 
   const handleContinue = useCallback(() => {
@@ -545,18 +602,25 @@ const MoneyOnboardingView = () => {
   return (
     <View style={styles.root}>
       {riveFile && instance && (
-        <RiveView
-          file={riveFile}
-          artboardName={RIVE_ARTBOARD_NAME}
-          stateMachineName={RIVE_STATE_MACHINE_NAME}
-          dataBind={instance}
-          autoPlay
-          fit={Fit.Layout}
-          layoutScaleFactor={PixelRatio.get()}
-          onError={handleError}
+        <View
+          collapsable={false}
+          pointerEvents={isRiveInputDisabled ? 'none' : 'auto'}
           style={StyleSheet.absoluteFill}
-          testID={MoneyOnboardingViewTestIds.RIVE_ANIMATION}
-        />
+          testID={MoneyOnboardingViewTestIds.RIVE_INPUT_CONTAINER}
+        >
+          <RiveView
+            file={riveFile}
+            artboardName={RIVE_ARTBOARD_NAME}
+            stateMachineName={RIVE_STATE_MACHINE_NAME}
+            dataBind={instance}
+            autoPlay
+            fit={Fit.Layout}
+            layoutScaleFactor={PixelRatio.get()}
+            onError={handleError}
+            style={StyleSheet.absoluteFill}
+            testID={MoneyOnboardingViewTestIds.RIVE_ANIMATION}
+          />
+        </View>
       )}
       <MoneyOnboardingTextOverlay
         content={stepContent[overlayStep]}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The Nitro Rive onboarding flow could navigate to Money Home before the final
animation finished, and rapid navigation taps could desynchronize the overlay
copy from the animation. The flow now waits for the final animation and locks
Rive navigation input during transitions. Also lowered the footer text that was partially covered on smaller devices.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: fix: Fixed Money onboarding navigation before the final animation completes

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1329: Bug: Money onboarding final animation screen closes before animation completes](https://consensyssoftware.atlassian.net/browse/MUSD-1329)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money onboarding navigation timing

  Scenario: user completes Money onboarding
    Given the user is viewing the final Money onboarding step
    When the user completes onboarding
    Then the final animation plays fully before Money Home opens

  Scenario: user taps navigation during a transition
    Given the user is viewing a Money onboarding step
    When the user taps the navigation area repeatedly during the transition
    Then navigation input remains blocked until the transition lock expires
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**
Money Home redirect before animation completes.

https://github.com/user-attachments/assets/647b489f-6980-41f2-968b-70da2e197046

### **After**

https://github.com/user-attachments/assets/ff6ba859-27d4-4407-8469-976c36d26e4e

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance%20Guide%20for%20Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding navigation timing and when users leave the flow; mistakes could block taps too long or delay redirects, but scope is limited to Money onboarding with new unit tests.
> 
> **Overview**
> Fixes Money onboarding regressions after the Nitro Rive upgrade by aligning React Native timing with authored animation lengths.
> 
> **Navigation input lock:** While a step transition runs, `goToStep` ignores overlapping navigations and sets `pointerEvents` to `none` on a new wrapper around `RiveView` until a timer expires—~3.2s forward, ~1.6s back—because Nitro has no transition-complete callback.
> 
> **Final step:** Completion analytics and redirect to Money Home now run after `FINAL_STEP_ANIMATION_MS` (~3.2s), not when the 300ms overlay transition settles, so the Coins-to-Fox animation can finish first.
> 
> **Layout:** Footer is nudged up (`FOOTER_BOTTOM_OFFSET` 100→75) and given `paddingTop` so disclaimer text isn’t clipped on smaller devices.
> 
> Tests add `RIVE_INPUT_CONTAINER`, advance fake timers for locks and final animation, and assert lock duration and deferred completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3966e4b5df7daf20fe4bda41c9bdaef167bb6595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->