### PR TITLE
fix(content): remove trailing space in onboarding browser copy

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -473,7 +473,7 @@
     },
     "step7": {
       "title": "Using the browser",
-      "content1": "Search for sites by keyword or enter a URL. Have fun out there! "
+      "content1": "Search for sites by keyword or enter a URL. Have fun out there!"
     }
   },
   "create_wallet": {


### PR DESCRIPTION
## **Description**

File: `locales/languages/en.json` (`onboarding.step7.content1`).

Rule: string-hygiene heuristic used in prior `fix(content)` PRs — trailing whitespace on a standalone sentence.

User impact: the browser onboarding tip no longer includes an invisible trailing space after “Have fun out there!”

## **Changelog**

CHANGELOG entry: Removed unintended trailing space from onboarding browser copy

## **Related issues**

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

```gherkin
Feature: onboarding browser tip
  Scenario: step 7 is shown
    Then the copy has no trailing whitespace
```

## **Screenshots/Recordings**

N/A — copy-only correction.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only locale string change with no logic, security, or data-handling impact.
> 
> **Overview**
> Removes a trailing space from the English onboarding **step 7** browser tip (`onboarding.step7.content1` in `en.json`). The sentence *“Have fun out there!”* is unchanged for users; only invisible whitespace at the end of the string is dropped, consistent with other `fix(content)` string-hygiene updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21935cd76f4dcf51cd3d6ba3f15378cd3c4039f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->