### PR TITLE
fix: use pill shape for chart selector controls

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/TimeRangeSelector.tsx
+++ b/app/components/UI/Charts/AdvancedChart/TimeRangeSelector.tsx
@@ -42,9 +42,9 @@ export const TIME_RANGE_CONFIGS: Record<TimeRange, TimeRangeConfig> = {
 
 const TIME_RANGES: TimeRange[] = ['1H', '1D', '1W', '1M', '1Y'];
 
-/** padding 4px 16px, gap spacing/1, rounded 8 — filter control spec */
+/** Padding 4px 16px with fully rounded pill corners. */
 const SEGMENT_BUTTON_BASE =
-  'min-w-0 flex-1 flex-row items-center justify-center gap-1 rounded-lg px-4 py-1 rounded-xl';
+  'min-w-0 flex-1 flex-row items-center justify-center gap-1 rounded-full px-4 py-1';
 
 /** @see TOKEN_OVERVIEW_TIME_RANGE_ROW_HEIGHT */
 const TIME_RANGE_SKELETON_HEIGHT = TOKEN_OVERVIEW_TIME_RANGE_ROW_HEIGHT;
@@ -98,7 +98,7 @@ const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
       {showChartLoadingSkeleton ? (
         <Box
           style={{ height: TIME_RANGE_SKELETON_HEIGHT }}
-          twClassName="w-full flex-1 overflow-hidden rounded-lg"
+          twClassName="w-full flex-1 overflow-hidden rounded-full"
         >
           <SkeletonPlaceholder
             backgroundColor={colors.background.section}
@@ -115,7 +115,7 @@ const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
         <Box
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Center}
-          twClassName="w-full flex-1 rounded-lg"
+          twClassName="w-full flex-1 rounded-full"
         >
           {ranges.map((range) => {
             const isSelected = selected === range;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

The chart timeframe and chart-type controls in `TimeRangeSelector` used rounded-rectangle corners (`rounded-lg` / `rounded-xl`) instead of the fully rounded pill treatment required by the brand migration.

This change swaps those radii for `rounded-full` on the segment buttons, the segment row container, and the loading skeleton wrapper, and removes a duplicate `rounded-lg` class. Selection state, chart-type toggling, loading behavior, and accessibility labels are untouched — this is a visual-only fix.

Follow-up: DSYS-1105 tracks migrating these controls to the appropriate MMDS component, at which point the radius will come from the design system rather than local Tailwind classes.

Design reference: [Mobile Papercuts (node 1485-16)](https://www.figma.com/design/aRyo0N82L0IoNlMVIKvSpc/Mobile-Papercuts?node-id=1485-16&t=S5OE0N4xh80CT0Oh-1)

## **Changelog**

CHANGELOG entry: Updated the token chart timeframe and chart-type controls to use the new fully rounded pill shape

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-1104
Refs: https://consensyssoftware.atlassian.net/browse/DSYS-1082 (parent epic), https://consensyssoftware.atlassian.net/browse/DSYS-1105 (MMDS migration follow-up)

## **Manual testing steps**

```gherkin
Feature: Chart timeframe controls use pill-shaped corners

  Scenario: Timeframe controls render as pills on token details
    Given the wallet is unlocked and the Home tab is visible
    When user taps a token with price history in the Tokens list (e.g. ETH)
    And user waits for the price chart to finish loading
    Then the 1H / 1D / 1W / 1M / 1Y controls below the chart have fully rounded corners
    And the selected timeframe's filled background is also fully rounded

  Scenario: Chart-type control matches the pill treatment
    Given user is on the token details screen with the chart loaded
    When user looks at the chart-type control at the end of the timeframe row
    Then it uses the same fully rounded corners as the timeframe controls
    When user taps the chart-type control
    Then the chart switches between line and candlestick as before

  Scenario: Loading skeleton keeps the pill silhouette
    Given user opens token details for a token whose chart data is still loading
    Then the timeframe row skeleton is fully rounded
    And no layout shift occurs when the real controls replace it
```

## **Screenshots/Recordings**

Visual evidence is being captured manually as part of the DSYS-1082 brand-migration baseline. Path to the affected surface: Home → Tokens list → token details → control row directly beneath the price chart.

### **Before**

Timeframe and chart-type controls render with rounded-rectangle corners.

<img width="515" height="164" alt="Screenshot 2026-09-10 at 3 35 26 PM" src="https://github.com/user-attachments/assets/460a96b8-5fdd-4a01-b6e7-958c1da71803" />

<!-- [screenshots/recordings] -->

### **After**

Timeframe and chart-type controls render as fully rounded pills.

https://github.com/user-attachments/assets/44d10d8d-553f-4390-9c1b-17e77b2f9ff6

<img width="392" height="125" alt="Screenshot 2026-09-10 at 3 34 23 PM" src="https://github.com/user-attachments/assets/dc3b69a7-bd14-4705-8bd2-47818d0e6251" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Not applicable — this change only swaps Tailwind border-radius classes on an already-rendered control row. No new renders, data fetching, or instrumented operations are introduced.

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e094100-862e-459e-ba72-1a87dd756519?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e094100-862e-459e-ba72-1a87dd756519&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
