### PR TITLE
feat: add trust signals to tokenized stock search results

### DIFF
--- a/app/components/UI/Trending/hooks/useRwaTokens/useRwaTokens.test.ts
+++ b/app/components/UI/Trending/hooks/useRwaTokens/useRwaTokens.test.ts
@@ -1,6 +1,6 @@
 import { useRwaTokens } from './useRwaTokens';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
-import { fetchRwas } from '@metamask/assets-controllers';
+import { fetchRwas, type TrendingAsset } from '@metamask/assets-controllers';
 import {
   PriceChangeOption,
   SortDirection,
@@ -15,8 +15,13 @@ jest.mock('@metamask/assets-controllers', () => ({
 
 const mockFetchRwas = jest.mocked(fetchRwas);
 type RwaToken = Awaited<ReturnType<typeof fetchRwas>>['data'][number];
+type RwaTokenWithSecurityData = RwaToken & {
+  securityData?: TrendingAsset['securityData'];
+};
 
-const createRwaToken = (overrides: Partial<RwaToken> = {}): RwaToken => ({
+const createRwaToken = (
+  overrides: Partial<RwaTokenWithSecurityData> = {},
+): RwaTokenWithSecurityData => ({
   id: '1',
   assetId: 'eip155:1/erc20:0xaaa' as CaipAssetType,
   symbol: 'OUSG',
@@ -87,6 +92,18 @@ describe('useRwaTokens', () => {
     });
   });
 
+  it('requests token security data when enabled', async () => {
+    renderHookWithProvider(() =>
+      useRwaTokens({ includeTokenSecurityData: true }),
+    );
+
+    await waitFor(() => {
+      expect(mockFetchRwas).toHaveBeenCalledWith(
+        expect.objectContaining({ includeTokenSecurityData: true }),
+      );
+    });
+  });
+
   it('uses provided chainIds instead of defaults', async () => {
     const customChainIds: CaipChainId[] = ['eip155:137' as CaipChainId];
 
@@ -153,6 +170,49 @@ describe('useRwaTokens', () => {
     });
 
     expect(result.current.data[0].price).toBe('200.00');
+  });
+
+  it('preserves token security data when normalizing the response', async () => {
+    const securityData: TrendingAsset['securityData'] = {
+      resultType: 'Verified',
+      maliciousScore: '0',
+      features: [],
+      fees: {
+        transfer: 0,
+        transferFeeMaxAmount: null,
+        buy: 0,
+        sell: null,
+      },
+      financialStats: {
+        supply: 1000000,
+        topHolders: [],
+        holdersCount: 100,
+        tradeVolume24h: null,
+        lockedLiquidityPct: null,
+        markets: [],
+      },
+      metadata: {
+        externalLinks: {
+          homepage: null,
+          twitterPage: null,
+          telegramChannelId: null,
+        },
+      },
+      created: '2023-01-01T00:00:00Z',
+    };
+    arrangeMocks({
+      tokens: [createRwaToken({ securityData })],
+    });
+
+    const { result } = renderHookWithProvider(() =>
+      useRwaTokens({ includeTokenSecurityData: true }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data[0].securityData).toEqual(securityData);
   });
 
   it('passes price_change_asc sortBy when ascending PriceChange selected', async () => {

--- a/app/components/UI/Trending/hooks/useRwaTokens/useRwaTokens.ts
+++ b/app/components/UI/Trending/hooks/useRwaTokens/useRwaTokens.ts
@@ -15,6 +15,11 @@ const DEFAULT_SORT_DIRECTION = SortDirection.Descending;
 type FetchRwasParams = Parameters<typeof fetchRwas>[0];
 type RwaSortBy = NonNullable<FetchRwasParams>['sortBy'];
 type RwaToken = Awaited<ReturnType<typeof fetchRwas>>['data'][number];
+// /v1/rwas returns this field when requested, but the controller response type
+// does not expose it yet.
+type RwaTokenWithSecurityData = RwaToken & {
+  securityData?: TrendingAsset['securityData'];
+};
 
 const buildSortBy = (
   option: PriceChangeOption,
@@ -37,7 +42,7 @@ const buildSortBy = (
   }
 };
 
-const normalizeRwaToken = (token: RwaToken): TrendingAsset => ({
+const normalizeRwaToken = (token: RwaTokenWithSecurityData): TrendingAsset => ({
   assetId: token.assetId,
   symbol: token.symbol,
   name: token.name,
@@ -47,6 +52,7 @@ const normalizeRwaToken = (token: RwaToken): TrendingAsset => ({
   marketCap: token.rwaData.marketCap,
   priceChangePct: { h24: token.rwaData.priceChange },
   rwaData: token.rwaData as unknown as TrendingAsset['rwaData'],
+  securityData: token.securityData,
 });
 
 /**
@@ -57,6 +63,7 @@ const normalizeRwaToken = (token: RwaToken): TrendingAsset => ({
  *
  * @param opts.searchQuery - Server-side query to filter results
  * @param opts.chainIds - Chain IDs to filter by (defaults to RWA_CHAIN_IDS)
+ * @param opts.includeTokenSecurityData - Whether the response should include trust-signal data
  * @param opts.sortTrendingTokensOptions - Sorting options for price change / volume / market cap
  * @returns Token data, loading state, pagination helpers, and refetch function for rwa tokens
  */
@@ -64,6 +71,7 @@ export const useRwaTokens = (opts?: {
   searchQuery?: string;
   chainIds?: CaipChainId[] | null;
   pageSize?: number;
+  includeTokenSecurityData?: boolean;
   sortTrendingTokensOptions?: {
     option: PriceChangeOption;
     direction: SortDirection;
@@ -73,6 +81,7 @@ export const useRwaTokens = (opts?: {
     searchQuery,
     chainIds,
     pageSize = RWA_PAGE_SIZE,
+    includeTokenSecurityData = false,
     sortTrendingTokensOptions,
   } = opts ?? {};
   const { option = DEFAULT_SORT_OPTION, direction = DEFAULT_SORT_DIRECTION } =
@@ -103,8 +112,9 @@ export const useRwaTokens = (opts?: {
         sortBy,
         limit: pageSize,
         after,
+        ...(includeTokenSecurityData && { includeTokenSecurityData: true }),
       }),
-    [stableChainIds, searchQuery, sortBy, pageSize],
+    [stableChainIds, searchQuery, sortBy, pageSize, includeTokenSecurityData],
   );
 
   const fetchTokens = useCallback(async () => {

--- a/app/components/Views/TrendingView/feeds/stocks/useStocksFeed.test.ts
+++ b/app/components/Views/TrendingView/feeds/stocks/useStocksFeed.test.ts
@@ -3,6 +3,12 @@ import type { TrendingAsset } from '@metamask/assets-controllers';
 import { useRwaTokens } from '../../../../UI/Trending/hooks/useRwaTokens/useRwaTokens';
 import { useStocksFeed } from './useStocksFeed';
 
+let mockIsBasicFunctionalityEnabled = true;
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(() => mockIsBasicFunctionalityEnabled),
+}));
+
 jest.mock('../../../../UI/Trending/hooks/useRwaTokens/useRwaTokens', () => ({
   useRwaTokens: jest.fn(),
 }));
@@ -40,6 +46,7 @@ const arrangeRwaTokens = (assets = ALL_RWA_ASSETS) => {
 describe('useStocksFeed', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsBasicFunctionalityEnabled = true;
     arrangeRwaTokens();
   });
 
@@ -64,6 +71,7 @@ describe('useStocksFeed', () => {
       expect(mockUseRwaTokens).toHaveBeenCalledWith(
         expect.objectContaining({
           chainIds: ['eip155:1', 'eip155:4663'],
+          includeTokenSecurityData: false,
         }),
       );
     });
@@ -103,7 +111,20 @@ describe('useStocksFeed', () => {
     it('passes the query through to useRwaTokens as searchQuery', () => {
       renderHook(() => useStocksFeed({ query: ' OUSG ' }));
       expect(mockUseRwaTokens).toHaveBeenCalledWith(
-        expect.objectContaining({ searchQuery: 'OUSG' }),
+        expect.objectContaining({
+          searchQuery: 'OUSG',
+          includeTokenSecurityData: true,
+        }),
+      );
+    });
+
+    it('does not request security data when Basic Functionality is off', () => {
+      mockIsBasicFunctionalityEnabled = false;
+
+      renderHook(() => useStocksFeed({ query: 'OUSG' }));
+
+      expect(mockUseRwaTokens).toHaveBeenCalledWith(
+        expect.objectContaining({ includeTokenSecurityData: false }),
       );
     });
 

--- a/app/components/Views/TrendingView/feeds/stocks/useStocksFeed.ts
+++ b/app/components/Views/TrendingView/feeds/stocks/useStocksFeed.ts
@@ -1,8 +1,10 @@
 import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import type { CaipChainId } from '@metamask/utils';
 import { NetworkToCaipChainId } from '../../../../UI/NetworkMultiSelector/NetworkMultiSelector.constants';
 import { useRwaTokens } from '../../../../UI/Trending/hooks/useRwaTokens/useRwaTokens';
+import { selectBasicFunctionalityEnabled } from '../../../../../selectors/settings';
 import { useFeedRefresh } from '../../hooks/useFeedRefresh';
 import type { RefreshConfig } from '../../hooks/useExploreRefresh';
 
@@ -50,6 +52,9 @@ export const useStocksFeed = ({
 }: UseStocksFeedOptions = {}): UseStocksFeedResult => {
   const trimmedQuery = query?.trim();
   const hasQuery = Boolean(trimmedQuery);
+  const isBasicFunctionalityEnabled = useSelector(
+    selectBasicFunctionalityEnabled,
+  );
   const {
     data,
     isLoading,
@@ -62,6 +67,7 @@ export const useStocksFeed = ({
     searchQuery: hasQuery ? trimmedQuery : undefined,
     chainIds: hasQuery ? undefined : STOCKS_FEED_RWA_CHAIN_IDS,
     pageSize,
+    includeTokenSecurityData: hasQuery && isBasicFunctionalityEnabled,
   });
 
   const filteredData = useMemo(() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->


Adds the existing Verified, Risky, and Malicious trust-signal badges to tokenized stock results in Explore search, covering both the Stocks section and the All aggregated view.

RWA searches now request security data inline from `/v1/rwas` and preserve it while normalizing results into `TrendingAsset`. This reuses the existing display-only `TrendingTokenRowItem` badge implementation and avoids a secondary request or loading-state layout shift. Security data is requested only for non-empty stock searches while Basic Functionality is enabled; with Basic Functionality disabled, the security parameter is omitted and no badges are shown.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added trust-signal badges to tokenized stock search results

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1358

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Tokenized stock trust signals in Explore search

  Scenario: Trust signals are shown in stock search results
    Given Basic Functionality is enabled
    And the RWA API returns Verified, Warning, or Malicious security data

    When the user searches for a tokenized stock from Explore
    Then the matching stock row shows the corresponding Verified, Risky, or Malicious badge
    And the badge is visible in both the Stocks section and the All aggregated view
    And the badge is display-only

  Scenario: Security data is not requested when Basic Functionality is disabled
    Given Basic Functionality is disabled

    When the user searches for a tokenized stock from Explore
    Then the RWA request does not include `includeTokenSecurityData`
    And no trust-signal badge is shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="381" height="265" alt="Screenshot 2026-09-10 at 14 15 55" src="https://github.com/user-attachments/assets/c3a75da9-0710-4cbc-aa6e-e65fe61b87d3" />

<!-- [screenshots/recordings] -->

### **After**
<img width="375" height="264" alt="Screenshot 2026-09-10 at 13 48 41" src="https://github.com/user-attachments/assets/6f6f8a9b-91e1-4680-a7b7-97c8d752f56c" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to optional RWA API params and stocks Explore search; other `useRwaTokens` callers keep defaults with no security fetch.
> 
> **Overview**
> **Explore stock search** can now load **trust-signal (security) data** inline with RWA results so existing Verified / Risky / Malicious badges can render without a second request.
> 
> `useRwaTokens` gains an optional `includeTokenSecurityData` flag that forwards to `fetchRwas` and maps `securityData` onto normalized `TrendingAsset` rows. `useStocksFeed` turns that on only for **non-empty search** when **Basic Functionality** is enabled; tab previews and disabled-basic-functionality searches omit the parameter. Tests cover the new request flag, normalization, and feed gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41bdeb989666089c613744f283ba8157e9051d9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->