### PR TITLE
fix(content): add missing period to SDK reconnect copy

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4901,7 +4901,7 @@
   "sdk_feedback_modal": {
     "ok": "OK",
     "title": "Account couldn't connect",
-    "info": "Please scan the QR code on the site to reconnect to MetaMask"
+    "info": "Please scan the QR code on the site to reconnect to MetaMask."
   },
   "app_information": {
     "title": "Information",


### PR DESCRIPTION
## **Description**

File: `locales/languages/en.json` (`sdk_feedback_modal.info`).

Rule: punctuation heuristic — complete instructional sentences should end with a period.

User impact: the reconnect instruction reads as a finished sentence, which is easier to scan after a failed SDK connect.

## **Changelog**

CHANGELOG entry: Added a missing period to SDK reconnect copy

## **Related issues**

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

```gherkin
Feature: SDK reconnect
  Scenario: account couldn't connect
    Then the info sentence ends with a period
```

## **Screenshots/Recordings**

N/A — copy-only correction.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in English locale strings with no logic or security impact.
> 
> **Overview**
> Updates the English **`sdk_feedback_modal.info`** string so the reconnect instruction ends with a period, matching punctuation rules for complete instructional sentences in the SDK “account couldn’t connect” feedback modal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f3845fcf15957185990e3d04681d430aa696b68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->