### PR TITLE
feat(card): instrument the redeem funnel for cashback and mUSD Back

### DIFF
--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -422,10 +422,6 @@ const CardHome = () => {
     refundFiatLabel,
   ]);
 
-  const handleRedeemCredit = useCallback(() => {
-    navigation.navigate(Routes.CARD.CREDIT_REDEEM);
-  }, [navigation]);
-
   const handleOpenUkMigrationSheet = useCallback(() => {
     navigation.navigate(Routes.CARD.MODALS.ID, {
       screen: Routes.CARD.MODALS.UK_MIGRATION,
@@ -758,7 +754,7 @@ const CardHome = () => {
                     : CardMessageBoxType.CreditAvailableNoMoneyAccount
                 }
                 values={{ amount: refundFiatLabel }}
-                onConfirm={handleRedeemCredit}
+                onConfirm={actions.redeemCreditAction}
               />
             </Box>
           )}

--- a/app/components/UI/Card/Views/CardHome/hooks/useCardHomeActions.test.ts
+++ b/app/components/UI/Card/Views/CardHome/hooks/useCardHomeActions.test.ts
@@ -22,13 +22,19 @@ jest.mock('../../../../../../util/theme', () => ({
   useTheme: () => ({ colors: { success: { default: 'mock-success' } } }),
 }));
 
+const mockCreateEventBuilder = jest.fn();
+const mockAddProperties = jest.fn(() => ({ build: () => ({}) }));
+
 jest.mock('../../../../../hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: () => ({
     trackEvent: jest.fn(),
-    createEventBuilder: () => ({
-      addProperties: () => ({ build: () => ({}) }),
-      build: () => ({}),
-    }),
+    createEventBuilder: (event: unknown) => {
+      mockCreateEventBuilder(event);
+      return {
+        addProperties: mockAddProperties,
+        build: () => ({}),
+      };
+    },
   }),
 }));
 
@@ -172,6 +178,42 @@ describe('useCardHomeActions — transactionHistoryAction', () => {
     expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.AUTHENTICATION, {
       showAuthPrompt: true,
       postAuthRedirect: { screen: Routes.CARD.TRANSACTION_HISTORY },
+    });
+  });
+});
+
+describe('useCardHomeActions — redeem entry points', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens the credit redeem screen and reports the entry click', () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.redeemCreditAction();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.CREDIT_REDEEM);
+    expect(mockAddProperties).toHaveBeenCalledWith({
+      provider: 'baanx',
+      action: 'CREDIT_BUTTON',
+      type: 'open_redeem',
+    });
+  });
+
+  it('distinguishes the cashback entry click from the withdraw press', () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.cashbackAction();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.CASHBACK);
+    expect(mockAddProperties).toHaveBeenCalledWith({
+      provider: 'baanx',
+      action: 'CASHBACK_BUTTON',
+      type: 'open_redeem',
     });
   });
 });

--- a/app/components/UI/Card/Views/CardHome/hooks/useCardHomeActions.ts
+++ b/app/components/UI/Card/Views/CardHome/hooks/useCardHomeActions.ts
@@ -670,6 +670,7 @@ export function useCardHomeActions({
         .addProperties(
           withCardProvider(activeProviderId, {
             action: CardActions.CASHBACK_BUTTON,
+            type: 'open_redeem',
           }),
         )
         .build(),
@@ -686,6 +687,20 @@ export function useCardHomeActions({
     createEventBuilder,
     activeProviderId,
   ]);
+
+  const redeemCreditAction = useCallback(() => {
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
+        .addProperties(
+          withCardProvider(activeProviderId, {
+            action: CardActions.CREDIT_BUTTON,
+            type: 'open_redeem',
+          }),
+        )
+        .build(),
+    );
+    navigation.navigate(Routes.CARD.CREDIT_REDEEM);
+  }, [navigation, trackEvent, createEventBuilder, activeProviderId]);
 
   const transactionHistoryAction = useCallback(
     (destination: 'card' | 'money') => {
@@ -734,6 +749,7 @@ export function useCardHomeActions({
     logoutAction,
     orderMetalCardAction,
     cashbackAction,
+    redeemCreditAction,
     transactionHistoryAction,
     navigateToTravelPage,
     navigateToCardTosPage,

--- a/app/components/UI/Card/Views/Cashback/Cashback.test.tsx
+++ b/app/components/UI/Card/Views/Cashback/Cashback.test.tsx
@@ -33,6 +33,7 @@ jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
 jest.mock('../../../../../core/Analytics', () => ({
   MetaMetricsEvents: {
     CARD_BUTTON_CLICKED: 'CARD_BUTTON_CLICKED',
+    CARD_VIEWED: 'CARD_VIEWED',
   },
 }));
 
@@ -818,6 +819,96 @@ describe('Cashback Component', () => {
         action: 'CASHBACK_BUTTON',
         type: 'withdraw',
         provider: 'baanx',
+      });
+    });
+  });
+
+  describe('funnel analytics', () => {
+    const withdrawableWallet = {
+      id: 'w1',
+      balance: '10.00',
+      currency: 'musd',
+      isWithdrawable: true,
+      type: 'reward',
+    };
+    const settledEstimation = {
+      wei: '100000',
+      eth: '0.0001',
+      price: '0.50',
+      network: 'linea',
+    };
+
+    const viewedCalls = () =>
+      mockCreateEventBuilder.mock.calls.filter(
+        ([name]) => name === 'CARD_VIEWED',
+      );
+
+    it('reports the view once the estimation settles', () => {
+      mockHookReturn.wallet = withdrawableWallet;
+      mockHookReturn.estimation = settledEstimation;
+
+      render();
+
+      expect(viewedCalls()).toHaveLength(1);
+      expect(mockEventBuilder.addProperties).toHaveBeenCalledWith({
+        provider: 'baanx',
+        screen: 'CASHBACK',
+        destination: 'wallet',
+        is_withdrawable: true,
+        needs_setup: false,
+        has_insufficient_balance: false,
+        has_loading_error: false,
+      });
+    });
+
+    it('holds the view until the estimation settles', () => {
+      mockHookReturn.wallet = withdrawableWallet;
+
+      render();
+
+      expect(viewedCalls()).toHaveLength(0);
+    });
+
+    it('reports the view with an unresolved destination when the estimation fails', () => {
+      mockHookReturn.wallet = withdrawableWallet;
+      mockHookReturn.estimationError = new Error('estimation unavailable');
+
+      render({ destination: { isResolved: false } });
+
+      expect(viewedCalls()).toHaveLength(1);
+      expect(mockEventBuilder.addProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          screen: 'CASHBACK',
+          destination: 'unresolved',
+        }),
+      );
+    });
+
+    it('reports the view as blocked when funding setup is missing', () => {
+      mockHookReturn.wallet = withdrawableWallet;
+      mockHookReturn.estimation = settledEstimation;
+
+      render({ destination: { hasApprovedDestination: false } });
+
+      expect(mockEventBuilder.addProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          screen: 'CASHBACK',
+          needs_setup: true,
+        }),
+      );
+    });
+
+    it('tracks the setup CTA press', () => {
+      mockHookReturn.wallet = withdrawableWallet;
+      mockHookReturn.estimation = settledEstimation;
+
+      render({ destination: { hasApprovedDestination: false } });
+      fireEvent.press(screen.getByText('Set up funding'));
+
+      expect(mockEventBuilder.addProperties).toHaveBeenCalledWith({
+        provider: 'baanx',
+        action: 'CASHBACK_BUTTON',
+        type: 'setup',
       });
     });
   });

--- a/app/components/UI/Card/Views/Cashback/Cashback.test.tsx
+++ b/app/components/UI/Card/Views/Cashback/Cashback.test.tsx
@@ -793,6 +793,52 @@ describe('Cashback Component', () => {
       });
     });
 
+    it('caps excess-precision balances before claiming and displaying', async () => {
+      mockHookReturn.wallet = {
+        id: 'w1',
+        balance: '17.96660759',
+        currency: 'musd',
+        isWithdrawable: true,
+        type: 'reward',
+      };
+      mockHookReturn.estimation = {
+        wei: '100000',
+        eth: '0.0001',
+        price: '0.50',
+      };
+
+      render();
+
+      expect(screen.getByText(/17\.9666/)).toBeOnTheScreen();
+
+      fireEvent.press(screen.getByTestId(CashbackSelectors.WITHDRAW_BUTTON));
+
+      await waitFor(() => {
+        expect(mockWithdraw).toHaveBeenCalledWith('17.9666');
+      });
+    });
+
+    it('disables withdraw when the capped balance is dust below 4 decimals', () => {
+      mockHookReturn.wallet = {
+        id: 'w1',
+        balance: '0.00009',
+        currency: 'musd',
+        isWithdrawable: true,
+        type: 'reward',
+      };
+      mockHookReturn.estimation = {
+        wei: '100000',
+        eth: '0.0001',
+        price: '0',
+      };
+
+      render();
+
+      expect(screen.getByText('Withdrawal unavailable')).toBeOnTheScreen();
+      fireEvent.press(screen.getByTestId(CashbackSelectors.WITHDRAW_BUTTON));
+      expect(mockWithdraw).not.toHaveBeenCalled();
+    });
+
     it('tracks analytics event on withdraw', () => {
       mockHookReturn.wallet = {
         id: 'w1',

--- a/app/components/UI/Card/Views/CreditRedeem/CreditRedeem.test.tsx
+++ b/app/components/UI/Card/Views/CreditRedeem/CreditRedeem.test.tsx
@@ -25,7 +25,10 @@ jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
 }));
 
 jest.mock('../../../../../core/Analytics', () => ({
-  MetaMetricsEvents: { CARD_BUTTON_CLICKED: 'CARD_BUTTON_CLICKED' },
+  MetaMetricsEvents: {
+    CARD_BUTTON_CLICKED: 'CARD_BUTTON_CLICKED',
+    CARD_VIEWED: 'CARD_VIEWED',
+  },
 }));
 
 jest.mock('../../util/metrics', () => ({
@@ -194,6 +197,42 @@ describe('CreditRedeem', () => {
     mockCreateEventBuilder.mockReturnValue(mockEventBuilder);
     mockHookReturn = createMockHookReturn();
     mockDestination = defaultDestination();
+  });
+
+  describe('funnel analytics', () => {
+    const viewedCalls = () =>
+      mockCreateEventBuilder.mock.calls.filter(
+        ([name]) => name === 'CARD_VIEWED',
+      );
+
+    it('reports the view against the credit screen and money account destination', () => {
+      render();
+
+      expect(viewedCalls()).toHaveLength(1);
+      expect(mockEventBuilder.addProperties).toHaveBeenCalledWith({
+        provider: 'baanx',
+        screen: 'CREDIT_REDEEM',
+        destination: 'money_account',
+        is_withdrawable: true,
+        needs_setup: false,
+        has_insufficient_balance: false,
+        has_loading_error: false,
+      });
+    });
+
+    it('tracks the refund info tooltip press', () => {
+      render();
+
+      fireEvent.press(
+        screen.getByTestId(CreditRedeemSelectors.REFUND_INFO_BUTTON),
+      );
+
+      expect(mockEventBuilder.addProperties).toHaveBeenCalledWith({
+        provider: 'baanx',
+        action: 'CREDIT_BUTTON',
+        type: 'refund_info',
+      });
+    });
   });
 
   it('renders the "Card refunds" title and "Refund balance" label', () => {

--- a/app/components/UI/Card/Views/RedeemWallet/RedeemWallet.config.ts
+++ b/app/components/UI/Card/Views/RedeemWallet/RedeemWallet.config.ts
@@ -1,5 +1,5 @@
 import { CardMessageBoxType } from '../../types';
-import { CardActions } from '../../util/metrics';
+import { CardActions, CardScreens } from '../../util/metrics';
 import {
   CASHBACK_MONEY_ACCOUNT_ORIGIN,
   CREDIT_MONEY_ACCOUNT_ORIGIN,
@@ -38,6 +38,7 @@ interface RedeemModeConfig {
   moneyAccountRequiredType: CardMessageBoxType;
   moneyAccountOrigin: LinkFlowOrigin;
   analyticsAction: CardActions;
+  analyticsScreen: CardScreens;
   showRefundInfo: boolean;
   showFiatBalance: boolean;
 }
@@ -60,6 +61,7 @@ export const REDEEM_CONFIG: Record<RedeemableWalletMode, RedeemModeConfig> = {
     moneyAccountRequiredType: CardMessageBoxType.CashbackMoneyAccountRequired,
     moneyAccountOrigin: CASHBACK_MONEY_ACCOUNT_ORIGIN,
     analyticsAction: CardActions.CASHBACK_BUTTON,
+    analyticsScreen: CardScreens.CASHBACK,
     showRefundInfo: false,
     showFiatBalance: false,
   },
@@ -82,6 +84,7 @@ export const REDEEM_CONFIG: Record<RedeemableWalletMode, RedeemModeConfig> = {
     moneyAccountRequiredType: CardMessageBoxType.CreditMoneyAccountRequired,
     moneyAccountOrigin: CREDIT_MONEY_ACCOUNT_ORIGIN,
     analyticsAction: CardActions.CREDIT_BUTTON,
+    analyticsScreen: CardScreens.CREDIT_REDEEM,
     showRefundInfo: true,
     showFiatBalance: true,
   },

--- a/app/components/UI/Card/Views/RedeemWallet/RedeemWallet.tsx
+++ b/app/components/UI/Card/Views/RedeemWallet/RedeemWallet.tsx
@@ -60,6 +60,7 @@ import {
 } from './RedeemWallet.utils';
 import { REDEEM_CONFIG } from './RedeemWallet.config';
 import { CardRedeemWithdrawalInProgressError } from '../../../../../core/Engine/controllers/card-controller/provider-types';
+import { capRedeemAmount } from '../../../../../core/Engine/controllers/card-controller/utils/redeemAmount';
 
 interface RedeemWalletProps {
   mode: RedeemableWalletMode;
@@ -96,7 +97,7 @@ const RedeemWallet: React.FC<RedeemWalletProps> = ({ mode }) => {
     resetWithdraw,
   } = useRedeemableWallet(mode);
 
-  const balance = wallet?.balance ?? '0';
+  const balance = capRedeemAmount(wallet?.balance ?? '0');
   const currency = formatCurrency(wallet?.currency ?? '');
   const isWithdrawable = wallet?.isWithdrawable ?? false;
 

--- a/app/components/UI/Card/Views/RedeemWallet/RedeemWallet.tsx
+++ b/app/components/UI/Card/Views/RedeemWallet/RedeemWallet.tsx
@@ -37,13 +37,8 @@ import useRedeemableWallet, {
 } from '../../hooks/useRedeemableWallet';
 import useRedeemDestination from '../../hooks/useRedeemDestination';
 import { useMoneyAccountCardLinkage } from '../../hooks/useMoneyAccountCardLinkage';
-import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../../../core/Analytics';
-import {
-  selectCardHomeDataStatus,
-  selectCardActiveProviderId,
-} from '../../../../../selectors/cardController';
-import { withCardProvider } from '../../util/metrics';
+import { selectCardHomeDataStatus } from '../../../../../selectors/cardController';
+import { useRedeemWalletAnalytics } from './hooks/useRedeemWalletAnalytics';
 import { getMemoizedInternalAccountByAddress } from '../../../../../selectors/accountsController';
 import { selectAvatarAccountType } from '../../../../../selectors/settings';
 import {
@@ -78,8 +73,6 @@ const RedeemWallet: React.FC<RedeemWalletProps> = ({ mode }) => {
   const headerHandlers = useCardHeaderHandlers('back');
   const theme = useTheme();
   const { toastRef } = useContext(ToastContext);
-  const { trackEvent, createEventBuilder } = useAnalytics();
-  const activeProviderId = useSelector(selectCardActiveProviderId);
 
   const cardHomeDataStatus = useSelector(selectCardHomeDataStatus);
   const currencyRates = useSelector(selectCurrencyRates);
@@ -93,6 +86,7 @@ const RedeemWallet: React.FC<RedeemWalletProps> = ({ mode }) => {
     error,
     estimation,
     isEstimating,
+    estimationError,
     fetchEstimation,
     withdraw,
     isWithdrawing,
@@ -204,6 +198,20 @@ const RedeemWallet: React.FC<RedeemWalletProps> = ({ mode }) => {
   const showSetupBanner =
     needsSetup && (!useMoneyAccountFlow || canLinkMoneyAccount);
 
+  const { trackRedeemButton } = useRedeemWalletAnalytics({
+    mode,
+    isWalletLoading: isLoading,
+    isFundingStatusLoading,
+    hasLoadingError: showLoadingError,
+    hasEstimation: !!estimation,
+    hasEstimationError: !!estimationError,
+    isDestinationResolved: destination.isResolved,
+    isMoneyAccountDestination: destination.isMoneyAccountDestination,
+    isWithdrawable,
+    needsSetup,
+    hasInsufficientBalance,
+  });
+
   // Fetch when wallet data becomes available (including late loads while focused).
   useEffect(() => {
     if (wallet) {
@@ -282,16 +290,7 @@ const RedeemWallet: React.FC<RedeemWalletProps> = ({ mode }) => {
       return;
     }
 
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
-        .addProperties(
-          withCardProvider(activeProviderId, {
-            action: config.analyticsAction,
-            type: 'withdraw',
-          }),
-        )
-        .build(),
-    );
+    trackRedeemButton('withdraw');
 
     try {
       await fetchEstimation();
@@ -304,14 +303,11 @@ const RedeemWallet: React.FC<RedeemWalletProps> = ({ mode }) => {
     balance,
     withdraw,
     fetchEstimation,
-    trackEvent,
-    createEventBuilder,
-    activeProviderId,
+    trackRedeemButton,
     needsSetup,
     isFundingStatusUnavailable,
     isWithdrawing,
     monitoringStatus,
-    config,
   ]);
 
   const handleNavigateToSpendingLimit = useCallback(() => {
@@ -324,12 +320,14 @@ const RedeemWallet: React.FC<RedeemWalletProps> = ({ mode }) => {
   }, [navigation, destination.delegationToken]);
 
   const handleSetupPress = useCallback(() => {
+    trackRedeemButton('setup');
     if (useMoneyAccountFlow) {
       startLinkFlow(config.moneyAccountOrigin);
       return;
     }
     handleNavigateToSpendingLimit();
   }, [
+    trackRedeemButton,
     useMoneyAccountFlow,
     startLinkFlow,
     handleNavigateToSpendingLimit,
@@ -337,11 +335,12 @@ const RedeemWallet: React.FC<RedeemWalletProps> = ({ mode }) => {
   ]);
 
   const handleOpenRefundInfo = useCallback(() => {
+    trackRedeemButton('refund_info');
     navigation.navigate(Routes.CARD.MODALS.ID, {
       screen: Routes.CARD.MODALS.CREDIT_REFUND_TOOLTIP,
       params: { isMoneyAccount: destination.isMoneyAccountDestination },
     });
-  }, [navigation, destination.isMoneyAccountDestination]);
+  }, [trackRedeemButton, navigation, destination.isMoneyAccountDestination]);
 
   // Keep the button locked through success until resetWithdraw/goBack run —
   // otherwise it briefly re-enables between monitor completion and navigation.

--- a/app/components/UI/Card/Views/RedeemWallet/RedeemWallet.utils.test.ts
+++ b/app/components/UI/Card/Views/RedeemWallet/RedeemWallet.utils.test.ts
@@ -3,6 +3,7 @@ import {
   formatCurrency,
   getRedeemWithdrawalAmounts,
 } from './RedeemWallet.utils';
+import { capRedeemAmount } from '../../../../../core/Engine/controllers/card-controller/utils/redeemAmount';
 
 describe('RedeemWallet.utils', () => {
   describe('formatCurrency', () => {
@@ -28,6 +29,28 @@ describe('RedeemWallet.utils', () => {
     it('returns 0.00 for NaN', () => {
       expect(formatAmount('invalid')).toBe('0.00');
     });
+  });
+
+  describe('shown-equals-claimed invariant', () => {
+    it.each([
+      '17.96660759',
+      '10.1234567',
+      '1.12345',
+      '0.99999',
+      '10.1234',
+      '10.00',
+      '0.0007',
+    ])(
+      'formatAmount of the capped value matches the displayed form of %s',
+      (raw) => {
+        const claimed = capRedeemAmount(raw);
+        // formatAmount pads to at least 2 decimals and trims trailing zeros
+        // beyond that; the claimed wire string may be shorter (e.g. '1.1').
+        // The invariant is that formatting the claimed amount reproduces the
+        // display of the raw amount — i.e. display and claim share one floor.
+        expect(formatAmount(claimed)).toBe(formatAmount(raw));
+      },
+    );
   });
 
   describe('getRedeemWithdrawalAmounts', () => {

--- a/app/components/UI/Card/Views/RedeemWallet/RedeemWallet.utils.ts
+++ b/app/components/UI/Card/Views/RedeemWallet/RedeemWallet.utils.ts
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { safeParseBigNumber } from '../../../../../util/number/bignumber';
+import { REDEEM_AMOUNT_DECIMALS } from '../../../../../core/Engine/controllers/card-controller/utils/redeemAmount';
 
 const CURRENCY_DISPLAY_MAP: Record<string, string> = {
   musd: 'mUSD',
@@ -7,7 +8,7 @@ const CURRENCY_DISPLAY_MAP: Record<string, string> = {
   usdt: 'USDT',
 };
 
-export const DISPLAY_PRECISION = 4;
+export const DISPLAY_PRECISION = REDEEM_AMOUNT_DECIMALS;
 const ZERO = new BigNumber(0);
 
 export const formatCurrency = (raw: string): string =>

--- a/app/components/UI/Card/Views/RedeemWallet/hooks/useRedeemWalletAnalytics.ts
+++ b/app/components/UI/Card/Views/RedeemWallet/hooks/useRedeemWalletAnalytics.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../../../core/Analytics';
+import { selectCardActiveProviderId } from '../../../../../../selectors/cardController';
+import { withCardProvider } from '../../../util/metrics';
+import type { RedeemableWalletMode } from '../../../hooks/useRedeemableWallet';
+import { REDEEM_CONFIG } from '../RedeemWallet.config';
+
+type RedeemDestination = 'money_account' | 'wallet' | 'unresolved';
+
+interface UseRedeemWalletAnalyticsParams {
+  mode: RedeemableWalletMode;
+  isWalletLoading: boolean;
+  isFundingStatusLoading: boolean;
+  hasLoadingError: boolean;
+  hasEstimation: boolean;
+  hasEstimationError: boolean;
+  isDestinationResolved: boolean;
+  isMoneyAccountDestination: boolean;
+  isWithdrawable: boolean;
+  needsSetup: boolean;
+  hasInsufficientBalance: boolean;
+}
+
+/**
+ * Redeem funnel instrumentation for both cashback and credit: the screen view
+ * plus the button clicks leading up to a withdrawal. The withdrawal outcome
+ * itself is emitted by `CardController`, which outlives this screen.
+ */
+export function useRedeemWalletAnalytics({
+  mode,
+  isWalletLoading,
+  isFundingStatusLoading,
+  hasLoadingError,
+  hasEstimation,
+  hasEstimationError,
+  isDestinationResolved,
+  isMoneyAccountDestination,
+  isWithdrawable,
+  needsSetup,
+  hasInsufficientBalance,
+}: UseRedeemWalletAnalyticsParams) {
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const activeProviderId = useSelector(selectCardActiveProviderId);
+  const config = REDEEM_CONFIG[mode];
+  const hasTrackedView = useRef(false);
+
+  const trackRedeemButton = useCallback(
+    (type: string) => {
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
+          .addProperties(
+            withCardProvider(activeProviderId, {
+              action: config.analyticsAction,
+              type,
+            }),
+          )
+          .build(),
+      );
+    },
+    [trackEvent, createEventBuilder, activeProviderId, config],
+  );
+
+  // Waits on the estimation because it resolves the destination chain, but
+  // settles on its failure too: an estimation that never succeeds leaves the
+  // withdraw button permanently disabled, which is a drop-off worth counting
+  // rather than a reason to stay silent.
+  const isSettled =
+    hasLoadingError ||
+    (!isWalletLoading &&
+      !isFundingStatusLoading &&
+      (hasEstimation || hasEstimationError));
+
+  useEffect(() => {
+    if (hasTrackedView.current || !isSettled) return;
+    hasTrackedView.current = true;
+
+    let destination: RedeemDestination = 'unresolved';
+    if (isDestinationResolved) {
+      destination = isMoneyAccountDestination ? 'money_account' : 'wallet';
+    }
+
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.CARD_VIEWED)
+        .addProperties(
+          withCardProvider(activeProviderId, {
+            screen: config.analyticsScreen,
+            destination,
+            is_withdrawable: isWithdrawable,
+            needs_setup: needsSetup,
+            has_insufficient_balance: hasInsufficientBalance,
+            has_loading_error: hasLoadingError,
+          }),
+        )
+        .build(),
+    );
+  }, [
+    isSettled,
+    isDestinationResolved,
+    isMoneyAccountDestination,
+    isWithdrawable,
+    needsSetup,
+    hasInsufficientBalance,
+    hasLoadingError,
+    trackEvent,
+    createEventBuilder,
+    activeProviderId,
+    config,
+  ]);
+
+  return { trackRedeemButton };
+}

--- a/app/components/UI/Card/util/metrics.ts
+++ b/app/components/UI/Card/util/metrics.ts
@@ -28,6 +28,8 @@ enum CardScreens {
   ORDER_COMPLETED = 'ORDER_COMPLETED',
   SET_PIN = 'SET_PIN',
   CONFIRM_PIN = 'CONFIRM_PIN',
+  CASHBACK = 'CASHBACK',
+  CREDIT_REDEEM = 'CREDIT_REDEEM',
 }
 
 enum CardActions {

--- a/app/core/Analytics/MetaMetrics.events.ts
+++ b/app/core/Analytics/MetaMetrics.events.ts
@@ -689,6 +689,9 @@ enum EVENT_NAME {
   CARD_TRANSACTION_HISTORY_OPENED = 'Card Transaction History Opened',
   CARD_TRANSACTION_DETAILS_OPENED = 'Card Transaction Details Opened',
   CARD_TRANSACTION_REPORT_STARTED = 'Card Transaction Report Started',
+  CARD_REDEEM_PROCESS_STARTED = 'Card Redeem Process Started',
+  CARD_REDEEM_PROCESS_COMPLETED = 'Card Redeem Process Completed',
+  CARD_REDEEM_PROCESS_FAILED = 'Card Redeem Process Failed',
   // Rewards
   REWARDS_ACCOUNT_LINKING_STARTED = 'Rewards Account Linking Started',
   REWARDS_ACCOUNT_LINKING_COMPLETED = 'Rewards Account Linking Completed',
@@ -1984,6 +1987,15 @@ const events = {
   ),
   CARD_TRANSACTION_REPORT_STARTED: generateOpt(
     EVENT_NAME.CARD_TRANSACTION_REPORT_STARTED,
+  ),
+  CARD_REDEEM_PROCESS_STARTED: generateOpt(
+    EVENT_NAME.CARD_REDEEM_PROCESS_STARTED,
+  ),
+  CARD_REDEEM_PROCESS_COMPLETED: generateOpt(
+    EVENT_NAME.CARD_REDEEM_PROCESS_COMPLETED,
+  ),
+  CARD_REDEEM_PROCESS_FAILED: generateOpt(
+    EVENT_NAME.CARD_REDEEM_PROCESS_FAILED,
   ),
   // Rewards
   REWARDS_ACCOUNT_LINKING_STARTED: generateOpt(

--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -4422,6 +4422,29 @@ describe('CardController — data pass-throughs', () => {
       });
     });
 
+    it('caps excess-precision amounts before submitting to the provider', async () => {
+      const mockWithdraw = jest.fn().mockResolvedValue({ txHash: '0xcap' });
+      const provider = buildMockProvider({
+        withdrawCashback: mockWithdraw,
+        getCashbackWithdrawEstimation: jest.fn().mockResolvedValue({
+          wei: '1',
+          eth: '0.001',
+          price: '0.5',
+          network: 'linea',
+        }),
+      });
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      wireRedeemNetworkMessenger(messenger);
+      jest.spyOn(controller, 'fetchCardHomeData').mockResolvedValue();
+
+      await controller.withdrawCashback({ amount: '17.96660759' });
+
+      expect(mockWithdraw).toHaveBeenCalledWith(
+        { amount: '17.9666' },
+        mockTokenSet,
+      );
+    });
+
     it('throws when unsupported', async () => {
       const provider = buildMockProvider({
         withdrawCashback: undefined,

--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -41,6 +41,13 @@ import Logger from '../../../../util/Logger';
 jest.mock('./CardTokenStore');
 jest.mock('./CardOnboardingStore');
 jest.mock('../../../../util/Logger');
+// Only the sink is mocked, so the real `AnalyticsEventBuilder` still runs.
+const mockTrackAnalyticsEvent = jest.fn();
+jest.mock('../../../../util/analytics/analytics', () => ({
+  analytics: {
+    trackEvent: (...args: unknown[]) => mockTrackAnalyticsEvent(...args),
+  },
+}));
 jest.mock('../../../../util/trace', () => ({
   ...jest.requireActual('../../../../util/trace'),
   trace: jest.fn((_request, fn) => fn(undefined)),
@@ -5077,6 +5084,349 @@ describe('CardController — data pass-throughs', () => {
         status: 'failed',
         error: { reason: 'submit_failed' },
       });
+    });
+  });
+
+  describe('redeem funnel analytics', () => {
+    // Literals, not `MetaMetricsEvents`: these strings are the wire contract
+    // for the dashboards, so a rename must fail the test.
+    const STARTED = 'Card Redeem Process Started';
+    const COMPLETED = 'Card Redeem Process Completed';
+    const FAILED = 'Card Redeem Process Failed';
+
+    // The parent suite only restores spies, so counts leak without this.
+    beforeEach(() => {
+      mockTrackAnalyticsEvent.mockClear();
+    });
+
+    const emitsOf = (name: string) =>
+      mockTrackAnalyticsEvent.mock.calls
+        .map(([event]) => event as { name: string; properties: unknown })
+        .filter((event) => event.name === name);
+
+    it.each([
+      {
+        mode: 'cashback' as const,
+        withdraw: (controller: CardController) =>
+          controller.withdrawCashback({ amount: '5' }),
+        providerOverrides: {
+          withdrawCashback: jest.fn().mockResolvedValue({ txHash: '0xok' }),
+          getCashbackWithdrawEstimation: jest
+            .fn()
+            .mockResolvedValue(lineaEstimation),
+        },
+        amountBucket: '1-10',
+      },
+      {
+        mode: 'credit' as const,
+        withdraw: (controller: CardController) =>
+          controller.withdrawCredit({ amount: '250' }),
+        providerOverrides: {
+          withdrawCredit: jest.fn().mockResolvedValue({ txHash: '0xok' }),
+          getCreditWithdrawEstimation: jest
+            .fn()
+            .mockResolvedValue(lineaEstimation),
+        },
+        amountBucket: '100-1000',
+      },
+    ])(
+      'emits started then completed for a successful $mode redeem',
+      async ({ mode, withdraw, providerOverrides, amountBucket }) => {
+        const provider = buildMockProvider(providerOverrides);
+        const { controller, messenger } =
+          buildAuthenticatedController(provider);
+        wireRedeemNetworkMessenger(messenger);
+        jest.spyOn(controller, 'fetchCardHomeData').mockResolvedValue();
+
+        await withdraw(controller);
+
+        expect(emitsOf(STARTED)).toHaveLength(1);
+        expect(emitsOf(STARTED)[0].properties).toStrictEqual({
+          provider: 'baanx',
+          mode,
+          amount_bucket: amountBucket,
+        });
+        expect(emitsOf(COMPLETED)).toHaveLength(1);
+        expect(emitsOf(COMPLETED)[0].properties).toMatchObject({
+          provider: 'baanx',
+          mode,
+          amount_bucket: amountBucket,
+          chain_id: '0xe708',
+          duration_ms: expect.any(Number),
+        });
+        expect(emitsOf(FAILED)).toHaveLength(0);
+      },
+    );
+
+    it.each([
+      {
+        mode: 'cashback' as const,
+        withdraw: (controller: CardController) =>
+          controller.withdrawCashback({ amount: '5' }),
+        estimationKey: 'getCashbackWithdrawEstimation' as const,
+        submitKey: 'withdrawCashback' as const,
+      },
+      {
+        mode: 'credit' as const,
+        withdraw: (controller: CardController) =>
+          controller.withdrawCredit({ amount: '5' }),
+        estimationKey: 'getCreditWithdrawEstimation' as const,
+        submitKey: 'withdrawCredit' as const,
+      },
+    ])(
+      'reports an estimation-stage failure for $mode',
+      async ({ mode, withdraw, estimationKey, submitKey }) => {
+        const provider = buildMockProvider({
+          [estimationKey]: jest
+            .fn()
+            .mockRejectedValue(
+              new CardApiError(503, '/withdraw-estimation', 'down'),
+            ),
+          [submitKey]: jest.fn(),
+        });
+        const { controller } = buildAuthenticatedController(provider);
+
+        await expect(withdraw(controller)).rejects.toBeInstanceOf(CardApiError);
+
+        expect(emitsOf(FAILED)).toHaveLength(1);
+        expect(emitsOf(FAILED)[0].properties).toMatchObject({
+          provider: 'baanx',
+          mode,
+          stage: 'estimation',
+          reason: 'server_error',
+          status_code: 503,
+          chain_id: null,
+          error_name: 'CardApiError',
+        });
+        expect(emitsOf(COMPLETED)).toHaveLength(0);
+      },
+    );
+
+    it.each([
+      {
+        mode: 'cashback' as const,
+        withdraw: (controller: CardController) =>
+          controller.withdrawCashback({ amount: '5' }),
+        providerOverrides: {
+          withdrawCashback: jest
+            .fn()
+            .mockRejectedValue(
+              new CardProviderError(
+                CardProviderErrorCode.Network,
+                'offline',
+                0,
+              ),
+            ),
+          getCashbackWithdrawEstimation: jest
+            .fn()
+            .mockResolvedValue(lineaEstimation),
+        },
+      },
+      {
+        mode: 'credit' as const,
+        withdraw: (controller: CardController) =>
+          controller.withdrawCredit({ amount: '5' }),
+        providerOverrides: {
+          withdrawCredit: jest
+            .fn()
+            .mockRejectedValue(
+              new CardProviderError(
+                CardProviderErrorCode.Network,
+                'offline',
+                0,
+              ),
+            ),
+          getCreditWithdrawEstimation: jest
+            .fn()
+            .mockResolvedValue(lineaEstimation),
+        },
+      },
+    ])(
+      'reports a submit-stage failure for $mode with the resolved chain',
+      async ({ mode, withdraw, providerOverrides }) => {
+        const provider = buildMockProvider(providerOverrides);
+        const { controller, messenger } =
+          buildAuthenticatedController(provider);
+        wireRedeemNetworkMessenger(messenger);
+
+        await expect(withdraw(controller)).rejects.toMatchObject({
+          message: 'offline',
+        });
+
+        expect(emitsOf(FAILED)).toHaveLength(1);
+        expect(emitsOf(FAILED)[0].properties).toMatchObject({
+          mode,
+          stage: 'submit',
+          reason: 'network',
+          error_code: CardProviderErrorCode.Network,
+          chain_id: '0xe708',
+        });
+      },
+    );
+
+    it.each([
+      {
+        mode: 'cashback' as const,
+        withdraw: (controller: CardController) =>
+          controller.withdrawCashback({ amount: '5' }),
+        providerOverrides: {
+          withdrawCashback: jest.fn().mockResolvedValue({ txHash: '0xrev' }),
+          getCashbackWithdrawEstimation: jest
+            .fn()
+            .mockResolvedValue(lineaEstimation),
+        },
+      },
+      {
+        mode: 'credit' as const,
+        withdraw: (controller: CardController) =>
+          controller.withdrawCredit({ amount: '5' }),
+        providerOverrides: {
+          withdrawCredit: jest.fn().mockResolvedValue({ txHash: '0xrev' }),
+          getCreditWithdrawEstimation: jest
+            .fn()
+            .mockResolvedValue(lineaEstimation),
+        },
+      },
+    ])(
+      'reports an on-chain revert for $mode',
+      async ({ mode, withdraw, providerOverrides }) => {
+        const provider = buildMockProvider(providerOverrides);
+        const { controller, messenger } =
+          buildAuthenticatedController(provider);
+        wireRedeemNetworkMessenger(
+          messenger,
+          jest.fn().mockResolvedValue({ status: '0x0' }),
+        );
+
+        await expect(withdraw(controller)).rejects.toMatchObject({
+          name: 'ExternalTransactionRevertedError',
+        });
+
+        expect(emitsOf(FAILED)).toHaveLength(1);
+        expect(emitsOf(FAILED)[0].properties).toMatchObject({
+          mode,
+          stage: 'on_chain',
+          reason: 'tx_reverted',
+          chain_id: '0xe708',
+          error_name: 'ExternalTransactionRevertedError',
+        });
+      },
+    );
+
+    it('reports an on-chain timeout with the polling chain', async () => {
+      jest.useFakeTimers();
+      try {
+        const provider = buildMockProvider({
+          withdrawCashback: jest.fn().mockResolvedValue({ txHash: '0xtime' }),
+          getCashbackWithdrawEstimation: jest
+            .fn()
+            .mockResolvedValue(lineaEstimation),
+        });
+        const { controller, messenger } =
+          buildAuthenticatedController(provider);
+        wireRedeemNetworkMessenger(
+          messenger,
+          jest.fn().mockReturnValue(new Promise(() => undefined)),
+        );
+
+        const withdrawal = controller.withdrawCashback({ amount: '5' });
+        withdrawal.catch(() => undefined);
+        await jest.advanceTimersByTimeAsync(3 * 60 * 1000 + 1000);
+        await expect(withdrawal).rejects.toMatchObject({
+          name: 'ExternalTransactionReceiptTimeoutError',
+        });
+
+        expect(emitsOf(FAILED)).toHaveLength(1);
+        expect(emitsOf(FAILED)[0].properties).toMatchObject({
+          mode: 'cashback',
+          stage: 'on_chain',
+          reason: 'tx_timeout',
+          chain_id: '0xe708',
+        });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('reports no_polling_chain at the estimation stage', async () => {
+      const provider = buildMockProvider({
+        withdrawCashback: jest.fn(),
+        getCashbackWithdrawEstimation: jest
+          .fn()
+          .mockResolvedValue({ ...lineaEstimation, network: 'nope' }),
+      });
+      const { controller } = buildAuthenticatedController(provider);
+
+      await expect(
+        controller.withdrawCashback({ amount: '5' }),
+      ).rejects.toThrow('Unable to resolve withdrawal network for monitoring');
+
+      expect(emitsOf(FAILED)).toHaveLength(1);
+      expect(emitsOf(FAILED)[0].properties).toMatchObject({
+        stage: 'estimation',
+        reason: 'no_polling_chain',
+        chain_id: null,
+      });
+    });
+
+    it('does not emit for a duplicate submit rejected while one is in flight', async () => {
+      let resolveEstimation!: (value: unknown) => void;
+      const provider = buildMockProvider({
+        withdrawCashback: jest.fn().mockResolvedValue({ txHash: '0xabc' }),
+        getCashbackWithdrawEstimation: jest.fn().mockReturnValue(
+          new Promise((resolve) => {
+            resolveEstimation = resolve;
+          }),
+        ),
+      });
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      wireRedeemNetworkMessenger(messenger);
+      jest.spyOn(controller, 'fetchCardHomeData').mockResolvedValue();
+
+      const first = controller.withdrawCashback({ amount: '5' });
+      await expect(
+        controller.withdrawCashback({ amount: '1' }),
+      ).rejects.toBeInstanceOf(CardRedeemWithdrawalInProgressError);
+
+      expect(emitsOf(STARTED)).toHaveLength(1);
+      expect(emitsOf(FAILED)).toHaveLength(0);
+
+      resolveEstimation(lineaEstimation);
+      await first;
+      expect(emitsOf(COMPLETED)).toHaveLength(1);
+    });
+
+    it('does not report a failure when monitoring is abandoned mid-withdrawal', async () => {
+      let resolveSubmit!: (value: unknown) => void;
+      const provider = buildMockProvider({
+        withdrawCashback: jest.fn().mockReturnValue(
+          new Promise((resolve) => {
+            resolveSubmit = resolve;
+          }),
+        ),
+        getCashbackWithdrawEstimation: jest
+          .fn()
+          .mockResolvedValue(lineaEstimation),
+      });
+      const { controller, messenger } = buildAuthenticatedController(provider);
+      const providerRequest = wireRedeemNetworkMessenger(messenger);
+
+      const withdrawal = controller.withdrawCashback({ amount: '5' });
+      withdrawal.catch(() => undefined);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Abandon while the submit is still in flight, so the monitor's first
+      // `shouldContinue` check cancels without waiting on a poll interval.
+      controller.clearRedeemWithdrawal();
+      resolveSubmit({ txHash: '0xgone' });
+
+      await expect(withdrawal).rejects.toMatchObject({
+        name: 'ExternalTransactionMonitorCancelledError',
+      });
+      expect(providerRequest).not.toHaveBeenCalled();
+      expect(emitsOf(FAILED)).toHaveLength(0);
+      expect(emitsOf(COMPLETED)).toHaveLength(0);
+      expect(emitsOf(STARTED)).toHaveLength(1);
     });
   });
 

--- a/app/core/Engine/controllers/card-controller/CardController.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.ts
@@ -11,6 +11,10 @@ import {
   TraceName,
   TraceOperation,
 } from '../../../../util/trace';
+import { MetaMetricsEvents } from '../../../Analytics';
+import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEventBuilder';
+import { analytics } from '../../../../util/analytics/analytics';
+import type { IMetaMetricsEvent } from '../../../../util/analytics/analytics.types';
 import ReduxService from '../../../redux';
 import type { RootState } from '../../../../reducers';
 import { getGasFeesSponsoredNetworkEnabled } from '../../../../selectors/featureFlagController/gasFeesSponsored';
@@ -119,6 +123,8 @@ import { safeFormatChainIdToHex } from '../../../../components/UI/Card/util/safe
 const CARDHOLDER_BATCH_SIZE = 50;
 const CARDHOLDER_MAX_BATCHES = 3;
 const CARD_HOME_DATA_FRESH_MS = 1000 * 60;
+
+type RedeemFailureStage = 'estimation' | 'submit' | 'on_chain';
 
 const bucketRedeemAmount = (amount: string): string => {
   const n = Number.parseFloat(amount);
@@ -2129,6 +2135,35 @@ export class CardController extends BaseController<
   }
 
   /**
+   * Emitted here rather than from the redeem screen because monitoring runs for
+   * up to three minutes and survives the user navigating away, so a view-side
+   * emit would drop exactly the slow failures worth measuring.
+   */
+  #trackRedeemEvent(
+    event: IMetaMetricsEvent,
+    properties: Record<string, string | number | null>,
+  ): void {
+    try {
+      analytics.trackEvent(
+        AnalyticsEventBuilder.createEventBuilder(event)
+          .addProperties({
+            provider: this.state.activeProviderId,
+            ...properties,
+          })
+          .build(),
+      );
+    } catch (error) {
+      Logger.error(error as Error, {
+        tags: { feature: 'card' },
+        context: {
+          name: 'CardController',
+          data: { method: '#trackRedeemEvent' },
+        },
+      });
+    }
+  }
+
+  /**
    * Submits a credit / mUSD Back withdrawal and monitors the returned txHash
    * until confirmed or failed. State lives on the controller so navigating
    * away from the redeem screen does not lose the outcome.
@@ -2153,6 +2188,7 @@ export class CardController extends BaseController<
 
     const submittedAt = Date.now();
     const generation = ++this.redeemGeneration;
+    const amountBucket = bucketRedeemAmount(amount);
     this.#setRedeemWithdrawal(
       {
         mode,
@@ -2164,6 +2200,14 @@ export class CardController extends BaseController<
       },
       generation,
     );
+
+    this.#trackRedeemEvent(MetaMetricsEvents.CARD_REDEEM_PROCESS_STARTED, {
+      mode,
+      amount_bucket: amountBucket,
+    });
+
+    let stage: RedeemFailureStage = 'estimation';
+    let pollingChainId: string | null = null;
 
     return await trace(
       {
@@ -2203,6 +2247,9 @@ export class CardController extends BaseController<
             throw error;
           }
 
+          pollingChainId = chainId;
+          stage = 'submit';
+
           const submitResult =
             mode === 'credit'
               ? await this.#submitCreditWithdraw({ amount })
@@ -2211,9 +2258,11 @@ export class CardController extends BaseController<
           Logger.log('Card redeem withdraw submitted', {
             mode,
             network: estimation.network,
-            amountBucket: bucketRedeemAmount(amount),
+            amountBucket,
             chainId,
           });
+
+          stage = 'on_chain';
 
           this.#setRedeemWithdrawal(
             {
@@ -2246,6 +2295,16 @@ export class CardController extends BaseController<
             generation,
           );
 
+          this.#trackRedeemEvent(
+            MetaMetricsEvents.CARD_REDEEM_PROCESS_COMPLETED,
+            {
+              mode,
+              amount_bucket: amountBucket,
+              chain_id: chainId,
+              duration_ms: Date.now() - submittedAt,
+            },
+          );
+
           // Refresh card home so headline balance / credit banner update.
           if (generation === this.redeemGeneration) {
             this.fetchCardHomeData({ force: true }).catch((refreshError) => {
@@ -2266,6 +2325,8 @@ export class CardController extends BaseController<
           return submitResult;
         } catch (error) {
           if (error instanceof ExternalTransactionMonitorCancelledError) {
+            // Abandoned, not failed — the outcome is unknowable, so it must not
+            // count against the failure rate.
             annotateTrace(context, { success: false, reason: 'cancelled' });
             throw error;
           }
@@ -2286,6 +2347,17 @@ export class CardController extends BaseController<
             code: classified?.code != null ? classified.code : 'none',
             statusCode:
               classified?.statusCode != null ? classified.statusCode : -1,
+          });
+          this.#trackRedeemEvent(MetaMetricsEvents.CARD_REDEEM_PROCESS_FAILED, {
+            mode,
+            amount_bucket: amountBucket,
+            chain_id: pollingChainId,
+            duration_ms: Date.now() - submittedAt,
+            stage,
+            reason: classified?.reason ?? 'unknown',
+            error_name: (error as Error)?.name ?? 'unknown',
+            error_code: classified?.code ?? null,
+            status_code: classified?.statusCode ?? null,
           });
           throw error;
         }

--- a/app/core/Engine/controllers/card-controller/CardController.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.ts
@@ -96,6 +96,7 @@ import {
   ExternalTransactionRevertedError,
 } from './utils/awaitExternalTransactionReceipt';
 import { resolveMoneyAccountCardToken } from './utils/moneyAccountCardToken';
+import { capRedeemAmount } from './utils/redeemAmount';
 import {
   MONEY_ACCOUNT_DELEGATION_NETWORK,
   MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
@@ -2172,7 +2173,8 @@ export class CardController extends BaseController<
     mode: RedeemWalletMode;
     amount: string;
   }): Promise<CreditWithdrawResponse | CashbackWithdrawResponse> {
-    const { mode, amount } = params;
+    const { mode } = params;
+    const amount = capRedeemAmount(params.amount);
     const existing = this.#getRedeemWithdrawal();
     // Terminal states are stale once the user leaves the redeem UI — allow a
     // fresh submit. The view keeps the button locked through `success` while

--- a/app/core/Engine/controllers/card-controller/utils/redeemAmount.test.ts
+++ b/app/core/Engine/controllers/card-controller/utils/redeemAmount.test.ts
@@ -1,0 +1,53 @@
+import { capRedeemAmount } from './redeemAmount';
+
+describe('capRedeemAmount', () => {
+  it('floors the reported reward-endpoint balance to 4 decimals', () => {
+    expect(capRedeemAmount('17.96660759')).toBe('17.9666');
+  });
+
+  it('leaves an amount already at 4 decimals unchanged', () => {
+    expect(capRedeemAmount('10.1234')).toBe('10.1234');
+  });
+
+  it('floors rather than rounds when the next digit is ≥ 5', () => {
+    expect(capRedeemAmount('1.12345')).toBe('1.1234');
+    expect(capRedeemAmount('0.99999')).toBe('0.9999');
+  });
+
+  it('returns 0 for dust below the 4-decimal floor', () => {
+    expect(capRedeemAmount('0.00009')).toBe('0');
+  });
+
+  it('normalizes redundant trailing zeros beyond 4 decimals', () => {
+    expect(capRedeemAmount('1.10000')).toBe('1.1');
+  });
+
+  it('preserves in-range strings byte-identical', () => {
+    expect(capRedeemAmount('10.00')).toBe('10.00');
+    expect(capRedeemAmount('0.0007')).toBe('0.0007');
+  });
+
+  it('strips commas and floors comma-formatted excess precision', () => {
+    expect(capRedeemAmount('1,000.12345')).toBe('1000.1234');
+  });
+
+  it('avoids exponential notation on very large values', () => {
+    expect(capRedeemAmount('1000000000.123456')).toBe('1000000000.1234');
+  });
+
+  it.each([
+    ['invalid', 'invalid'],
+    ['empty string', ''],
+    ['undefined', undefined],
+    ['Infinity', Infinity],
+    ['negative', '-1.2345'],
+    ['zero', '0'],
+    ['negative zero', '-0'],
+  ])('returns 0 for %s', (_label, value) => {
+    expect(capRedeemAmount(value as string | number)).toBe('0');
+  });
+
+  it('accepts a number input with excess precision', () => {
+    expect(capRedeemAmount(10.12345)).toBe('10.1234');
+  });
+});

--- a/app/core/Engine/controllers/card-controller/utils/redeemAmount.test.ts
+++ b/app/core/Engine/controllers/card-controller/utils/redeemAmount.test.ts
@@ -50,4 +50,16 @@ describe('capRedeemAmount', () => {
   it('accepts a number input with excess precision', () => {
     expect(capRedeemAmount(10.12345)).toBe('10.1234');
   });
+
+  it('does not leak scientific notation from number inputs', () => {
+    expect(capRedeemAmount(1e-7)).toBe('0');
+    expect(capRedeemAmount(1e-6)).toBe('0');
+    expect(capRedeemAmount(1e21)).toBe('1000000000000000000000');
+  });
+
+  it('does not leak scientific notation from string inputs', () => {
+    expect(capRedeemAmount('1e-7')).toBe('0');
+    expect(capRedeemAmount('1E-6')).toBe('0');
+    expect(capRedeemAmount('1.23456e2')).toBe('123.456');
+  });
 });

--- a/app/core/Engine/controllers/card-controller/utils/redeemAmount.ts
+++ b/app/core/Engine/controllers/card-controller/utils/redeemAmount.ts
@@ -12,9 +12,11 @@ export const REDEEM_AMOUNT_DECIMALS = 4;
 /**
  * Floors an amount to {@link REDEEM_AMOUNT_DECIMALS} fractional digits.
  *
- * In-range strings (≤ 4 fractional digits) are returned byte-identical so
- * existing callers that send `'10.00'` or `'0.0007'` keep their wire format.
- * Only strings that genuinely carry excess precision are re-serialized.
+ * Plain decimal strings that are already in range (≤ 4 fractional digits) are
+ * returned byte-identical so callers that send `'10.00'` or `'0.0007'` keep
+ * their wire format. Numbers and scientific-notation strings always go through
+ * BigNumber — `String(1e-7)` is `'1e-7'`, which has no `.` and would otherwise
+ * leak exponential notation onto the wire.
  */
 export const capRedeemAmount = (
   amount: string | number | undefined,
@@ -22,8 +24,18 @@ export const capRedeemAmount = (
   const parsed = safeParseBigNumber(amount);
   if (!parsed.isFinite() || parsed.lte(0)) return '0';
 
-  const fraction = String(amount).split('.')[1] ?? '';
-  if (fraction.length <= REDEEM_AMOUNT_DECIMALS) return String(amount);
+  // Only plain decimal strings are safe to short-circuit. Numbers and any
+  // string carrying `e`/`E` (or thousands separators) must be re-serialized
+  // via BigNumber so the result is always a fixed decimal.
+  const isPlainDecimalString =
+    typeof amount === 'string' && !/[eE]/.test(amount) && !amount.includes(',');
+
+  if (isPlainDecimalString) {
+    const fraction = amount.split('.')[1] ?? '';
+    if (fraction.length <= REDEEM_AMOUNT_DECIMALS) {
+      return amount;
+    }
+  }
 
   return parsed
     .decimalPlaces(REDEEM_AMOUNT_DECIMALS, BigNumber.ROUND_FLOOR)

--- a/app/core/Engine/controllers/card-controller/utils/redeemAmount.ts
+++ b/app/core/Engine/controllers/card-controller/utils/redeemAmount.ts
@@ -1,0 +1,31 @@
+import BigNumber from 'bignumber.js';
+import { safeParseBigNumber } from '../../../../../util/number/bignumber';
+
+/**
+ * Max fractional digits for a redeem claim. Matches the display precision so
+ * the amount shown on the redeem screen is the amount submitted to the
+ * provider. Digits beyond this are floored (never rounded up) so we never
+ * request more than the available balance.
+ */
+export const REDEEM_AMOUNT_DECIMALS = 4;
+
+/**
+ * Floors an amount to {@link REDEEM_AMOUNT_DECIMALS} fractional digits.
+ *
+ * In-range strings (≤ 4 fractional digits) are returned byte-identical so
+ * existing callers that send `'10.00'` or `'0.0007'` keep their wire format.
+ * Only strings that genuinely carry excess precision are re-serialized.
+ */
+export const capRedeemAmount = (
+  amount: string | number | undefined,
+): string => {
+  const parsed = safeParseBigNumber(amount);
+  if (!parsed.isFinite() || parsed.lte(0)) return '0';
+
+  const fraction = String(amount).split('.')[1] ?? '';
+  if (fraction.length <= REDEEM_AMOUNT_DECIMALS) return String(amount);
+
+  return parsed
+    .decimalPlaces(REDEEM_AMOUNT_DECIMALS, BigNumber.ROUND_FLOOR)
+    .toFixed();
+};


### PR DESCRIPTION
## **Description**

The Card redeem flow — cashback and credit (mUSD Back) — shipped with almost no instrumentation. There was a single `Card Button Clicked` event on the withdraw press and no outcome events at all, so we could not answer how often a redemption fails, at which stage it fails, or why users who open the screen never withdraw. Sentry had no signal for the flow either, because the feature is new and had not yet reached a deployed environment.

This adds a five-step funnel. Cashback and credit share both `RedeemWallet` and `CardController.withdrawRedeemable`, so a single code path instruments both modes.

| Step | Event | Emitted from |
| --- | --- | --- |
| Entry click | `Card Button Clicked` — `type: 'open_redeem'` | `useCardHomeActions` |
| Screen usable | `Card Viewed` | `useRedeemWalletAnalytics` |
| Blocked CTA | `Card Button Clicked` — `type: 'setup'` | `useRedeemWalletAnalytics` |
| Withdraw press | `Card Button Clicked` — `type: 'withdraw'` | `useRedeemWalletAnalytics` |
| Outcome | `Card Redeem Process Started` / `Completed` / `Failed` | `CardController` |

Three decisions worth reviewing:

**Outcome events are emitted from the controller, not the view.** Receipt monitoring runs for up to three minutes and survives the user navigating away, so a view-side emit would drop exactly the slow failures worth measuring. `Failed` reports the `stage` (`estimation`, `submit`, `on_chain`) alongside `reason`, `error_name`, `error_code` and `status_code`, because `reason` alone cannot separate a network error thrown before submission from one thrown while polling for a receipt — the first costs the user nothing, the second may have already moved funds. An abandoned monitor is deliberately **not** counted as a failure, since its outcome is unknowable. This follows the precedent set by `ramps-controller`.

**`Card Viewed` settles on estimation failure as well as success.** The destination chain is derived from the estimation, so gating the event on a resolved destination meant a failed estimation never produced an event — despite leaving the withdraw button permanently disabled, which is precisely the drop-off worth counting. That case now reports `destination: 'unresolved'` rather than going dark. The event also carries `is_withdrawable`, `needs_setup`, `has_insufficient_balance` and `has_loading_error`, so a view that never converts explains itself.

**Card Home's entry click is the funnel denominator, not the screen view.** `Card Viewed` waits for the screen to become legible, so a user who bounces during load still registers as drop-off between the entry click and the view. This also means views cannot exceed entry clicks, which would break the funnel arithmetic.

Two changes to existing behaviour that reviewers should be aware of:

- The cashback entry click previously fired a bare `action: 'CASHBACK_BUTTON'`, indistinguishable from the withdraw press except by the absence of a `type`. It now carries `type: 'open_redeem'`. This is additive, so dashboards keyed on `action` keep working — but anything currently counting `CASHBACK_BUTTON` as a single thing is conflating two funnel steps and should be split.
- The credit entry point was untracked entirely and lived as an inline `handleRedeemCredit` in `CardHome.tsx` with no test coverage. It moved into `useCardHomeActions` next to its cashback counterpart, and both are now covered.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: null

## **Manual testing steps**

```gherkin
Feature: Card redeem funnel instrumentation

  Scenario: user redeems cashback successfully
    Given user is a cardholder with a positive cashback balance
    And user has an approved funding source
    When user taps Cashback on Card Home
    Then a Card Button Clicked event fires with type "open_redeem"
    And a Card Viewed event fires for the CASHBACK screen once the balance and fee load

    When user taps Withdraw
    Then a Card Button Clicked event fires with type "withdraw"
    And a Card Redeem Process Started event fires
    And a Card Redeem Process Completed event fires once the transaction confirms
    And a success toast is shown and the screen closes

  Scenario: user opens the refunds screen while funding setup is missing
    Given user is a cardholder with a positive refund balance
    And user has no approved funding source
    When user taps the refund banner on Card Home
    Then a Card Button Clicked event fires with type "open_redeem"
    And a Card Viewed event fires for the CREDIT_REDEEM screen with needs_setup true
    And the withdraw button is disabled

    When user taps the setup call to action
    Then a Card Button Clicked event fires with type "setup"
    And user is taken to the funding or Money Account setup flow

  Scenario: user abandons a redemption mid-flight
    Given user has tapped Withdraw and the transaction is being monitored
    When user navigates away and logs out of Card
    Then no Card Redeem Process Failed event fires
    And no Card Redeem Process Completed event fires

  Scenario: redemption fails on chain
    Given user has tapped Withdraw and the transaction reverts
    Then a Card Redeem Process Failed event fires with stage "on_chain" and reason "tx_reverted"
    And a failure toast is shown
```

## **Screenshots/Recordings**

### **Before**

N/A — no user-facing UI change.

### **After**

N/A — no user-facing UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
