### PR TITLE
perf: restore native secp256k1 on the HD derivation path

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -55,6 +55,14 @@ ignores:
   # direct dependency.
   - 'babel-preset-expo'
 
+  # Required directly only by shimPerf.test.js, the regression guard asserting
+  # that @scure/bip32 resolves the same @noble/curves copy shimPerf.js patches
+  # with native secp256k1. It reaches us transitively via
+  # @metamask/eth-hd-keyring -> ethereum-cryptography, and declaring it as a
+  # direct dependency would pin a second range on the very edge the guard
+  # exists to keep deduped. See docs/performance/native-crypto.md.
+  - '@scure/bip32'
+
   # tsconfig path alias pointing to app/controllers/perps (not an npm package)
   - '@metamask/perps-controller'
   # Used in scripts/repack for CI optimization

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -47,6 +47,7 @@ Always measure on **Android** (more sensitive, more representative) with the **p
 - **[anti-patterns.md](./anti-patterns.md)** — the catalogue: selectors, Redux/`useSelector`, Context, hook deps, unstable hook returns, lists, layout animations, eager-work-on-mount, streaming, bundle/barrel, memory.
 - **[tools.md](./tools.md)** — symptom-first decision tree + when/how to use each tool (Perf Monitor, RN DevTools, Flashlight, `trace()`, Reassure, E2E gates, Release Profiler, Sentry).
 - **[measuring.md](./measuring.md)** — the power-user scenario, TTI via `trace()`, render-regression tests, FPS benchmarking, CI gates.
+- **[native-crypto.md](./native-crypto.md)** — the native secp256k1 patch in `shimPerf.js` and the `@noble/curves` single-copy invariant it depends on. **Read this before bumping a dependency that does elliptic-curve work.**
 - **[react-compiler.md](./react-compiler.md)** — automatic memoization: how it's set up here and how to opt a feature in.
 
 ## Deep dives & references

--- a/docs/performance/native-crypto.md
+++ b/docs/performance/native-crypto.md
@@ -1,0 +1,145 @@
+# Native crypto and the `@noble/curves` single-copy invariant
+
+`shimPerf.js` replaces the pure-JS elliptic-curve and hashing primitives with native (C++)
+implementations from [`@metamask/native-utils`](https://www.npmjs.com/package/@metamask/native-utils).
+It is one of the highest-leverage performance mechanisms in the app, and it has a sharp edge that
+already cut us once.
+
+## How it works
+
+`@metamask/native-utils` is a **Nitro** module, so it is JSI-backed and therefore **synchronous**.
+That matters: it can be dropped into synchronous call sites such as `@scure/bip32`'s `HDKey`
+constructor, which an async bridge module could never serve.
+
+`shimPerf.js` installs it by **mutating module instances**:
+
+```js
+const secp256k1_1 = require('@noble/curves/secp256k1');
+secp256k1_1.secp256k1.getPublicKey = getPublicKey;
+```
+
+## The edge: it only reaches the copy it mutates
+
+Mutating a module instance only affects consumers that resolve **the very same copy**. `shimPerf.js`
+says so explicitly:
+
+> IMPORTANT: This patching works only if @noble/curves version in root package.json is same as
+> @noble/curves version in package.json of @scure/bip32.
+
+That invariant broke silently. The repo root pinned `@noble/curves` to `1.9.6`, while:
+
+| Package              | Declared range | Resolved       | Patched? |
+| -------------------- | -------------- | -------------- | -------- |
+| `@scure/bip32`       | `~1.9.0`       | nested `1.9.7` | **no**   |
+| `@metamask/key-tree` | `^1.8.1`       | nested `1.9.7` | **no**   |
+
+Both ranges _accept_ `1.9.6`, but Yarn resolves each range independently to the highest matching
+version, so each package got its own nested `1.9.7` and dropped off the patched path.
+
+Nothing threw. Nothing logged. HD key derivation simply went back to interpreted BigInt maths on
+Hermes — and `KeyringController.submitPassword` re-derives every account's key from the seed on
+**every unlock**, with the homepage blocked behind it.
+
+Measured cost of the drift, unlock submit → usable homepage, on a Samsung Galaxy A14 5G
+(Android 15, `production` release build, populated wallet, cold starts, n=5 medians):
+
+|                                  |           unlock → homepage |
+| -------------------------------- | --------------------------: |
+| Drifted (nested copies, pure JS) |                    3,846 ms |
+| Deduped (patch reaches both)     | **2,059 ms** (p90 2,204 ms) |
+|                                  |       **−1,787 ms / −46 %** |
+
+No other stage moved: controller rehydration 88 → 79 ms, `Engine.init` 778 → 686 ms, post-init gap
+1,102 → 1,069 ms, navigator module-eval 24 → 23 ms, splash reveal tax 1,752 → 1,785 ms — all within
+run-to-run noise.
+
+**How these were obtained, and why they are not reproducible from this repo alone.** The per-stage
+numbers came from throwaway local instrumentation that logged stage marks through
+`global.nativeLoggingHook` (the one log channel `transform-remove-console` does not strip from
+release builds), driven over `adb`. That instrumentation was deliberately **not** merged — it is
+measurement code, and this repo ships product code. Reproducing the table therefore means
+re-adding equivalent local probes. The `HomepageReady` Sentry CUF already covers the
+unlock → homepage window in production and is the durable place to watch this number, though it is
+not yet dashboarded.
+
+## The fix: make the root pin the version the floating ranges already want
+
+One line in `package.json`:
+
+```diff
+-"@noble/curves": "1.9.6",
++"@noble/curves": "1.9.7",
+```
+
+`1.9.7` was already the highest published `1.x`, so every floating range in the tree resolved there
+while the root's exact pin stayed behind. Moving the root forward makes `~1.9.0` and `^1.8.1`
+converge on it naturally — no `resolutions` entries, no patch files, and the change is a net
+deletion in the lockfile.
+
+Two alternatives were tried and rejected:
+
+- **Pinning the two edges down to 1.9.6** via `resolutions`. Works, and was the original approach,
+  but it leaves the rest of the tree fragmented and adds two entries that have to be kept in step
+  with the root pin forever.
+- **Patching sources with `yarn patch`.** Would carry two patch files and a
+  `require('@metamask/native-utils')` inside third-party code, to achieve what a version bump does
+  declaratively.
+
+### What this widens
+
+Deduplication drops `@noble/curves` from **25 copies (58.6 MB) to 12 (25.4 MB)** and puts 15
+packages on the patched copy, up from 3. Of the newcomers, only three actually call the patched
+`getPublicKey` — `@solana/web3.js` (7 call sites), `ripple-keypairs` (2) and
+`@metamask/toprf-secure-backup` (2). The rest import `@noble/curves/secp256k1` for signing, point
+arithmetic or modular utilities, or use ed25519/p256, none of which `shimPerf.js` touches.
+
+Seven consumers keep their own copies because they pin exact versions: `ethers` (`1.2.0`),
+`ethereum-cryptography` (`1.4.2` and `1.9.0`), `@walletconnect/relay-auth` (`1.8.0`),
+`@walletconnect/utils@2.19.x` (`1.8.1`), `ox@0.9.3` (`1.9.1`) and `viem` (`1.9.2`). Forcing those
+would mean overriding exact pins across seven minor versions of internal API churn, for no startup
+benefit. Don't.
+
+### Why 1.9.6 -> 1.9.7 is safe for the packages that move
+
+`secp256k1.js` and `abstract/weierstrass.js` — the entire secp256k1 implementation — are
+**byte-identical** between the two versions. The only differences anywhere are an ed25519 method
+rename (`toMontgomeryPriv` -> `toMontgomerySecret`) and re-export plumbing in
+`abstract/utils.js`, which drops three underscore-prefixed internals (`_abool2`, `_abytes2`,
+`_validateObject`). Nothing in the tree references any of them; the sole tree-wide hit is a
+self-bundled snap that resolves no dependencies of its own.
+
+## Guarding it
+
+The failure mode is silent version drift, so it needs a test that fails loudly:
+[`shimPerf.test.js`](../../shimPerf.test.js). It asserts that the HD-derivation packages resolve the
+**same** `@noble/curves` copy as the repo root, and pins derivation behaviour to published
+constants — the secp256k1 generator point, and the BIP-32 Test Vector 1 master fingerprint
+(`0x3442193e`).
+
+Note the guard is a **resolution** check, not a runtime one. A runtime variant (patch the root copy,
+assert `HDKey` observes it) was written and rejected: it passes even with the nested copies present,
+verified by reinstalling the drifted tree. It could not detect the regression it existed to catch.
+
+The resolution checks were verified in both directions — they fail on a drifted tree, naming the
+offending nested path, and pass once the versions converge. They assert _sameness with the root_,
+not a specific version, so they keep working across future bumps.
+
+Correctness was additionally verified **on device** against 13 vectors (4 private keys × compressed
+and uncompressed, the BIP-32 master fingerprint, three derivation paths, and `key-tree`'s
+uncompressed output): `pass=13 fail=0`, with 5/5 cold unlocks reaching a usable homepage.
+
+## If you add or bump a dependency that does elliptic-curve work
+
+1. Run `yarn jest shimPerf.test.js`. If it fails, a new nested `@noble/curves` appeared on the
+   unlock path.
+2. Prefer moving the root pin to the version the floating ranges already resolve to. Pin an
+   individual edge in `resolutions` only when that is impossible, and never patch sources.
+3. If a _new_ package needs to join the patched set, validate its output against the native
+   implementation before pinning it — native and pure-JS must be byte-identical, for both
+   compressed (33-byte) and uncompressed (65-byte) public keys.
+
+## Related
+
+- `shimPerf.js` — the patch site
+- `app/core/Engine/wallet-init/keyrings.ts` — where native `pbkdf2Sha512`/`hmacSha512` are injected
+  into the HD keyring via `CryptographicFunctions`

--- a/package.json
+++ b/package.json
@@ -410,7 +410,7 @@
     "@metamask/wallet": "^12.0.3",
     "@ngraveio/bc-ur": "^1.1.6",
     "@nktkas/hyperliquid": "^0.33.1",
-    "@noble/curves": "1.9.6",
+    "@noble/curves": "1.9.7",
     "@noble/hashes": "1.8.0",
     "@notifee/react-native": "^9.1.8",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/shimPerf.test.js
+++ b/shimPerf.test.js
@@ -1,0 +1,142 @@
+/**
+ * Guards the native-crypto monkey patch applied by `shimPerf.js`.
+ *
+ * `shimPerf.js` replaces `@noble/curves`' `secp256k1.getPublicKey` with the
+ * native (C++) implementation from `@metamask/native-utils`. Because it mutates
+ * a *module instance*, it only reaches consumers that resolve to the very same
+ * copy of `@noble/curves` — a constraint `shimPerf.js` itself calls out:
+ *
+ *   "IMPORTANT: This patching works only if @noble/curves version in root
+ *    package.json is same as @noble/curves version in package.json of
+ *    @scure/bip32."
+ *
+ * That invariant silently broke: the repo root pinned `1.9.6` while
+ * `@scure/bip32` (`~1.9.0`) and `@metamask/key-tree` (`^1.8.1`) each resolved a
+ * nested `1.9.7`. HD key derivation therefore ran the pure-JS elliptic-curve
+ * maths, measured at ~1.8 s of every unlock on a mid-range Android device.
+ * Nothing threw, so nothing caught it.
+ *
+ * The guard is a *resolution* check rather than a runtime one. A runtime
+ * variant — patch the root copy, then assert `HDKey` observes the patch — was
+ * written and rejected: it passes even with the nested copies present (verified
+ * by reinstalling the drifted tree), so it cannot detect the regression it
+ * exists to catch. Module identity on disk is what actually determines whether
+ * the patch lands, and it discriminates correctly.
+ */
+
+/* eslint-disable import-x/no-commonjs, import-x/no-nodejs-modules */
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Resolve the `@noble/curves` copy that `startDir` would load, mirroring the
+ * `node_modules` upward walk used by both Node and Metro.
+ *
+ * @param {string} startDir - Directory to resolve from, relative to the repo root.
+ * @returns {string | null} Absolute path to the resolved `package.json`, or null.
+ */
+const resolveCurvesFrom = (startDir) => {
+  let dir = path.resolve(startDir);
+
+  for (;;) {
+    const candidate = path.join(
+      dir,
+      'node_modules',
+      '@noble',
+      'curves',
+      'package.json',
+    );
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+};
+
+describe('shimPerf native secp256k1 patch coverage', () => {
+  it.each([
+    ['@scure/bip32', 'node_modules/@scure/bip32'],
+    ['@metamask/key-tree', 'node_modules/@metamask/key-tree'],
+    ['@metamask/eth-hd-keyring', 'node_modules/@metamask/eth-hd-keyring'],
+  ])(
+    'resolves the same @noble/curves copy as the repo root for %s',
+    (_packageName, packageDir) => {
+      // Arrange
+      const rootCurves = resolveCurvesFrom('.');
+
+      // Act
+      const packageCurves = resolveCurvesFrom(packageDir);
+
+      // Assert: a nested copy means shimPerf.js's patch cannot reach this
+      // package, silently returning HD derivation to pure JS. Fix by pinning
+      // the offending edge in `resolutions` (see `@scure/bip32/@noble/curves`
+      // in package.json) rather than by patching package sources.
+      expect(packageCurves).toBe(rootCurves);
+    },
+  );
+
+  it('derives the BIP-32 spec Test Vector 1 fingerprint', () => {
+    // Arrange: the seed and expected parent fingerprint are published in BIP-32
+    // Test Vector 1, so this is anchored to the spec rather than to whichever
+    // implementation happens to be wired in. Guards the resolution change
+    // against a dedupe that silently altered derivation behaviour.
+    /* eslint-disable-next-line import-x/no-extraneous-dependencies */
+    const { HDKey } = require('@scure/bip32');
+    const seed = Uint8Array.from([
+      0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+      0x0c, 0x0d, 0x0e, 0x0f,
+    ]);
+
+    // Act
+    const master = HDKey.fromMasterSeed(seed);
+
+    // Assert
+    expect(master.fingerprint.toString(16)).toBe('3442193e');
+  });
+
+  it('computes the secp256k1 generator point for a private key of 1', () => {
+    // Arrange: privkey 1 must yield the generator G, a published constant.
+    /* eslint-disable-next-line import-x/no-extraneous-dependencies */
+    const { secp256k1 } = require('@noble/curves/secp256k1');
+    const privateKey = new Uint8Array(32);
+    privateKey[31] = 1;
+    const generatorCompressed =
+      '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+
+    // Act
+    const publicKey = secp256k1.getPublicKey(privateKey, true);
+
+    // Assert
+    const toHex = (bytes) =>
+      Array.from(bytes)
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('');
+    expect(toHex(publicKey)).toBe(generatorCompressed);
+  });
+
+  it('pins every HD-derivation consumer to one @noble/curves version', () => {
+    // Arrange: the packages whose elliptic-curve work happens on the unlock
+    // path. Keeping them on a single copy is what makes the patch effective.
+    const hdDerivationPackages = [
+      'node_modules/@scure/bip32',
+      'node_modules/@metamask/key-tree',
+      'node_modules/@metamask/eth-hd-keyring',
+    ];
+
+    // Act
+    const resolvedVersions = new Set(
+      hdDerivationPackages
+        .map(resolveCurvesFrom)
+        .filter(Boolean)
+        // eslint-disable-next-line import-x/no-dynamic-require, global-require
+        .map((packageJsonPath) => require(packageJsonPath).version),
+    );
+
+    // Assert
+    expect([...resolvedVersions]).toHaveLength(1);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -12657,15 +12657,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:1.9.6":
-  version: 1.9.6
-  resolution: "@noble/curves@npm:1.9.6"
-  dependencies:
-    "@noble/hashes": "npm:1.8.0"
-  checksum: 10/74b603bbf95cab1b6eb147d02febe55bc19cf57c324bf2ff04b44ff9be3f88affc1a57da0805c74803e27c25687079251f9c788f93f0e6fd1c5d02163996460c
-  languageName: node
-  linkType: hard
-
 "@noble/curves@npm:1.9.7, @noble/curves@npm:^1.0.0, @noble/curves@npm:^1.2.0, @noble/curves@npm:^1.4.2, @noble/curves@npm:^1.8.0, @noble/curves@npm:^1.8.1, @noble/curves@npm:^1.9.1, @noble/curves@npm:^1.9.2, @noble/curves@npm:^1.9.7, @noble/curves@npm:~1.9.0":
   version: 1.9.7
   resolution: "@noble/curves@npm:1.9.7"
@@ -39773,7 +39764,7 @@ __metadata:
     "@metamask/wallet": "npm:^12.0.3"
     "@ngraveio/bc-ur": "npm:^1.1.6"
     "@nktkas/hyperliquid": "npm:^0.33.1"
-    "@noble/curves": "npm:1.9.6"
+    "@noble/curves": "npm:1.9.7"
     "@noble/hashes": "npm:1.8.0"
     "@notifee/react-native": "npm:^9.1.8"
     "@octokit/rest": "npm:^21.0.0"


### PR DESCRIPTION
## **Description**

`shimPerf.js` swaps `@noble/curves`' `secp256k1.getPublicKey` for the native C++ implementation from `@metamask/native-utils`. It does that by **mutating a module instance**, so it only reaches consumers that resolve the *same copy* of `@noble/curves`. The file says so itself:

> IMPORTANT: This patching works only if @noble/curves version in root package.json is same as @noble/curves version in package.json of @scure/bip32.

**That invariant had silently broken.** The root pinned `@noble/curves` to `1.9.6`, while `1.9.7` was the highest published `1.x` — so every floating range in the tree resolved there instead:

| Package | Declares | Resolved | Reached by the patch? |
|---|---|---|---|
| `@scure/bip32` | `~1.9.0` | nested `1.9.7` | **no** |
| `@metamask/key-tree` | `^1.8.1` | nested `1.9.7` | **no** |

Both ranges *accept* `1.9.6`, but Yarn resolves each range independently to the highest match. Nothing was misconfigured — the root pin simply stopped being the newest `1.9.x` the moment `1.9.7` shipped.

Nothing threw and nothing logged. HD key derivation just went back to interpreted BigInt maths on Hermes. `KeyringController.submitPassword` re-derives every account's key from the seed on **every unlock**, and the homepage is blocked behind it, so this landed squarely on the most-executed cold path in the app.

### The fix

One line — move the root pin to the version the rest of the tree already wanted:

```diff
-"@noble/curves": "1.9.6",
+"@noble/curves": "1.9.7",
```

### Why a version bump rather than a pin

Pinning the two edges *down* to `1.9.6` via `resolutions` also works and measures identically (2,059 ms). It was rejected because it leaves the tree fragmented and adds two entries that silently become wrong the next time someone bumps the root. Moving the root forward instead:

- **no `resolutions` entries** that have to be kept in step with the root pin forever
- **the lockfile change is a net deletion**
- **deduplication**: `@noble/curves` goes from **25 copies (58.6 MB) to 12 (25.4 MB)**

Patching sources with `yarn patch` was also considered and rejected — it would carry patch files plus a `require('@metamask/native-utils')` inside third-party code, to achieve declaratively what a version bump already does.

### What this widens — the part that needs review

15 packages now share the patched copy, up from 3. Of the newcomers, only three actually call the patched `getPublicKey`:

| Package | `secp256k1.getPublicKey` call sites | What it does |
|---|---:|---|
| `@solana/web3.js` | 7 | `Secp256k1Program` instructions |
| `ripple-keypairs` | 2 | XRP address derivation |
| `@metamask/toprf-secure-backup` | 2 | threshold OPRF for seedless onboarding |

The other nine import `@noble/curves/secp256k1` for signing, point arithmetic or modular utilities, or use ed25519/p256 — none of which `shimPerf.js` touches.

Seven consumers pin exact versions, keep their own copies and are **untouched**: `ethers` (`1.2.0`), `ethereum-cryptography` (`1.4.2`, `1.9.0`), `@walletconnect/relay-auth` (`1.8.0`), `@walletconnect/utils@2.19.x` (`1.8.1`), `ox@0.9.3` (`1.9.1`), `viem` (`1.9.2`). Forcing those onto 1.9.7 would mean overriding exact pins across seven minor versions of internal API churn for no benefit — explicitly not done here.

### Why 1.9.6 → 1.9.7 is safe for the packages that move

`secp256k1.js` and `abstract/weierstrass.js` — the entire secp256k1 implementation — are **byte-identical** between the two versions.

The only differences anywhere in the package are an ed25519 method rename (`toMontgomeryPriv` → `toMontgomerySecret`) and re-export plumbing in `abstract/utils.js`, which drops three underscore-prefixed internals (`_abool2`, `_abytes2`, `_validateObject`). A tree-wide grep finds no consumer of any of them — the single hit is `@metamask/bitcoin-wallet-snap`, which is self-bundled and resolves no dependencies of its own.

### Results

Samsung Galaxy A14 5G, Android 15, `production` release build, populated wallet, cold starts only, n=5 medians. Unlock submit → usable homepage:

| | unlock → homepage |
|---|---:|
| Before (drifted, pure JS) | 3,846 ms |
| **After** | **2,050 ms** (p90 2,098 ms) |
| | **−1,796 ms / −47 %** |

No other startup stage moved beyond run-to-run noise: controller rehydration 88 → 93 ms, `Engine.init` 778 → 760 ms, splash reveal tax 1,752 → 1,688 ms.

### Correctness

Re-verified **on device** after the bump, and deliberately extended past the maths, because twelve more packages now share the patched copy:

- compressed (33-byte) and uncompressed (65-byte) output
- **input types** — hex string and `bigint`, not just `Uint8Array`; a silent coercion difference would be a real bug
- **error semantics** — zero key, private key equal to the curve order `n`, 31-byte and 33-byte keys must all still **throw** rather than return a point

```
CRYPTOVERIFY RESULT pass=15 fail=0
```

5/5 cold unlocks reached a usable homepage with real wallet data. The `@noble/curves` baseline for those expectations was captured from the unpatched package under Node first, rather than assumed.

### Reviewer notes

- **This is the part that needs a second opinion:** twelve packages join the patched copy, and three of them (Solana, XRP keypairs, seedless-onboarding OPRF) genuinely call the patched function. The primitive is verified equivalent including error paths, but a reviewer who owns those paths should confirm they are happy.
- The guard test asserts *sameness with the root*, not a specific version, so it keeps working across future bumps. It was verified to fail on a drifted tree, naming the offending nested path.
- `@noble/curves@2.0.1` exists and nothing in the tree uses it. A major bump would likely need `shimPerf.js` updated — `_setWindowSize` and the `ProjectivePoint`/`utils` layout moved across 1.x.
- The device measurement was taken before current `main` was merged in; the intervening upstream deltas were `transaction-controller` patch bumps, design-system and TypeScript, none on the HD path. Install, dedupe, guard test, depcheck and `tsc` were all re-verified after the merge.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs:

## **Manual testing steps**

```gherkin
Feature: Single @noble/curves copy on the HD derivation path

  Scenario: user unlocks a populated wallet from a cold start
    Given a production release build is installed on a mid-range Android device
    And the wallet has several accounts already imported
    And the app has been force-stopped

    When user launches the app
    And user enters their password and submits
    Then the homepage renders a usable state
    And every account address matches what it was before this change

  Scenario: non-EVM key paths still work
    Given the wallet is unlocked

    When user views a Solana account
    And user completes a seedless onboarding backup or recovery
    Then addresses and recovery both behave exactly as before
```

## **Screenshots/Recordings**

### **Before**

N/A — no UI change. The measurable difference is startup timing and dependency-tree size, both reported above.

### **After**

N/A — no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
  - `shimPerf.test.js` guards the invariant: resolution identity against the root, plus derivation pinned to published constants (the secp256k1 generator point and BIP-32 Test Vector 1's `0x3442193e` fingerprint). 6/6 pass, and verified to fail on a drifted tree.
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Samsung Galaxy A14 5G (SM-A146P), Android 15, `production` release build — a mid-range physical device.
- [x] I've tested with a power user scenario
  - Populated wallet with several imported accounts. Cost scales with account count, so a larger wallet shows a larger absolute gain.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - The `HomepageReady` CUF already covers this window. No new instrumentation ships in this PR.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
