### PR TITLE
fix(content): use “it’s” in security alerts setup copy

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -213,7 +213,7 @@
     "does_not_look_right": "Something doesn’t look right?",
     "report_an_issue": "Report an issue",
     "before_you_proceed": "Before you proceed",
-    "enable_blockaid_alerts": "To enable this feature we need to set up some security alert. This page will need to stay open while its being set up. This will take less than a minute to complete.",
+    "enable_blockaid_alerts": "To enable this feature we need to set up some security alert. This page will need to stay open while it's being set up. This will take less than a minute to complete.",
     "enable_blockaid_alerts_description": "This page will need to stay open while security alerts are being set up. This process will take less than a minute to complete.",
     "setting_up_alerts": "Setting up security alerts",
     "setting_up_alerts_description": "We are going as fast as we can to set up security alerts. Hang in there, we are almost done.",


### PR DESCRIPTION
## **Description**

File: `locales/languages/en.json` (`blockaid_banner.enable_blockaid_alerts`).

Rule: grammar heuristic — “its being set up” uses the possessive instead of the contraction for “it is”.

User impact: the security-alerts setup explanation reads as intended English, which supports comprehension during a wait state.

No other wording in the string is changed.

## **Changelog**

CHANGELOG entry: Corrected “its” to “it’s” in security alerts setup copy

## **Related issues**

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

```gherkin
Feature: security alerts setup copy

  Scenario: enabling security alerts
    When the setup explanation is shown
    Then it uses “while it’s being set up”
```

## **Screenshots/Recordings**

N/A — copy-only correction with no component, styling, or layout changes.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single locale string grammar fix with no logic, API, or security impact.
> 
> **Overview**
> Corrects English copy in **`blockaid_banner.enable_blockaid_alerts`** (`locales/languages/en.json`): **“its being set up”** → **“it's being set up”** so the contraction reads as “it is” during the Blockaid security-alerts setup wait message. No other strings or locales change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd525744005935bebb50af517bb3b51926f8753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->