### PR TITLE
fix(content): replace “check by soon” with “check back soon”

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6843,8 +6843,8 @@
       "continue_to_amount": "Continue to amount",
       "no_payment_methods_title": "No payment methods in {{regionName}}",
       "no_cash_destinations_title": "No cash destinations in {{regionName}}",
-      "no_payment_methods_description": "There are currently no supported payment methods in your region. Please check by soon; we are frequently expanding support to new regions.\n\nIf you selected {{regionName}} by mistake, click the button below to reset your region.",
-      "no_cash_destinations_description": "There are currently no supported cash destinations in your region. Please check by soon; we are frequently expanding support to new regions.\n\nIf you selected {{regionName}} by mistake, click the button below to reset your region.",
+      "no_payment_methods_description": "There are currently no supported payment methods in your region. Please check back soon; we are frequently expanding support to new regions.\n\nIf you selected {{regionName}} by mistake, click the button below to reset your region.",
+      "no_cash_destinations_description": "There are currently no supported cash destinations in your region. Please check back soon; we are frequently expanding support to new regions.\n\nIf you selected {{regionName}} by mistake, click the button below to reset your region.",
       "reset_region": "Reset region"
     },
     "continue": "Continue",


### PR DESCRIPTION
## **Description**

File: `locales/languages/en.json` (`no_payment_methods_description`, `no_cash_destinations_description`).

Rule: grammar / comprehension heuristic — “check by soon” is not English and does not tell the user when to return.

User impact: people who hit an unsupported-region empty state get a clear next step (“check back soon”) instead of a broken phrase.

This is the same wording in two adjacent empty-state strings; both are updated so the Ramp region screens stay consistent.

## **Changelog**

CHANGELOG entry: Corrected “check by soon” to “check back soon” in Ramp region empty states

## **Related issues**

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

```gherkin
Feature: Ramp region empty state

  Scenario: no payment methods in the selected region
    Given a region with no supported payment methods
    When the empty state is displayed
    Then the description says “Please check back soon”
```

## **Screenshots/Recordings**

N/A — copy-only correction with no component, styling, or layout changes.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to English locale strings with no logic, layout, or security impact.
> 
> **Overview**
> Fixes English copy in two Ramp region empty-state strings in `en.json`: **`no_payment_methods_description`** and **`no_cash_destinations_description`**.
> 
> Both descriptions now say **“Please check back soon”** instead of the ungrammatical **“Please check by soon”**, so users in unsupported regions see consistent, understandable guidance on both payment-method and cash-destination screens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fba8f869ec691ec1c5a183012b1d4d0f23963204. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->