### PR TITLE
[DON'T MERGE] Bump authenticated-user-storage to use mutations for persisting watchlist

### DIFF
--- a/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistMutations.ts
+++ b/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistMutations.ts
@@ -113,10 +113,16 @@ export const tokenWatchlistBatcher = createAsyncBatcher<WatchlistOp>(
       (acc, op) => applyOp(acc, op),
       [...current.assets],
     );
+    console.log(
+      '[useTokenWatchlistUpdateListMutation] Calling writeToTokenWatchList...',
+    );
     await writeToTokenWatchList({
       ...current,
       assets: nextAssets,
     });
+    console.log(
+      '[useTokenWatchlistUpdateListMutation] FINISHED calling writeToTokenWatchList',
+    );
     // Soft-fail mirror — never rolls back a successful real-watchlist write.
     await syncPriceAlertsWatchlistMirror(current.assets, nextAssets);
   },

--- a/app/components/UI/Assets/watchlist/storage.ts
+++ b/app/components/UI/Assets/watchlist/storage.ts
@@ -39,6 +39,9 @@ export async function writeToTokenWatchList(
   blob: WatchlistBlob,
 ): Promise<void> {
   const validated = create(blob, WatchlistBlobSchema);
+  console.log(
+    `[writeToTokenWatchList] Calling ${SET_ASSETS_WATCHLIST_ACTION}...`,
+  );
   await (Engine.controllerMessenger.call as CallableFunction)(
     SET_ASSETS_WATCHLIST_ACTION,
     validated,

--- a/package.json
+++ b/package.json
@@ -259,6 +259,16 @@
     "@metamask/profile-sync-controller": "^30.0.0",
     "@metamask/account-tree-controller": "^9.0.0"
   },
+  "previewBuilds": {
+    "@metamask/base-data-service": {
+      "type": "non-breaking",
+      "previewVersion": "1.0.0-preview-8bfa290fb"
+    },
+    "@metamask/authenticated-user-storage": {
+      "type": "non-breaking",
+      "previewVersion": "3.0.2-preview-8bfa290fb"
+    }
+  },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",
     "@consensys/on-ramp-sdk": "2.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9654,16 +9654,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/authenticated-user-storage@npm:^3.0.1, @metamask/authenticated-user-storage@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "@metamask/authenticated-user-storage@npm:3.0.2"
+"@metamask/authenticated-user-storage@npm:@metamask-previews/authenticated-user-storage@3.0.2-preview-8bfa290fb":
+  version: 3.0.2-preview-8bfa290fb
+  resolution: "@metamask-previews/authenticated-user-storage@npm:3.0.2-preview-8bfa290fb"
   dependencies:
     "@metamask/base-data-service": "npm:^1.0.0"
     "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/superstruct": "npm:^3.4.1"
-    "@metamask/utils": "npm:^11.11.0"
-  checksum: 10/b368bce476e7d56af7b0bb321c4885bc1f4a60a9bee3a97234aa37fdae016cf072eee5eb010ef7c272b90c41574e0e661503bb4519738facbc4adbd781ffc967
+    "@metamask/utils": "npm:^11.12.0"
+  checksum: 10/d1a1a28bc523fd4d9d1603c63dcac080262765f6b30ab7988f04d9639ef5fe5ca234b60741a626a33bfb0e7ebd9a431a4beab50094752e25f6832d1201096ab3
   languageName: node
   linkType: hard
 
@@ -9701,19 +9701,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-data-service@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@metamask/base-data-service@npm:1.0.0"
+"@metamask/base-data-service@npm:@metamask-previews/base-data-service@1.0.0-preview-8bfa290fb":
+  version: 1.0.0-preview-8bfa290fb
+  resolution: "@metamask-previews/base-data-service@npm:1.0.0-preview-8bfa290fb"
   dependencies:
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/storage-service": "npm:^1.0.2"
     "@metamask/superstruct": "npm:^3.4.1"
-    "@metamask/utils": "npm:^11.11.0"
+    "@metamask/utils": "npm:^11.12.0"
     "@tanstack/query-core": "npm:^5.62.16"
     cockatiel: "npm:^3.1.2"
     fast-deep-equal: "npm:^3.1.3"
     lodash: "npm:^4.17.21"
-  checksum: 10/c965dc930a3c172c71624278499f4ec2da829def684c3923b2729d1a31dd2635d5c05230a9dc9ea8546adc029c4e2ed782fdc992be4692d47d9aafdb2d778deb
+  checksum: 10/d822362667db2a1da05525985d94449be5edefc1f20541121cff1fdf0f41ecbad84cf53a6834fdda3ba02d3dea775cccb85eb0f340a280bbb3bd3cdbf4178f8e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR bumps `@metamask/authenticated-user-storage` and `@metamask/base-data-service` to preview versions where `AuthenticatedUserStorageService.setAssetsWatchlist` uses `executeMutation` — a new method in `BaseDataService` — to make the underlying API request.

Also see https://github.com/MetaMask/core/pull/9324 for the changes to `BaseDataService` which make this possible.

This PR will be removed once this smoke test is complete.

## Manual testing steps

1. Check out this branch and run `yarn watch:clean`.
2. Open your emulator, then open MetaMask.
3. Load the home screen.
4. Scroll down to Watchlist and tap on the header.
5. Tap on the Edit button in the corner.
6. Reorder the list of tokens by holding down on the scrub icon until the row grows bigger and then dragging up or down. Then tap Done.
7. Observe the following lines in your terminal:
   ```
   LOG  [useTokenWatchlistUpdateListMutation] Calling writeToTokenWatchList...
   LOG  [writeToTokenWatchList] Calling AuthenticatedUserStorageService:setAssetsWatchlist...
   LOG  [useTokenWatchlistUpdateListMutation] FINISHED calling writeToTokenWatchList
   ```
8. This proves that the messenger call continues to work without producing any errors.
9. Go back to the home screen and pull down to refresh.
10. Scroll back down to Watchlist. Your tokens should be in the same order that you arranged them in.