### PR TITLE
feat: MUSD-1331 Wrap redesigned Earn row in trade menu with feature flag cp-8.11.0

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -116,6 +116,7 @@ export MM_POOLED_STAKING_ENABLED="true"
 export MM_POOLED_STAKING_SERVICE_INTERRUPTION_BANNER_ENABLED="true"
 export MM_EARN_HOME_SECTION_ENABLED="false"
 export MM_EXPLORE_EARN_SECTION_ENABLED="false"
+export MM_EARN_TRADE_MENU_ROW_REDESIGN_ENABLED="false"
 # mUSD
 export MM_MUSD_CONVERSION_FLOW_ENABLED="false"
 # See app/components/UI/Earn/docs/wildcard-token-list.md for more information.

--- a/app/components/UI/Earn/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Earn/selectors/featureFlags/index.test.ts
@@ -18,6 +18,7 @@ import {
   selectMusdBalanceChainIds,
   MUSD_BALANCE_CHAIN_IDS_FALLBACK,
   selectExploreEarnSectionEnabledFlag,
+  selectEarnTradeMenuRowRedesignEnabled,
 } from '.';
 import mockedEngine from '../../../../../core/__mocks__/MockedEngine';
 import type { Json } from '@metamask/utils';
@@ -2270,6 +2271,83 @@ describe('Earn Feature Flag Selectors', () => {
       process.env.MM_EXPLORE_EARN_SECTION_ENABLED = 'false';
 
       const result = selectExploreEarnSectionEnabledFlag(mockedEmptyFlagsState);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('selectEarnTradeMenuRowRedesignEnabled', () => {
+    it('returns true when remote flag is enabled and version check passes', () => {
+      process.env.MM_EARN_TRADE_MENU_ROW_REDESIGN_ENABLED = 'false';
+
+      const stateWithEnabledRemoteFlag = createStateWithRemoteFlags({
+        earnTradeMenuRowRedesignEnabled: {
+          enabled: true,
+          minimumVersion: '1.0.0',
+        },
+      });
+
+      const result = selectEarnTradeMenuRowRedesignEnabled(
+        stateWithEnabledRemoteFlag,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when remote flag is disabled', () => {
+      process.env.MM_EARN_TRADE_MENU_ROW_REDESIGN_ENABLED = 'true';
+
+      const stateWithDisabledRemoteFlag = createStateWithRemoteFlags({
+        earnTradeMenuRowRedesignEnabled: {
+          enabled: false,
+          minimumVersion: '1.0.0',
+        },
+      });
+
+      const result = selectEarnTradeMenuRowRedesignEnabled(
+        stateWithDisabledRemoteFlag,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote flag minimum version is not met', () => {
+      process.env.MM_EARN_TRADE_MENU_ROW_REDESIGN_ENABLED = 'true';
+
+      const stateWithVersionMismatch = createStateWithRemoteFlags({
+        earnTradeMenuRowRedesignEnabled: {
+          enabled: true,
+          minimumVersion: '99.0.0',
+        },
+      });
+
+      const result = selectEarnTradeMenuRowRedesignEnabled(
+        stateWithVersionMismatch,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('falls back to local flag when remote flag is invalid', () => {
+      process.env.MM_EARN_TRADE_MENU_ROW_REDESIGN_ENABLED = 'true';
+
+      const stateWithInvalidRemoteFlag = createStateWithRemoteFlags({
+        earnTradeMenuRowRedesignEnabled: null,
+      });
+
+      const result = selectEarnTradeMenuRowRedesignEnabled(
+        stateWithInvalidRemoteFlag,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('falls back to false when remote flag is unavailable and local flag is disabled', () => {
+      process.env.MM_EARN_TRADE_MENU_ROW_REDESIGN_ENABLED = 'false';
+
+      const result = selectEarnTradeMenuRowRedesignEnabled(
+        mockedEmptyFlagsState,
+      );
 
       expect(result).toBe(false);
     });

--- a/app/components/UI/Earn/selectors/featureFlags/index.ts
+++ b/app/components/UI/Earn/selectors/featureFlags/index.ts
@@ -396,3 +396,18 @@ export const selectExploreEarnSectionEnabledFlag = createSelector(
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );
+
+/**
+ * Selects whether the redesigned Earn row is rendered in the Trade menu.
+ */
+export const selectEarnTradeMenuRowRedesignEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const localFlag =
+      process.env.MM_EARN_TRADE_MENU_ROW_REDESIGN_ENABLED === 'true';
+    const remoteFlag =
+      remoteFeatureFlags?.earnTradeMenuRowRedesignEnabled as unknown as VersionGatedFeatureFlag;
+
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
+  },
+);

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.test.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.test.tsx
@@ -19,7 +19,10 @@ import {
 } from '../../../util/test/accountsControllerTestUtils';
 import { backgroundState } from '../../../util/test/initial-root-state';
 import { mockNetworkState } from '../../../util/test/network';
-import { selectIsEarnSectionEligible } from '../../UI/Earn/selectors/eligibility';
+import {
+  selectEarnTradeMenuRowRedesignEnabled,
+  selectStablecoinLendingEnabledFlag,
+} from '../../UI/Earn/selectors/featureFlags';
 import { selectPerpsEnabledFlag } from '../../UI/Perps';
 import { selectPerpsProModeEnabledFlag } from '../../UI/Perps/selectors/featureFlags';
 import {
@@ -31,12 +34,6 @@ import { selectPredictEnabledFlag } from '../../UI/Predict';
 import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 import { isHardwareAccount } from '../../../util/address';
 import { selectBatchSellEnabled } from '../../../selectors/featureFlagController/batchSell';
-import useEarnHighestRate from '../../UI/Earn/hooks/useEarnHighestRate';
-import {
-  EARN_MODULE_COMPONENT_NAMES,
-  EARN_MODULE_REDIRECT_TARGETS,
-  EARN_MODULE_ENTRY_POINTS,
-} from '../../UI/Earn/constants/earnModuleEvents';
 import TradeWalletActions from './TradeWalletActions';
 
 jest.mock('react-native-device-info', () => ({
@@ -139,6 +136,30 @@ jest.mock('../../UI/Earn/selectors/eligibility', () => ({
   selectIsEarnSectionEligible: jest.fn(),
 }));
 
+jest.mock('../../UI/Earn/selectors/featureFlags', () => ({
+  selectEarnTradeMenuRowRedesignEnabled: jest.fn().mockReturnValue(false),
+  selectPooledStakingEnabledFlag: jest.fn().mockReturnValue(false),
+  selectStablecoinLendingEnabledFlag: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../../../selectors/earnController/earn', () => ({
+  earnSelectors: {
+    selectEarnTokens: jest.fn().mockReturnValue({
+      earnTokens: [],
+    }),
+  },
+}));
+
+jest.mock('../../UI/Stake/hooks/useStakingEligibility', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue({
+    isEligible: true,
+    isLoadingEligibility: false,
+    error: null,
+    refreshPooledStakingEligibility: jest.fn(),
+  }),
+}));
+
 jest.mock('@metamask/bridge-controller', () => {
   const actual = jest.requireActual('@metamask/bridge-controller');
   return {
@@ -226,10 +247,18 @@ jest.mock('../../UI/Earn/hooks/useEarnHighestRate', () => ({
   default: jest.fn(),
 }));
 
-const mockTrackEarnSurfaceClicked = jest.fn();
-jest.mock('../../UI/Earn/hooks/useEarnAnalytics', () => ({
-  useEarnAnalytics: () => ({
-    trackSurfaceClicked: mockTrackEarnSurfaceClicked,
+const mockTrackEvent = jest.fn();
+const mockCreateEventBuilder = jest.fn();
+const mockLegacyEvent = { event: 'EARN_BUTTON_CLICKED' };
+const mockLegacyEventBuilder = {
+  addProperties: jest.fn(),
+  build: jest.fn().mockReturnValue(mockLegacyEvent),
+};
+
+jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
   }),
 }));
 
@@ -366,13 +395,6 @@ jest.mock('@react-navigation/native', () => {
   };
 });
 
-const mockSelectIsEarnSectionEligible = jest.mocked(
-  selectIsEarnSectionEligible,
-);
-const mockUseEarnHighestRate = useEarnHighestRate as jest.MockedFunction<
-  typeof useEarnHighestRate
->;
-
 const pressActionButton = async (
   getByTestId: ReturnType<typeof renderScreen>['getByTestId'],
   testId: string,
@@ -397,6 +419,8 @@ describe('TradeWalletActions', () => {
     jest.clearAllMocks();
     mockParentCanGoBack = true;
     mockHasCompletedPerpsModeSelection.mockResolvedValue(false);
+    jest.mocked(selectEarnTradeMenuRowRedesignEnabled).mockReturnValue(false);
+    jest.mocked(selectStablecoinLendingEnabledFlag).mockReturnValue(false);
     (
       selectPerpsProModeEnabledFlag as jest.MockedFunction<
         typeof selectPerpsProModeEnabledFlag
@@ -421,14 +445,10 @@ describe('TradeWalletActions', () => {
     });
     jest.mocked(isHardwareAccount).mockReturnValue(false);
 
-    mockSelectIsEarnSectionEligible.mockReturnValue(false);
-    mockUseEarnHighestRate.mockReturnValue({
-      highestRate: {
-        type: 'APY',
-        percentage: 6.2,
-        status: 'ready',
-      },
-    });
+    mockCreateEventBuilder.mockReturnValue(mockLegacyEventBuilder);
+    mockLegacyEventBuilder.addProperties.mockReturnValue(
+      mockLegacyEventBuilder,
+    );
 
     mockUseParams.mockReturnValue({
       onDismiss: mockOnDismiss,
@@ -483,8 +503,10 @@ describe('TradeWalletActions', () => {
     ).toBeNull();
   });
 
-  it('renders Earn button when Earn section is eligible', () => {
-    mockSelectIsEarnSectionEligible.mockReturnValue(true);
+  it('renders the legacy Earn button when user is eligible and feature is enabled', () => {
+    jest.mocked(selectEarnTradeMenuRowRedesignEnabled).mockReturnValue(false);
+    jest.mocked(selectStablecoinLendingEnabledFlag).mockReturnValue(true);
+
     const { getByTestId } = renderScreen(
       TradeWalletActions,
       {
@@ -494,48 +516,10 @@ describe('TradeWalletActions', () => {
         state: mockInitialState,
       },
     );
+
     expect(
       getByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON),
-    ).toBeDefined();
-  });
-
-  it.each([
-    [
-      { type: 'APY' as const, percentage: 6.2, status: 'ready' as const },
-      '6.2% APY',
-    ],
-    [
-      { type: 'APR' as const, percentage: 4.2, status: 'ready' as const },
-      '4.2% APR',
-    ],
-  ])('renders a ready APR or APY rate in the Earn tag', (highestRate, copy) => {
-    mockSelectIsEarnSectionEligible.mockReturnValue(true);
-    mockUseEarnHighestRate.mockReturnValue({ highestRate });
-
-    const { getByTestId } = renderScreen(
-      TradeWalletActions,
-      { name: 'TradeWalletActions' },
-      { state: mockInitialState },
-    );
-
-    expect(
-      getByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_RATE_TAG),
-    ).toHaveTextContent(copy);
-  });
-
-  it('omits the Earn rate tag when no ready rate is available', () => {
-    mockSelectIsEarnSectionEligible.mockReturnValue(true);
-    mockUseEarnHighestRate.mockReturnValue({ highestRate: undefined });
-
-    const { queryByTestId } = renderScreen(
-      TradeWalletActions,
-      { name: 'TradeWalletActions' },
-      { state: mockInitialState },
-    );
-
-    expect(
-      queryByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_RATE_TAG),
-    ).toBeNull();
+    ).toBeOnTheScreen();
   });
 
   it('does not render Batch Sell for hardware wallets', () => {
@@ -574,19 +558,6 @@ describe('TradeWalletActions', () => {
 
     expect(
       queryByTestId(WalletActionsBottomSheetSelectorsIDs.BATCH_SELL_BUTTON),
-    ).toBeNull();
-  });
-
-  it('does not render Earn button when Earn section is ineligible', () => {
-    mockSelectIsEarnSectionEligible.mockReturnValue(false);
-    const { queryByTestId } = renderScreen(
-      TradeWalletActions,
-      { name: 'TradeWalletActions' },
-      { state: mockInitialState },
-    );
-
-    expect(
-      queryByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON),
     ).toBeNull();
   });
 
@@ -805,7 +776,7 @@ describe('TradeWalletActions', () => {
   });
 
   it('registers a hardware back handler that dismisses the sheet', () => {
-    mockSelectIsEarnSectionEligible.mockReturnValue(true);
+    jest.mocked(selectStablecoinLendingEnabledFlag).mockReturnValue(true);
     (
       selectPerpsEnabledFlag as jest.MockedFunction<
         typeof selectPerpsEnabledFlag
@@ -1154,106 +1125,6 @@ describe('TradeWalletActions', () => {
         params: {
           entryPoint: PredictEventValues.ENTRY_POINT.MAIN_TRADE_BUTTON,
         },
-      });
-    });
-
-    it('navigates to EarnSectionListView after dismissing RootModalFlow', async () => {
-      mockSelectIsEarnSectionEligible.mockReturnValue(true);
-      const { getByTestId } = renderScreen(
-        TradeWalletActions,
-        { name: 'TradeWalletActions' },
-        { state: mockInitialState },
-      );
-
-      await pressActionButton(
-        getByTestId,
-        WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON,
-      );
-
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.EARN.ROOT, {
-        screen: Routes.EARN.SEARCH_LIST,
-        params: {
-          analyticsContext: {
-            entry_point: EARN_MODULE_ENTRY_POINTS.TRADE_MENU,
-          },
-        },
-      });
-    });
-
-    it('tracks Earn click with ready rate details', async () => {
-      mockSelectIsEarnSectionEligible.mockReturnValue(true);
-      mockUseEarnHighestRate.mockReturnValue({
-        highestRate: {
-          type: 'APY',
-          percentage: 6.2,
-          status: 'ready',
-        },
-      });
-
-      const { getByTestId } = renderScreen(
-        TradeWalletActions,
-        { name: 'TradeWalletActions' },
-        { state: mockInitialState },
-      );
-
-      await pressActionButton(
-        getByTestId,
-        WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON,
-      );
-
-      expect(mockTrackEarnSurfaceClicked).toHaveBeenCalledWith({
-        component_name: EARN_MODULE_COMPONENT_NAMES.EARN_TRADE_MENU_ROW,
-        redirect_target: EARN_MODULE_REDIRECT_TARGETS.EARN_SECTION_LIST_VIEW,
-        rate_type: 'apy',
-        rate_percentage: 6.2,
-      });
-    });
-
-    it('tracks Earn click without rate percentage when rate is not ready', async () => {
-      mockSelectIsEarnSectionEligible.mockReturnValue(true);
-      mockUseEarnHighestRate.mockReturnValue({
-        highestRate: {
-          type: 'APR',
-          status: 'error',
-        },
-      });
-
-      const { getByTestId } = renderScreen(
-        TradeWalletActions,
-        { name: 'TradeWalletActions' },
-        { state: mockInitialState },
-      );
-
-      await pressActionButton(
-        getByTestId,
-        WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON,
-      );
-
-      expect(mockTrackEarnSurfaceClicked).toHaveBeenCalledWith({
-        component_name: EARN_MODULE_COMPONENT_NAMES.EARN_TRADE_MENU_ROW,
-        redirect_target: EARN_MODULE_REDIRECT_TARGETS.EARN_SECTION_LIST_VIEW,
-        rate_type: 'apr',
-      });
-    });
-
-    it('tracks Earn click without rate details when no rate is available', async () => {
-      mockSelectIsEarnSectionEligible.mockReturnValue(true);
-      mockUseEarnHighestRate.mockReturnValue({ highestRate: undefined });
-
-      const { getByTestId } = renderScreen(
-        TradeWalletActions,
-        { name: 'TradeWalletActions' },
-        { state: mockInitialState },
-      );
-
-      await pressActionButton(
-        getByTestId,
-        WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON,
-      );
-
-      expect(mockTrackEarnSurfaceClicked).toHaveBeenCalledWith({
-        component_name: EARN_MODULE_COMPONENT_NAMES.EARN_TRADE_MENU_ROW,
-        redirect_target: EARN_MODULE_REDIRECT_TARGETS.EARN_SECTION_LIST_VIEW,
       });
     });
 

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -33,7 +33,6 @@ import {
   BoxFlexDirection,
   FontWeight,
   IconName,
-  IconSize,
   Tag,
   TagSeverity,
   Text,
@@ -65,8 +64,6 @@ import {
   SwapBridgeNavigationLocation,
   useSwapBridgeNavigation,
 } from '../../UI/Bridge/hooks/useSwapBridgeNavigation';
-import { getEarnRateCopy } from '../../UI/Earn/utils/earnRate';
-import useEarnHighestRate from '../../UI/Earn/hooks/useEarnHighestRate';
 import { selectPerpsEnabledFlag } from '../../UI/Perps';
 import { selectPerpsProModeEnabledFlag } from '../../UI/Perps/selectors/featureFlags';
 import { usePerpsMode } from '../../UI/Perps/hooks';
@@ -83,15 +80,7 @@ import { ActionLocation } from '../../../util/analytics/actionButtonTracking';
 import BottomShape from './components/BottomShape';
 import OverlayWithHole from './components/OverlayWithHole';
 import { selectIsFirstTimePerpsUser } from '../../UI/Perps/selectors/perpsController';
-import { selectIsEarnSectionEligible } from '../../UI/Earn/selectors/eligibility';
-import { useEarnAnalytics } from '../../UI/Earn/hooks/useEarnAnalytics';
-import {
-  EARN_MODULE_COMPONENT_NAMES,
-  EARN_MODULE_REDIRECT_TARGETS,
-  EARN_MODULE_ENTRY_POINTS,
-} from '../../UI/Earn/constants/earnModuleEvents';
-import { EarnRate } from '../../UI/Earn/types/earnAssets';
-import { truncateNumber } from '../../UI/Earn/utils/number';
+import EarnTradeMenuRow from './components/EarnTradeMenuRow/EarnTradeMenuRow';
 
 const bottomMaskHeight = 35;
 const animationDuration = AnimationDuration.Fast;
@@ -172,14 +161,6 @@ function TradeWalletActions() {
     perpsMode === PerpsMode.Pro ? PerpsMode.Pro : PerpsMode.Lite;
   const getPerpsHomeNavigationTarget = useGetPerpsHomeNavigationTarget();
 
-  const { highestRate } = useEarnHighestRate();
-
-  const isEarnWalletActionEnabled = useSelector(selectIsEarnSectionEligible);
-
-  const { trackSurfaceClicked: trackEarnSurfaceClicked } = useEarnAnalytics({
-    entry_point: EARN_MODULE_ENTRY_POINTS.TRADE_MENU,
-  });
-
   const { goToSwaps: goToSwapsBase } = useSwapBridgeNavigation({
     location: SwapBridgeNavigationLocation.MainView,
     sourcePage: 'MainView',
@@ -200,6 +181,14 @@ function TradeWalletActions() {
     onDismiss?.();
     setIsVisible(false);
   }, [onDismiss]);
+
+  const onActionSelected = useCallback(
+    (callback: () => void | Promise<void>) => {
+      postCallback.current = callback;
+      handleNavigateBack();
+    },
+    [handleNavigateBack],
+  );
 
   const goToSwaps = useCallback(() => {
     postCallback.current = () => {
@@ -261,32 +250,6 @@ function TradeWalletActions() {
     };
     handleNavigateBack();
   }, [handleNavigateBack, navigate]);
-
-  const onEarn = useCallback(async () => {
-    trackEarnSurfaceClicked({
-      component_name: EARN_MODULE_COMPONENT_NAMES.EARN_TRADE_MENU_ROW,
-      redirect_target: EARN_MODULE_REDIRECT_TARGETS.EARN_SECTION_LIST_VIEW,
-      ...(highestRate?.type && {
-        rate_type: highestRate.type.toLowerCase() as Lowercase<
-          EarnRate['type']
-        >,
-      }),
-      ...(highestRate?.status === 'ready' && {
-        rate_percentage: Number(truncateNumber(highestRate.percentage)),
-      }),
-    });
-    postCallback.current = () => {
-      navigation.navigate(Routes.EARN.ROOT, {
-        screen: Routes.EARN.SEARCH_LIST,
-        params: {
-          analyticsContext: {
-            entry_point: EARN_MODULE_ENTRY_POINTS.TRADE_MENU,
-          },
-        },
-      });
-    };
-    handleNavigateBack();
-  }, [trackEarnSurfaceClicked, handleNavigateBack, navigation, highestRate]);
 
   useFocusEffect(
     useCallback(() => {
@@ -415,41 +378,10 @@ function TradeWalletActions() {
           isDisabled={!canSignTransactions}
         />
       )}
-      {isEarnWalletActionEnabled && (
-        <ActionListItem
-          label={
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              gap={2}
-            >
-              <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-                {strings('asset_overview.earn_button')}
-              </Text>
-              {highestRate?.status === 'ready' && (
-                <Tag
-                  startIconName={IconName.Sparkle}
-                  startIconProps={{
-                    size: IconSize.Sm,
-                  }}
-                  severity={TagSeverity.Success}
-                  testID={WalletActionsBottomSheetSelectorsIDs.EARN_RATE_TAG}
-                >
-                  {getEarnRateCopy({
-                    percentage: highestRate.percentage,
-                    rateType: highestRate.type,
-                  })}
-                </Tag>
-              )}
-            </Box>
-          }
-          description={strings('asset_overview.earn_description')}
-          iconName={IconName.Plant}
-          onPress={onEarn}
-          testID={WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON}
-          isDisabled={!canSignTransactions}
-        />
-      )}
+      <EarnTradeMenuRow
+        onActionSelected={onActionSelected}
+        isDisabled={!canSignTransactions}
+      />
     </>
   );
 

--- a/app/components/Views/TradeWalletActions/components/EarnTradeMenuRow/EarnTradeMenuRow.test.tsx
+++ b/app/components/Views/TradeWalletActions/components/EarnTradeMenuRow/EarnTradeMenuRow.test.tsx
@@ -1,0 +1,72 @@
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { selectEarnTradeMenuRowRedesignEnabled } from '../../../../../components/UI/Earn/selectors/featureFlags';
+import type { RootState } from '../../../../../reducers';
+import EarnTradeMenuRow from './EarnTradeMenuRow';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../../components/UI/Earn/selectors/featureFlags', () => ({
+  selectEarnTradeMenuRowRedesignEnabled: jest.fn(),
+}));
+
+jest.mock('./LegacyEarnTradeMenuRow', () => ({
+  __esModule: true,
+  default: () => {
+    const ReactModule = jest.requireActual('react');
+    const { Text: MockText } = jest.requireActual('react-native');
+    return ReactModule.createElement(MockText, {
+      testID: 'legacy-earn-trade-menu-row',
+    });
+  },
+}));
+
+jest.mock('./RedesignedEarnTradeMenuRow', () => ({
+  __esModule: true,
+  default: () => {
+    const ReactModule = jest.requireActual('react');
+    const { Text: MockText } = jest.requireActual('react-native');
+    return ReactModule.createElement(MockText, {
+      testID: 'redesigned-earn-trade-menu-row',
+    });
+  },
+}));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockSelectEarnTradeMenuRowRedesignEnabled = jest.mocked(
+  selectEarnTradeMenuRowRedesignEnabled,
+);
+
+describe('EarnTradeMenuRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelector.mockImplementation((selector) => selector({} as RootState));
+  });
+
+  it('renders the legacy row when redesign flag is disabled', () => {
+    mockSelectEarnTradeMenuRowRedesignEnabled.mockReturnValue(false);
+
+    const { getByTestId, queryByTestId } = render(
+      <EarnTradeMenuRow onActionSelected={jest.fn()} isDisabled={false} />,
+    );
+
+    expect(getByTestId('legacy-earn-trade-menu-row')).toBeOnTheScreen();
+    expect(
+      queryByTestId('redesigned-earn-trade-menu-row'),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('renders the redesigned row when redesign flag is enabled', () => {
+    mockSelectEarnTradeMenuRowRedesignEnabled.mockReturnValue(true);
+
+    const { getByTestId, queryByTestId } = render(
+      <EarnTradeMenuRow onActionSelected={jest.fn()} isDisabled={false} />,
+    );
+
+    expect(getByTestId('redesigned-earn-trade-menu-row')).toBeOnTheScreen();
+    expect(queryByTestId('legacy-earn-trade-menu-row')).not.toBeOnTheScreen();
+  });
+});

--- a/app/components/Views/TradeWalletActions/components/EarnTradeMenuRow/EarnTradeMenuRow.tsx
+++ b/app/components/Views/TradeWalletActions/components/EarnTradeMenuRow/EarnTradeMenuRow.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { selectEarnTradeMenuRowRedesignEnabled } from '../../../../../components/UI/Earn/selectors/featureFlags';
+import LegacyEarnTradeMenuRow from './LegacyEarnTradeMenuRow';
+import RedesignedEarnTradeMenuRow from './RedesignedEarnTradeMenuRow';
+
+export interface EarnTradeMenuRowProps {
+  onActionSelected: (callback: () => void | Promise<void>) => void;
+  isDisabled: boolean;
+}
+
+const EarnTradeMenuRow = (props: EarnTradeMenuRowProps) => {
+  const isRedesignEnabled = useSelector(selectEarnTradeMenuRowRedesignEnabled);
+
+  return isRedesignEnabled ? (
+    <RedesignedEarnTradeMenuRow {...props} />
+  ) : (
+    <LegacyEarnTradeMenuRow {...props} />
+  );
+};
+
+export default EarnTradeMenuRow;

--- a/app/components/Views/TradeWalletActions/components/EarnTradeMenuRow/LegacyEarnTradeMenuRow.test.tsx
+++ b/app/components/Views/TradeWalletActions/components/EarnTradeMenuRow/LegacyEarnTradeMenuRow.test.tsx
@@ -1,0 +1,216 @@
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import Routes from '../../../../../constants/navigation/Routes';
+import { EARN_INPUT_VIEW_ACTIONS } from '../../../../../components/UI/Earn/Views/EarnInputView/EarnInputView.types';
+import { EVENT_LOCATIONS as STAKE_EVENT_LOCATIONS } from '../../../../../components/UI/Stake/constants/events';
+import useStakingEligibility from '../../../../../components/UI/Stake/hooks/useStakingEligibility';
+import {
+  selectPooledStakingEnabledFlag,
+  selectStablecoinLendingEnabledFlag,
+} from '../../../../../components/UI/Earn/selectors/featureFlags';
+import { earnSelectors } from '../../../../../selectors/earnController/earn';
+import { selectChainId } from '../../../../../selectors/networkController';
+import type { RootState } from '../../../../../reducers';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import { WalletActionsBottomSheetSelectorsIDs } from '../../../WalletActions/WalletActionsBottomSheet.testIds';
+import LegacyEarnTradeMenuRow from './LegacyEarnTradeMenuRow';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+}));
+
+jest.mock('../../../../../components/UI/Earn/selectors/featureFlags', () => ({
+  selectPooledStakingEnabledFlag: jest.fn(),
+  selectStablecoinLendingEnabledFlag: jest.fn(),
+}));
+
+jest.mock('../../../../../selectors/earnController/earn', () => ({
+  earnSelectors: {
+    selectEarnTokens: jest.fn(),
+  },
+}));
+
+jest.mock('../../../../../selectors/networkController', () => ({
+  selectChainId: jest.fn(),
+}));
+
+jest.mock(
+  '../../../../../components/UI/Stake/hooks/useStakingEligibility',
+  () => ({
+    __esModule: true,
+    default: jest.fn(),
+  }),
+);
+
+const mockTrackEvent = jest.fn();
+const mockCreateEventBuilder = jest.fn();
+const mockLegacyEvent = { event: 'EARN_BUTTON_CLICKED' };
+const mockLegacyEventBuilder = {
+  addProperties: jest.fn(),
+  build: jest.fn().mockReturnValue(mockLegacyEvent),
+};
+
+jest.mock('../../../../../components/hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
+  }),
+}));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockOnActionSelected = jest.fn<void, [() => void | Promise<void>]>();
+const mockUseStakingEligibility = jest.mocked(useStakingEligibility);
+const mockSelectPooledStakingEnabledFlag = jest.mocked(
+  selectPooledStakingEnabledFlag,
+);
+const mockSelectStablecoinLendingEnabledFlag = jest.mocked(
+  selectStablecoinLendingEnabledFlag,
+);
+const mockSelectEarnTokens = jest.mocked(earnSelectors.selectEarnTokens);
+const mockSelectChainId = jest.mocked(selectChainId);
+
+const getEarnTokensSelectorResult = (
+  earnTokens: ReturnType<
+    typeof earnSelectors.selectEarnTokens
+  >['earnTokens'] = [],
+): ReturnType<typeof earnSelectors.selectEarnTokens> => ({
+  earnTokens,
+  earnTokensByChainIdAndAddress: {},
+  earnOutputTokens: [],
+  earnOutputTokensByChainIdAndAddress: {},
+  earnTokenPairsByChainIdAndAddress: {},
+  earnOutputTokenPairsByChainIdAndAddress: {},
+  earnableTotalFiatNumber: 0,
+  earnableTotalFiatFormatted: '$0',
+});
+
+const renderLegacyRow = () =>
+  render(
+    <LegacyEarnTradeMenuRow
+      onActionSelected={mockOnActionSelected}
+      isDisabled={false}
+    />,
+  );
+
+describe('LegacyEarnTradeMenuRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNavigate.mockReset();
+    mockUseSelector.mockImplementation((selector) => selector({} as RootState));
+    mockSelectPooledStakingEnabledFlag.mockReturnValue(false);
+    mockSelectStablecoinLendingEnabledFlag.mockReturnValue(true);
+    mockSelectEarnTokens.mockReturnValue(getEarnTokensSelectorResult());
+    mockSelectChainId.mockReturnValue('0x1');
+    mockUseStakingEligibility.mockReturnValue({
+      isEligible: true,
+      isLoadingEligibility: false,
+      error: null,
+      refreshPooledStakingEligibility: jest.fn(),
+    });
+    mockCreateEventBuilder.mockReturnValue(mockLegacyEventBuilder);
+    mockLegacyEventBuilder.addProperties.mockReturnValue(
+      mockLegacyEventBuilder,
+    );
+  });
+
+  it('renders the legacy row when lending and staking eligibility pass', () => {
+    const { getByTestId, queryByTestId } = renderLegacyRow();
+
+    expect(
+      getByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_RATE_TAG),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('hides the row when staking eligibility fails', () => {
+    mockUseStakingEligibility.mockReturnValue({
+      isEligible: false,
+      isLoadingEligibility: false,
+      error: null,
+      refreshPooledStakingEligibility: jest.fn(),
+    });
+
+    const { queryByTestId } = renderLegacyRow();
+
+    expect(
+      queryByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('hides the row when only ETH is available and pooled staking is disabled', () => {
+    mockSelectEarnTokens.mockReturnValue(
+      getEarnTokensSelectorResult([
+        {
+          address: '0x0',
+          chainId: '0x1',
+          decimals: 18,
+          image: '',
+          name: 'ETH',
+          isETH: true,
+          isStaked: false,
+        },
+      ] as never),
+    );
+
+    const { queryByTestId } = renderLegacyRow();
+
+    expect(
+      queryByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('queues legacy Earn navigation with token-list params', () => {
+    const { getByTestId } = renderLegacyRow();
+
+    fireEvent.press(
+      getByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON),
+    );
+    const callback = mockOnActionSelected.mock.calls[0][0];
+    callback();
+
+    expect(mockNavigate).toHaveBeenCalledWith('StakeModals', {
+      screen: Routes.STAKING.MODALS.EARN_TOKEN_LIST,
+      params: {
+        tokenFilter: {
+          includeNativeTokens: true,
+          includeStakingTokens: false,
+          includeLendingTokens: true,
+          includeReceiptTokens: false,
+        },
+        onItemPressScreen: EARN_INPUT_VIEW_ACTIONS.DEPOSIT,
+      },
+    });
+  });
+
+  it('tracks legacy Earn navigation with wallet action properties', () => {
+    const { getByTestId } = renderLegacyRow();
+
+    act(() => {
+      fireEvent.press(
+        getByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON),
+      );
+      mockOnActionSelected.mock.calls[0][0]();
+    });
+
+    expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+      MetaMetricsEvents.EARN_BUTTON_CLICKED,
+    );
+    expect(mockLegacyEventBuilder.addProperties).toHaveBeenCalledWith({
+      text: 'Earn',
+      location: STAKE_EVENT_LOCATIONS.WALLET_ACTIONS_BOTTOM_SHEET,
+      chain_id_destination: '1',
+    });
+    expect(mockTrackEvent).toHaveBeenCalledWith(mockLegacyEvent);
+  });
+});

--- a/app/components/Views/TradeWalletActions/components/EarnTradeMenuRow/LegacyEarnTradeMenuRow.tsx
+++ b/app/components/Views/TradeWalletActions/components/EarnTradeMenuRow/LegacyEarnTradeMenuRow.tsx
@@ -1,0 +1,92 @@
+import { useNavigation } from '@react-navigation/native';
+import React, { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { ActionListItem, IconName } from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import Routes from '../../../../../constants/navigation/Routes';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { earnSelectors } from '../../../../../selectors/earnController/earn';
+import { selectChainId } from '../../../../../selectors/networkController';
+import { getDecimalChainId } from '../../../../../util/networks';
+import { useAnalytics } from '../../../../../components/hooks/useAnalytics/useAnalytics';
+import { EARN_INPUT_VIEW_ACTIONS } from '../../../../../components/UI/Earn/Views/EarnInputView/EarnInputView.types';
+import {
+  selectPooledStakingEnabledFlag,
+  selectStablecoinLendingEnabledFlag,
+} from '../../../../../components/UI/Earn/selectors/featureFlags';
+import { EVENT_LOCATIONS as STAKE_EVENT_LOCATIONS } from '../../../../../components/UI/Stake/constants/events';
+import useStakingEligibility from '../../../../../components/UI/Stake/hooks/useStakingEligibility';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import { WalletActionsBottomSheetSelectorsIDs } from '../../../WalletActions/WalletActionsBottomSheet.testIds';
+import type { EarnTradeMenuRowProps } from './EarnTradeMenuRow';
+
+const LegacyEarnTradeMenuRow = ({
+  onActionSelected,
+  isDisabled,
+}: EarnTradeMenuRowProps) => {
+  const { navigate } = useNavigation();
+  const chainId = useSelector(selectChainId);
+  const isPooledStakingEnabled = useSelector(selectPooledStakingEnabledFlag);
+  const isStablecoinLendingEnabled = useSelector(
+    selectStablecoinLendingEnabledFlag,
+  );
+  const { isEligible: isEarnEligible } = useStakingEligibility();
+  const { earnTokens } = useSelector(earnSelectors.selectEarnTokens);
+  const { trackEvent, createEventBuilder } = useAnalytics();
+
+  const isEarnWalletActionEnabled = useMemo(() => {
+    if (
+      !isStablecoinLendingEnabled ||
+      (earnTokens.length <= 1 &&
+        earnTokens[0]?.isETH &&
+        !isPooledStakingEnabled)
+    ) {
+      return false;
+    }
+    return true;
+  }, [isStablecoinLendingEnabled, earnTokens, isPooledStakingEnabled]);
+
+  const onEarn = useCallback(() => {
+    onActionSelected(() => {
+      navigate('StakeModals', {
+        screen: Routes.STAKING.MODALS.EARN_TOKEN_LIST,
+        params: {
+          tokenFilter: {
+            includeNativeTokens: true,
+            includeStakingTokens: false,
+            includeLendingTokens: true,
+            includeReceiptTokens: false,
+          },
+          onItemPressScreen: EARN_INPUT_VIEW_ACTIONS.DEPOSIT,
+        },
+      });
+
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.EARN_BUTTON_CLICKED)
+          .addProperties({
+            text: 'Earn',
+            location: STAKE_EVENT_LOCATIONS.WALLET_ACTIONS_BOTTOM_SHEET,
+            chain_id_destination: getDecimalChainId(chainId),
+          })
+          .build(),
+      );
+    });
+  }, [chainId, createEventBuilder, navigate, onActionSelected, trackEvent]);
+
+  if (!isEarnWalletActionEnabled || !isEarnEligible) {
+    return null;
+  }
+
+  return (
+    <ActionListItem
+      label={strings('asset_overview.earn_button')}
+      description={strings('asset_overview.earn_description')}
+      iconName={IconName.Stake}
+      onPress={onEarn}
+      testID={WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON}
+      isDisabled={isDisabled}
+    />
+  );
+};
+
+export default LegacyEarnTradeMenuRow;

--- a/app/components/Views/TradeWalletActions/components/EarnTradeMenuRow/RedesignedEarnTradeMenuRow.test.tsx
+++ b/app/components/Views/TradeWalletActions/components/EarnTradeMenuRow/RedesignedEarnTradeMenuRow.test.tsx
@@ -1,0 +1,174 @@
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import Routes from '../../../../../constants/navigation/Routes';
+import {
+  EARN_MODULE_COMPONENT_NAMES,
+  EARN_MODULE_ENTRY_POINTS,
+  EARN_MODULE_REDIRECT_TARGETS,
+} from '../../../../../components/UI/Earn/constants/earnModuleEvents';
+import useEarnHighestRate from '../../../../../components/UI/Earn/hooks/useEarnHighestRate';
+import { selectIsEarnSectionEligible } from '../../../../../components/UI/Earn/selectors/eligibility';
+import type { RootState } from '../../../../../reducers';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import { WalletActionsBottomSheetSelectorsIDs } from '../../../WalletActions/WalletActionsBottomSheet.testIds';
+import RedesignedEarnTradeMenuRow from './RedesignedEarnTradeMenuRow';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+}));
+
+jest.mock('../../../../../components/UI/Earn/selectors/eligibility', () => ({
+  selectIsEarnSectionEligible: jest.fn(),
+}));
+
+jest.mock('../../../../../components/UI/Earn/hooks/useEarnHighestRate', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockTrackEarnSurfaceClicked = jest.fn();
+jest.mock('../../../../../components/UI/Earn/hooks/useEarnAnalytics', () => ({
+  useEarnAnalytics: () => ({
+    trackSurfaceClicked: mockTrackEarnSurfaceClicked,
+  }),
+}));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockOnActionSelected = jest.fn<
+  void,
+  [callback: () => void | Promise<void>]
+>();
+const mockSelectIsEarnSectionEligible = jest.mocked(
+  selectIsEarnSectionEligible,
+);
+const mockUseEarnHighestRate = jest.mocked(useEarnHighestRate);
+
+const renderRedesignedRow = () =>
+  render(
+    <RedesignedEarnTradeMenuRow
+      onActionSelected={mockOnActionSelected}
+      isDisabled={false}
+    />,
+  );
+
+describe('RedesignedEarnTradeMenuRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNavigate.mockReset();
+    mockUseSelector.mockImplementation((selector) => selector({} as RootState));
+    mockSelectIsEarnSectionEligible.mockReturnValue(true);
+    mockUseEarnHighestRate.mockReturnValue({ highestRate: undefined });
+  });
+
+  it.each([
+    [
+      { type: 'APY' as const, percentage: 6.2, status: 'ready' as const },
+      '6.2% APY',
+    ],
+    [
+      { type: 'APR' as const, percentage: 4.2, status: 'ready' as const },
+      '4.2% APR',
+    ],
+  ])('renders the ready %s rate tag', (highestRate, copy) => {
+    mockUseEarnHighestRate.mockReturnValue({ highestRate });
+
+    const { getByTestId } = renderRedesignedRow();
+
+    expect(mockUseEarnHighestRate).toHaveBeenCalled();
+    expect(
+      getByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_RATE_TAG),
+    ).toHaveTextContent(copy);
+  });
+
+  it('omits the rate tag when no ready rate is available', () => {
+    const { queryByTestId } = renderRedesignedRow();
+
+    expect(
+      queryByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_RATE_TAG),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('hides the row when Earn section eligibility fails', () => {
+    mockSelectIsEarnSectionEligible.mockReturnValue(false);
+
+    const { queryByTestId } = renderRedesignedRow();
+
+    expect(
+      queryByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('queues Earn section list navigation with Trade menu context', () => {
+    const { getByTestId } = renderRedesignedRow();
+
+    fireEvent.press(
+      getByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON),
+    );
+    mockOnActionSelected.mock.calls[0][0]();
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.EARN.ROOT, {
+      screen: Routes.EARN.SEARCH_LIST,
+      params: {
+        analyticsContext: {
+          entry_point: EARN_MODULE_ENTRY_POINTS.TRADE_MENU,
+        },
+      },
+    });
+  });
+
+  it('tracks ready rate details when Earn row is pressed', () => {
+    mockUseEarnHighestRate.mockReturnValue({
+      highestRate: {
+        type: 'APY',
+        percentage: 6.2,
+        status: 'ready',
+      },
+    });
+
+    const { getByTestId } = renderRedesignedRow();
+
+    act(() => {
+      fireEvent.press(
+        getByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON),
+      );
+    });
+
+    expect(mockTrackEarnSurfaceClicked).toHaveBeenCalledWith({
+      component_name: EARN_MODULE_COMPONENT_NAMES.EARN_TRADE_MENU_ROW,
+      redirect_target: EARN_MODULE_REDIRECT_TARGETS.EARN_SECTION_LIST_VIEW,
+      rate_type: 'apy',
+      rate_percentage: 6.2,
+    });
+  });
+
+  it('tracks rate type without percentage when rate is not ready', () => {
+    mockUseEarnHighestRate.mockReturnValue({
+      highestRate: {
+        type: 'APR',
+        status: 'error',
+      },
+    });
+
+    const { getByTestId } = renderRedesignedRow();
+
+    act(() => {
+      fireEvent.press(
+        getByTestId(WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON),
+      );
+    });
+
+    expect(mockTrackEarnSurfaceClicked).toHaveBeenCalledWith({
+      component_name: EARN_MODULE_COMPONENT_NAMES.EARN_TRADE_MENU_ROW,
+      redirect_target: EARN_MODULE_REDIRECT_TARGETS.EARN_SECTION_LIST_VIEW,
+      rate_type: 'apr',
+    });
+  });
+});

--- a/app/components/Views/TradeWalletActions/components/EarnTradeMenuRow/RedesignedEarnTradeMenuRow.tsx
+++ b/app/components/Views/TradeWalletActions/components/EarnTradeMenuRow/RedesignedEarnTradeMenuRow.tsx
@@ -1,0 +1,112 @@
+import { useNavigation } from '@react-navigation/native';
+import React, { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  ActionListItem,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  FontWeight,
+  IconName,
+  IconSize,
+  Tag,
+  TagSeverity,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import Routes from '../../../../../constants/navigation/Routes';
+import { selectIsEarnSectionEligible } from '../../../../../components/UI/Earn/selectors/eligibility';
+import useEarnHighestRate from '../../../../../components/UI/Earn/hooks/useEarnHighestRate';
+import { useEarnAnalytics } from '../../../../../components/UI/Earn/hooks/useEarnAnalytics';
+import {
+  EARN_MODULE_COMPONENT_NAMES,
+  EARN_MODULE_ENTRY_POINTS,
+  EARN_MODULE_REDIRECT_TARGETS,
+} from '../../../../../components/UI/Earn/constants/earnModuleEvents';
+import { EarnRate } from '../../../../../components/UI/Earn/types/earnAssets';
+import { getEarnRateCopy } from '../../../../../components/UI/Earn/utils/earnRate';
+import { truncateNumber } from '../../../../../components/UI/Earn/utils/number';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import { WalletActionsBottomSheetSelectorsIDs } from '../../../WalletActions/WalletActionsBottomSheet.testIds';
+import type { EarnTradeMenuRowProps } from './EarnTradeMenuRow';
+
+const RedesignedEarnTradeMenuRow = ({
+  onActionSelected,
+  isDisabled,
+}: EarnTradeMenuRowProps) => {
+  const navigation = useNavigation();
+  const isEarnWalletActionEnabled = useSelector(selectIsEarnSectionEligible);
+  const { highestRate } = useEarnHighestRate();
+  const { trackSurfaceClicked: trackEarnSurfaceClicked } = useEarnAnalytics({
+    entry_point: EARN_MODULE_ENTRY_POINTS.TRADE_MENU,
+  });
+
+  const onEarn = useCallback(() => {
+    trackEarnSurfaceClicked({
+      component_name: EARN_MODULE_COMPONENT_NAMES.EARN_TRADE_MENU_ROW,
+      redirect_target: EARN_MODULE_REDIRECT_TARGETS.EARN_SECTION_LIST_VIEW,
+      ...(highestRate?.type && {
+        rate_type: highestRate.type.toLowerCase() as Lowercase<
+          EarnRate['type']
+        >,
+      }),
+      ...(highestRate?.status === 'ready' && {
+        rate_percentage: Number(truncateNumber(highestRate.percentage)),
+      }),
+    });
+
+    onActionSelected(() => {
+      navigation.navigate(Routes.EARN.ROOT, {
+        screen: Routes.EARN.SEARCH_LIST,
+        params: {
+          analyticsContext: {
+            entry_point: EARN_MODULE_ENTRY_POINTS.TRADE_MENU,
+          },
+        },
+      });
+    });
+  }, [highestRate, navigation, onActionSelected, trackEarnSurfaceClicked]);
+
+  if (!isEarnWalletActionEnabled) {
+    return null;
+  }
+
+  return (
+    <ActionListItem
+      label={
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={2}
+        >
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+            {strings('asset_overview.earn_button')}
+          </Text>
+          {highestRate?.status === 'ready' && (
+            <Tag
+              startIconName={IconName.Sparkle}
+              startIconProps={{
+                size: IconSize.Sm,
+              }}
+              severity={TagSeverity.Success}
+              testID={WalletActionsBottomSheetSelectorsIDs.EARN_RATE_TAG}
+            >
+              {getEarnRateCopy({
+                percentage: highestRate.percentage,
+                rateType: highestRate.type,
+              })}
+            </Tag>
+          )}
+        </Box>
+      }
+      description={strings('asset_overview.earn_description')}
+      iconName={IconName.Plant}
+      onPress={onEarn}
+      testID={WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON}
+      isDisabled={isDisabled}
+    />
+  );
+};
+
+export default RedesignedEarnTradeMenuRow;

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -3771,6 +3771,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  earnTradeMenuRowRedesignEnabled: {
+    name: 'earnTradeMenuRowRedesignEnabled',
+    type: FeatureFlagType.Remote,
+    inProd: false,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '0.0.0',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   enableFiatToggle: {
     name: 'enableFiatToggle',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.
Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Wraps the Redesigned Earn row in the trade menu with a feature flag and brings back the legacy Earn trade menu row. We only plan to enable the redesigned Earn row as part of the Earn module release.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: wrap redesigned Earn row in trade menu in feature flag

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1331: Wrap redesigned Earn row in trade menu with feature flag](https://consensyssoftware.atlassian.net/browse/MUSD-1331)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: feature-flagged Earn trade menu row

  Scenario: user opens redesigned Earn row
    Given the redesigned Earn trade menu feature flag is enabled
    When user opens the trade wallet actions menu and taps Earn
    Then the app opens the Earn section list view

  Scenario: user opens legacy Earn row
    Given the redesigned Earn trade menu feature flag is disabled or unset
    When user opens the trade wallet actions menu and taps Earn
    Then the app opens the Earn asset bottom sheet
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

#### Redesigned Earn trade menu row always displayed
<img width="490" height="265" alt="image" src="https://github.com/user-attachments/assets/beaf3286-6b36-4bb6-a8aa-ce114b24ee0e" />

### **After**

#### Legacy Earn trade menu row displayed when feature flag disabled
<img width="490" height="265" alt="image" src="https://github.com/user-attachments/assets/568834d5-e28d-4de1-920d-5e95d6e5effe" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Trade menu Earn entry points, eligibility rules, navigation targets, and analytics between legacy and redesigned paths; rollout is flag-controlled but wrong flag state could send users to the wrong Earn flow.
> 
> **Overview**
> Introduces **`earnTradeMenuRowRedesignEnabled`** (local `MM_EARN_TRADE_MENU_ROW_REDESIGN_ENABLED`, remote version-gated flag) so the Trade menu Earn row can ship behind a flag defaulting to **off**.
> 
> **Trade wallet actions** no longer inline Earn logic. A new **`EarnTradeMenuRow`** wrapper picks **`LegacyEarnTradeMenuRow`** vs **`RedesignedEarnTradeMenuRow`** from that flag, and uses a shared **`onActionSelected`** callback so navigation runs after the sheet dismisses (same pattern as other trade actions).
> 
> When the flag is **disabled** (current default), users get the **legacy** row: lending/pooled-staking gating, **Stake** icon, navigation to **`StakeModals` → earn token list**, and **`EARN_BUTTON_CLICKED`** analytics. When **enabled**, they get the **redesigned** row: Earn section eligibility, optional **APY/APR** tag, **Plant** icon, navigation to **`Routes.EARN.SEARCH_LIST`**, and Earn module **`trackSurfaceClicked`** analytics.
> 
> Selector and component tests cover flag resolution and both row variants; parent **`TradeWalletActions`** tests were trimmed now that Earn behavior lives in the child components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c1c03bd2108efcc7ecbdd7745a33435874287c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->