### PR TITLE
perf: skip the splash exit animation when the wallet is ready first

### DIFF
--- a/app/components/UI/FoxLoader/FoxLoader.test.tsx
+++ b/app/components/UI/FoxLoader/FoxLoader.test.tsx
@@ -186,6 +186,70 @@ describe('FoxLoader', () => {
     expect(mockTriggerInput).not.toHaveBeenCalledWith('Start');
   });
 
+  it('reveals immediately, without starting the animation, when the wallet is ready before Rive', () => {
+    // Measured on a Galaxy A14: in 5/5 cold starts `appServicesReady` flipped
+    // ~216ms BEFORE Rive became playable, so `Start` and `Stop` fired ~10ms
+    // apart and the authored `Buildup` never ran. There is nothing to exit
+    // from, so paying `EXIT_ANIMATION_MS` shows the user nothing.
+    mockRiveViewReady = false;
+    const onAnimationComplete = jest.fn();
+
+    renderFoxLoader({ appServicesReady: true, onAnimationComplete });
+
+    expect(onAnimationComplete).toHaveBeenCalledTimes(1);
+    // Neither trigger should fire — the animation is skipped, not started and
+    // immediately stopped.
+    expect(mockTriggerInput).not.toHaveBeenCalled();
+  });
+
+  it('does not start the animation after revealing, even once Rive becomes ready', () => {
+    mockRiveViewReady = false;
+    const onAnimationComplete = jest.fn();
+    const { rerender } = renderFoxLoader({
+      appServicesReady: true,
+      onAnimationComplete,
+    });
+
+    expect(onAnimationComplete).toHaveBeenCalledTimes(1);
+
+    // Rive finishes loading after we already revealed — it must stay quiet
+    // rather than animating over live UI.
+    mockRiveViewReady = true;
+    rerender(
+      <FoxLoader appServicesReady onAnimationComplete={onAnimationComplete} />,
+    );
+
+    expect(mockTriggerInput).not.toHaveBeenCalled();
+  });
+
+  it('still plays the authored exit when Rive starts before the wallet is ready', () => {
+    // The slow-cold-start path, unchanged: the animation genuinely plays, so
+    // the exit must run exactly as before.
+    jest.useFakeTimers();
+    mockRiveViewReady = true;
+    const onAnimationComplete = jest.fn();
+    const { rerender } = renderFoxLoader({
+      appServicesReady: false,
+      onAnimationComplete,
+    });
+
+    expect(mockTriggerInput).toHaveBeenCalledWith('Start');
+    expect(onAnimationComplete).not.toHaveBeenCalled();
+
+    rerender(
+      <FoxLoader appServicesReady onAnimationComplete={onAnimationComplete} />,
+    );
+
+    expect(mockTriggerInput).toHaveBeenCalledWith('Stop');
+    expect(onAnimationComplete).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(800);
+    });
+    expect(onAnimationComplete).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
   it('fires Stop and completes after the exit animation delay when app services are ready', () => {
     jest.useFakeTimers();
     mockRiveViewReady = true;

--- a/app/components/UI/FoxLoader/FoxLoader.tsx
+++ b/app/components/UI/FoxLoader/FoxLoader.tsx
@@ -118,7 +118,7 @@ const FoxLoaderAnimation = ({
   }, [riveRef]);
 
   useEffect(() => {
-    if (!isPlaying) return;
+    if (!isPlaying || isCompleteRef.current) return;
     riveHandlers.onPlay();
     isPlayingRef.current = true;
     startAnimation();
@@ -165,11 +165,44 @@ const FoxLoaderAnimation = ({
     return () => clearTimeout(timeout);
   }, [completeAnimation]);
 
+  // If the wallet is ready before Rive can start, there is nothing to exit
+  // from — so reveal immediately rather than paying for an exit animation the
+  // user never saw begin.
+  //
+  // Measured on a Galaxy A14 (production release, 5/5 cold starts):
+  // `appServicesReady` flipped ~216ms BEFORE Rive became playable, and
+  // `stopAnimation()` then fired just ~10ms after `startAnimation()`. The
+  // authored `Buildup` was cut off almost immediately, so the only thing that
+  // ever rendered was the *exit* of an animation that never played — for
+  // ~880ms, on top of the wait for the 182KB `.riv` to finish loading.
+  //
+  // The static fox is already on screen at full opacity here (the cross-fade
+  // to Rive lives in the effect above, which is now skipped), so it stays
+  // visible and `ControllersGate` fades the whole overlay out. No blank frame.
+  //
+  // When Rive *does* start first — a slower cold start, where the animation
+  // genuinely plays and loops — `isPlayingRef` is already set and this is a
+  // no-op, leaving the authored exit below to run exactly as before.
+  useEffect(() => {
+    if (!appServicesReady || isCompleteRef.current || isPlayingRef.current) {
+      return;
+    }
+    completeAnimation();
+  }, [appServicesReady, completeAnimation]);
+
   // Once app is ready and the fox is playing, fire the exit trigger and
   // complete on a timer. Legacy observed `onStateChanged`/`ExitState`;
   // Nitro exposes neither signal, so completion is timed instead.
   useEffect(() => {
-    if (!appServicesReady || !isPlaying || exitTriggered.current) {
+    // `isCompleteRef` matters here: if the reveal already happened because the
+    // wallet was ready first, Rive may still finish loading afterwards, and
+    // triggering an exit on an overlay that is gone is pure dead work.
+    if (
+      !appServicesReady ||
+      !isPlaying ||
+      exitTriggered.current ||
+      isCompleteRef.current
+    ) {
       return undefined;
     }
     stopAnimation();


### PR DESCRIPTION
## **Description**

`FoxLoader` fires `triggerInput('Start')` when Rive becomes playable, then waits for `appServicesReady` to fire `triggerInput('Stop')`, and reveals the app `EXIT_ANIMATION_MS` (800 ms) later.

Instrumenting the gate on a Galaxy A14 (`production` release) showed the order is **consistently the other way round**. Across 5 cold starts, `appServicesReady` flipped **~216 ms before** Rive became playable:

| | r1 | r2 | r3 | r4 | r5 |
|---|---:|---:|---:|---:|---:|
| `services_ready` | 856 | 1737 | 926 | 981 | 970 |
| `rive_playing` | 1168 | 2164 | 1133 | 1196 | 1186 |
| `stop_triggered` | 1178 | 2174 | 1144 | 1207 | 1196 |

`Stop` fired just **10–11 ms after `Start`**, so the authored `Buildup` was cut off almost immediately. **The only thing that ever rendered was the *exit* of an animation the user never saw begin** — and we paid ~880 ms for it, on top of ~216 ms waiting for the 182 KB `.riv` to finish loading.

### The change

When the wallet is ready before Rive can start, there is nothing to exit from — reveal immediately.

The static fox is already on screen at full opacity (the cross-fade to Rive lives in the effect that is now skipped), so it simply stays visible and `ControllersGate` fades the whole overlay out. No blank frame, no flash.

**The slow-cold-start path is untouched.** When Rive starts first — which does happen, e.g. a first launch after install where services took ~4.6 s — the animation genuinely plays and loops, `isPlayingRef` is already set, and the authored exit runs exactly as before. A screen recording from such a run confirmed the loop (pixel diff 2.76 between frames 1 s apart, 0.22 between frames at the same loop phase).

Also guards the exit effect on `isCompleteRef`: without it, Rive finishing its load *after* the reveal would still trigger an exit on an overlay that no longer exists. One of the new tests caught that.

### Results

`app_services_ready` → `splash_loader_done`, n=5 medians:

| | ms |
|---|---:|
| Baseline | 1,752 |
| This PR alone | ~631 |
| **With #36041** (the 250 ms frozen frame) | **406** — runs 372 / 377 / 406 / 407 / 435 |

The residual ~406 ms is essentially the 300 ms cross-fade, which is real and visible.

### What a reviewer should push back on

- **It is a visible change on fast startups.** Today the user sees a brief fox morph; after this they see the static fox fade. Design should confirm they're happy — but the ask is narrow, because on this device the animation *was not playing anyway*.
- **Device-dependent.** All 5 runs on a Galaxy A14 had services ready first. On a faster device Rive may load sooner, in which case this self-disables and the animation plays as authored — correct behaviour, but a smaller saving.
- The 3,000 ms `ANIMATION_TIMEOUT_MS` fallback is untouched.
- `tsc` currently fails on `app/components/Views/ChoosePassword/index.tsx:914` — **pre-existing on clean `origin/main`**, verified by stashing this change and re-running. Not introduced here.

## **Changelog**

CHANGELOG entry: Reduced the delay before the wallet appears on app launch

## **Related issues**

Refs: #36041

## **Manual testing steps**

```gherkin
Feature: Splash reveal when the wallet is ready before the animation

  Scenario: fast cold start (wallet ready first)
    Given the app has been force-stopped
    And a production build is installed on an Android device

    When user launches the app
    Then the fox is shown while the wallet initialises
    And the app appears as soon as it is ready, with a single smooth fade
    And there is no blank frame, flash or visible pop

  Scenario: slow cold start (animation plays first)
    Given a first launch after install, or a heavily loaded device

    When user launches the app
    Then the fox animation plays and loops as authored
    And its exit animation plays before the app is revealed, as before

  Scenario: Rive cannot play at all
    Given a device where the Rive renderer is unsupported

    When user launches the app
    Then the static fox is shown
    And the app is still revealed via the existing timeout fallback
```

## **Screenshots/Recordings**

### **Before**

Gate timings from the instrumented build (ms from `FoxLoader` first render):

```
foxloader_render        0
rivefile_loaded       831   <- 182KB .riv finishes loading
services_ready_true   926   <- wallet is ready HERE
rive_playing         1186   <- animation can finally start
stop_triggered       1196   <- ...and is stopped 10ms later
animation_complete   2075   <- ~880ms spent exiting an animation never seen
```

### **After**

`animation_complete` moves to ~`services_ready`, and the 300 ms fade follows immediately. Measured `app_services_ready` → `splash_loader_done`: **406 ms**, down from 1,752 ms.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
  - 3 new cases: reveal-without-starting, no-start-after-reveal (which caught a real bug in the first draft), and the unchanged slow-start path. 24 tests pass across `FoxLoader` + `ControllersGate`.
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Samsung Galaxy A14 5G (SM-A146P), Android 15, `production` release build — a mid-range physical device.
- [x] I've tested with a power user scenario
  - Populated wallet with several imported accounts. Note this saving *grows* as the wallet gets faster to initialise, since it removes a fixed wait rather than shrinking work.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - No new instrumentation. This window is **not** covered by any shipped span today — `UIStartup` ends at `App`'s first render and `HomepageReady` starts later — so the saving will not appear in Sentry until something covers it.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
