### PR TITLE
fix(content): spell out first-interaction alert title

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -164,7 +164,7 @@
     },
     "first_time_interaction": {
       "message": "You're interacting with this address for the first time. Make sure that it's correct before you continue.",
-      "title": "1st interaction"
+      "title": "First interaction"
     },
     "address_trust_signal": {
       "malicious": {


### PR DESCRIPTION
## **Description**

File: `locales/languages/en.json` (`alert_system.first_time_interaction.title`).

Rule: comprehension / screen-reader heuristic — ordinal abbreviations like “1st” are harder to parse than “First”, and the body already says “first time”.

User impact: the confirmation alert title matches the surrounding sentence case and is clearer when read aloud.

## **Changelog**

CHANGELOG entry: Replaced “1st interaction” with “First interaction”

## **Related issues**

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

```gherkin
Feature: first-time interaction alert
  Scenario: the user interacts with an address for the first time
    Then the alert title is “First interaction”
```

## **Screenshots/Recordings**

N/A — copy-only correction.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> English copy-only change to a confirmation alert title; no logic, security, or data-handling impact.
> 
> **Overview**
> Updates the English alert title for first-time address interactions from **“1st interaction”** to **“First interaction”** in `locales/languages/en.json` (`alert_system.first_time_interaction.title`).
> 
> That string is shown via `useFirstTimeInteractionAlert` on confirmation flows; behavior is unchanged—only the displayed title copy is clearer and aligns with the message’s “first time” wording and screen-reader readability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b672881390049cd04bedc8a2b17c813dd3bf566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->