### PR TITLE
perf: stop full-parsing 4,107 URLs at startup to read hostnames

### DIFF
--- a/app/util/rpc-domain-utils.test.ts
+++ b/app/util/rpc-domain-utils.test.ts
@@ -10,6 +10,7 @@ import {
   isPublicRpcDomain,
   getNetworkRpcUrl,
   getModuleState,
+  extractHostname,
 } from './rpc-domain-utils';
 
 // Mock dependencies
@@ -241,6 +242,168 @@ describe('rpc-domain-utils', () => {
       });
     });
   });
+  describe('extractHostname', () => {
+    // Reference implementation. Jest's global URL is a spec-compliant WHATWG
+    // parser, so it is what the fast path has to agree with.
+    const spec = (url: string): string | undefined => {
+      try {
+        return new URL(url).hostname.toLowerCase();
+      } catch {
+        return undefined;
+      }
+    };
+
+    describe('agrees with new URL() on realistic RPC endpoints', () => {
+      // Sampled from chainid.network/chains.json, which is the actual input to
+      // `initializeRpcProviderDomains`. The full 4,107-URL corpus was checked
+      // locally with zero divergences; these cover every shape present in it.
+      const realistic = [
+        'https://mainnet.infura.io/v3/abc123',
+        'https://eth-mainnet.alchemyapi.io/v2/key',
+        'https://cloudflare-eth.com',
+        'https://rpc.ankr.com/eth',
+        'https://bsc-dataseed1.binance.org:443',
+        'http://localhost:8545',
+        'http://127.0.0.1:8545',
+        'https://rpc.example.com:8545/path?query=1#frag',
+        'https://user:pass@rpc.example.com:8545/path',
+        'wss://rpc.example.com/ws',
+        'ws://127.0.0.1:8546',
+        'HTTPS://RPC.EXAMPLE.COM/Path',
+        'https://sub.domain.rpc.example.co.uk',
+        'https://rpc.example.com.',
+        'https://[2001:db8::1]:8545/rpc',
+        'https://[::1]',
+        'https://192.168.1.1:8545',
+        'https://rpc-mainnet.matic.network',
+        'https://api.avax.network/ext/bc/C/rpc',
+      ];
+
+      it.each(realistic)('matches for %s', (url) => {
+        expect(extractHostname(url)).toBe(spec(url));
+      });
+    });
+
+    describe('rejects what new URL() rejects', () => {
+      const invalid = [
+        ['no scheme', 'invalid-url'],
+        ['empty string', ''],
+        ['prose', 'not a url at all'],
+        ['scheme only', 'https://'],
+        ['empty host with port', 'https://:8545'],
+        ['triple colon', 'https://:::invalid'],
+        ['empty scheme', '://no-scheme.com'],
+        ['numeric scheme', '1bad://example.com'],
+        ['scheme with space', 'ht tp://example.com'],
+        ['port out of range', 'https://example.com:99999'],
+        ['non-numeric port', 'https://example.com:abc'],
+        ['ipv6 port out of range', 'https://[2001:db8::1]:99999'],
+        ['unterminated ipv6', 'https://[2001:db8::1'],
+      ];
+
+      it.each(invalid)('returns undefined for %s', (_label, url) => {
+        expect(extractHostname(url as string)).toBeUndefined();
+        // Also assert the reference agrees, so these stay meaningful if the
+        // spec parser ever changes underneath us.
+        expect(spec(url as string)).toBeUndefined();
+      });
+    });
+
+    describe('fails closed where it diverges from the spec', () => {
+      // These are deliberate divergences. `isPublicRpcDomain` gates whether an
+      // endpoint URL is reported to analytics, so being stricter is correct;
+      // being more permissive would leak a private endpoint.
+      const stricterThanSpec = [
+        'https://example.com\\evil.com',
+        'https://mainnet.infura.io\\.evil.com',
+        'https://exa\tmple.com',
+        'https://exa\nmple.com',
+        'https://%2e.infura.io',
+        'https://ex%41mple.com',
+        // `new URL()` trims leading C0/space and parses this fine.
+        '  https://example.com',
+      ];
+
+      it.each(stricterThanSpec)(
+        'rejects %s even though the spec accepts it',
+        (url) => {
+          expect(extractHostname(url)).toBeUndefined();
+          expect(spec(url)).toBeDefined();
+        },
+      );
+
+      it('returns an unnormalised host for exotic IPv4, which matches nothing', () => {
+        // The spec normalises this to 127.0.0.1; we return it verbatim, so it
+        // falls through to `private` rather than being recognised.
+        expect(extractHostname('https://0x7f.1')).toBe('0x7f.1');
+        expect(spec('https://0x7f.1')).toBe('127.0.0.1');
+      });
+    });
+
+    describe('security properties', () => {
+      const ALLOWED = ['infura.io', 'alchemyapi.io'];
+      const isAllowed = (host?: string) =>
+        Boolean(host) &&
+        ALLOWED.some(
+          (domain) => host === domain || host?.endsWith(`.${domain}`),
+        );
+
+      // Mirrors the local 58k-input fuzz, kept small enough to run in CI.
+      const fuzzInputs: string[] = [];
+      for (const scheme of ['https', 'http', 'wss', 'HTTPS', '', '1bad']) {
+        for (const host of [
+          'example.com',
+          'mainnet.infura.io',
+          'mainnet.infura.io\\.evil.com',
+          '%2e.infura.io',
+          'exa\tmple.com',
+          '0x7f.1',
+          '[2001:db8::1]',
+          '',
+        ]) {
+          for (const userinfo of ['', 'user:pass@', 'evil.com@']) {
+            for (const port of ['', ':8545', ':99999', ':abc']) {
+              for (const tail of ['', '/v3/k', '?a=b', '\\path']) {
+                fuzzInputs.push(`${scheme}://${userinfo}${host}${port}${tail}`);
+              }
+            }
+          }
+        }
+      }
+
+      it('never accepts a URL that new URL() rejects', () => {
+        const permissive = fuzzInputs.filter(
+          (url) =>
+            extractHostname(url) !== undefined && spec(url) === undefined,
+        );
+        expect(permissive).toEqual([]);
+      });
+
+      it('never matches the provider allowlist when the spec would not', () => {
+        const unsafe = fuzzInputs.filter(
+          (url) => isAllowed(extractHostname(url)) && !isAllowed(spec(url)),
+        );
+        expect(unsafe).toEqual([]);
+      });
+
+      it('strips userinfo so credentials never reach analytics', () => {
+        expect(extractHostname('https://user:secret@rpc.example.com/v1')).toBe(
+          'rpc.example.com',
+        );
+        expect(extractHostname('https://key@mainnet.infura.io')).toBe(
+          'mainnet.infura.io',
+        );
+      });
+    });
+
+    it('rejects a scheme-less URL exactly as new URL() throws on it', () => {
+      // `initializeRpcProviderDomains` feeds raw RPC values straight in and
+      // previously relied on `new URL()` throwing to skip them.
+      expect(() => new URL('invalid-url')).toThrow();
+      expect(extractHostname('invalid-url')).toBeUndefined();
+    });
+  });
+
   describe('extractRpcDomain', () => {
     describe('when processing URLs', () => {
       beforeEach(async () => {

--- a/app/util/rpc-domain-utils.ts
+++ b/app/util/rpc-domain-utils.ts
@@ -46,6 +46,126 @@ export async function getSafeChainsListFromCacheOnly(): Promise<SafeChain[]> {
 }
 
 /**
+ * Extract the lowercased hostname from a URL, without a full WHATWG parse.
+ *
+ * `new URL()` is the obvious way to do this, and it is what this module used
+ * to do. The polyfill installed by `react-native-url-polyfill`
+ * (`whatwg-url-without-unicode`) runs a full state-machine parse with
+ * `ucs2decode`, percent-decoding and IDNA mapping for every URL.
+ *
+ * Per call that is unremarkable — a release-build CPU profile puts it at
+ * roughly 0.24 ms on a mid-range Android device. The problem is volume:
+ * {@link initializeRpcProviderDomains} parses every RPC endpoint of every chain
+ * in the cached safe-chains list, and `chainid.network/chains.json` currently
+ * carries **2,757 chains with 4,107 RPC URLs**. That measured **~1 second of
+ * the startup JS thread**, purely to read hostnames.
+ *
+ * This reads the authority component directly, which is all the callers need.
+ * Deliberately matched to `new URL()` on the inputs that matter:
+ *
+ * It requires a scheme, so a bare `"invalid-url"` is rejected exactly as
+ * `new URL()` throws on it. It strips userinfo, port, path, query and fragment,
+ * preserves IPv6 literals in brackets, and lowercases, since callers compare
+ * case-insensitively.
+ *
+ * It agrees with `new URL().hostname` on all 4,107 RPC URLs in
+ * `chains.json`, and on a 58k-input fuzz it **never accepts a URL that
+ * `new URL()` rejects**. That direction matters: `isPublicRpcDomain` decides
+ * whether an endpoint URL is safe to report to analytics, so every divergence
+ * has to fail closed.
+ *
+ * Where it does diverge, it is always stricter or produces an unrecognised
+ * hostname — both of which classify as `invalid`/`private` and are therefore
+ * *not* reported:
+ *
+ * Backslashes: `new URL()` treats them as a path separator for special schemes,
+ * so `https://host\\evil.com` parses as host `host`. Rejected here.
+ * Whitespace: `new URL()` strips tabs and newlines mid-host. Rejected here.
+ * Percent-encoding: `new URL()` decodes it, and guessing at that could turn a
+ * hostile host into a trusted-looking one, so it is rejected.
+ * Exotic IPv4 and IDN: `new URL()` normalises `0x7f.1` to `127.0.0.1` and
+ * unicode hosts to punycode. This returns the raw form, which will not match
+ * anything.
+ *
+ * Both the set-building and lookup paths use this function, so set membership
+ * stays self-consistent regardless.
+ *
+ * @param url - The URL to extract a hostname from.
+ * @returns The lowercased hostname, or `undefined` if the URL has no usable one.
+ */
+export function extractHostname(url: string): string | undefined {
+  const schemeEnd = url.indexOf('://');
+  if (schemeEnd === -1) {
+    return undefined;
+  }
+
+  // A URL needs a real scheme; `new URL('://example.com')` throws.
+  if (!/^[a-z][a-z0-9+.-]*$/iu.test(url.slice(0, schemeEnd))) {
+    return undefined;
+  }
+
+  let authority = url.slice(schemeEnd + 3);
+
+  const pathStart = authority.search(/[/?#]/u);
+  if (pathStart !== -1) {
+    authority = authority.slice(0, pathStart);
+  }
+
+  // Userinfo may itself contain '@', so the last one delimits the host.
+  const userInfoEnd = authority.lastIndexOf('@');
+  if (userInfoEnd !== -1) {
+    authority = authority.slice(userInfoEnd + 1);
+  }
+
+  let host: string;
+  let port: string | undefined;
+
+  if (authority.startsWith('[')) {
+    // IPv6 literal, which keeps its brackets in `URL.hostname`.
+    const bracketEnd = authority.indexOf(']');
+    if (bracketEnd === -1) {
+      return undefined;
+    }
+    host = authority.slice(0, bracketEnd + 1);
+    const afterHost = authority.slice(bracketEnd + 1);
+    if (afterHost !== '') {
+      if (!afterHost.startsWith(':')) {
+        return undefined;
+      }
+      port = afterHost.slice(1);
+    }
+  } else {
+    const portStart = authority.indexOf(':');
+    host = portStart === -1 ? authority : authority.slice(0, portStart);
+    if (portStart !== -1) {
+      port = authority.slice(portStart + 1);
+    }
+
+    // `new URL()` rejects empty hosts and these forbidden characters.
+    // `%` is rejected rather than decoded: `new URL()` percent-decodes hosts,
+    // and guessing at that here could turn a hostile host into a trusted-looking
+    // one. No real RPC endpoint uses it (0 of 4,107 in `chains.json`).
+    if (!host || /[\s\\/?#@[\]<>"^|%]/u.test(host)) {
+      return undefined;
+    }
+  }
+
+  // `new URL()` rejects the whole URL on a malformed port, so this must too.
+  // Without it, `https://example.com:99999` would yield a hostname here while
+  // `new URL()` throws — making this function *more* permissive than the spec,
+  // which is the wrong direction: `isPublicRpcDomain` decides whether an
+  // endpoint URL is safe to report to analytics, so every divergence should
+  // fail closed.
+  if (port !== undefined && port !== '') {
+    if (!/^\d{1,5}$/u.test(port) || Number(port) > 65535) {
+      return undefined;
+    }
+  }
+
+  return host.toLowerCase();
+}
+
+/**
  * Initialize the set of known domains from the chains list
  */
 export async function initializeRpcProviderDomains(): Promise<void> {
@@ -61,11 +181,9 @@ export async function initializeRpcProviderDomains(): Promise<void> {
       for (const chain of chainsList) {
         if (chain.rpc && Array.isArray(chain.rpc)) {
           for (const rpcUrl of chain.rpc) {
-            try {
-              const url = new URL(rpcUrl);
-              newKnownDomainsSet.add(url.hostname.toLowerCase());
-            } catch (e) {
-              continue; // Skip invalid URLs
+            const hostname = extractHostname(rpcUrl);
+            if (hostname) {
+              newKnownDomainsSet.add(hostname);
             }
           }
         }
@@ -120,12 +238,11 @@ export function isPublicRpcDomain(endpointUrl: string): boolean {
 }
 
 function parseDomain(url: string): string | undefined {
-  try {
-    const normalizedUrl = url.includes('://') ? url : `https://${url}`;
-    return new URL(normalizedUrl).hostname.toLowerCase();
-  } catch {
-    return undefined;
-  }
+  // Must use the same extractor as `initializeRpcProviderDomains`, otherwise a
+  // hostname could be stored one way and looked up another, and known domains
+  // would silently report as `private`.
+  const normalizedUrl = url.includes('://') ? url : `https://${url}`;
+  return extractHostname(normalizedUrl);
 }
 
 // Allowed provider domains for RPC endpoint validation


### PR DESCRIPTION
## **Description**

`initializeRpcProviderDomains` builds the known-RPC-domain set used to label RPC endpoints in analytics. For every RPC endpoint of every chain in the cached safe-chains list, it called `new URL(rpcUrl)` and read `.hostname`:

```js
const url = new URL(rpcUrl);
newKnownDomainsSet.add(url.hostname.toLowerCase());
```

`chainid.network/chains.json` currently carries **2,757 chains with 4,107 RPC URLs**, so that is 4,107 full WHATWG parses during startup.

A **symbolicated** release-build CPU profile attributes **~1,000 ms of a Galaxy A14 cold start to this one call site** — 98.3 % of all URL parsing during startup, and the bulk of the post-init gap:

```
1000 ms  98.3%  ?anon_0_@/app/util/rpc-domain-utils.ts:65
  17 ms   1.7%  UiSlotsApiReadClient@.../UiSlotsApiReadClient.ts:89
```

`Engine.ts:581` fires it fire-and-forget with the comment *"runs asynchronously and doesn't block Engine initialization"*. That is true of the synchronous init, but not of the single JS thread it competes for.

### The fix

Per call the polyfill is unremarkable — about **0.24 ms**, roughly 2× an M1, i.e. normal. **The problem is volume, not the parser**, so this replaces the *parse* rather than the parser. `extractHostname` reads the authority component directly, which is all either caller needs.

**Both call sites move together** — the set builder and the lookup (`parseDomain`). Had only one moved, a hostname could be stored one way and looked up another, and known domains would silently report as `private`.

### Correctness

This matters more than the speed: `isPublicRpcDomain` feeds `isPublicEndpointUrl`, which decides whether a user's RPC endpoint URL is **safe to send to Segment**. So every divergence has to fail closed.

| Check | Result |
|---|---|
| Differential vs `new URL()` on **all 4,107 real RPC URLs** in `chains.json` | **0 divergences** |
| 58k-input fuzz — ever accepts a URL `new URL()` rejects? | **0 cases** |
| Ever matches the infura/alchemy allowlist when the spec would not? | **0 cases** |

Where it does diverge it is always **stricter**, or returns an unnormalised host that matches nothing and therefore classifies as `private`:

- **Backslashes** — `new URL()` treats `\` as a path separator for special schemes, so `https://host\evil.com` parses as host `host`. Rejected here.
- **Whitespace** — `new URL()` strips tabs and newlines mid-host. Rejected here.
- **Percent-encoded hosts** — `new URL()` decodes them. Rejected rather than decoded, because guessing at the decoding could turn a hostile host into a trusted-looking one. Zero of the 4,107 real URLs use it.
- **Exotic IPv4 / IDN** — `new URL()` normalises `0x7f.1` to `127.0.0.1` and unicode to punycode. Returned verbatim, so it simply matches nothing.

The fuzz earned its place — it drove two real fixes during development:

1. Invalid ports such as `:99999` were initially **accepted** where `new URL()` rejects the whole URL (9,102 inputs). Added port validation.
2. After that, 1,224 remained because the IPv6 branch returned before the port check. Restructured so both host forms validate it.

### Results

Galaxy A14 5G, Android 15, `production` release build, populated wallet, cold starts, n=5 medians. `engine_init_end` → `appServicesReady`:

| | post-init gap |
|---|---:|
| Before | 1,097 ms |
| After | **152 ms** |
| | **−945 ms** |

No other stage moved: controller rehydration 93 → 115 ms, `Engine.init` 760 → 786 ms — both inside run-to-run noise.

### Alternatives considered

- **Upgrade `react-native-url-polyfill`.** No help: the latest 2.0.0 depends on the identical `whatwg-url-without-unicode@8.0.0-3` as our 1.3.0.
- **[`react-native-fast-url`](https://github.com/KusStar/react-native-fast-url)** — JSI bindings to `ada`, the parser Node.js uses, benchmarked ~34× faster. Genuinely promising for URL parsing *app-wide*, but it is 25 stars with one maintainer, last commit Sep 2025, tested on RN 0.76/0.80 (we are on 0.83.6), and ~500 KB of native binary per ABI. Adopting it as the URL parser for deeplinks, dapp origins and phishing checks is a supply-chain decision, not a perf tweak — and it would still leave 4,107 parses happening at startup, just faster.
- **Don't derive the set at startup at all.** Strictly better and worth a follow-up: `useSafeChains` already writes `SAFE_CHAINS_CACHE`, so it could persist the hostname set and startup would parse nothing. Left out here to keep this change behaviour-preserving.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs:

## **Manual testing steps**

```gherkin
Feature: RPC domain labelling after removing the startup URL parse

  Scenario: analytics still labels a known public RPC endpoint
    Given the safe-chains cache has been populated
    And metrics are enabled

    When user submits a transaction on a public network such as Ethereum mainnet
    Then the finalized transaction event carries rpc_domain with the real hostname
    And it matches what was reported before this change

  Scenario: a private endpoint is still not reported
    Given the wallet has a custom network on a private or localhost RPC URL

    When user submits a transaction on that network
    Then rpc_domain is "private" and the endpoint URL is not shared

  Scenario: adding a custom network
    When user adds a network whose RPC URL is a known public provider
    Then it is treated as public exactly as before
    And an unknown or private RPC URL is still treated as private
```

## **Screenshots/Recordings**

### **Before**

N/A — no UI change. The measured difference is startup timing, in the Results table above.

### **After**

N/A — no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
  - 83 tests in `rpc-domain-utils.test.ts`, including spec-equivalence on realistic endpoints, explicit fail-closed cases for every known divergence, and two security properties over a fuzz corpus. 213 tests pass across the two consumer suites.
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Samsung Galaxy A14 5G (SM-A146P), Android 15, `production` release build — a mid-range physical device.
- [x] I've tested with a power user scenario
  - Populated wallet with several imported accounts. This cost is driven by the size of the chains list rather than by wallet contents, so it is paid identically by every user.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - No new instrumentation. Note this window is not covered by a shipped span today, so the saving will not appear in Sentry until something covers it.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
