### PR TITLE
fix(earn): size the gas impact sheet header to the app standard

### DIFF
--- a/app/components/UI/Stake/components/GasImpactModal/GasImpactModal.styles.ts
+++ b/app/components/UI/Stake/components/GasImpactModal/GasImpactModal.styles.ts
@@ -7,6 +7,7 @@ const styleSheet = () =>
     },
     content: {
       paddingBottom: 16,
+      textAlign: 'center',
     },
     footer: {
       paddingBottom: 16,

--- a/app/components/UI/Stake/components/GasImpactModal/GasImpactModal.test.tsx
+++ b/app/components/UI/Stake/components/GasImpactModal/GasImpactModal.test.tsx
@@ -114,8 +114,7 @@ describe('GasImpactModal', () => {
     expect(getByText(strings('stake.gas_cost_impact'))).toHaveStyle({
       fontSize: mockTheme.typography.sHeadingSM.fontSize,
     });
-    // Md keeps the close button in step with the design-system sheet default,
-    // which the legacy BottomSheetHeader would otherwise render one size up.
+    // The legacy BottomSheetHeader hardcoded this one size up.
     expect(getByTestId(GAS_IMPACT_MODAL_CLOSE_BUTTON_TEST_ID)).toHaveStyle({
       height: 32,
       width: 32,

--- a/app/components/UI/Stake/components/GasImpactModal/GasImpactModal.test.tsx
+++ b/app/components/UI/Stake/components/GasImpactModal/GasImpactModal.test.tsx
@@ -8,12 +8,13 @@ import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import { flushPromises } from '../../../../../util/test/utils';
+import { mockTheme } from '../../../../../util/theme';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { createMockUseAnalyticsHook } from '../../../../../util/test/analyticsMock';
 
 import usePoolStakedDeposit from '../../hooks/usePoolStakedDeposit';
 import { GasImpactModalRouteParams } from './GasImpactModal.types';
-import GasImpactModal from './index';
+import GasImpactModal, { GAS_IMPACT_MODAL_CLOSE_BUTTON_TEST_ID } from './index';
 
 const MOCK_SELECTED_INTERNAL_ACCOUNT = {
   address: '0x123',
@@ -105,6 +106,27 @@ describe('GasImpactModal', () => {
 
     expect(getByText(strings('stake.cancel'))).toBeOnTheScreen();
     expect(getByText(strings('stake.proceed_anyway'))).toBeOnTheScreen();
+  });
+
+  it('uses the standard sheet title size and centers the warning', () => {
+    const { getByText, getByTestId } = renderGasImpactModal();
+
+    expect(getByText(strings('stake.gas_cost_impact'))).toHaveStyle({
+      fontSize: mockTheme.typography.sHeadingSM.fontSize,
+    });
+    // Md keeps the close button in step with the design-system sheet default,
+    // which the legacy BottomSheetHeader would otherwise render one size up.
+    expect(getByTestId(GAS_IMPACT_MODAL_CLOSE_BUTTON_TEST_ID)).toHaveStyle({
+      height: 32,
+      width: 32,
+    });
+    expect(
+      getByText(
+        strings('stake.gas_cost_impact_warning', {
+          percentOverDeposit: 30,
+        }),
+      ),
+    ).toHaveStyle({ textAlign: 'center' });
   });
 
   it('closes gas impact modal on cancel', () => {

--- a/app/components/UI/Stake/components/GasImpactModal/index.tsx
+++ b/app/components/UI/Stake/components/GasImpactModal/index.tsx
@@ -14,6 +14,7 @@ import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import { ButtonIconSizes } from '../../../../../component-library/components/Buttons/ButtonIcon';
 import BottomSheetFooter, {
   ButtonsAlignment,
 } from '../../../../../component-library/components/BottomSheets/BottomSheetFooter';
@@ -32,6 +33,9 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { EVENT_LOCATIONS, EVENT_PROVIDERS } from '../../constants/events';
 import usePoolStakedDeposit from '../../hooks/usePoolStakedDeposit';
 import { EVM_SCOPE } from '../../../Earn/constants/networks';
+
+export const GAS_IMPACT_MODAL_CLOSE_BUTTON_TEST_ID =
+  'gas-impact-modal-close-button';
 
 const GasImpactModal = () => {
   const route =
@@ -166,8 +170,14 @@ const GasImpactModal = () => {
   return (
     <BottomSheet ref={sheetRef}>
       <View style={styles.container}>
-        <BottomSheetHeader onClose={handleClose}>
-          <Text variant={TextVariant.HeadingMD}>
+        <BottomSheetHeader
+          onClose={handleClose}
+          closeButtonProps={{
+            size: ButtonIconSizes.Md,
+            testID: GAS_IMPACT_MODAL_CLOSE_BUTTON_TEST_ID,
+          }}
+        >
+          <Text variant={TextVariant.HeadingSM}>
             {strings('stake.gas_cost_impact')}
           </Text>
         </BottomSheetHeader>

--- a/app/components/UI/Stake/components/GasImpactModal/index.tsx
+++ b/app/components/UI/Stake/components/GasImpactModal/index.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import { View } from 'react-native';
+import { BottomSheetHeader } from '@metamask/design-system-react-native';
 
 import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
 import BottomSheet, {
@@ -13,8 +14,6 @@ import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
-import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import { ButtonIconSizes } from '../../../../../component-library/components/Buttons/ButtonIcon';
 import BottomSheetFooter, {
   ButtonsAlignment,
 } from '../../../../../component-library/components/BottomSheets/BottomSheetFooter';
@@ -172,14 +171,9 @@ const GasImpactModal = () => {
       <View style={styles.container}>
         <BottomSheetHeader
           onClose={handleClose}
-          closeButtonProps={{
-            size: ButtonIconSizes.Md,
-            testID: GAS_IMPACT_MODAL_CLOSE_BUTTON_TEST_ID,
-          }}
+          closeButtonProps={{ testID: GAS_IMPACT_MODAL_CLOSE_BUTTON_TEST_ID }}
         >
-          <Text variant={TextVariant.HeadingSM}>
-            {strings('stake.gas_cost_impact')}
-          </Text>
+          {strings('stake.gas_cost_impact')}
         </BottomSheetHeader>
         <Text style={styles.content}>
           {strings('stake.gas_cost_impact_warning', { percentOverDeposit: 30 })}


### PR DESCRIPTION

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Earn "Gas cost impact" bottom sheet rendered its header one size step above every other sheet in the app: the title used `HeadingMD`, and the close button inherited the legacy `component-library` `BottomSheetHeader` default of `ButtonIconSizes.Lg` (40pt target, 32pt glyph). The design-system `BottomSheetHeader` — now the majority of sheets — defaults that close button to `Md` (32pt target, 24pt glyph), and the comparable Earn TRX learn-more sheet already uses `HeadingSM`.

This PR brings the gas-impact sheet onto that standard without migrating the whole modal off the legacy BottomSheet stack:

- Title: `HeadingMD` → `HeadingSM`
- Close button: `closeButtonProps={{ size: ButtonIconSizes.Md }}` (same override Bridge already uses on its leftover legacy headers)
- Warning copy: `textAlign: 'center'`

A regression test asserts the title font size, the 32×32 close-button target, and the centered warning. Changing the legacy header's own `Lg` default would fix ~49 other sheets in one go, but that is a cross-team visual change and is left for a follow-up.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Earn gas cost warning sheet using a larger header and close button than other bottom sheets

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: no GitHub issue — visual-only Earn gas-impact sheet header size and alignment fix

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Earn gas cost impact sheet header matches other bottom sheets

  Background:
    Given I am logged into MetaMask Mobile
    And I can open Stake ETH with a small deposit whose estimated gas is more than 30% of the amount

  Scenario: header title and close button match other sheets
    Given I enter a deposit amount that triggers the gas cost warning
    When the "Gas cost impact" bottom sheet opens
    Then the title uses the standard sheet heading size (HeadingSM)
    And the close "X" is the same size as on other bottom sheets (Md)
    And the warning copy is centered under the title

  Scenario: actions are unchanged
    Given the "Gas cost impact" bottom sheet is open
    When I tap Cancel
    Then the sheet closes without staking
    When I reopen the sheet and tap Proceed anyway
    Then the stake confirmation flow continues as before
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

The title and close "X" sit one size step above other bottom sheets, and the warning is left-aligned.

<img width="600" alt="Gas cost impact sheet before — oversized header and close button" src="https://github.com/user-attachments/assets/c22a2432-cd97-4855-805f-615a72b390f7" />

### **After**

<!-- [screenshots/recordings] -->

Title and close button match the app-standard sheet header; warning copy is centered.

<img width="600" alt="Gas cost impact sheet after — standard header size and centered warning" src="https://github.com/user-attachments/assets/d5a1b6d1-3f20-4245-8345-755df63e213f" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Not applicable — typography and a close-button size prop only; no list, network, or render-count impact. The existing GasImpactModal suite (10 tests) passes.

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and header-component swap only; staking navigation and deposit logic are untouched.
> 
> **Overview**
> The Earn **Gas cost impact** bottom sheet now uses the design-system `BottomSheetHeader` instead of the legacy component-library header, so the title and close control match other sheets.
> 
> The custom `HeadingMD` title wrapper is removed in favor of the header’s default **HeadingSM** title. The close button gets a stable `testID` and inherits the design-system **Md** (32×32) target. Warning copy is **centered** via `textAlign: 'center'` on the content style.
> 
> A regression test checks title font size (`sHeadingSM`), close-button dimensions, and centered warning text. Cancel / proceed behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 405999a415b8d2ba5ebb4fdf6d3c1740811dbc30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->