### PR TITLE
fix(content): use tap instead of click in network privacy link

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8552,7 +8552,7 @@
     "manage_networks": "Choose your network",
     "manage_networks_body": "We use Infura as our remote procedure call (RPC) provider to offer the most reliable and private access to Ethereum data we can. You can choose your own RPC, but remember that any RPC will receive your IP address and Ethereum wallet to make transactions. Read our ",
     "manage_networks_body2": " to learn more about how Infura handles data for EVM accounts, for Solana accounts ",
-    "manage_networks_body3": "click here.",
+    "manage_networks_body3": "tap here.",
     "functionality_body": "MetaMask offers basic features like token details and gas settings through internet services. When you use internet services, your IP address is shared, in this case with MetaMask. This is just like when you visit any website. MetaMask uses this data temporarily and never sells your data. You can use a VPN or turn off these services, but it may affect your MetaMask experience. Read our ",
     "functionality_body2": " to learn more.",
     "sheet": {


### PR DESCRIPTION
## **Description**

File: `locales/languages/en.json` (`default_settings.manage_networks_body3`).

Rule: mobile interaction heuristic — in-app links are tapped, not clicked. The string stays lowercase because it continues the preceding sentence.

User impact: the Solana privacy-policy link instruction matches mobile interaction language.

## **Changelog**

CHANGELOG entry: Replaced “click here” with “tap here” in network privacy copy

## **Related issues**

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

```gherkin
Feature: manage networks privacy link
  Scenario: default settings describe Infura
    Then the Solana privacy link label is “tap here.”
```

## **Screenshots/Recordings**

N/A — copy-only correction.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only English locale change with no functional or security impact.
> 
> **Overview**
> Updates the English **default settings → manage networks** privacy copy so the Solana-related link CTA says **“tap here.”** instead of **“click here.”**, aligning with mobile interaction wording while keeping the lowercase continuation of the preceding sentence.
> 
> No code or behavior changes—only the `default_settings.manage_networks_body3` string in `locales/languages/en.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e4a3d2d5daff2552253330f7b7ee0c4c20d84c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->