### PR TITLE
fix: use pill buttons in perps positions filters

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.tsx
@@ -1307,6 +1307,7 @@ const PerpsProPositionsPanel = ({
           variant={ButtonVariant.Secondary}
           size={ButtonSize.Sm}
           endIconName={IconName.ArrowDown}
+          twClassName="rounded-full"
           onPress={() => setIsSideFilterSheetOpen(true)}
           testID={
             isChaseTab
@@ -1318,7 +1319,7 @@ const PerpsProPositionsPanel = ({
         >
           {strings(getProPositionSideFilterButtonLabelKey(activeSideFilter))}
         </Button>
-        <Box twClassName="bg-muted rounded-lg px-2 py-1">
+        <Box twClassName="bg-muted rounded-full px-2 py-1">
           {renderTickerOnlyCheckbox()}
         </Box>
         {isChaseTab && chaseActivityFilter === 'history' ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Updated the Perps Pro positions filter controls to use fully rounded pill styling for the side filter button and ticker-only control. This is a visual-only brand migration fix and preserves existing interactions, spacing, and states.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [DSYS-1107](https://consensyssoftware.atlassian.net/browse/DSYS-1107)

Figma reference: https://www.figma.com/design/aRyo0N82L0IoNlMVIKvSpc/Mobile-Papercuts?node-id=1485-16&t=S5OEwN4xh80CT0Oh-1

## **Manual testing steps**

```gherkin
Feature: Perps Pro positions filter pills

  Scenario: view pill-shaped position filters
    Given the Perps Pro market view is open with the Positions tab selected
    When the positions filter controls are displayed
    Then the side filter and ticker-only controls use fully rounded pill shapes
    And their existing behavior is unchanged
```

## **Screenshots/Recordings**

### **Before**

N/A — source screenshot is attached to the Jira ticket.

### **After**

N/A — visual-only style change; to be verified on device.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ee4d002-7291-4fe8-bf0a-84cff081d97e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ee4d002-7291-4fe8-bf0a-84cff081d97e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[DSYS-1107]: https://consensyssoftware.atlassian.net/browse/DSYS-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ