### PR TITLE
fix(content): add missing article in token detection banner

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3909,7 +3909,7 @@
       "search_link": "Enable it from Settings.",
       "custom_warning_desc": "Anyone can create a token, including creating fake versions of existing tokens. Learn more about ",
       "custom_warning_link": "scams and security risks.",
-      "custom_info_desc": "Token detection is not available on this network yet. Please import token manually and make sure you trust it. Learn about ",
+      "custom_info_desc": "Token detection is not available on this network yet. Please import the token manually and make sure you trust it. Learn about ",
       "custom_info_link": "token scams and security risks.",
       "custom_security_tips": "Security tips"
     }


### PR DESCRIPTION
## **Description**

File: `locales/languages/en.json` (`app_settings.banners.custom_info_desc`).

Rule: grammar / missing-article heuristic, matching existing `fix(content)` article corrections.

User impact: the token-detection banner reads as natural English (“import the token manually”), which is easier to scan when detection is unavailable.

## **Changelog**

CHANGELOG entry: Added the missing article in the token detection unavailable banner

## **Related issues**

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

```gherkin
Feature: token detection banner

  Scenario: detection is unavailable on the current network
    When the custom token info banner is shown
    Then the copy says “Please import the token manually”
```

## **Screenshots/Recordings**

N/A — copy-only correction with no component, styling, or layout changes.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single English locale string change with no behavioral or security impact.
> 
> **Overview**
> **Copy-only grammar fix** for the token-detection unavailable banner in English (`app_settings.banners.custom_info_desc`).
> 
> The string now says **“Please import the token manually”** instead of **“Please import token manually”** — no UI, logic, or other locales changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a0be0fd1c13575c134571f8eeb18e6664668870. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->