### PR TITLE
fix(content): add missing period to enable-card copy

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9939,7 +9939,7 @@
         },
         "no_card": {
           "title": "You need to enable your card",
-          "description": "Please enable your card to start spending"
+          "description": "Please enable your card to start spending."
         },
         "frozen": {
           "title": "Your card is frozen",


### PR DESCRIPTION
## **Description**

File: `locales/languages/en.json` (`card.home.no_card.description`).

Rule: punctuation heuristic — complete instructional sentences should end with a period.

User impact: the enable-card empty state matches nearby card status copy that already uses terminal punctuation.

## **Changelog**

CHANGELOG entry: Added a missing period to enable-card copy

## **Related issues**

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

```gherkin
Feature: enable card
  Scenario: the user has no card
    Then the description ends with a period
```

## **Screenshots/Recordings**

N/A — copy-only correction.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single English locale string punctuation change with no functional or security impact.
> 
> **Overview**
> Adds a trailing period to the **no-card** enable-card empty-state description in English (`card.home.no_card.description`), so it reads as a complete sentence and aligns with neighboring card status strings (e.g. frozen/blocked) that already use terminal punctuation.
> 
> No logic, routing, or behavior changes—copy-only in `locales/languages/en.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f563494887c15c23f7488e001dce91075e234b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->