### PR TITLE
feat: surface relayer fee in quote details

### DIFF
--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
@@ -316,6 +316,50 @@ describe('QuoteDetailsCard', () => {
     expect(getByTestId('price-impact-info-button')).toBeOnTheScreen();
   });
 
+  it('renders the relayer fee when the selected quote includes one', () => {
+    const mockModule = jest.requireMock('../../hooks/useBridgeQuoteData');
+    const originalImpl = mockModule.useBridgeQuoteData.getMockImplementation();
+
+    mockModule.useBridgeQuoteData.mockImplementationOnce(() => ({
+      ...originalImpl(),
+      activeQuote: {
+        ...mockQuotes[0],
+        quote: {
+          ...mockQuotes[0].quote,
+          feeData: {
+            relayer: [
+              {
+                amount: '1000000',
+                valueInCurrency: '1.23',
+                asset: mockQuotes[0].quote.feeData.metabridge[0].asset,
+              },
+            ],
+          },
+        },
+      },
+    }));
+
+    const { getByText } = renderScreen(
+      QuoteDetailsCardTestScreen,
+      { name: Routes.BRIDGE.ROOT },
+      { state: testState },
+    );
+
+    expect(getByText(strings('bridge.relayer_fee'))).toBeOnTheScreen();
+    expect(getByText('$1.23')).toBeOnTheScreen();
+    mockModule.useBridgeQuoteData.mockImplementation(originalImpl);
+  });
+
+  it('does not render the relayer fee when the selected quote omits it', () => {
+    const { queryByText } = renderScreen(
+      QuoteDetailsCardTestScreen,
+      { name: Routes.BRIDGE.ROOT },
+      { state: testState },
+    );
+
+    expect(queryByText(strings('bridge.relayer_fee'))).toBeNull();
+  });
+
   it('displays fee amount', () => {
     const { getByText, getByTestId } = renderScreen(
       QuoteDetailsCardTestScreen,

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -328,7 +328,7 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
           />
         )}
 
-        {relayerFee?.length > 0 && (
+        {Boolean(relayerFee?.length) && (
           <KeyValueRow
             field={{
               label: {

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -150,7 +150,7 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
 
   const relayerFee = activeQuote?.quote?.feeData?.relayer;
   const formattedRelayerFee = useMemo(() => {
-    if (!relayerFee) {
+    if (!relayerFee?.length) {
       return '-';
     }
 
@@ -328,7 +328,7 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
           />
         )}
 
-        {relayerFee && (
+        {relayerFee?.length > 0 && (
           <KeyValueRow
             field={{
               label: {

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -1,5 +1,7 @@
 import React, { useMemo } from 'react';
 import { TouchableOpacity, Platform, UIManager } from 'react-native';
+import { BigNumber } from 'bignumber.js';
+import { sumAmounts } from '@metamask/bridge-controller';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import { strings } from '../../../../../../locales/i18n';
@@ -56,6 +58,8 @@ import KeyValueRowLabel from '../../../../../component-library/components-temp/K
 import { usePriceImpactViewData } from '../../hooks/usePriceImpactViewData';
 import AppConstants from '../../../../../core/AppConstants';
 import { parsePriceImpact } from '../../utils/getPriceImpactViewData';
+import formatFiat from '../../../../../util/formatFiat';
+import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
 
 if (
   Platform.OS === 'android' &&
@@ -82,6 +86,7 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
   const sourceToken = useSelector(selectSourceToken);
   const destToken = useSelector(selectDestToken);
   const sourceAmount = useSelector(selectSourceAmount);
+  const currency = useSelector(selectCurrentCurrency);
   const {
     estimatedPoints,
     isLoading: isRewardsLoading,
@@ -142,6 +147,21 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
   };
 
   const isGasless = isGaslessQuote(activeQuote?.quote);
+
+  const relayerFee = activeQuote?.quote?.feeData?.relayer;
+  const formattedRelayerFee = useMemo(() => {
+    if (!relayerFee) {
+      return '-';
+    }
+
+    const fee = sumAmounts(relayerFee);
+    const valueInCurrency = fee?.valueInCurrency;
+    if (valueInCurrency == null) {
+      return '-';
+    }
+
+    return formatFiat(new BigNumber(valueInCurrency), currency);
+  }, [currency, relayerFee]);
 
   const formattedMinToTokenAmount = formatMinimumReceived(
     activeQuote?.quote.dest?.minAmountNormalized || '0',
@@ -301,6 +321,25 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
             value={{
               label: {
                 text: formattedQuoteData.networkFee,
+                variant: TextVariantLegacy.BodyMD,
+                color: TextColorLegacy.Default,
+              },
+            }}
+          />
+        )}
+
+        {relayerFee && (
+          <KeyValueRow
+            field={{
+              label: {
+                text: toSentenceCase(strings('bridge.relayer_fee')),
+                variant: TextVariantLegacy.BodyMD,
+                color: TextColorLegacy.Alternative,
+              },
+            }}
+            value={{
+              label: {
+                text: formattedRelayerFee,
                 variant: TextVariantLegacy.BodyMD,
                 color: TextColorLegacy.Default,
               },

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9044,6 +9044,7 @@
     "slippage": "Slippage",
     "slippage_info": "If the price changes between the time your order is placed and confirmed it’s called “slippage.” Your swap will automatically cancel if slippage exceeds the tolerance you set here.",
     "network_fee": "Network fee",
+    "relayer_fee": "Relayer fee",
     "gas_fees_sponsored": "Paid by MetaMask",
     "included": "Included",
     "estimated_time": "Estimated time",


### PR DESCRIPTION
## **Description**

Added a dedicated Relayer fee row to the selected swap/bridge quote details card when the selected quote includes `feeData.relayer`. The row uses the existing currency formatting and fee aggregation utilities, without changing quote totals, ranking, or submission behavior.

## **Changelog**

CHANGELOG entry: Added relayer fee transparency to swap and bridge quote details

## **Related issues**

Refs: N/A

## **Manual testing steps**

```gherkin
Feature: Relayer fee transparency

  Scenario: Display relayer fee for a quote that includes one
    Given a swap or bridge quote includes a relayer fee
    When the quote details card is displayed
    Then a Relayer fee row appears below Network fee with the formatted fee amount

  Scenario: Hide relayer fee when a quote does not include one
    Given a selected quote does not include a relayer fee
    When the quote details card is displayed
    Then no Relayer fee row appears
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only disclosure on quote details with conditional rendering and tests; no changes to quote logic or transaction submission.
> 
> **Overview**
> Adds **relayer fee transparency** on the bridge/swap **quote details card**: when the active quote has `feeData.relayer`, a new row appears under **Network fee** with the label from `bridge.relayer_fee` and a fiat amount from `sumAmounts` + `formatFiat` using the user’s current currency; the row is omitted when relayer fees are absent.
> 
> Adds English copy for **Relayer fee** and unit tests that assert the row shows with a mocked `$1.23` value and stays hidden when relayer data is missing. Quote selection, totals, and submission are unchanged—this is display-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d21cb7a8d22c3885e5c7c4f6083b1a4378893cd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->