### PR TITLE
fix: perps position actions to use pill buttons

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionCard.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionCard.tsx
@@ -53,7 +53,7 @@ interface PerpsProPositionCardProps {
   isEditMarginDisabled?: boolean;
 }
 
-const ACTION_BUTTON_CLASS_NAME = 'flex-1';
+const ACTION_BUTTON_CLASS_NAME = 'flex-1 rounded-full';
 const ACTION_BUTTON_TEXT_PROPS = {
   variant: TextVariant.BodySm,
   fontWeight: FontWeight.Medium,
@@ -446,7 +446,7 @@ const PerpsProPositionCard = ({
             size={ButtonIconSize.Md}
             variant={ButtonIconVariant.Filled}
             iconProps={{ size: IconSize.Md }}
-            twClassName="rounded-md"
+            twClassName="rounded-full"
             onPress={() => onShare?.(position)}
             testID={PerpsProMarketViewSelectorsIDs.POSITION_SHARE}
             accessibilityLabel={strings('perps.pro_positions_panel.card.share')}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Updated the Perps Pro position card action controls to use fully rounded pill/circular styling for Close, Reverse, and Share. The controls already use MMDS components, so this is a focused visual fix that preserves existing behavior, layout, and interactions.

Reference: [DSYS-1113](https://consensyssoftware.atlassian.net/browse/DSYS-1113)
Figma: [Mobile Papercuts — node 1485-16](https://www.figma.com/design/aRyo0N82L0IoNlMVIKvSpc/Mobile-Papercuts?node-id=1485-16&t=S5OEwN4xh80CT0Oh-1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [DSYS-1113](https://consensyssoftware.atlassian.net/browse/DSYS-1113)

## **Manual testing steps**

N/A — visual-only styling change. Device visual verification remains for reviewer validation.

## **Screenshots/Recordings**

### **Before**

See the original image attached to the Jira ticket.

### **After**

N/A — no device capture available in this environment.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9960edc3-70d3-44aa-9cf7-c3e8a61b2c75?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9960edc3-70d3-44aa-9cf7-c3e8a61b2c75&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[DSYS-1107]: https://consensyssoftware.atlassian.net/browse/DSYS-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSYS-1107]: https://consensyssoftware.atlassian.net/browse/DSYS-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DSYS-1113]: https://consensyssoftware.atlassian.net/browse/DSYS-1113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSYS-1113]: https://consensyssoftware.atlassian.net/browse/DSYS-1113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ