### PR TITLE
fix(content): use tap instead of click in bank transfer copy

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1058,7 +1058,7 @@
       "button_cancel": "Cancel order",
       "main_title": "To complete your order",
       "main_content_1": "Initiate a transfer from your preferred bank using the information below.",
-      "main_content_2": "Once you’re finished, come back and click “Confirm transfer” to confirm.",
+      "main_content_2": "Once you’re finished, come back and tap “Confirm transfer” to confirm.",
       "show_bank_info": "Show bank information",
       "hide_bank_info": "Hide bank information",
       "transfer_amount": "Transfer amount",


### PR DESCRIPTION
## **Description**

File: `locales/languages/en.json` (`deposit.bank_details.main_content_2`).

Rule: mobile interaction heuristic — the in-app Confirm transfer control is tapped, not clicked.

User impact: after sending a bank transfer, the return instruction names the same gesture people use in the app.

## **Changelog**

CHANGELOG entry: Replaced “click” with “tap” in bank transfer confirmation copy

## **Related issues**

Refs: N/A — found during a user-facing content audit

## **Manual testing steps**

```gherkin
Feature: deposit bank details
  Scenario: the user is completing a bank transfer
    Then the copy says to tap “Confirm transfer”
```

## **Screenshots/Recordings**

N/A — copy-only correction.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single English locale string change with no logic, API, or security impact.
> 
> **Overview**
> Updates **English** deposit bank-transfer instructions so users are told to **tap** “Confirm transfer” instead of **click**, matching mobile interaction language on `BankDetails`.
> 
> Only `locales/languages/en.json` (`deposit.bank_details.main_content_2`) changes; other locales still use click-equivalent wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28fc259bd6e5762d47a08047c0cf7f4d063e45a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->