### PR TITLE
perf: drop the 250ms frozen frame from the splash reveal

### DIFF
--- a/app/components/Nav/ControllersGate/ControllersGate.test.tsx
+++ b/app/components/Nav/ControllersGate/ControllersGate.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 // Jest accepts prefixing out-of-scope variables with `mock`
-import { View as MockView } from 'react-native';
+import { Animated, View as MockView } from 'react-native';
 import { render, act, screen } from '@testing-library/react-native';
 import ControllersGate from './ControllersGate';
 import { useSelector } from 'react-redux';
@@ -79,11 +79,11 @@ describe('ControllersGate', () => {
 
     render(<ControllersGate>{mockChildren}</ControllersGate>);
 
-    // First act: fire onAnimationComplete → setAnimationDone(true) → useEffect schedules setTimeout
+    // First act: fire onAnimationComplete → setAnimationDone(true) → useEffect starts the fade
     act(() => {
       capturedOnAnimationComplete?.();
     });
-    // Second act: advance past the setTimeout so fadeOutLoader runs
+    // Second act: let the opacity animation run to completion
     act(() => {
       jest.runAllTimers();
     });
@@ -107,6 +107,32 @@ describe('ControllersGate', () => {
 
     // Overlay must remain — removing it now would show a blank screen
     expect(screen.getByTestId(MOCK_FOX_LOADER_ID)).toBeOnTheScreen();
+    jest.useRealTimers();
+  });
+
+  it('starts the fade immediately, with no delay before it', () => {
+    // Guards a removed 250ms `setTimeout`. A frame-by-frame capture showed that
+    // window to be a frozen, pixel-identical blank screen — the Rive exit has
+    // already faded the fox out, so there is nothing to settle. Re-introducing
+    // a delay here would silently add latency to every cold start.
+    jest.useFakeTimers();
+    (useSelector as jest.Mock).mockReturnValue(true);
+    const timingSpy = jest.spyOn(Animated, 'timing');
+
+    render(<ControllersGate>{mockChildren}</ControllersGate>);
+
+    act(() => {
+      capturedOnAnimationComplete?.();
+    });
+
+    // The fade must already be running, before any timer is advanced.
+    expect(timingSpy).toHaveBeenCalledTimes(1);
+    expect(timingSpy.mock.calls[0][1]).toMatchObject({
+      toValue: 0,
+      duration: 300,
+    });
+
+    timingSpy.mockRestore();
     jest.useRealTimers();
   });
 });

--- a/app/components/Nav/ControllersGate/ControllersGate.tsx
+++ b/app/components/Nav/ControllersGate/ControllersGate.tsx
@@ -30,12 +30,17 @@ const ControllersGate: React.FC<ControllersGateProps> = ({
 
   // Only fade out once BOTH the animation is done AND app services are ready.
   // This prevents a blank screen when Rive fails or times out before services finish.
+  //
+  // The fade starts immediately. There used to be a 250ms delay here, which a
+  // frame-by-frame capture showed to be a frozen, pixel-identical blank screen:
+  // the Rive exit animation has already finished and faded the fox out, so the
+  // overlay is blank white with nothing left to settle. 20 consecutive recorded
+  // frames measured a zero difference before the fade began. It was pure added
+  // latency on the most-executed cold path in the app.
   useEffect(() => {
     if (animationDone && appServicesReady) {
-      const timer = setTimeout(fadeOutLoader, 250);
-      return () => clearTimeout(timer);
+      fadeOutLoader();
     }
-    return undefined;
   }, [animationDone, appServicesReady, fadeOutLoader]);
 
   const handleAnimationComplete = useCallback(() => {


### PR DESCRIPTION
## **Description**

`ControllersGate` waited **250 ms** after the splash animation finished before starting the fade to the app:

```js
const timer = setTimeout(fadeOutLoader, 250);
```

A frame-by-frame capture of a cold start shows that window is a **completely frozen screen** — 20 consecutive recorded frames with a mean pixel difference of exactly `0.0000`, spanning **225 ms**:

| Recorded frames | Mean pixel difference |
|---|---|
| 5.918 s — last visible change (Rive exit finishes, fox gone) | 1.90 |
| 5.941 → 6.165 s — **20 frames** | **0.0000** ← the 250 ms delay |
| 6.177 → 6.457 s — the fade | 0.14 → 1.21 → 0.20 |

Nothing is settling during it. The Rive exit has already faded the fox out, so the overlay is blank white and the app is fully rendered underneath — the unlock field has been accepting input for over a second by that point. It was pure added latency on the most-executed cold path in the app.

### The fix

Start the fade immediately. Re-recorded on device to confirm:

| | Longest pixel-identical run across the reveal |
|---|---|
| Before | **225 ms** (20 frames) |
| After | **22 ms** (2 frames) |

The exit now runs continuously into the fade, with no dead frame.

### The other two constants were measured and deliberately left alone

This is the part worth reviewing, because "delete the splash timers" would have been the wrong change:

- **The 300 ms fade is real.** The capture shows continuous motion across it as the unlock screen cross-fades in. Removing it would be a visible pop, not a saving.
- **`EXIT_ANIMATION_MS` (800 ms) matches what the Rive exit actually needs.** I instrumented the `Stop` trigger locally and measured trigger → completion over 5 cold starts: **684 / 730 / 805 / 805 / 1053 ms**. The capture shows the fox still fading right up to the end of that window. Shortening the timer would cut the animation off rather than remove waste — that needs the `.riv` re-authored, not a smaller constant.

Worth noting for anyone who picks that up later: the code comments say completion can't be observed because "the Nitro runtime has no `onStateChanged`". That's narrowly true but misleading — `@rive-app/react-native@0.4.19` does expose `onEventListener` (deprecated) and data-binding `onChanged`, either of which could drive the reveal from a real signal instead of a blind timer. The blocker is the **asset**: `splash_screen.riv` contains only the `Splash_animation` state machine and `Start`/`Stop` triggers — no events, no view models, no data binding. It also no longer contains the `ExitState` those comments reference. So making the reveal self-correcting is a design/animation task, not a runtime limitation.

### How this was measured

`FLAG_SECURE` blanks `screenrecord` on `production` builds, so capture protection was disabled **locally only** for the recording — that keeps everything else identical to a real production build, unlike measuring an `exp` variant. None of that instrumentation is in this PR.

Motion was derived per frame with `ffmpeg -vf "tblend=all_mode=difference,signalstats"`, which gives the mean luma change since the previous frame; `0.0000` means pixel-identical.

## **Changelog**

CHANGELOG entry: Reduced the delay before the wallet appears on app launch

## **Related issues**

Refs:

## **Manual testing steps**

```gherkin
Feature: Splash reveal

  Scenario: user cold-starts the app
    Given the app has been force-stopped
    And a production build is installed on an Android device

    When user launches the app
    Then the fox animation plays and exits as before
    And the app fades in immediately after the animation, with no frozen pause
    And there is no visible flash, pop or blank frame during the transition

  Scenario: Rive fails or is slow to load
    Given a device where the Rive animation cannot play

    When user launches the app
    Then the static fox is shown
    And the app is still revealed via the existing timeout fallback
    And no blank screen is shown at any point
```

## **Screenshots/Recordings**

### **Before**

Frame trace across the reveal — the run of `0.0000` is the frozen 250 ms:

```
 5.918    1.8991  #######      <- fox gone, screen blank
 5.941    0.0000
 5.952    0.0000
 ...                           <- 20 frames, pixel-identical, 225 ms
 6.165    0.0000
 6.177    0.1413               <- fade finally starts
 6.312    1.2147  ####
 6.457    0.1962               <- fade done
```

### **After**

```
 5.476    0.7020  ##           <- exit runs straight into the fade
 5.599    0.9159  ###
 5.655    1.1441  ####
 5.779    0.1986               <- fade done, no dead frame
```

Longest pixel-identical run in the window: **22 ms**, down from 225 ms.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
  - Added a guard asserting the fade starts before any timer is advanced. Verified to fail if the 250 ms delay is reintroduced. 6/6 pass.
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Samsung Galaxy A14 5G (SM-A146P), Android 15, `production` release build — a mid-range physical device, not an emulator.
- [x] I've tested with a power user scenario
  - Populated wallet with several imported accounts. This delay is a fixed timer, so it is wallet-size independent — an empty wallet pays exactly the same 250 ms.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - No new instrumentation. Note the splash reveal window is **not** covered by any shipped span today: `UIStartup` ends at `App`'s first render and `HomepageReady` starts later, so this saving will not show up in Sentry until something covers it.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
