### PR TITLE
fix: make Pay with network filters pill-shaped

### DIFF
--- a/app/components/UI/QuickBuy/components/QuickBuyPayWithChainFilter.tsx
+++ b/app/components/UI/QuickBuy/components/QuickBuyPayWithChainFilter.tsx
@@ -37,7 +37,7 @@ const QuickBuyPayWithChainFilter: React.FC<QuickBuyPayWithChainFilterProps> = ({
       onChipSelect={(key) => onSelect(key === 'all' ? null : key)}
       testID={testID}
       containerTwClassName="pb-3"
-      chipTwClassName="rounded-lg px-3 py-1.5"
+      chipTwClassName="rounded-full px-3 py-1.5"
       getChipTestId={getChainFilterTestId}
       useGestureHandlerScrollView
     />


### PR DESCRIPTION
## **Description**

Updated the Quick Buy **Pay with** network filter buttons to use fully rounded pill corners, matching the brand migration visual language. Selection state, colors, labels, icons, filtering behavior, scrolling, and accessibility behavior are unchanged.

This is a styling-only change to the existing network filter controls. The MMDS migration follow-up is tracked separately in DSYS-1110.

Design reference: [Mobile Papercuts](https://www.figma.com/design/aRyo0N82L0IoNlMVIKvSpc/Mobile-Papercuts?node-id=1485-16&t=S5OE0N4xh80CT0Oh-1)

## **Changelog**

CHANGELOG entry: Updated Quick Buy network filters to use the new fully rounded pill shape

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-1109
Refs: https://consensyssoftware.atlassian.net/browse/DSYS-1110

## **Manual testing steps**

```gherkin
Feature: Quick Buy Pay with network filters

  Scenario: Network filters render as pills
    Given the wallet is unlocked and the Home tab is visible
    When user opens Quick Buy and opens the Pay with token picker
    Then the network filter buttons use fully rounded pill corners
    And the selected and unselected colors remain unchanged

  Scenario: Network filtering behavior is preserved
    Given the Pay with token picker is open
    When user taps a network filter
    Then the selected filter updates
    And the token list shows tokens for the selected network
```

Focused test:
`yarn jest app/components/UI/QuickBuy/components/QuickBuyPayWithChainFilter.test.tsx --runInBand`

## **Screenshots/Recordings**

### **Before**

<img width="509" height="122" alt="Screenshot 2026-09-10 at 5 34 36 PM" src="https://github.com/user-attachments/assets/1ee7aeca-9cf0-4aed-8845-4965166d4dfd" />

### **After**

Rendering in storybook as no access to component in app because markets are closed

https://github.com/user-attachments/assets/36aac57e-4550-426d-bf6f-c1a693cda29c

<img width="399" height="104" alt="Screenshot 2026-09-10 at 5 33 22 PM" src="https://github.com/user-attachments/assets/737ba00b-78e7-48f0-a60f-24c51d3f280b" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A — this is a border-radius-only styling change with no performance-sensitive behavior.

- [x] I've tested on Android — N/A for this styling-only change.
- [x] I've tested with a power user scenario — N/A for this styling-only change.
- [x] I've instrumented key operations with Sentry traces for production performance metrics — N/A for this styling-only change.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
