### PR TITLE
ci: enable RC repack by default with opt-out label

### DIFF
--- a/.github/workflows/build-rc-auto.yml
+++ b/.github/workflows/build-rc-auto.yml
@@ -54,22 +54,21 @@
 #   thumbs-up, the last cherry-pick has landed, and the branch is being prepared to
 #   merge into stable. Removing the label resumes normal auto RC builds.
 #
-# Repack fast path (opt-in):
-#   Add the 'repack-rc-enabled' label to the release PR to let a push reuse the signed
-#   IPA/APK of an earlier auto RC build on the SAME release branch whose @expo/fingerprint
-#   hash matches, swapping in a freshly bundled JS layer via @expo/repack-app instead of
-#   compiling natively (build-rc-repack.yml). Without the label — and on any fingerprint
-#   miss, expired artifact, or failure — the run takes the unchanged native path below.
-#   Note the first build after labelling always compiles natively: it is the one that
+# Repack fast path (on by default):
+#   A push reuses the signed IPA/APK of an earlier auto RC build on the SAME release
+#   branch whose @expo/fingerprint hash matches, swapping in a freshly bundled JS layer
+#   via @expo/repack-app instead of compiling natively (build-rc-repack.yml). On any
+#   fingerprint miss, expired artifact, or failure the run takes the unchanged native
+#   path below. Add the 'repack-rc-disabled' label to the release PR to skip the fast
+#   path for that cycle — the next push compiles natively again, with no revert PR.
+#   Note the first RC build of a cycle always compiles natively: it is the one that
 #   publishes the build-source-hash status the next push looks up.
 #
-#   Removing the label reverts instantly — the next push builds natively again, with no
-#   revert PR. The label lives on the release PR, so enabling it scopes the fast path to
-#   one release cycle. On the first repacked build of a cycle, compare it against a native
-#   RC build of the same commit: launch, OTA update check, Sentry symbolication, deep
-#   links, Apple Sign-In, and the build number matching what the RC comment claims. The JS
-#   here is bundled by `expo export:embed`, not by the bundler scripts/build.sh uses, and
-#   RC builds reach external testers.
+#   On the first repacked build of a cycle, compare it against a native RC build of the
+#   same commit: launch, OTA update check, Sentry symbolication, deep links, Apple
+#   Sign-In, and the build number matching what the RC comment claims. The JS here is
+#   bundled by `expo export:embed`, not by the bundler scripts/build.sh uses, and RC
+#   builds reach external testers.
 #
 ##############################################################################################
 name: Auto RC builds
@@ -174,14 +173,14 @@ jobs:
             echo "Found PR #$PR_NUMBER - proceeding with RC build"
           fi
 
-          # Opt-in gate for the repack fast path. Absent label means the native build
-          # path, so this feature is inert on any release branch that has not asked for it.
-          REPACK_ENABLED=$(echo "$PR_JSON" | jq -r '[.labels[].name] | map(select(. == "repack-rc-enabled")) | length > 0')
+          # Opt-out gate for the repack fast path. Absent label means the fast path is
+          # eligible; add 'repack-rc-disabled' to compile natively for this cycle.
+          REPACK_ENABLED=$(echo "$PR_JSON" | jq -r '[.labels[].name] | map(select(. == "repack-rc-disabled")) | length == 0')
 
           if [[ "$REPACK_ENABLED" == "true" ]]; then
-            echo "::notice::PR #$PR_NUMBER has the 'repack-rc-enabled' label — repack fast path is eligible."
+            echo "PR #$PR_NUMBER has no 'repack-rc-disabled' label — repack fast path is eligible."
           else
-            echo "No 'repack-rc-enabled' label on PR #$PR_NUMBER — native builds only."
+            echo "::notice::PR #$PR_NUMBER has the 'repack-rc-disabled' label — native builds only."
           fi
 
           {
@@ -204,9 +203,9 @@ jobs:
   # SAME release branch whose hash matches and whose IPA/APK are still available.
   #
   # This job must always run to completion, even when the repack fast path is disabled: the
-  # native build jobs depend on it, and a skipped job would take them down with it. When the
-  # label is absent every step is skipped, `found` stays empty, and the run behaves exactly
-  # as it did before this fast path existed.
+  # native build jobs depend on it, and a skipped job would take them down with it. When
+  # 'repack-rc-disabled' is present every step is skipped, `found` stays empty, and the run
+  # behaves exactly as it did before this fast path existed.
   resolve-rc-reuse:
     name: Resolve repack donor build
     runs-on: ubuntu-latest
@@ -288,7 +287,7 @@ jobs:
             echo "### RC build source"
             echo ""
             if [[ "$REPACK_ENABLED" != "true" ]]; then
-              echo "Native build — the \`repack-rc-enabled\` label is not on the release PR."
+              echo "Native build — the \`repack-rc-disabled\` label is on the release PR."
             elif [[ "$FOUND" == "true" ]]; then
               echo "Repack — reusing native artifacts from run [$RUN_ID](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}) (commit \`${SOURCE_SHA}\`)."
               echo ""
@@ -313,7 +312,7 @@ jobs:
     secrets: inherit
 
   # Fast path: reuse the donor's native artifacts and swap in this commit's JS. Requires a
-  # donor, which in turn requires the opt-in label, so this is skipped by default.
+  # donor. Skipped when the release PR has 'repack-rc-disabled', or when no donor matches.
   repack-ios-rc-build:
     name: Repack iOS RC Build
     uses: ./.github/workflows/build-rc-repack.yml

--- a/.github/workflows/build-rc-repack.yml
+++ b/.github/workflows/build-rc-repack.yml
@@ -8,8 +8,8 @@
 # re-signs. The result is uploaded under the same artifact names build.yml uses, so
 # upload-to-testflight.yml and the next donor lookup work unchanged.
 #
-# The caller only routes here when a donor exists AND the release PR carries the
-# 'repack-rc-enabled' label. Everything else takes auto-rc-ota-build-core.yml as before.
+# The caller only routes here when a donor exists AND the release PR does not carry
+# 'repack-rc-disabled'. Everything else takes auto-rc-ota-build-core.yml as before.
 #
 # Inputs and outputs deliberately mirror auto-rc-ota-build-core.yml so the two are
 # interchangeable from the caller's point of view.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Auto RC builds on `release/X.Y.Z` already know how to reuse a matching native IPA/APK and swap in a fresh JS bundle (`build-rc-repack.yml`), but that path was gated on the `repack-rc-enabled` label. Release PRs do not get that label unless someone remembers to add it, so cycles such as `release/8.11.0` kept compiling natively on every cherry-pick.

This PR inverts the gate: the fast path is eligible whenever the release PR exists and is not frozen. Add `repack-rc-disabled` to compile natively for that cycle. Job graph, donor lookup, and native fallback are unchanged. The first RC of a cycle still compiles natively so it can publish the `build-source-hash` status the next push looks up. Fingerprint miss, expired artifacts, or a failed repack still fall back to a full native build.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: none — CI-only default for auto RC repack; no tracking issue

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Auto RC repack opt-out

  Scenario: matching fingerprint reuses a prior native RC
    Given an open native release PR without the "repack-rc-disabled" label
    And a completed Auto RC run on the same branch that posted build-source-hash
    And the next push does not change the @expo/fingerprint

    When Auto RC builds runs
    Then resolve-rc-reuse reports a donor
    And iOS and Android take the repack path
    And the native fallback jobs are skipped

  Scenario: opt-out compiles natively
    Given an open native release PR with the "repack-rc-disabled" label

    When Auto RC builds runs
    Then fingerprint lookup steps are skipped
    And iOS and Android take the native RC path

  Scenario: first build of a cycle still compiles natively
    Given a newly opened native release PR with no prior Auto RC donor

    When Auto RC builds runs
    Then the run compiles natively
    And it publishes a build-source-hash status for later pushes
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — CI workflow change, no UI.

### **After**

N/A — CI workflow change, no UI.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which RC builds ship via repack vs full native compile for external testers; misconfiguration or repack bugs could affect release binaries, though existing fallback paths remain.
> 
> **Overview**
> **Auto RC repack is now the default** on release branches: when a matching `@expo/fingerprint` donor exists, pushes take the repack fast path without anyone adding a label first.
> 
> The gate flips from **`repack-rc-enabled` (opt-in)** to **`repack-rc-disabled` (opt-out)**. `validate-and-find-pr` sets `repack-enabled` when the release PR does **not** carry `repack-rc-disabled`; adding that label forces native-only RC builds for that cycle. Comments, step summaries, and `build-rc-repack.yml` header text are updated to match. Donor lookup, native fallback on fingerprint miss/failure, and the first-build-of-cycle native compile behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1facb624b0c6802da6abc48beb086ea5325ca192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->