### PR TITLE
feat(deeplinks): claim link.metamask.com app links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for `link.metamask.com` iOS Universal Links and Android App Links
+
 ## [8.10.2]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added support for `link.metamask.com` iOS Universal Links and Android App Links
+- Added support for `link.metamask.com` and `metamask.com` iOS Universal Links and Android App Links
 
 ## [8.10.2]
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -119,6 +119,13 @@
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />
 				<data android:scheme="https" />
+				<data android:host="link.metamask.com" />
+			</intent-filter>
+			<intent-filter android:autoVerify="true">
+				<action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				<data android:scheme="https" />
 				<data android:host="link-test.metamask.io" />
 			</intent-filter>
 			<intent-filter android:autoVerify="true">

--- a/ios/MetaMask/AppDelegate.swift
+++ b/ios/MetaMask/AppDelegate.swift
@@ -310,6 +310,7 @@ extension AppDelegate: BrazeDelegate {
     return host.contains("app.link") ||
       host.contains("test-app.link") ||
       host.contains("link.metamask.io") ||
+      host.contains("link.metamask.com") ||
       host.contains("link-test.metamask.io")
   }
 

--- a/ios/MetaMask/Info.plist
+++ b/ios/MetaMask/Info.plist
@@ -140,6 +140,7 @@
 	<array>
 		<string>metamask.app.link</string>
 		<string>link.metamask.io</string>
+		<string>link.metamask.com</string>
 		<string>link-test.metamask.io</string>
 		<string>metamask-alternate.app.link</string>
 		<string>metamask.test-app.link</string>

--- a/ios/MetaMask/MetaMask-Flask-Info.plist
+++ b/ios/MetaMask/MetaMask-Flask-Info.plist
@@ -127,6 +127,7 @@
 	<array>
 		<string>metamask.app.link</string>
 		<string>link.metamask.io</string>
+		<string>link.metamask.com</string>
 		<string>link-test.metamask.io</string>
 		<string>metamask-alternate.app.link</string>
 		<string>metamask.test-app.link</string>

--- a/ios/MetaMask/MetaMask.entitlements
+++ b/ios/MetaMask/MetaMask.entitlements
@@ -14,6 +14,7 @@
 		<string>applinks:metamask.app.link</string>
 		<string>applinks:metamask-alternate.app.link</string>
 		<string>applinks:link.metamask.io</string>
+		<string>applinks:link.metamask.com</string>
 		<string>applinks:link-test.metamask.io</string>
 		<string>applinks:metamask.test-app.link</string>
 		<string>applinks:metamask-alternate.test-app.link</string>

--- a/ios/MetaMask/MetaMask.entitlements
+++ b/ios/MetaMask/MetaMask.entitlements
@@ -11,6 +11,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:metamask.io</string>
+		<string>applinks:metamask.com</string>
 		<string>applinks:metamask.app.link</string>
 		<string>applinks:metamask-alternate.app.link</string>
 		<string>applinks:link.metamask.io</string>
@@ -19,6 +20,7 @@
 		<string>applinks:metamask.test-app.link</string>
 		<string>applinks:metamask-alternate.test-app.link</string>
 		<string>webcredentials:link.metamask.io</string>
+		<string>webcredentials:link.metamask.com</string>
 	</array>
 	<key>com.apple.developer.in-app-payments</key>
 	<array>

--- a/ios/MetaMask/MetaMaskDebug.entitlements
+++ b/ios/MetaMask/MetaMaskDebug.entitlements
@@ -14,6 +14,7 @@
 		<string>applinks:metamask.app.link</string>
 		<string>applinks:metamask-alternate.app.link</string>
 		<string>applinks:link.metamask.io</string>
+		<string>applinks:link.metamask.com</string>
 		<string>applinks:link-test.metamask.io</string>
 		<string>applinks:metamask.test-app.link</string>
 		<string>applinks:metamask-alternate.test-app.link</string>

--- a/ios/MetaMask/MetaMaskDebug.entitlements
+++ b/ios/MetaMask/MetaMaskDebug.entitlements
@@ -11,6 +11,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:metamask.io</string>
+		<string>applinks:metamask.com</string>
 		<string>applinks:metamask.app.link</string>
 		<string>applinks:metamask-alternate.app.link</string>
 		<string>applinks:link.metamask.io</string>
@@ -19,6 +20,7 @@
 		<string>applinks:metamask.test-app.link</string>
 		<string>applinks:metamask-alternate.test-app.link</string>
 		<string>webcredentials:link.metamask.io</string>
+		<string>webcredentials:link.metamask.com</string>
 	</array>
 	<key>com.apple.developer.in-app-payments</key>
 	<array>


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds native associated-domain claims for the `.com` universal-link migration while retaining every existing `.io` domain. This lets iOS and Android associate the new hosts with MetaMask Mobile ahead of the separately feature-gated JS routing work.

The change:

- Adds `applinks:link.metamask.com`, `applinks:metamask.com`, and `webcredentials:link.metamask.com` to iOS release and debug entitlements
- Adds `link.metamask.com` to the main and Flask Branch `branch_universal_link_domains` lists
- Forwards `link.metamask.com` through the Braze universal-link host helper in `AppDelegate`
- Adds a verified Android App Link intent-filter for `https://link.metamask.com` (Android does not claim apex `metamask.com`)

JavaScript host acceptance and signature-origin rewrite remain in follow-up PRs and stay feature-gated.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added support for `link.metamask.com` and `metamask.com` iOS Universal Links and Android App Links

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: [MCWP-894](https://consensyssoftware.atlassian.net/browse/MCWP-894), [DUS-15688](https://consensyssoftware.atlassian.net/browse/DUS-15688)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: .com native app association

  Scenario: iOS opens a link.metamask.com universal link in MetaMask
    Given a build signed with the updated associated-domains entitlement
    And link.metamask.com serves an AASA file containing the app identifier

    When user opens a supported https://link.metamask.com link
    Then iOS should launch MetaMask Mobile

  Scenario: iOS opens a metamask.com universal link in MetaMask
    Given a build signed with the updated associated-domains entitlement
    And metamask.com serves an AASA file containing the app identifier

    When user opens a supported https://metamask.com link
    Then iOS should launch MetaMask Mobile

  Scenario: Android opens a verified link.metamask.com App Link in MetaMask
    Given an installed build with verified App Links
    And link.metamask.com serves assetlinks.json containing the application identifier

    When user opens a supported https://link.metamask.com link
    Then Android should launch MetaMask Mobile

  Scenario: existing .io App Links and Universal Links still open MetaMask
    Given the same installed build

    When user opens a supported https://link.metamask.io link
    Then the app should still launch MetaMask Mobile
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

[MCWP-894]: https://consensyssoftware.atlassian.net/browse/MCWP-894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
