### PR TITLE
fix:  Fix issue 34724 classify ERC-20 transfers by decoded recipient

### DIFF
--- a/app/components/UI/TokenDetails/hooks/useTokenTransactions.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenTransactions.test.ts
@@ -52,6 +52,7 @@ jest.mock('../../../../selectors/currencyRateController', () => ({
 }));
 
 jest.mock('../../../../util/activity', () => ({
+  ...jest.requireActual('../../../../util/activity'),
   sortTransactions: jest.fn((txs: unknown[]) => txs),
 }));
 
@@ -145,22 +146,25 @@ const createAsset = (overrides: Partial<TokenI> = {}): TokenI => ({
 
 const setupMocks = (
   transactions: unknown[] = [],
-  { bridgeHistory = {} as Record<string, unknown> } = {},
+  {
+    bridgeHistory = {} as Record<string, unknown>,
+    selectedAddress = MOCK_ADDRESS,
+  } = {},
 ) => {
   mockUseSelector.mockImplementation((selector) => {
     if (selector === selectTransactions) return transactions;
     if (selector === selectBridgeHistoryForAccount) return bridgeHistory;
     if (selector === selectTokens) return [];
     if (selector === selectSelectedInternalAccount) {
-      return { address: MOCK_ADDRESS, metadata: { importTime: 0 } };
+      return { address: selectedAddress, metadata: { importTime: 0 } };
     }
     if (selector === selectSelectedInternalAccountByScope) {
-      return () => ({ address: MOCK_ADDRESS });
+      return () => ({ address: selectedAddress });
     }
     if (selector === selectConversionRate) return 1;
     if (selector === selectCurrentCurrency) return 'usd';
     // Inline selector for selectedAddressForAsset
-    return MOCK_ADDRESS;
+    return selectedAddress;
   });
 };
 
@@ -264,6 +268,43 @@ describe('useTokenTransactions', () => {
       });
 
       expect(result.current.confirmedTxs.length).toBe(1);
+    });
+
+    it('includes an ERC20 transfer on the recipient token page', async () => {
+      const transferData =
+        `0xa9059cbb${MOCK_RECIPIENT.slice(2).padStart(64, '0')}` +
+        '1'.padStart(64, '0');
+      const tx = createMockTransaction({
+        chainId: ETH_CHAIN_ID,
+        txParams: {
+          from: MOCK_ADDRESS,
+          to: MOCK_TOKEN_ADDRESS,
+          data: transferData,
+        },
+        isTransfer: true,
+        transferInformation: {
+          contractAddress: MOCK_TOKEN_ADDRESS,
+        },
+      });
+      setupMocks([tx], { selectedAddress: MOCK_RECIPIENT });
+
+      const asset = createAsset({
+        symbol: 'DAI',
+        isETH: false,
+        isNative: false,
+        address: MOCK_TOKEN_ADDRESS,
+        chainId: ETH_CHAIN_ID,
+      });
+
+      const { result } = renderHook(() => useTokenTransactions(asset));
+
+      await waitFor(() => {
+        expect(result.current.transactionsUpdated).toBe(true);
+      });
+
+      expect(result.current.confirmedTxs).toEqual([
+        expect.objectContaining({ id: 'tx-1' }),
+      ]);
     });
 
     it('excludes unrelated transactions from ERC20 token view', async () => {

--- a/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
@@ -12,7 +12,7 @@ import {
 import { NATIVE_SWAPS_TOKEN_ADDRESS } from '../../../../constants/bridge';
 import { selectTokens } from '../../../../selectors/tokensController';
 import {
-  getTokenTransferRecipient,
+  getTokenTransferRecipients,
   sortTransactions,
 } from '../../../../util/activity';
 import {
@@ -509,7 +509,7 @@ export const useTokenTransactions = (
         isTransfer,
         transferInformation,
       } = tx;
-      const tokenTransferRecipient = getTokenTransferRecipient(tx);
+      const tokenTransferRecipients = getTokenTransferRecipients(tx);
 
       if (checkIsMusdClaimForCurrentView(tx)) {
         return true;
@@ -522,9 +522,8 @@ export const useTokenTransactions = (
       if (
         (areAddressesEqual(from ?? '', selectedAddress ?? '') ||
           areAddressesEqual(to ?? '', selectedAddress ?? '') ||
-          areAddressesEqual(
-            tokenTransferRecipient ?? '',
-            selectedAddress ?? '',
+          tokenTransferRecipients.some((recipient) =>
+            areAddressesEqual(recipient, selectedAddress ?? ''),
           )) &&
         (chainId === tx.chainId ||
           (!tx.chainId && networkId === tx.networkID)) &&

--- a/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
@@ -11,7 +11,10 @@ import {
 } from '../../../../constants/transaction';
 import { NATIVE_SWAPS_TOKEN_ADDRESS } from '../../../../constants/bridge';
 import { selectTokens } from '../../../../selectors/tokensController';
-import { sortTransactions } from '../../../../util/activity';
+import {
+  getTokenTransferRecipient,
+  sortTransactions,
+} from '../../../../util/activity';
 import {
   areAddressesEqual,
   safeToChecksumAddress,
@@ -506,6 +509,7 @@ export const useTokenTransactions = (
         isTransfer,
         transferInformation,
       } = tx;
+      const tokenTransferRecipient = getTokenTransferRecipient(tx);
 
       if (checkIsMusdClaimForCurrentView(tx)) {
         return true;
@@ -517,7 +521,11 @@ export const useTokenTransactions = (
 
       if (
         (areAddressesEqual(from ?? '', selectedAddress ?? '') ||
-          areAddressesEqual(to ?? '', selectedAddress ?? '')) &&
+          areAddressesEqual(to ?? '', selectedAddress ?? '') ||
+          areAddressesEqual(
+            tokenTransferRecipient ?? '',
+            selectedAddress ?? '',
+          )) &&
         (chainId === tx.chainId ||
           (!tx.chainId && networkId === tx.networkID)) &&
         tx.status !== 'unapproved'

--- a/app/components/UI/TransactionElement/utils.test.js
+++ b/app/components/UI/TransactionElement/utils.test.js
@@ -6,6 +6,7 @@ import {
 import decodeTransaction from './utils';
 import { strings } from '../../../../locales/i18n';
 import { toFormattedAddress } from '../../../util/address';
+import { TX_CONFIRMED } from '../../../constants/transaction';
 
 jest.mock('../../../core/Engine', () => ({
   context: {
@@ -371,6 +372,50 @@ describe('Transaction Element Utils', () => {
         summarySecondaryTotalAmount: undefined,
         txChainId: '0x89',
       });
+    });
+
+    it('labels a locally submitted token transfer as received for the recipient account', async () => {
+      const recipient = '0x1234567890abcdef1234567890abcdef12345678';
+      const tokenAddress = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359';
+      const args = {
+        tx: {
+          txParams: {
+            to: tokenAddress,
+            from: '0x1440ec793ae50fa046b95bfeca5af475b6003f9e',
+            data: `0xa9059cbb${recipient.slice(2).padStart(64, '0')}${'52daf0'.padStart(64, '0')}`,
+            gas: '0x12345',
+            maxFeePerGas: '0x123456789',
+            maxPriorityFeePerGas: '0x123456789',
+            estimatedBaseFee: '0xABCDEF123',
+          },
+          hash: '0x942d7843454266b81bf631022aa5f3f944691731b62d67c4e80c4bb5740058bb',
+          status: TX_CONFIRMED,
+        },
+        currentCurrency: 'usd',
+        contractExchangeRates: {},
+        totalGas: '0x64',
+        actionKey: 'key',
+        primaryCurrency: 'ETH',
+        selectedAddress: recipient,
+        ticker: 'ETH',
+        txChainId: '0x1',
+        tokens: {
+          [tokenAddress]: {
+            symbol: 'USDC',
+            decimals: 6,
+          },
+        },
+      };
+
+      const [transactionElement] = await decodeTransaction(args);
+
+      expect(transactionElement).toEqual(
+        expect.objectContaining({
+          actionKey: 'Received USDC',
+          renderTo: recipient,
+          transactionType: 'transaction_received_token',
+        }),
+      );
     });
 
     it.each([

--- a/app/util/activity/index.test.ts
+++ b/app/util/activity/index.test.ts
@@ -12,7 +12,7 @@ import {
   isTransactionOnChains,
   isTrustedAddress,
   buildTrustedAddressSet,
-  getTokenTransferRecipient,
+  getTokenTransferRecipients,
 } from '.';
 import { Token } from '@metamask/assets-controllers';
 import { TX_SUBMITTED, TX_UNAPPROVED } from '../../constants/transaction';
@@ -113,7 +113,7 @@ describe('Activity utils :: isFromOrToSelectedAddress', () => {
   });
 });
 
-describe('Activity utils :: getTokenTransferRecipient', () => {
+describe('Activity utils :: getTokenTransferRecipients', () => {
   it('decodes the recipient from ERC-20 transfer calldata', () => {
     const data =
       `0xa9059cbb${TEST_ADDRESS_TWO.slice(2).padStart(64, '0')}` +
@@ -126,9 +126,54 @@ describe('Activity utils :: getTokenTransferRecipient', () => {
       },
     } as DeepPartial<TransactionMeta> as TransactionMeta;
 
-    expect(getTokenTransferRecipient(transaction)).toBe(
+    expect(getTokenTransferRecipients(transaction)).toEqual([
       TEST_ADDRESS_TWO.toLowerCase(),
-    );
+    ]);
+  });
+
+  it('decodes the recipient from ERC-20 transferFrom calldata', () => {
+    const data =
+      `0x23b872dd${TEST_ADDRESS_ONE.slice(2).padStart(64, '0')}` +
+      `${TEST_ADDRESS_TWO.slice(2).padStart(64, '0')}` +
+      '1'.padStart(64, '0');
+    const transaction = {
+      type: TransactionType.tokenMethodTransferFrom,
+      txParams: {
+        from: TEST_ADDRESS_THREE,
+        to: TEST_ADDRESS_THREE,
+        data,
+      },
+    } as DeepPartial<TransactionMeta> as TransactionMeta;
+
+    expect(getTokenTransferRecipients(transaction)).toEqual([
+      TEST_ADDRESS_TWO.toLowerCase(),
+    ]);
+  });
+
+  it('decodes every recipient from a nested transfer batch', () => {
+    const transferTo = (recipient: string) =>
+      `0xa9059cbb${recipient.slice(2).padStart(64, '0')}${'1'.padStart(64, '0')}`;
+    const transaction = {
+      txParams: {
+        from: TEST_ADDRESS_THREE,
+        to: TEST_ADDRESS_THREE,
+      },
+      nestedTransactions: [
+        {
+          type: TransactionType.tokenMethodTransfer,
+          data: transferTo(TEST_ADDRESS_ONE),
+        },
+        {
+          type: TransactionType.tokenMethodTransfer,
+          data: transferTo(TEST_ADDRESS_TWO),
+        },
+      ],
+    } as DeepPartial<TransactionMeta> as TransactionMeta;
+
+    expect(getTokenTransferRecipients(transaction)).toEqual([
+      TEST_ADDRESS_ONE.toLowerCase(),
+      TEST_ADDRESS_TWO.toLowerCase(),
+    ]);
   });
 });
 
@@ -288,6 +333,46 @@ describe('Activity utils :: filterByAddressAndNetwork', () => {
     const result = filterByAddressAndNetwork(
       transaction,
       tokens,
+      TEST_ADDRESS_TWO,
+      { '0x1': true },
+      [],
+      {},
+      {},
+      [TEST_ADDRESS_ONE, TEST_ADDRESS_TWO],
+    );
+
+    expect(result).toEqual(true);
+  });
+
+  it('returns true when the selected account is a later recipient in a nested batch', () => {
+    const transferTo = (recipient: string) =>
+      `0xa9059cbb${recipient.slice(2).padStart(64, '0')}${'1'.padStart(64, '0')}`;
+    const transaction = {
+      chainId: '0x1',
+      status: TX_SUBMITTED,
+      txParams: {
+        from: TEST_ADDRESS_ONE,
+        to: TEST_ADDRESS_THREE,
+      },
+      nestedTransactions: [
+        {
+          type: TransactionType.tokenMethodTransfer,
+          data: transferTo(TEST_ADDRESS_THREE),
+        },
+        {
+          type: TransactionType.tokenMethodTransfer,
+          data: transferTo(TEST_ADDRESS_TWO),
+        },
+      ],
+      isTransfer: true,
+      transferInformation: {
+        contractAddress: TEST_ADDRESS_THREE,
+      },
+    } as DeepPartial<TransactionMeta> as TransactionMeta;
+
+    const result = filterByAddressAndNetwork(
+      transaction,
+      [{ address: TEST_ADDRESS_THREE }],
       TEST_ADDRESS_TWO,
       { '0x1': true },
       [],

--- a/app/util/activity/index.test.ts
+++ b/app/util/activity/index.test.ts
@@ -12,6 +12,7 @@ import {
   isTransactionOnChains,
   isTrustedAddress,
   buildTrustedAddressSet,
+  getTokenTransferRecipient,
 } from '.';
 import { Token } from '@metamask/assets-controllers';
 import { TX_SUBMITTED, TX_UNAPPROVED } from '../../constants/transaction';
@@ -109,6 +110,25 @@ describe('Activity utils :: isFromOrToSelectedAddress', () => {
     const selectedAddress = '';
     const result = isFromOrToSelectedAddress(from, to, selectedAddress);
     expect(result).toEqual(false);
+  });
+});
+
+describe('Activity utils :: getTokenTransferRecipient', () => {
+  it('decodes the recipient from ERC-20 transfer calldata', () => {
+    const data =
+      `0xa9059cbb${TEST_ADDRESS_TWO.slice(2).padStart(64, '0')}` +
+      '1'.padStart(64, '0');
+    const transaction = {
+      txParams: {
+        from: TEST_ADDRESS_ONE,
+        to: TEST_ADDRESS_THREE,
+        data,
+      },
+    } as DeepPartial<TransactionMeta> as TransactionMeta;
+
+    expect(getTokenTransferRecipient(transaction)).toBe(
+      TEST_ADDRESS_TWO.toLowerCase(),
+    );
   });
 });
 
@@ -242,6 +262,40 @@ describe('Activity utils :: filterByAddressAndNetwork', () => {
       TEST_ADDRESS_ONE,
       { '0x1': true },
     );
+    expect(result).toEqual(true);
+  });
+
+  it('returns true for an ERC-20 transfer sent to the selected internal account', () => {
+    const chainId = '0x1';
+    const data =
+      `0xa9059cbb${TEST_ADDRESS_TWO.slice(2).padStart(64, '0')}` +
+      '1'.padStart(64, '0');
+    const transaction = {
+      chainId,
+      status: TX_SUBMITTED,
+      txParams: {
+        from: TEST_ADDRESS_ONE,
+        to: TEST_ADDRESS_THREE,
+        data,
+      },
+      isTransfer: true,
+      transferInformation: {
+        contractAddress: TEST_ADDRESS_THREE,
+      },
+    } as DeepPartial<TransactionMeta> as TransactionMeta;
+    const tokens = [{ address: TEST_ADDRESS_THREE }];
+
+    const result = filterByAddressAndNetwork(
+      transaction,
+      tokens,
+      TEST_ADDRESS_TWO,
+      { '0x1': true },
+      [],
+      {},
+      {},
+      [TEST_ADDRESS_ONE, TEST_ADDRESS_TWO],
+    );
+
     expect(result).toEqual(true);
   });
 

--- a/app/util/activity/index.ts
+++ b/app/util/activity/index.ts
@@ -9,6 +9,7 @@ import { uniq } from 'lodash';
 import { Hex } from '@metamask/utils';
 import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import { AddressBookControllerState } from '@metamask/address-book-controller';
+import { decodeErc20Transfer } from '../transactions/erc20-transfer';
 
 export const PAY_TYPES = [
   TransactionType.moneyAccountDeposit,
@@ -42,31 +43,26 @@ export const isFromOrToSelectedAddress = (
   return false;
 };
 
-const ERC20_TRANSFER_SELECTOR = '0xa9059cbb';
-const ERC20_TRANSFER_CALLDATA_LENGTH = 138;
-
 /**
- * Returns the recipient encoded by an ERC-20 transfer call.
+ * Returns the recipients encoded by ERC-20 transfer calls.
  *
  * The transaction-level `to` address is the token contract, so it cannot be
  * used to decide whether the selected account received the transfer.
  */
-export const getTokenTransferRecipient = (
-  tx: TransactionMeta,
-): string | undefined => {
-  const calldataCandidates = [
-    tx.txParams.data,
-    ...(tx.nestedTransactions ?? []).map(({ data }) => data),
+export const getTokenTransferRecipients = (tx: TransactionMeta): string[] => {
+  const transferCalls = [
+    { data: tx.txParams.data, type: tx.type },
+    ...(tx.nestedTransactions ?? []).map(({ data, type }) => ({ data, type })),
   ];
-  const transferData = calldataCandidates.find(
-    (data) =>
-      data?.toLowerCase().startsWith(ERC20_TRANSFER_SELECTOR) &&
-      data.length >= ERC20_TRANSFER_CALLDATA_LENGTH,
-  );
 
-  return transferData
-    ? `0x${transferData.slice(34, 74).toLowerCase()}`
-    : undefined;
+  return [
+    ...new Set(
+      transferCalls.flatMap(({ data, type }) => {
+        const transfer = decodeErc20Transfer(data, type);
+        return transfer ? [transfer.recipient] : [];
+      }),
+    ),
+  ];
 };
 
 const isTransactionFromOrToSelectedAddress = (
@@ -74,13 +70,12 @@ const isTransactionFromOrToSelectedAddress = (
   selectedAddress: string,
 ): boolean => {
   const { from, to } = tx.txParams;
-  const tokenTransferRecipient = getTokenTransferRecipient(tx);
+  const tokenTransferRecipients = getTokenTransferRecipients(tx);
 
   return (
     isFromOrToSelectedAddress(from, to ?? '', selectedAddress) ||
-    Boolean(
-      tokenTransferRecipient &&
-        areAddressesEqual(tokenTransferRecipient, selectedAddress),
+    tokenTransferRecipients.some((recipient) =>
+      areAddressesEqual(recipient, selectedAddress),
     )
   );
 };

--- a/app/util/activity/index.ts
+++ b/app/util/activity/index.ts
@@ -42,6 +42,49 @@ export const isFromOrToSelectedAddress = (
   return false;
 };
 
+const ERC20_TRANSFER_SELECTOR = '0xa9059cbb';
+const ERC20_TRANSFER_CALLDATA_LENGTH = 138;
+
+/**
+ * Returns the recipient encoded by an ERC-20 transfer call.
+ *
+ * The transaction-level `to` address is the token contract, so it cannot be
+ * used to decide whether the selected account received the transfer.
+ */
+export const getTokenTransferRecipient = (
+  tx: TransactionMeta,
+): string | undefined => {
+  const calldataCandidates = [
+    tx.txParams.data,
+    ...(tx.nestedTransactions ?? []).map(({ data }) => data),
+  ];
+  const transferData = calldataCandidates.find(
+    (data) =>
+      data?.toLowerCase().startsWith(ERC20_TRANSFER_SELECTOR) &&
+      data.length >= ERC20_TRANSFER_CALLDATA_LENGTH,
+  );
+
+  return transferData
+    ? `0x${transferData.slice(34, 74).toLowerCase()}`
+    : undefined;
+};
+
+const isTransactionFromOrToSelectedAddress = (
+  tx: TransactionMeta,
+  selectedAddress: string,
+): boolean => {
+  const { from, to } = tx.txParams;
+  const tokenTransferRecipient = getTokenTransferRecipient(tx);
+
+  return (
+    isFromOrToSelectedAddress(from, to ?? '', selectedAddress) ||
+    Boolean(
+      tokenTransferRecipient &&
+        areAddressesEqual(tokenTransferRecipient, selectedAddress),
+    )
+  );
+};
+
 /**
  * Builds a normalized Set of trusted addresses for O(1) lookup.
  * Includes all of the user's own account addresses and every entry in
@@ -222,7 +265,7 @@ export const filterByAddressAndNetwork = (
   const {
     isTransfer,
     transferInformation,
-    txParams: { from, to },
+    txParams: { from },
   } = tx;
 
   if (isFilteredByMetaMaskPay(tx, allTransactions ?? [], bridgeHistory)) {
@@ -238,7 +281,7 @@ export const filterByAddressAndNetwork = (
   );
 
   if (
-    isFromOrToSelectedAddress(from, to ?? '', selectedAddress) &&
+    isTransactionFromOrToSelectedAddress(tx, selectedAddress) &&
     condition &&
     tx.status !== TX_UNAPPROVED
   ) {
@@ -273,7 +316,7 @@ export const filterByAddress = (
   const {
     isTransfer,
     transferInformation,
-    txParams: { from, to },
+    txParams: { from },
   } = tx;
 
   if (isFilteredByMetaMaskPay(tx, allTransactions ?? [], bridgeHistory)) {
@@ -281,7 +324,7 @@ export const filterByAddress = (
   }
 
   if (
-    isFromOrToSelectedAddress(from, to ?? '', selectedAddress) &&
+    isTransactionFromOrToSelectedAddress(tx, selectedAddress) &&
     tx.status !== TX_UNAPPROVED
   ) {
     if (isIncomingNativeTransfer(tx, selectedAddress)) {


### PR DESCRIPTION
## **Description**

Fixes recipient-side activity for locally submitted ERC-20 transfers. Activity filtering now decodes all `transfer` and `transferFrom` recipients, including every transfer in nested batches, rather than treating the token contract in `txParams.to` as the recipient.

## **Changelog**

CHANGELOG entry: Fixed ERC-20 transfers appearing incorrectly or missing from recipient account activity.

## **Related issues**

Fixes: #34724
Refs: https://consensyssoftware.atlassian.net/browse/WPN-1849

## **Manual testing steps**

```gherkin
Feature: Recipient token activity

  Scenario: Transfer an ERC-20 token between wallet accounts
    Given two wallet accounts on the same EVM network
    And the first account owns an ERC-20 token

    When the first account sends the token to the second account
    Then the first account displays a Sent activity row
    And the second account displays a Received activity row
    And the second account token details page displays the transfer as Received
```

## **Screenshots/Recordings**

Original reproduction: https://github.com/user-attachments/assets/6372c0aa-ccb7-4b2b-b1d5-9969f5bc55fa

After: N/A — the recipient classification paths are covered by focused unit tests.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I've included tests if applicable.
- [x] I've documented the code using JSDoc where applicable.
- [x] I've applied the appropriate labels.

#### Performance checks (if applicable)

N/A — this is a small synchronous decode over existing transaction calldata and does not add network or background work.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR.
- [x] I confirm that this PR addresses all acceptance criteria and includes the necessary testing evidence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared activity filtering logic used across the wallet; incorrect decoding could show or hide transfers for the wrong account, though scope is limited to ERC-20 calldata parsing and existing trusted-sender rules still apply.
> 
> **Overview**
> Fixes **recipient-side ERC-20 activity** when the wallet only has a locally submitted transfer. Activity and token-detail filtering no longer treat `txParams.to` (the token contract) as the recipient.
> 
> A new **`getTokenTransferRecipients`** helper decodes recipients from `transfer` / `transferFrom` calldata on the top-level tx and on **nested batch** legs, via `decodeErc20Transfer`. **`filterByAddress`**, **`filterByAddressAndNetwork`**, and **`useTokenTransactions`**’ ERC-20 filter now treat the selected account as involved when it matches a decoded recipient—not only `from`/`to`.
> 
> Unit tests cover decoding, nested batches, recipient token pages, and **Received** labeling for locally submitted transfers in **`decodeTransaction`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66837450a6be3b771e5c6cf248d6c3f0e1250573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->