### PR TITLE
fix(content): add missing article in return-to-app toast

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4895,7 +4895,7 @@
     "cancel": "Cancel"
   },
   "sdk_return_to_app_toast": {
-    "returnToAppLabel": "Now you can return to app",
+    "returnToAppLabel": "Now you can return to the app",
     "networkSwitchMethodLabel": "Network successfully switched"
   },
   "sdk_feedback_modal": {


### PR DESCRIPTION
## **Description**

File: `locales/languages/en.json` (`sdk_return_to_app_toast.returnToAppLabel`).

Rule: missing-article heuristic matching existing `fix(content)` article PRs.

User impact: “return to the app” is the natural English next step after a dapp handoff, instead of “return to app”.

## **Changelog**

CHANGELOG entry: Added the missing article in the return-to-app toast

## **Related issues**

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

```gherkin
Feature: return to app toast
  Scenario: the user should go back to the requesting app
    Then the toast says “return to the app”
```

## **Screenshots/Recordings**

N/A — copy-only correction.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only locale string change with no behavioral, security, or data-handling impact.
> 
> **Overview**
> Updates the SDK **return-to-app** toast copy in `en.json`: `sdk_return_to_app_toast.returnToAppLabel` now reads **“Now you can return to the app”** instead of **“Now you can return to app”**.
> 
> No code or logic changes—only the English string shown by `ReturnToAppNotification` after a dapp handoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b88383049e823b31f9ca85ad769e7a9953184d61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->