### PR TITLE
fix: use alternative text colour for the notifications empty state description

### DIFF
--- a/app/components/UI/Notification/Empty/index.tsx
+++ b/app/components/UI/Notification/Empty/index.tsx
@@ -8,6 +8,7 @@ import {
   IconName,
   IconSize,
   Text,
+  TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 const Empty = ({ testID }: { testID?: string }) => (
@@ -21,7 +22,11 @@ const Empty = ({ testID }: { testID?: string }) => (
     <Text style={styles.text} variant={TextVariant.HeadingMd}>
       {strings('notifications.empty.title')}
     </Text>
-    <Text style={styles.text} variant={TextVariant.BodyMd}>
+    <Text
+      style={styles.text}
+      variant={TextVariant.BodyMd}
+      color={TextColor.TextAlternative}
+    >
       {strings('notifications.empty.message')}
     </Text>
   </View>


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

The notifications empty state renders a heading ("Nothing to see here") directly above supporting copy ("This is where you can find notifications once there's activity in your wallet."). The supporting copy carried no `color` prop, so it fell through to the default text colour and rendered as dark as the heading, flattening the hierarchy between the two.

This sets the description to `TextColor.TextAlternative`, which is the treatment supporting copy gets elsewhere in the app.

- `app/components/UI/Notification/Empty/index.tsx` — the message `Text` gains `color={TextColor.TextAlternative}`

Sampling the running simulator confirms the two now read as distinct levels: the heading renders at `rgb(19, 20, 22)` and the description at `rgb(102, 103, 106)`. The heading, bell icon and layout are untouched.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed the notifications empty state description so it no longer renders as dark as the heading above it

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: UI polish — no linked GitHub issue

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Notifications empty state description colour

  Scenario: user sees de-emphasised supporting copy in the notifications empty state
    Given I am logged into MetaMask Mobile
    And I have notifications enabled
    And I have no notifications yet

    When I open the notifications screen
    Then I see the "Nothing to see here" heading in the default text colour
    And the supporting description below it renders in the alternative text colour
    And the bell icon and the centred layout are unchanged
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

The description rendered in the default text colour, the same weight of colour as the heading above it.

<img width="360" alt="Before: empty state description as dark as the heading" src="https://github.com/user-attachments/assets/e51f4347-b89c-4555-9213-8ac27d968fc9" />

### **After**

The description now sits back as supporting copy.

<img width="360" alt="After: empty state description in the alternative text colour" src="https://github.com/user-attachments/assets/1941d657-307d-4510-a781-ccedbc4e46db" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component visual tweak with no logic, data, or security impact.
> 
> **Overview**
> The notifications empty state description now uses **`TextColor.TextAlternative`** on the supporting message `Text`, matching how secondary copy is styled elsewhere in the app.
> 
> The heading and bell icon are unchanged; only the description under “Nothing to see here” is visually de-emphasised so it no longer matches the heading’s default text colour.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72e4e3d785e16216f64031fc6f14485988105ab5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->