### PR TITLE
fix: use pill shape for Predictions popular filters

### DIFF
--- a/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
@@ -227,7 +227,7 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
                     onPress={() => handleChipPress(option)}
                     accessibilityRole="button"
                     accessibilityLabel={label}
-                    style={tw.style('rounded-xl bg-muted px-4 py-2')}
+                    style={tw.style('rounded-full bg-muted px-4 py-2')}
                   >
                     <Text
                       variant={TextVariant.BodySm}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Updated the Predictions home "Popular today" filter chips to use the fully rounded pill shape required by the brand migration. The existing Pressable implementation and interaction behavior are unchanged. The implementation is intentionally a quick visual fix; the follow-up MMDS migration is tracked separately.

Figma reference: https://www.figma.com/design/aRyo0N82L0IoNlMVIKvSpc/Mobile-Papercuts?node-id=1485-16&t=S5OEwN4xh80CT0Oh-1

## **Changelog**

CHANGELOG entry: Fixed the shape of Predictions popular filter buttons to match the brand migration.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-1108

Follow-up MMDS migration: https://consensyssoftware.atlassian.net/browse/DSYS-1111

## **Manual testing steps**

```gherkin
Feature: Predictions popular filter pills
  Scenario: User views the Predictions home filters
    Given the Predictions home screen is open
    When the Popular today section is displayed
    Then each filter chip has a fully rounded pill shape
    And tapping a chip continues to open the selected filter
```

Automated tests were not run before handoff; this is a one-line styling change.

## **Screenshots/Recordings**

### **Before**

N/A — source screenshot is captured in the linked Figma file.

### **After**

N/A — no simulator session was available for this styling-only change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401486401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74755e4b-9f1e-4f86-ba21-9b2ad5e7eac5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74755e4b-9f1e-4f86-ba21-9b2ad5e7eac5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

