### PR TITLE
fix(content): remove leading space in invalid contract address copy

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5535,7 +5535,7 @@
     "contract": "Contract ({{address}})",
     "contract_name": "Contract name:",
     "contract_address": "Contract address:",
-    "invalid_contract_address": " Contract address is invalid. Enter a new one",
+    "invalid_contract_address": "Contract address is invalid. Enter a new one",
     "contract_allowance": "Allowance:",
     "data": "Data",
     "function_approve": "Function: Approve",


### PR DESCRIPTION
## **Description**

File: `locales/languages/en.json` (`spend.invalid_contract_address`).

Rule: string-hygiene heuristic — leading space on a standalone error, not a concatenation fragment.

User impact: the invalid-contract error starts on the left edge instead of looking indented.

## **Changelog**

CHANGELOG entry: Removed unintended leading space from invalid contract address copy

## **Related issues**

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

```gherkin
Feature: invalid contract address
  Scenario: the address is invalid
    Then the error has no leading whitespace
```

## **Screenshots/Recordings**

N/A — copy-only correction.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> English locale string hygiene only; no functional or security impact.
> 
> **Overview**
> Removes an unintended **leading space** from the English `spend.invalid_contract_address` string in `en.json`, so the invalid-contract error aligns with the left edge instead of appearing indented.
> 
> Copy-only; no logic or behavior changes beyond displayed text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72259b6c57eb6e126ab74d0774397e60a24aad80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->