### PR TITLE
chore: collapse @noble/curves to one copy by bumping the root pin to 1.9.7

### DIFF
--- a/docs/performance/native-crypto.md
+++ b/docs/performance/native-crypto.md
@@ -62,23 +62,51 @@ re-adding equivalent local probes. The `HomepageReady` Sentry CUF already covers
 unlock → homepage window in production and is the durable place to watch this number, though it is
 not yet dashboarded.
 
-## The fix: pin the edge, don't patch the source
+## The fix: make the root pin the version the floating ranges already want
 
-Two targeted entries in `package.json` `resolutions`:
+One line in `package.json`:
 
-```json
-"@scure/bip32/@noble/curves": "1.9.6",
-"@metamask/key-tree/@noble/curves": "1.9.6",
+```diff
+-"@noble/curves": "1.9.6",
++"@noble/curves": "1.9.7",
 ```
 
-This dedupes exactly those two edges onto the root copy that `shimPerf.js` already patches. Nothing
-else in the tree moves — the other `@noble/curves` copies (`1.2.0` through `1.9.7`, spread across
-Ledger, Trezor, WalletConnect, Solana, viem and others) are untouched, which is deliberate: those
-packages have not been validated against the native implementation.
+`1.9.7` was already the highest published `1.x`, so every floating range in the tree resolved there
+while the root's exact pin stayed behind. Moving the root forward makes `~1.9.0` and `^1.8.1`
+converge on it naturally — no `resolutions` entries, no patch files, and the change is a net
+deletion in the lockfile.
 
-Patching package sources with `yarn patch` was considered and rejected. It would have carried two
-patch files and a `require('@metamask/native-utils')` inside third-party code, to achieve what a
-resolution pin achieves declaratively.
+Two alternatives were tried and rejected:
+
+- **Pinning the two edges down to 1.9.6** via `resolutions`. Works, and was the original approach,
+  but it leaves the rest of the tree fragmented and adds two entries that have to be kept in step
+  with the root pin forever.
+- **Patching sources with `yarn patch`.** Would carry two patch files and a
+  `require('@metamask/native-utils')` inside third-party code, to achieve what a version bump does
+  declaratively.
+
+### What this widens
+
+Deduplication drops `@noble/curves` from **25 copies (58.6 MB) to 12 (25.4 MB)** and puts 15
+packages on the patched copy, up from 3. Of the newcomers, only three actually call the patched
+`getPublicKey` — `@solana/web3.js` (7 call sites), `ripple-keypairs` (2) and
+`@metamask/toprf-secure-backup` (2). The rest import `@noble/curves/secp256k1` for signing, point
+arithmetic or modular utilities, or use ed25519/p256, none of which `shimPerf.js` touches.
+
+Seven consumers keep their own copies because they pin exact versions: `ethers` (`1.2.0`),
+`ethereum-cryptography` (`1.4.2` and `1.9.0`), `@walletconnect/relay-auth` (`1.8.0`),
+`@walletconnect/utils@2.19.x` (`1.8.1`), `ox@0.9.3` (`1.9.1`) and `viem` (`1.9.2`). Forcing those
+would mean overriding exact pins across seven minor versions of internal API churn, for no startup
+benefit. Don't.
+
+### Why 1.9.6 -> 1.9.7 is safe for the packages that move
+
+`secp256k1.js` and `abstract/weierstrass.js` — the entire secp256k1 implementation — are
+**byte-identical** between the two versions. The only differences anywhere are an ed25519 method
+rename (`toMontgomeryPriv` -> `toMontgomerySecret`) and re-export plumbing in
+`abstract/utils.js`, which drops three underscore-prefixed internals (`_abool2`, `_abytes2`,
+`_validateObject`). Nothing in the tree references any of them; the sole tree-wide hit is a
+self-bundled snap that resolves no dependencies of its own.
 
 ## Guarding it
 
@@ -92,8 +120,9 @@ Note the guard is a **resolution** check, not a runtime one. A runtime variant (
 assert `HDKey` observes it) was written and rejected: it passes even with the nested copies present,
 verified by reinstalling the drifted tree. It could not detect the regression it existed to catch.
 
-The resolution checks were verified in both directions — they fail on the drifted tree, naming the
-offending nested path, and pass once the edges are pinned.
+The resolution checks were verified in both directions — they fail on a drifted tree, naming the
+offending nested path, and pass once the versions converge. They assert _sameness with the root_,
+not a specific version, so they keep working across future bumps.
 
 Correctness was additionally verified **on device** against 13 vectors (4 private keys × compressed
 and uncompressed, the BIP-32 master fingerprint, three derivation paths, and `key-tree`'s
@@ -103,7 +132,8 @@ uncompressed output): `pass=13 fail=0`, with 5/5 cold unlocks reaching a usable 
 
 1. Run `yarn jest shimPerf.test.js`. If it fails, a new nested `@noble/curves` appeared on the
    unlock path.
-2. Fix it by pinning the edge in `resolutions`, not by patching sources.
+2. Prefer moving the root pin to the version the floating ranges already resolve to. Pin an
+   individual edge in `resolutions` only when that is impossible, and never patch sources.
 3. If a _new_ package needs to join the patched set, validate its output against the native
    implementation before pinning it — native and pure-JS must be byte-identical, for both
    compressed (33-byte) and uncompressed (65-byte) public keys.

--- a/package.json
+++ b/package.json
@@ -187,8 +187,6 @@
     ]
   },
   "resolutions": {
-    "@scure/bip32/@noble/curves": "1.9.6",
-    "@metamask/key-tree/@noble/curves": "1.9.6",
     "@metamask/network-controller": "35.0.0",
     "@metamask/analytics-controller": "^2.0.0",
     "@metamask/geolocation-controller": "^1.0.0",
@@ -412,7 +410,7 @@
     "@metamask/wallet": "^12.0.3",
     "@ngraveio/bc-ur": "^1.1.6",
     "@nktkas/hyperliquid": "^0.33.1",
-    "@noble/curves": "1.9.6",
+    "@noble/curves": "1.9.7",
     "@noble/hashes": "1.8.0",
     "@notifee/react-native": "^9.1.8",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12664,16 +12664,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:1.9.6":
-  version: 1.9.6
-  resolution: "@noble/curves@npm:1.9.6"
-  dependencies:
-    "@noble/hashes": "npm:1.8.0"
-  checksum: 10/74b603bbf95cab1b6eb147d02febe55bc19cf57c324bf2ff04b44ff9be3f88affc1a57da0805c74803e27c25687079251f9c788f93f0e6fd1c5d02163996460c
-  languageName: node
-  linkType: hard
-
-"@noble/curves@npm:1.9.7, @noble/curves@npm:^1.0.0, @noble/curves@npm:^1.2.0, @noble/curves@npm:^1.4.2, @noble/curves@npm:^1.8.0, @noble/curves@npm:^1.8.1, @noble/curves@npm:^1.9.1, @noble/curves@npm:^1.9.2, @noble/curves@npm:^1.9.7":
+"@noble/curves@npm:1.9.7, @noble/curves@npm:^1.0.0, @noble/curves@npm:^1.2.0, @noble/curves@npm:^1.4.2, @noble/curves@npm:^1.8.0, @noble/curves@npm:^1.8.1, @noble/curves@npm:^1.9.1, @noble/curves@npm:^1.9.2, @noble/curves@npm:^1.9.7, @noble/curves@npm:~1.9.0":
   version: 1.9.7
   resolution: "@noble/curves@npm:1.9.7"
   dependencies:
@@ -39780,7 +39771,7 @@ __metadata:
     "@metamask/wallet": "npm:^12.0.3"
     "@ngraveio/bc-ur": "npm:^1.1.6"
     "@nktkas/hyperliquid": "npm:^0.33.1"
-    "@noble/curves": "npm:1.9.6"
+    "@noble/curves": "npm:1.9.7"
     "@noble/hashes": "npm:1.8.0"
     "@notifee/react-native": "npm:^9.1.8"
     "@octokit/rest": "npm:^21.0.0"


### PR DESCRIPTION
## **Description**

> **Stacked on #35984** — base branch is `perf/dedupe-noble-curves-native-secp256k1`, not `main`. Review #35984 first. This PR swaps its two `resolutions` pins for a single root version bump, and it is deliberately separate so the two approaches can be judged on their own merits.

#35984 restores native secp256k1 to HD key derivation by pinning two dependency edges down to the root's `@noble/curves@1.9.6`. This PR achieves the same thing by moving the root *forward* instead:

```diff
-"@noble/curves": "1.9.6",
+"@noble/curves": "1.9.7",
```

and deletes the two pins, which are then unnecessary.

### Why this is the better shape

`1.9.7` was already the highest published `1.x`, so **every floating range in the tree already resolved there** — `~1.9.0` (`@scure/bip32`), `^1.8.1` (`@metamask/key-tree`), and ten others. Only the root's exact pin stayed behind, and that split is the whole bug.

Moving the root forward makes those ranges converge naturally:

- **no `resolutions` entries** that have to be kept in step with the root pin forever
- **the lockfile change is a net deletion**
- **deduplication**: `@noble/curves` goes from **25 copies (58.6 MB) to 12 (25.4 MB)**

The pin approach in #35984 works and measures identically, but it leaves the tree fragmented and adds two entries that silently become wrong the next time someone bumps the root.

### What this widens — the part that needs review

15 packages now share the patched copy, up from 3. Of the newcomers, only three actually call the patched `getPublicKey`:

| Package | `secp256k1.getPublicKey` call sites | What it does |
|---|---:|---|
| `@solana/web3.js` | 7 | `Secp256k1Program` instructions |
| `ripple-keypairs` | 2 | XRP address derivation |
| `@metamask/toprf-secure-backup` | 2 | threshold OPRF for seedless onboarding |

The other nine import `@noble/curves/secp256k1` for signing, point arithmetic or modular utilities, or use ed25519/p256 — none of which `shimPerf.js` touches.

Seven consumers pin exact versions, keep their own copies and are **untouched**: `ethers` (`1.2.0`), `ethereum-cryptography` (`1.4.2`, `1.9.0`), `@walletconnect/relay-auth` (`1.8.0`), `@walletconnect/utils@2.19.x` (`1.8.1`), `ox@0.9.3` (`1.9.1`), `viem` (`1.9.2`). Forcing those onto 1.9.7 would mean overriding exact pins across seven minor versions of internal API churn for no benefit — explicitly not done here.

### Why 1.9.6 → 1.9.7 is safe for the packages that move

`secp256k1.js` and `abstract/weierstrass.js` — the entire secp256k1 implementation — are **byte-identical** between the two versions.

The only differences anywhere in the package are an ed25519 method rename (`toMontgomeryPriv` → `toMontgomerySecret`) and re-export plumbing in `abstract/utils.js`, which drops three underscore-prefixed internals (`_abool2`, `_abytes2`, `_validateObject`). A tree-wide grep finds no consumer of any of them — the single hit is `@metamask/bitcoin-wallet-snap`, which is self-bundled and resolves no dependencies of its own.

### Results

Samsung Galaxy A14 5G, Android 15, `production` release build, populated wallet, cold starts only, n=5 medians. Unlock submit → usable homepage:

| | unlock → homepage |
|---|---:|
| Before (drifted, pure JS) | 3,846 ms |
| #35984 (edge pins on 1.9.6) | 2,059 ms (p90 2,204 ms) |
| **This PR (root on 1.9.7)** | **2,050 ms** (p90 2,098 ms) |

Identical within the ~120 ms run-to-run noise floor, so the dedupe is free.

### Correctness

Re-verified **on device** after the bump, and deliberately extended past the maths, because twelve more packages now share the patched copy:

- compressed (33-byte) and uncompressed (65-byte) output
- **input types** — hex string and `bigint`, not just `Uint8Array`; a silent coercion difference would be a real bug
- **error semantics** — zero key, private key equal to the curve order `n`, 31-byte and 33-byte keys must all still **throw** rather than return a point

```
CRYPTOVERIFY RESULT pass=15 fail=0
```

5/5 cold unlocks reached a usable homepage with real wallet data. The `@noble/curves` baseline for those expectations was captured from the unpatched package under Node first, rather than assumed.

### Reviewer notes

- **If #35984's approach is preferred, just close this PR** — it is an alternative, not a follow-up.
- **Do not merge the root bump without deleting the pins.** Pins at `1.9.6` plus a root at `1.9.7` re-splits the copies and silently regresses the 1.8 s. This PR does both together; `shimPerf.test.js` (from #35984) fails loudly if they ever drift apart again.
- `@noble/curves@2.0.1` exists and nothing in the tree uses it. A major bump would likely need `shimPerf.js` updated — `_setWindowSize` and the `ProjectivePoint`/`utils` layout moved across 1.x.
- The device measurement was taken before current `main` was merged in; the intervening upstream deltas were `transaction-controller` patch bumps, design-system and TypeScript, none on the HD path. Install, dedupe, guard test, depcheck and `tsc` were all re-verified after the merge.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #35984

## **Manual testing steps**

```gherkin
Feature: Single @noble/curves copy on the HD derivation path

  Scenario: user unlocks a populated wallet from a cold start
    Given a production release build is installed on a mid-range Android device
    And the wallet has several accounts already imported
    And the app has been force-stopped

    When user launches the app
    And user enters their password and submits
    Then the homepage renders a usable state
    And every account address matches what it was before this change

  Scenario: non-EVM key paths still work
    Given the wallet is unlocked

    When user views a Solana account
    And user completes a seedless onboarding backup or recovery
    Then addresses and recovery both behave exactly as before
```

## **Screenshots/Recordings**

### **Before**

N/A — no UI change. The measurable difference is startup timing and dependency-tree size, both reported above.

### **After**

N/A — no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
  - `shimPerf.test.js` (added in #35984) asserts sameness with the root rather than a specific version, so it covers this bump unchanged. 6/6 pass.
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Samsung Galaxy A14 5G (SM-A146P), Android 15, `production` release build — a mid-range physical device.
- [x] I've tested with a power user scenario
  - Populated wallet with several imported accounts. Cost scales with account count, so a larger wallet shows a larger absolute gain.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - The `HomepageReady` CUF already covers this window. No new instrumentation ships in this PR.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
