### PR TITLE
fix(content): add missing period to blocked-card copy

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9947,7 +9947,7 @@
         },
         "blocked": {
           "title": "Your card is blocked",
-          "description": "Please contact support to unblock your card"
+          "description": "Please contact support to unblock your card."
         },
         "kyc_pending": {
           "title": "Verification in progress",


### PR DESCRIPTION
## **Description**

File: `locales/languages/en.json` (`card.home.blocked.description`).

Rule: punctuation heuristic — complete next-step sentences should end with a period.

User impact: the blocked-card state tells people to contact support in a complete sentence.

## **Changelog**

CHANGELOG entry: Added a missing period to blocked-card copy

## **Related issues**

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

```gherkin
Feature: blocked card
  Scenario: the card is blocked
    Then the description ends with a period
```

## **Screenshots/Recordings**

N/A — copy-only correction.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string locale tweak with no functional, security, or data impact.
> 
> **Overview**
> Adds a trailing period to the English **blocked card** home-state description (`card.home.blocked.description`) so the “contact support” line matches the punctuation rule used for other complete sentences in that flow.
> 
> Copy-only; no logic or layout changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4e24a33a976de8af20d7c5c4a34ed1d9da6bfca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->