### PR TITLE
fix: make quick-pick buttons pill-shaped

### DIFF
--- a/app/components/UI/Bridge/components/SwapsKeypad/QuickPickButtons.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsKeypad/QuickPickButtons.test.tsx
@@ -324,6 +324,18 @@ describe('QuickPickButtons', () => {
         });
       });
     });
+
+    it('applies the fully rounded pill shape', () => {
+      const { getAllByRole } = render(
+        <QuickPickButtons options={defaultOptions} show />,
+      );
+
+      getAllByRole('button').forEach((button) => {
+        expect(StyleSheet.flatten(button.props.style)).toMatchObject({
+          borderRadius: 999,
+        });
+      });
+    });
   });
 
   describe('re-rendering behavior', () => {

--- a/app/components/UI/Bridge/components/SwapsKeypad/styles.tsx
+++ b/app/components/UI/Bridge/components/SwapsKeypad/styles.tsx
@@ -12,5 +12,6 @@ export const quickPickButtonsStyles = StyleSheet.create({
     flexBasis: 0,
     flexShrink: 1,
     minWidth: 0,
+    borderRadius: 999,
   },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- apply the fully rounded pill treatment to swap/send quick-pick buttons
- add a regression test for the pill shape

## Jira
- [DSYS-1112](https://consensyssoftware.atlassian.net/browse/DSYS-1112)
- Parent epic: [DSYS-1082](https://consensyssoftware.atlassian.net/browse/DSYS-1082)
- Figma: https://www.figma.com/design/aRyo0N82L0IoNlMVIKvSpc/Mobile-Papercuts?node-id=1485-16&t=S5OEWn4xh80CT0Oh-1

## Testing
- Pending local Jest test
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6a1652b-ad1e-49dc-bd26-9b3df7507cdb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6a1652b-ad1e-49dc-bd26-9b3df7507cdb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[DSYS-1112]: https://consensyssoftware.atlassian.net/browse/DSYS-1112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSYS-1082]: https://consensyssoftware.atlassian.net/browse/DSYS-1082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ