### PR TITLE
fix(content): use tap instead of click in connect warning

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6056,7 +6056,7 @@
     "address": "public address",
     "sign_messages": "Sign messages",
     "on_your_behalf": "on your behalf",
-    "warning": "By clicking connect, you allow this site to view your public address. This is an important security step to protect your data from potential phishing risks."
+    "warning": "By tapping connect, you allow this site to view your public address. This is an important security step to protect your data from potential phishing risks."
   },
   "import_private_key": {
     "title": "Import account",


### PR DESCRIPTION
## **Description**

File: `locales/languages/en.json` (`accountApproval.warning`).

Rule: mobile interaction heuristic — on-device controls are tapped, not clicked.

User impact: the connect permission warning matches how people actually complete the action on a phone.

## **Changelog**

CHANGELOG entry: Replaced “clicking” with “tapping” in the connect warning

## **Related issues**

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

```gherkin
Feature: account approval warning
  Scenario: a site requests the public address
    Then the warning says “By tapping connect”
```

## **Screenshots/Recordings**

N/A — copy-only correction.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> English copy-only change with no functional, security, or data-handling impact.
> 
> **Overview**
> Updates the **account connect permission** warning in `en.json` (`accountApproval.warning`) so it says **“By tapping connect”** instead of **“By clicking connect,”** aligning the copy with mobile interaction language.
> 
> The string is shown in the account approval flow (e.g. `AccountApproval` UI); wording only—no logic or behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7346857bcb5a1b425e75d67d2810639032876d14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->