### PR TITLE
feat: show current-period Plus usage on Member pricing

### DIFF
--- a/app/components/Views/ProHub/ProHub.constants.ts
+++ b/app/components/Views/ProHub/ProHub.constants.ts
@@ -47,6 +47,11 @@ export interface TradeAllowanceItem {
   used: number;
   allowance: number;
   kind: TradeAllowanceKind;
+  /**
+   * When true, the period cap is spent even if used/allowance would otherwise
+   * compute a 0% bar (missing consumed with remaining 0).
+   */
+  exhausted?: boolean;
 }
 
 // TODO: replace with real API data once the membership endpoint is available.

--- a/app/components/Views/ProHub/ProHub.test.tsx
+++ b/app/components/Views/ProHub/ProHub.test.tsx
@@ -2,11 +2,15 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import ProHub from './ProHub';
 import { ProHubTestIds } from './ProHub.testIds';
-import { ALSO_INCLUDED_ITEMS } from './ProHub.constants';
+import { ALSO_INCLUDED_ITEMS, MOCK_TRADE_ALLOWANCES } from './ProHub.constants';
 import { MemberPricingOnTradesTestIds } from './components/MemberPricingOnTrades';
 import { strings } from '../../../../locales/i18n';
 import Routes from '../../../constants/navigation/Routes';
 import { MoneyAccountPlusAccess } from '../../../hooks/useMoneyAccountPlusAccess';
+import {
+  MoneyAccountPlusBenefitsStatus,
+  useMoneyAccountPlusBenefits,
+} from '../../../hooks/useMoneyAccountPlusBenefits';
 
 // ─── Navigation ───────────────────────────────────────────────────────────────
 
@@ -37,6 +41,14 @@ jest.mock('../../../hooks/useMoneyAccountPlusAccess', () => ({
   useMoneyAccountPlusAccess: () => mockUseMoneyAccountPlusAccess(),
 }));
 
+const mockUseMoneyAccountPlusBenefits = jest.mocked(
+  useMoneyAccountPlusBenefits,
+);
+jest.mock('../../../hooks/useMoneyAccountPlusBenefits', () => ({
+  ...jest.requireActual('../../../hooks/useMoneyAccountPlusBenefits'),
+  useMoneyAccountPlusBenefits: jest.fn(),
+}));
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const renderProHub = () => render(<ProHub />);
@@ -63,6 +75,14 @@ describe('ProHub', () => {
     mockUseMoneyAccountPlusAccess.mockReturnValue(
       MoneyAccountPlusAccess.Subscriber,
     );
+    mockUseMoneyAccountPlusBenefits.mockReturnValue({
+      status: MoneyAccountPlusBenefitsStatus.Ready,
+      items: MOCK_TRADE_ALLOWANCES,
+      resetsOn: 'Sep 15',
+      isRefreshing: false,
+      hasError: false,
+      retry: jest.fn(),
+    });
   });
 
   // ── Access guard ───────────────────────────────────────────────────────────

--- a/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.test.tsx
+++ b/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 import MemberPricingOnTrades from './MemberPricingOnTrades';
 import TradeAllowanceRow from './TradeAllowanceRow';
 import { MemberPricingOnTradesTestIds } from './MemberPricingOnTrades.testIds';
@@ -8,12 +8,25 @@ import {
   type TradeAllowanceItem,
 } from '../../ProHub.constants';
 import { strings } from '../../../../../../locales/i18n';
+import {
+  MoneyAccountPlusBenefitsStatus,
+  useMoneyAccountPlusBenefits,
+} from '../../../../../hooks/useMoneyAccountPlusBenefits';
+
+jest.mock('../../../../../hooks/useMoneyAccountPlusBenefits', () => ({
+  ...jest.requireActual('../../../../../hooks/useMoneyAccountPlusBenefits'),
+  useMoneyAccountPlusBenefits: jest.fn(),
+}));
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => ({
     style: (..._args: unknown[]) => ({}),
   }),
 }));
+
+const mockUseMoneyAccountPlusBenefits = jest.mocked(
+  useMoneyAccountPlusBenefits,
+);
 
 const renderMemberPricingOnTrades = () => render(<MemberPricingOnTrades />);
 
@@ -32,6 +45,17 @@ const getFlattenedStyle = (style: unknown) => {
 };
 
 describe('MemberPricingOnTrades', () => {
+  beforeEach(() => {
+    mockUseMoneyAccountPlusBenefits.mockReturnValue({
+      status: MoneyAccountPlusBenefitsStatus.Ready,
+      items: MOCK_TRADE_ALLOWANCES,
+      resetsOn: 'Sep 15',
+      isRefreshing: false,
+      hasError: false,
+      retry: jest.fn(),
+    });
+  });
+
   it('renders the section title from i18n', () => {
     const { getByTestId } = renderMemberPricingOnTrades();
 
@@ -40,7 +64,7 @@ describe('MemberPricingOnTrades', () => {
     expect(title).toHaveTextContent(strings('pro_hub.member_pricing.title'));
   });
 
-  it('renders a row and progress bar for each mock trade allowance', () => {
+  it('renders a row and progress bar for each trade allowance', () => {
     const { getByTestId } = renderMemberPricingOnTrades();
 
     MOCK_TRADE_ALLOWANCES.forEach((item) => {
@@ -55,6 +79,82 @@ describe('MemberPricingOnTrades', () => {
         toRegex(strings(`pro_hub.member_pricing.${item.id}.label`)),
       );
     });
+  });
+
+  it('renders the shared reset date under the rows', () => {
+    const { getByTestId } = renderMemberPricingOnTrades();
+
+    expect(
+      getByTestId(MemberPricingOnTradesTestIds.RESETS_ON),
+    ).toHaveTextContent(
+      strings('pro_hub.member_pricing.resets_on', { date: 'Sep 15' }),
+    );
+  });
+
+  it('renders skeletons instead of rows while benefits load', () => {
+    mockUseMoneyAccountPlusBenefits.mockReturnValue({
+      status: MoneyAccountPlusBenefitsStatus.Loading,
+      items: [],
+      resetsOn: undefined,
+      isRefreshing: true,
+      hasError: false,
+      retry: jest.fn(),
+    });
+
+    const { getByTestId, queryByTestId } = renderMemberPricingOnTrades();
+
+    expect(
+      getByTestId(MemberPricingOnTradesTestIds.LOADING_SKELETON),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(MemberPricingOnTradesTestIds.ROW('swaps')),
+    ).not.toBeOnTheScreen();
+    expect(getByTestId(MemberPricingOnTradesTestIds.TITLE)).toBeOnTheScreen();
+  });
+
+  it('renders an error with retry when benefits cannot be loaded', () => {
+    const retry = jest.fn();
+    mockUseMoneyAccountPlusBenefits.mockReturnValue({
+      status: MoneyAccountPlusBenefitsStatus.Failed,
+      items: [],
+      resetsOn: undefined,
+      isRefreshing: false,
+      hasError: true,
+      retry,
+    });
+
+    const { getByTestId, queryByTestId } = renderMemberPricingOnTrades();
+
+    expect(getByTestId(MemberPricingOnTradesTestIds.ERROR)).toHaveTextContent(
+      toRegex(strings('pro_hub.member_pricing.load_error')),
+    );
+    expect(
+      queryByTestId(MemberPricingOnTradesTestIds.ROW('swaps')),
+    ).not.toBeOnTheScreen();
+
+    fireEvent.press(getByTestId(MemberPricingOnTradesTestIds.RETRY_BUTTON));
+
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits a product that was not mapped from benefits', () => {
+    mockUseMoneyAccountPlusBenefits.mockReturnValue({
+      status: MoneyAccountPlusBenefitsStatus.Incomplete,
+      items: MOCK_TRADE_ALLOWANCES.filter((item) => item.id !== 'predict'),
+      resetsOn: 'Sep 15',
+      isRefreshing: false,
+      hasError: false,
+      retry: jest.fn(),
+    });
+
+    const { getByTestId, queryByTestId } = renderMemberPricingOnTrades();
+
+    expect(
+      getByTestId(MemberPricingOnTradesTestIds.ROW('swaps')),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(MemberPricingOnTradesTestIds.ROW('predict')),
+    ).not.toBeOnTheScreen();
   });
 });
 
@@ -177,5 +277,25 @@ describe('TradeAllowanceRow', () => {
       max: 500,
       now: 500,
     });
+  });
+
+  it('fills the bar completely when the meter is exhausted with zero used', () => {
+    const exhaustedItem: TradeAllowanceItem = {
+      id: 'swaps',
+      used: 0,
+      allowance: 500,
+      kind: 'currency',
+      exhausted: true,
+    };
+
+    const { getByTestId } = renderTradeAllowanceRow(exhaustedItem);
+
+    const fill = getByTestId(
+      MemberPricingOnTradesTestIds.PROGRESS_FILL('swaps'),
+    );
+
+    expect(getFlattenedStyle(fill.props.style)).toEqual(
+      expect.objectContaining({ width: '100%' }),
+    );
   });
 });

--- a/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.testIds.ts
+++ b/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.testIds.ts
@@ -3,6 +3,10 @@ import type { TradeAllowanceItem } from '../../ProHub.constants';
 export const MemberPricingOnTradesTestIds = {
   SECTION: 'pro-hub-member-pricing-section',
   TITLE: 'pro-hub-member-pricing-title',
+  LOADING_SKELETON: 'pro-hub-member-pricing-loading-skeleton',
+  ERROR: 'pro-hub-member-pricing-error',
+  RETRY_BUTTON: 'pro-hub-member-pricing-retry-button',
+  RESETS_ON: 'pro-hub-member-pricing-resets-on',
   ROW: (id: TradeAllowanceItem['id']) => `pro-hub-member-pricing-row-${id}`,
   PROGRESS: (id: TradeAllowanceItem['id']) =>
     `pro-hub-member-pricing-progress-${id}`,

--- a/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.tsx
+++ b/app/components/Views/ProHub/components/MemberPricingOnTrades/MemberPricingOnTrades.tsx
@@ -1,33 +1,91 @@
 import React from 'react';
 import {
   Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
   FontWeight,
+  Skeleton,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
-import { MOCK_TRADE_ALLOWANCES } from '../../ProHub.constants';
+import {
+  MoneyAccountPlusBenefitsStatus,
+  useMoneyAccountPlusBenefits,
+} from '../../../../../hooks/useMoneyAccountPlusBenefits';
 import { MemberPricingOnTradesTestIds } from './MemberPricingOnTrades.testIds';
 import TradeAllowanceRow from './TradeAllowanceRow';
 
-const MemberPricingOnTrades = () => (
-  <Box twClassName="gap-y-6" testID={MemberPricingOnTradesTestIds.SECTION}>
-    <Text
-      variant={TextVariant.HeadingMd}
-      fontWeight={FontWeight.Bold}
-      color={TextColor.TextDefault}
-      testID={MemberPricingOnTradesTestIds.TITLE}
-    >
-      {strings('pro_hub.member_pricing.title')}
-    </Text>
-
-    <Box twClassName="gap-y-6">
-      {MOCK_TRADE_ALLOWANCES.map((item) => (
-        <TradeAllowanceRow key={item.id} item={item} />
-      ))}
-    </Box>
+const LoadingSkeletons = () => (
+  <Box
+    twClassName="gap-y-6"
+    testID={MemberPricingOnTradesTestIds.LOADING_SKELETON}
+  >
+    <Skeleton height={72} twClassName="w-full rounded-xl" />
+    <Skeleton height={72} twClassName="w-full rounded-xl" />
+    <Skeleton height={72} twClassName="w-full rounded-xl" />
   </Box>
 );
+
+const MemberPricingOnTrades = () => {
+  const { status, items, resetsOn, retry } = useMoneyAccountPlusBenefits();
+
+  const showError = status === MoneyAccountPlusBenefitsStatus.Failed;
+  const showLoading = status === MoneyAccountPlusBenefitsStatus.Loading;
+  const showRows =
+    status === MoneyAccountPlusBenefitsStatus.Ready ||
+    status === MoneyAccountPlusBenefitsStatus.Incomplete;
+
+  return (
+    <Box twClassName="gap-y-6" testID={MemberPricingOnTradesTestIds.SECTION}>
+      <Text
+        variant={TextVariant.HeadingMd}
+        fontWeight={FontWeight.Bold}
+        color={TextColor.TextDefault}
+        testID={MemberPricingOnTradesTestIds.TITLE}
+      >
+        {strings('pro_hub.member_pricing.title')}
+      </Text>
+
+      {showLoading ? <LoadingSkeletons /> : null}
+
+      {showError ? (
+        <Box twClassName="gap-y-4" testID={MemberPricingOnTradesTestIds.ERROR}>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+            {strings('pro_hub.member_pricing.load_error')}
+          </Text>
+          <Button
+            variant={ButtonVariant.Secondary}
+            size={ButtonSize.Md}
+            onPress={retry}
+            testID={MemberPricingOnTradesTestIds.RETRY_BUTTON}
+          >
+            {strings('pro_hub.member_pricing.retry')}
+          </Button>
+        </Box>
+      ) : null}
+
+      {showRows ? (
+        <Box twClassName="gap-y-6">
+          {items.map((item) => (
+            <TradeAllowanceRow key={item.id} item={item} />
+          ))}
+        </Box>
+      ) : null}
+
+      {showRows && resetsOn ? (
+        <Text
+          variant={TextVariant.BodyXs}
+          color={TextColor.TextAlternative}
+          testID={MemberPricingOnTradesTestIds.RESETS_ON}
+        >
+          {strings('pro_hub.member_pricing.resets_on', { date: resetsOn })}
+        </Text>
+      ) : null}
+    </Box>
+  );
+};
 
 export default MemberPricingOnTrades;

--- a/app/components/Views/ProHub/components/MemberPricingOnTrades/TradeAllowanceRow.tsx
+++ b/app/components/Views/ProHub/components/MemberPricingOnTrades/TradeAllowanceRow.tsx
@@ -44,6 +44,10 @@ const formatUsedValue = (item: TradeAllowanceItem): string => {
 };
 
 const calculateProgress = (item: TradeAllowanceItem): number => {
+  if (item.exhausted) {
+    return 1;
+  }
+
   if (item.allowance <= 0) {
     return 0;
   }

--- a/app/components/Views/ProHub/components/MemberPricingOnTrades/mapPlusBenefitsToTradeAllowances.test.ts
+++ b/app/components/Views/ProHub/components/MemberPricingOnTrades/mapPlusBenefitsToTradeAllowances.test.ts
@@ -1,0 +1,142 @@
+import type { SubscriptionBenefitsState } from '@metamask/subscription-controller';
+import {
+  formatPlusPeriodEnd,
+  mapPlusBenefitsToTradeAllowances,
+} from './mapPlusBenefitsToTradeAllowances';
+
+const createBenefits = (
+  overrides: Partial<SubscriptionBenefitsState> = {},
+): SubscriptionBenefitsState => ({
+  billingPeriodId: 'bp_2026_08_15',
+  swaps: {
+    feeBips: '0',
+    capMicroUsd: 500_000_000,
+    consumedMicroUsd: 310_000_000,
+    remainingMicroUsd: 190_000_000,
+    exhausted: false,
+  },
+  perps: {
+    builderFeeBips: '0',
+    builderCode: 'code',
+    capMicroUsd: 1_000_000_000,
+    consumedMicroUsd: 240_000_000,
+    remainingMicroUsd: 760_000_000,
+    exhausted: false,
+  },
+  predict: {
+    builderCode: 'code',
+    capTxCount: 1,
+    consumedTxCount: 0,
+    remainingTxCount: 1,
+    exhausted: false,
+  },
+  ...overrides,
+});
+
+describe('mapPlusBenefitsToTradeAllowances', () => {
+  it('converts swap and perps micro-USD meters to dollar rows', () => {
+    const items = mapPlusBenefitsToTradeAllowances(createBenefits());
+
+    expect(items).toEqual([
+      {
+        id: 'swaps',
+        used: 310,
+        allowance: 500,
+        kind: 'currency',
+        exhausted: false,
+      },
+      {
+        id: 'perps',
+        used: 240,
+        allowance: 1000,
+        kind: 'currency',
+        exhausted: false,
+      },
+      {
+        id: 'predict',
+        used: 0,
+        allowance: 1,
+        kind: 'count',
+        exhausted: false,
+      },
+    ]);
+  });
+
+  it('derives used from remaining when consumed is omitted', () => {
+    const items = mapPlusBenefitsToTradeAllowances(
+      createBenefits({
+        swaps: {
+          feeBips: '0',
+          capMicroUsd: 500_000_000,
+          remainingMicroUsd: 200_000_000,
+          exhausted: false,
+        },
+      }),
+    );
+
+    const swaps = items.find((item) => item.id === 'swaps');
+
+    expect(swaps).toEqual(
+      expect.objectContaining({ used: 300, allowance: 500 }),
+    );
+  });
+
+  it('omits a product that has no cap', () => {
+    const items = mapPlusBenefitsToTradeAllowances(
+      createBenefits({
+        predict: {
+          builderCode: 'code',
+          remainingTxCount: null,
+          exhausted: false,
+        },
+      }),
+    );
+
+    expect(items.map((item) => item.id)).toEqual(['swaps', 'perps']);
+  });
+
+  it('clamps an exhausted meter to a full allowance bar', () => {
+    const items = mapPlusBenefitsToTradeAllowances(
+      createBenefits({
+        swaps: {
+          feeBips: '0',
+          capMicroUsd: 500_000_000,
+          consumedMicroUsd: 0,
+          remainingMicroUsd: 0,
+          exhausted: true,
+        },
+      }),
+    );
+
+    expect(items.find((item) => item.id === 'swaps')).toEqual({
+      id: 'swaps',
+      used: 500,
+      allowance: 500,
+      kind: 'currency',
+      exhausted: true,
+    });
+  });
+
+  it('returns an empty list when benefits are missing', () => {
+    expect(mapPlusBenefitsToTradeAllowances(undefined)).toEqual([]);
+  });
+});
+
+describe('formatPlusPeriodEnd', () => {
+  it('formats an ISO timestamp as a short month-day string', () => {
+    expect(formatPlusPeriodEnd('2026-09-15T00:00:00.000Z')).toBe(
+      new Date('2026-09-15T00:00:00.000Z').toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+      }),
+    );
+  });
+
+  it('returns undefined for a missing timestamp', () => {
+    expect(formatPlusPeriodEnd(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for an unparseable timestamp', () => {
+    expect(formatPlusPeriodEnd('not-a-date')).toBeUndefined();
+  });
+});

--- a/app/components/Views/ProHub/components/MemberPricingOnTrades/mapPlusBenefitsToTradeAllowances.ts
+++ b/app/components/Views/ProHub/components/MemberPricingOnTrades/mapPlusBenefitsToTradeAllowances.ts
@@ -1,0 +1,145 @@
+import type {
+  PerpsBenefitUsage,
+  PredictBenefitUsage,
+  SubscriptionBenefitsState,
+  SwapsBenefitUsage,
+} from '@metamask/subscription-controller';
+import type {
+  TradeAllowanceItem,
+  TradeAllowanceKind,
+} from '../../ProHub.constants';
+
+export const MICRO_USD_PER_USD = 1_000_000;
+
+/** Swap, perps, and predict — the products Member pricing can show. */
+export const PLUS_BENEFIT_PRODUCT_COUNT = 3;
+
+const toUsd = (microUsd: number): number =>
+  Math.round(microUsd / MICRO_USD_PER_USD);
+
+const mapMeteredRow = ({
+  id,
+  kind,
+  cap,
+  consumed,
+  remaining,
+  exhausted,
+}: {
+  id: TradeAllowanceItem['id'];
+  kind: TradeAllowanceKind;
+  cap: number | undefined;
+  consumed: number | undefined;
+  remaining: number | null;
+  exhausted: boolean;
+}): TradeAllowanceItem | undefined => {
+  if (cap === undefined || cap <= 0) {
+    return undefined;
+  }
+
+  let used: number | undefined;
+  if (consumed !== undefined) {
+    used = consumed;
+  } else if (remaining !== null) {
+    used = cap - remaining;
+  } else if (exhausted) {
+    used = cap;
+  }
+
+  if (used === undefined) {
+    return undefined;
+  }
+
+  const allowance = kind === 'currency' ? toUsd(cap) : cap;
+  let displayUsed = kind === 'currency' ? toUsd(used) : used;
+  displayUsed = Math.max(0, displayUsed);
+
+  if (exhausted) {
+    displayUsed = Math.max(displayUsed, allowance);
+  }
+
+  return {
+    id,
+    used: displayUsed,
+    allowance,
+    kind,
+    exhausted,
+  };
+};
+
+const mapSwaps = (usage: SwapsBenefitUsage): TradeAllowanceItem | undefined =>
+  mapMeteredRow({
+    id: 'swaps',
+    kind: 'currency',
+    cap: usage.capMicroUsd,
+    consumed: usage.consumedMicroUsd,
+    remaining: usage.remainingMicroUsd,
+    exhausted: usage.exhausted,
+  });
+
+const mapPerps = (usage: PerpsBenefitUsage): TradeAllowanceItem | undefined =>
+  mapMeteredRow({
+    id: 'perps',
+    kind: 'currency',
+    cap: usage.capMicroUsd,
+    consumed: usage.consumedMicroUsd,
+    remaining: usage.remainingMicroUsd,
+    exhausted: usage.exhausted,
+  });
+
+const mapPredict = (
+  usage: PredictBenefitUsage,
+): TradeAllowanceItem | undefined =>
+  mapMeteredRow({
+    id: 'predict',
+    kind: 'count',
+    cap: usage.capTxCount,
+    consumed: usage.consumedTxCount,
+    remaining: usage.remainingTxCount,
+    exhausted: usage.exhausted,
+  });
+
+/**
+ * Maps persisted Plus benefits onto the Member pricing rows. Products without
+ * a cap are omitted so the UI never invents an allowance bar.
+ *
+ * @param benefits - Persisted `SubscriptionController` benefits, if any.
+ * @returns Rows that can be rendered, in swaps / perps / predict order.
+ */
+export const mapPlusBenefitsToTradeAllowances = (
+  benefits: SubscriptionBenefitsState | undefined,
+): TradeAllowanceItem[] => {
+  if (!benefits) {
+    return [];
+  }
+
+  return [
+    mapSwaps(benefits.swaps),
+    mapPerps(benefits.perps),
+    mapPredict(benefits.predict),
+  ].filter((item): item is TradeAllowanceItem => item !== undefined);
+};
+
+/**
+ * Formats a subscription period-end ISO timestamp for the shared reset line.
+ *
+ * @param currentPeriodEnd - ISO 8601 timestamp from the Plus subscription.
+ * @returns A short month-day string, or undefined when the timestamp is missing
+ * or unparseable.
+ */
+export const formatPlusPeriodEnd = (
+  currentPeriodEnd: string | undefined,
+): string | undefined => {
+  if (!currentPeriodEnd) {
+    return undefined;
+  }
+
+  const date = new Date(currentPeriodEnd);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+};

--- a/app/core/Subscription/benefitsResolution.test.ts
+++ b/app/core/Subscription/benefitsResolution.test.ts
@@ -1,0 +1,167 @@
+import {
+  __resetForTest,
+  ensureResolved,
+  getSnapshot,
+  refresh,
+  reset,
+  subscribe,
+} from './benefitsResolution';
+import Engine from '../Engine';
+import Logger from '../../util/Logger';
+
+jest.mock('../Engine', () => ({
+  context: {
+    SubscriptionController: {
+      getBenefits: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../util/Logger', () => ({
+  error: jest.fn(),
+}));
+
+const mockGetBenefits = jest.mocked(
+  Engine.context.SubscriptionController.getBenefits,
+);
+
+describe('benefitsResolution', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetForTest();
+    mockGetBenefits.mockResolvedValue({
+      eligible: true,
+      billingPeriodId: 'bp_1',
+      products: {
+        swaps: {
+          feeBips: '0',
+          remainingMicroUsd: 0,
+          exhausted: false,
+        },
+        perps: {
+          builderFeeBips: '0',
+          builderCode: null,
+          remainingMicroUsd: 0,
+          exhausted: false,
+        },
+        predict: {
+          builderCode: null,
+          remainingTxCount: 0,
+          exhausted: false,
+        },
+      },
+    });
+  });
+
+  describe('ensureResolved', () => {
+    it('starts idle and reports resolved after a successful fetch', async () => {
+      expect(getSnapshot()).toBe('idle');
+
+      await ensureResolved();
+
+      expect(getSnapshot()).toBe('resolved');
+      expect(mockGetBenefits).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not refetch once resolved', async () => {
+      await ensureResolved();
+      await ensureResolved();
+
+      expect(mockGetBenefits).toHaveBeenCalledTimes(1);
+    });
+
+    it('shares one request between concurrent callers', async () => {
+      await Promise.all([ensureResolved(), ensureResolved(), ensureResolved()]);
+
+      expect(mockGetBenefits).toHaveBeenCalledTimes(1);
+      expect(getSnapshot()).toBe('resolved');
+    });
+
+    it('reports error and logs when the fetch fails', async () => {
+      const error = new Error('network down');
+      mockGetBenefits.mockRejectedValue(error);
+
+      await ensureResolved();
+
+      expect(getSnapshot()).toBe('error');
+      expect(Logger.error).toHaveBeenCalledWith(
+        error,
+        '[benefitsResolution] Failed to resolve subscription benefits',
+      );
+    });
+  });
+
+  describe('refresh', () => {
+    it('refetches even when already resolved', async () => {
+      await ensureResolved();
+
+      await refresh();
+
+      expect(mockGetBenefits).toHaveBeenCalledTimes(2);
+      expect(getSnapshot()).toBe('resolved');
+    });
+  });
+
+  describe('reset', () => {
+    it('clears resolution so the next caller refetches', async () => {
+      await ensureResolved();
+
+      reset();
+
+      expect(getSnapshot()).toBe('idle');
+
+      await ensureResolved();
+
+      expect(mockGetBenefits).toHaveBeenCalledTimes(2);
+    });
+
+    it('discards a request that was already in flight', async () => {
+      let completeFetch: () => void = () => undefined;
+      mockGetBenefits.mockReturnValue(
+        new Promise((resolve) => {
+          completeFetch = () =>
+            resolve({
+              eligible: true,
+              billingPeriodId: 'bp_1',
+              products: {
+                swaps: {
+                  feeBips: '0',
+                  remainingMicroUsd: null,
+                  exhausted: false,
+                },
+                perps: {
+                  builderFeeBips: '0',
+                  builderCode: null,
+                  remainingMicroUsd: null,
+                  exhausted: false,
+                },
+                predict: {
+                  builderCode: null,
+                  remainingTxCount: null,
+                  exhausted: false,
+                },
+              },
+            });
+        }),
+      );
+
+      const pending = ensureResolved();
+      reset();
+      completeFetch();
+      await pending;
+
+      expect(getSnapshot()).toBe('idle');
+    });
+  });
+
+  describe('subscribe', () => {
+    it('notifies listeners on each status change', async () => {
+      const listener = jest.fn();
+      subscribe(listener);
+
+      await ensureResolved();
+
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/app/core/Subscription/benefitsResolution.ts
+++ b/app/core/Subscription/benefitsResolution.ts
@@ -1,0 +1,137 @@
+import Engine from '../Engine';
+import Logger from '../../util/Logger';
+
+/**
+ * Whether this session has attempted `getBenefits()`.
+ *
+ * The controller persists `state.benefits` but has no loading flag, and
+ * lifecycle refreshes swallow errors. This store tracks the in-flight attempt
+ * so the overview can distinguish first load, retry, and stale cache.
+ */
+export type BenefitsResolutionStatus =
+  | 'idle'
+  | 'loading'
+  | 'resolved'
+  | 'error';
+
+interface BenefitsResolutionStore {
+  status: BenefitsResolutionStatus;
+  listeners: Set<() => void>;
+  inFlight: Promise<void> | undefined;
+  generation: number;
+}
+
+const store: BenefitsResolutionStore = {
+  status: 'idle',
+  listeners: new Set(),
+  inFlight: undefined,
+  generation: 0,
+};
+
+const emit = () => {
+  store.listeners.forEach((listener) => listener());
+};
+
+const setStatus = (status: BenefitsResolutionStatus) => {
+  if (store.status === status) {
+    return;
+  }
+  store.status = status;
+  emit();
+};
+
+const fetchBenefits = async (): Promise<void> => {
+  const generation = store.generation;
+  setStatus('loading');
+
+  try {
+    await Engine.context.SubscriptionController.getBenefits();
+    if (generation === store.generation) {
+      setStatus('resolved');
+    }
+  } catch (error) {
+    Logger.error(
+      error as Error,
+      '[benefitsResolution] Failed to resolve subscription benefits',
+    );
+    if (generation === store.generation) {
+      setStatus('error');
+    }
+  } finally {
+    if (generation === store.generation) {
+      store.inFlight = undefined;
+    }
+  }
+};
+
+/**
+ * Resolves benefits once per session. Repeat calls while a request is in
+ * flight share it, and calls after a successful resolution are a no-op.
+ *
+ * @returns A promise that settles when benefits have been resolved.
+ */
+export const ensureResolved = async (): Promise<void> => {
+  if (store.status === 'resolved') {
+    return;
+  }
+
+  if (store.inFlight) {
+    return await store.inFlight;
+  }
+
+  store.inFlight = fetchBenefits();
+  return await store.inFlight;
+};
+
+/**
+ * Re-fetches benefits after subscribe, cancel, account change, or a manual
+ * retry. Joins an in-flight request instead of issuing a second one.
+ *
+ * @returns A promise that settles when benefits have been re-resolved.
+ */
+export const refresh = async (): Promise<void> => {
+  if (store.inFlight) {
+    return await store.inFlight;
+  }
+
+  store.inFlight = fetchBenefits();
+  return await store.inFlight;
+};
+
+/**
+ * Clears resolution so the next subscriber re-fetches. Call this on sign-out
+ * and lock so a new session never inherits the previous user's status.
+ */
+export const reset = () => {
+  store.generation += 1;
+  store.inFlight = undefined;
+  setStatus('idle');
+};
+
+/**
+ * Subscribes to resolution status changes.
+ *
+ * @param listener - Called whenever the status changes.
+ * @returns An unsubscribe function.
+ */
+export const subscribe = (listener: () => void): (() => void) => {
+  store.listeners.add(listener);
+  return () => {
+    store.listeners.delete(listener);
+  };
+};
+
+/**
+ * Reads the current resolution status.
+ *
+ * @returns The current status.
+ */
+export const getSnapshot = (): BenefitsResolutionStatus => store.status;
+
+/** Test-only: clears status, listeners, and any in-flight request. */
+export const __resetForTest = () => {
+  store.status = 'idle';
+  store.inFlight = undefined;
+  store.listeners.clear();
+  store.generation = 0;
+};

--- a/app/hooks/useMoneyAccountPlusBenefits.test.tsx
+++ b/app/hooks/useMoneyAccountPlusBenefits.test.tsx
@@ -1,0 +1,272 @@
+import React from 'react';
+import { act, renderHook } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+import {
+  PRODUCT_TYPES,
+  SUBSCRIPTION_STATUSES,
+  type SubscriptionBenefitsState,
+  type Subscription,
+} from '@metamask/subscription-controller';
+import type { RootState } from '../reducers';
+import configureStore from '../util/test/configureStore';
+import Engine from '../core/Engine';
+import { __resetForTest } from '../core/Subscription/benefitsResolution';
+import {
+  MoneyAccountPlusAccess,
+  useMoneyAccountPlusAccess,
+} from './useMoneyAccountPlusAccess';
+import {
+  MoneyAccountPlusBenefitsStatus,
+  useMoneyAccountPlusBenefits,
+} from './useMoneyAccountPlusBenefits';
+
+jest.mock('../core/Engine', () => ({
+  context: {
+    SubscriptionController: {
+      getBenefits: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../util/Logger', () => ({
+  error: jest.fn(),
+}));
+
+jest.mock('./useMoneyAccountPlusAccess', () => ({
+  ...jest.requireActual('./useMoneyAccountPlusAccess'),
+  useMoneyAccountPlusAccess: jest.fn(),
+}));
+
+jest.mock('@react-navigation/native', () => {
+  const ReactNav = jest.requireActual('react');
+  return {
+    useFocusEffect: (callback: () => void) => {
+      ReactNav.useEffect(callback, [callback]);
+    },
+  };
+});
+
+const mockUseMoneyAccountPlusAccess = jest.mocked(useMoneyAccountPlusAccess);
+const mockGetBenefits = jest.mocked(
+  Engine.context.SubscriptionController.getBenefits,
+);
+
+const BENEFITS: SubscriptionBenefitsState = {
+  billingPeriodId: 'bp_2026_08_15',
+  swaps: {
+    feeBips: '0',
+    capMicroUsd: 500_000_000,
+    consumedMicroUsd: 310_000_000,
+    remainingMicroUsd: 190_000_000,
+    exhausted: false,
+  },
+  perps: {
+    builderFeeBips: '0',
+    builderCode: 'code',
+    capMicroUsd: 1_000_000_000,
+    consumedMicroUsd: 240_000_000,
+    remainingMicroUsd: 760_000_000,
+    exhausted: false,
+  },
+  predict: {
+    builderCode: 'code',
+    capTxCount: 1,
+    consumedTxCount: 0,
+    remainingTxCount: 1,
+    exhausted: false,
+  },
+};
+
+const createPlusSubscription = (): Subscription =>
+  ({
+    id: 'sub-plus',
+    currentPeriodStart: '2026-08-15T00:00:00.000Z',
+    currentPeriodEnd: '2026-09-15T00:00:00.000Z',
+    status: SUBSCRIPTION_STATUSES.active,
+    products: [
+      {
+        name: PRODUCT_TYPES.MONEY_ACCOUNT_PLUS,
+        currency: 'usd',
+        unitAmount: 499,
+        unitDecimals: 2,
+      },
+    ],
+  }) as Subscription;
+
+const createState = ({
+  isSignedIn = true,
+  isUnlocked = true,
+  benefits,
+}: {
+  isSignedIn?: boolean;
+  isUnlocked?: boolean;
+  benefits?: SubscriptionBenefitsState;
+} = {}) =>
+  ({
+    engine: {
+      backgroundState: {
+        AuthenticationController: { isSignedIn },
+        KeyringController: { isUnlocked, keyrings: [] },
+        SubscriptionController: {
+          subscriptions: [createPlusSubscription()],
+          trialedProducts: [],
+          ...(benefits ? { benefits } : {}),
+        },
+      },
+    },
+  }) as unknown as RootState;
+
+const renderBenefits = (state: RootState) => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={configureStore(state)}>{children}</Provider>
+  );
+
+  return renderHook(() => useMoneyAccountPlusBenefits(), { wrapper: Wrapper });
+};
+
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+describe('useMoneyAccountPlusBenefits', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetForTest();
+    mockUseMoneyAccountPlusAccess.mockReturnValue(
+      MoneyAccountPlusAccess.Subscriber,
+    );
+    mockGetBenefits.mockResolvedValue({
+      eligible: true,
+      billingPeriodId: BENEFITS.billingPeriodId,
+      products: {
+        swaps: BENEFITS.swaps,
+        perps: BENEFITS.perps,
+        predict: BENEFITS.predict,
+      },
+    });
+  });
+
+  it('does not fetch benefits for a non-subscriber', async () => {
+    mockUseMoneyAccountPlusAccess.mockReturnValue(
+      MoneyAccountPlusAccess.Eligible,
+    );
+
+    const { result } = renderBenefits(createState());
+    await flush();
+
+    expect(mockGetBenefits).not.toHaveBeenCalled();
+    expect(result.current.status).toBe(MoneyAccountPlusBenefitsStatus.Loading);
+  });
+
+  it('reports loading while benefits are unresolved and uncached', () => {
+    mockGetBenefits.mockReturnValue(new Promise(() => undefined));
+
+    const { result } = renderBenefits(createState());
+
+    expect(result.current.status).toBe(MoneyAccountPlusBenefitsStatus.Loading);
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('maps cached benefits after a successful fetch', async () => {
+    const { result } = renderBenefits(createState({ benefits: BENEFITS }));
+    await flush();
+
+    expect(mockGetBenefits).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe(MoneyAccountPlusBenefitsStatus.Ready);
+    expect(result.current.items).toHaveLength(3);
+    expect(result.current.resetsOn).toBe(
+      new Date('2026-09-15T00:00:00.000Z').toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+      }),
+    );
+  });
+
+  it('reports partial when a product cannot be mapped', async () => {
+    const { result } = renderBenefits(
+      createState({
+        benefits: {
+          ...BENEFITS,
+          predict: {
+            builderCode: 'code',
+            remainingTxCount: null,
+            exhausted: false,
+          },
+        },
+      }),
+    );
+    await flush();
+
+    expect(result.current.status).toBe(
+      MoneyAccountPlusBenefitsStatus.Incomplete,
+    );
+    expect(result.current.items.map((item) => item.id)).toEqual([
+      'swaps',
+      'perps',
+    ]);
+  });
+
+  it('reports error when the fetch fails and no cache exists', async () => {
+    mockGetBenefits.mockRejectedValue(new Error('network down'));
+
+    const { result } = renderBenefits(createState());
+    await flush();
+
+    expect(result.current.status).toBe(MoneyAccountPlusBenefitsStatus.Failed);
+    expect(result.current.hasError).toBe(true);
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('keeps cached rows when a refresh fails', async () => {
+    const { result } = renderBenefits(createState({ benefits: BENEFITS }));
+    await flush();
+    expect(result.current.status).toBe(MoneyAccountPlusBenefitsStatus.Ready);
+
+    mockGetBenefits.mockRejectedValue(new Error('network down'));
+    await act(async () => {
+      result.current.retry();
+      await Promise.resolve();
+    });
+
+    expect(result.current.status).toBe(MoneyAccountPlusBenefitsStatus.Ready);
+    expect(result.current.hasError).toBe(true);
+    expect(result.current.items).toHaveLength(3);
+  });
+
+  it('retries a failed fetch from the error state', async () => {
+    mockGetBenefits.mockRejectedValueOnce(new Error('network down'));
+
+    const { result } = renderBenefits(createState());
+    await flush();
+    expect(result.current.status).toBe(MoneyAccountPlusBenefitsStatus.Failed);
+
+    await act(async () => {
+      result.current.retry();
+      await Promise.resolve();
+    });
+
+    expect(mockGetBenefits).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears resolution when the session ends so the next user re-fetches', async () => {
+    renderBenefits(createState({ benefits: BENEFITS }));
+    await flush();
+    expect(mockGetBenefits).toHaveBeenCalledTimes(1);
+
+    mockUseMoneyAccountPlusAccess.mockReturnValue(
+      MoneyAccountPlusAccess.Eligible,
+    );
+    renderBenefits(createState({ isSignedIn: false, benefits: BENEFITS }));
+    await flush();
+
+    mockUseMoneyAccountPlusAccess.mockReturnValue(
+      MoneyAccountPlusAccess.Subscriber,
+    );
+    renderBenefits(createState({ benefits: BENEFITS }));
+    await flush();
+
+    expect(mockGetBenefits).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/hooks/useMoneyAccountPlusBenefits.ts
+++ b/app/hooks/useMoneyAccountPlusBenefits.ts
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+import {
+  PLUS_BENEFIT_PRODUCT_COUNT,
+  formatPlusPeriodEnd,
+  mapPlusBenefitsToTradeAllowances,
+} from '../components/Views/ProHub/components/MemberPricingOnTrades/mapPlusBenefitsToTradeAllowances';
+import type { TradeAllowanceItem } from '../components/Views/ProHub/ProHub.constants';
+import {
+  ensureResolved,
+  getSnapshot,
+  refresh,
+  reset,
+  subscribe,
+} from '../core/Subscription/benefitsResolution';
+import { selectIsSignedIn } from '../selectors/identity';
+import { selectIsUnlocked } from '../selectors/keyringController';
+import {
+  selectMoneyAccountPlusSubscription,
+  selectSubscriptionBenefits,
+} from '../selectors/subscriptionController';
+import {
+  MoneyAccountPlusAccess,
+  useMoneyAccountPlusAccess,
+} from './useMoneyAccountPlusAccess';
+
+/**
+ * Presentation state for the Member pricing on trades section.
+ */
+export enum MoneyAccountPlusBenefitsStatus {
+  Loading = 'loading',
+  Ready = 'ready',
+  Incomplete = 'incomplete',
+  Empty = 'empty',
+  Failed = 'failed',
+}
+
+export interface MoneyAccountPlusBenefits {
+  status: MoneyAccountPlusBenefitsStatus;
+  items: TradeAllowanceItem[];
+  resetsOn: string | undefined;
+  isRefreshing: boolean;
+  hasError: boolean;
+  retry: () => void;
+}
+
+/**
+ * Loads current-period Plus benefit usage through SubscriptionController.
+ *
+ * `getBenefits()` is only called for entitled subscribers. Cached
+ * `state.benefits` stays visible during a refresh or a failed refresh; an
+ * error with no cache surfaces retry UI instead of paid meters.
+ *
+ * @returns Mapped trade-allowance rows and the shared reset date.
+ */
+export function useMoneyAccountPlusBenefits(): MoneyAccountPlusBenefits {
+  const access = useMoneyAccountPlusAccess();
+  const isSignedIn = useSelector(selectIsSignedIn);
+  const isUnlocked = Boolean(useSelector(selectIsUnlocked));
+  const benefits = useSelector(selectSubscriptionBenefits);
+  const plusSubscription = useSelector(selectMoneyAccountPlusSubscription);
+  const resolutionStatus = useSyncExternalStore(subscribe, getSnapshot);
+
+  const isSubscriber = access === MoneyAccountPlusAccess.Subscriber;
+
+  useEffect(() => {
+    if (!isSignedIn || !isUnlocked) {
+      reset();
+    }
+  }, [isSignedIn, isUnlocked]);
+
+  useEffect(() => {
+    if (!isSubscriber) {
+      return;
+    }
+
+    ensureResolved().catch(() => {
+      // Status is already recorded as `error` by the store.
+    });
+  }, [isSubscriber]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!isSubscriber) {
+        return;
+      }
+
+      refresh().catch(() => {
+        // Status is already recorded as `error` by the store.
+      });
+    }, [isSubscriber]),
+  );
+
+  const retry = useCallback(() => {
+    refresh().catch(() => {
+      // Status is already recorded as `error` by the store.
+    });
+  }, []);
+
+  const items = useMemo(
+    () => mapPlusBenefitsToTradeAllowances(benefits),
+    [benefits],
+  );
+  const resetsOn = formatPlusPeriodEnd(plusSubscription?.currentPeriodEnd);
+  const hasCache = benefits !== undefined;
+  const isUnresolved =
+    resolutionStatus === 'idle' || resolutionStatus === 'loading';
+
+  if (!isSubscriber) {
+    return {
+      status: MoneyAccountPlusBenefitsStatus.Loading,
+      items: [],
+      resetsOn: undefined,
+      isRefreshing: false,
+      hasError: false,
+      retry,
+    };
+  }
+
+  if (!hasCache && isUnresolved) {
+    return {
+      status: MoneyAccountPlusBenefitsStatus.Loading,
+      items: [],
+      resetsOn: undefined,
+      isRefreshing: true,
+      hasError: false,
+      retry,
+    };
+  }
+
+  if (!hasCache && resolutionStatus === 'error') {
+    return {
+      status: MoneyAccountPlusBenefitsStatus.Failed,
+      items: [],
+      resetsOn: undefined,
+      isRefreshing: false,
+      hasError: true,
+      retry,
+    };
+  }
+
+  if (items.length === 0) {
+    return {
+      status: MoneyAccountPlusBenefitsStatus.Empty,
+      items: [],
+      resetsOn,
+      isRefreshing: isUnresolved,
+      hasError: resolutionStatus === 'error',
+      retry,
+    };
+  }
+
+  return {
+    status:
+      items.length < PLUS_BENEFIT_PRODUCT_COUNT
+        ? MoneyAccountPlusBenefitsStatus.Incomplete
+        : MoneyAccountPlusBenefitsStatus.Ready,
+    items,
+    resetsOn,
+    isRefreshing: isUnresolved,
+    hasError: resolutionStatus === 'error',
+    retry,
+  };
+}

--- a/app/selectors/subscriptionController.test.ts
+++ b/app/selectors/subscriptionController.test.ts
@@ -21,6 +21,8 @@ import {
   selectLastSelectedPaymentMethodByProduct,
   selectLastSubscriptionByProduct,
   selectMoneyAccountPlusClaim,
+  selectMoneyAccountPlusSubscription,
+  selectSubscriptionBenefits,
   selectSubscriptionByProduct,
   selectSubscriptionControllerState,
   selectSubscriptionPricing,
@@ -633,6 +635,95 @@ describe('subscriptionController selectors', () => {
         expect(selectHasAnyMoneyAccountPlusEntitlement(createState())).toBe(
           false,
         );
+      });
+    });
+
+    describe('selectSubscriptionBenefits', () => {
+      const benefits = {
+        billingPeriodId: 'bp_2026_08_15',
+        swaps: {
+          feeBips: '0',
+          capMicroUsd: 500_000_000,
+          consumedMicroUsd: 100_000_000,
+          remainingMicroUsd: 400_000_000,
+          exhausted: false,
+        },
+        perps: {
+          builderFeeBips: '0',
+          builderCode: 'code',
+          capMicroUsd: 1_500_000_000,
+          consumedMicroUsd: 500_000_000,
+          remainingMicroUsd: 1_000_000_000,
+          exhausted: false,
+        },
+        predict: {
+          builderCode: 'code',
+          capTxCount: 3,
+          consumedTxCount: 1,
+          remainingTxCount: 2,
+          exhausted: false,
+        },
+      };
+
+      it('returns persisted benefits from controller state', () => {
+        const result = selectSubscriptionBenefits(
+          createState({
+            subscriptions: [],
+            trialedProducts: [],
+            benefits,
+          }),
+        );
+
+        expect(result).toEqual(benefits);
+      });
+
+      it('returns undefined when benefits have not been fetched', () => {
+        expect(
+          selectSubscriptionBenefits(
+            createState({
+              subscriptions: [],
+              trialedProducts: [],
+            }),
+          ),
+        ).toBeUndefined();
+      });
+
+      it('returns undefined when the controller is absent', () => {
+        expect(selectSubscriptionBenefits(createState())).toBeUndefined();
+      });
+    });
+
+    describe('selectMoneyAccountPlusSubscription', () => {
+      it('returns the Plus subscription when present', () => {
+        const plusSubscription = createSubscription({
+          id: 'sub-plus',
+          products: [createProduct(PRODUCT_TYPES.MONEY_ACCOUNT_PLUS)],
+        });
+
+        expect(
+          selectMoneyAccountPlusSubscription(
+            createState({
+              subscriptions: [plusSubscription],
+              trialedProducts: [],
+            }),
+          ),
+        ).toEqual(plusSubscription);
+      });
+
+      it('returns undefined when no Plus subscription exists', () => {
+        expect(
+          selectMoneyAccountPlusSubscription(
+            createState({
+              subscriptions: [
+                createSubscription({
+                  id: 'sub-shield',
+                  products: [createProduct(PRODUCT_TYPES.SHIELD)],
+                }),
+              ],
+              trialedProducts: [],
+            }),
+          ),
+        ).toBeUndefined();
       });
     });
   });

--- a/app/selectors/subscriptionController.ts
+++ b/app/selectors/subscriptionController.ts
@@ -9,6 +9,7 @@ import {
   type MoneyAccountPlusClaim,
   type ProductType,
   type Subscription,
+  type SubscriptionBenefitsState,
   type SubscriptionControllerState,
 } from '@metamask/subscription-controller';
 import { RootState } from '../reducers';
@@ -195,3 +196,27 @@ export const selectHasAnyMoneyAccountPlusEntitlement = createSelector(
       Boolean(claim?.entitlements?.[feature]),
     ),
 );
+
+/**
+ * Selects persisted Money Account Plus benefit usage for the current billing
+ * period. Undefined until `getBenefits()` has stored a snapshot.
+ *
+ * @param state - The root Redux state.
+ * @returns The benefits snapshot, or undefined when it has not been fetched.
+ */
+export const selectSubscriptionBenefits = createSelector(
+  selectSubscriptionControllerState,
+  (subscriptionControllerState): SubscriptionBenefitsState | undefined =>
+    subscriptionControllerState?.benefits,
+);
+
+/**
+ * Selects the current Money Account Plus subscription, if any.
+ *
+ * @param state - The root Redux state.
+ * @returns The Plus subscription, or undefined when none exists.
+ */
+export const selectMoneyAccountPlusSubscription = (
+  state: RootState,
+): Subscription | undefined =>
+  selectSubscriptionByProduct(state, PRODUCT_TYPES.MONEY_ACCOUNT_PLUS);

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -11494,7 +11494,10 @@
       "predict": {
         "label": "Predict",
         "footnote": "One prediction trade per month. Unused trades don't roll over."
-      }
+      },
+      "resets_on": "Resets {{date}}",
+      "load_error": "Couldn't load your allowances.",
+      "retry": "Try again"
     },
     "physical_card": {
       "title": "Get your free MetaMask Card",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->


## **Description**

<!-- mms-check: type=text required=true -->

Stacked on #35964 (SUB-1031). Pro Hub Member pricing still rendered `MOCK_TRADE_ALLOWANCES` instead of current-period usage from `SubscriptionController.getBenefits()`.

This PR maps persisted `state.benefits` (swaps/perps micro-USD and predict tx counts) plus the Plus subscription's `currentPeriodEnd` into the existing trade-allowance rows. `getBenefits()` runs only for entitled subscribers. Benefits resolution is tracked app-side because controller polling swallows errors and has no loading flag: loading skeletons, retry with no cache, keep stale bars on refresh failure, omit products without a cap, and force a full fill when a row is exhausted.

Stays on `@metamask/subscription-controller@^8.1.0` (benefits API is unchanged in 9.0.0). Lifetime-earnings mocks and benefit detail sheets are unchanged (SUB-1033).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Added current-period Plus swap, perps, and predict usage on Pro Hub Member pricing

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: SUB-1032

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Pro Hub Member pricing current-period usage

  Scenario: subscriber sees mapped usage bars
    Given the Pro subscription A/B flag is on
    And the user is an active Money Account Plus subscriber
    And getBenefits returns swaps, perps, and predict caps with consumed amounts
    When the user opens Pro Hub
    Then Member pricing shows three usage rows
    And a shared Resets date from the Plus currentPeriodEnd is shown

  Scenario: loading then error with retry
    Given the user is an active Money Account Plus subscriber
    And there is no cached benefits snapshot
    When the user opens Pro Hub before getBenefits returns
    Then Member pricing shows the section title and row skeletons
    When getBenefits fails
    Then an error message and Retry are shown
    When the user taps Retry and getBenefits succeeds
    Then the usage rows are shown

  Scenario: exhausted and partial products
    Given getBenefits marks swaps exhausted
    And predict has no cap
    When the user opens Pro Hub
    Then the swaps bar is fully filled
    And the predict row is omitted
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subscription benefit fetching and billing-period usage display for paying subscribers; incorrect mapping or cache/retry logic could misstate allowances, though scope is limited to Pro Hub UI and read-only `getBenefits()` calls.
> 
> **Overview**
> **Pro Hub Member pricing** now shows **live Money Account Plus usage** instead of `MOCK_TRADE_ALLOWANCES`. Subscribers load data through `SubscriptionController.getBenefits()`; persisted `state.benefits` is mapped to swaps/perps (micro-USD → dollars) and predict (tx counts), with a shared **“Resets {date}”** line from the Plus subscription’s `currentPeriodEnd`.
> 
> A new **`benefitsResolution`** session store tracks fetch status (idle/loading/resolved/error) because the controller has no loading flag and can swallow errors. **`useMoneyAccountPlusBenefits`** wires that store to Redux selectors, calls `getBenefits()` only for entitled subscribers, refreshes on screen focus, resets on lock/sign-out, and exposes loading skeletons, retry when there’s no cache, stale bars on failed refresh, and **Incomplete** when a product has no cap. Rows support an **`exhausted`** flag so progress bars fill to 100% when the period cap is spent but consumed data would show 0%.
> 
> New Redux selectors **`selectSubscriptionBenefits`** and **`selectMoneyAccountPlusSubscription`** plus i18n for reset date, load error, and retry. Tests cover mapping, resolution deduping, the hook, and UI states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c913c2e4d737730378fdce533a57965def589b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->