### PR TITLE
fix(predict): use pill-shaped controls

### DIFF
--- a/app/components/UI/Predict/components/PredictChipList/PredictChipList.tsx
+++ b/app/components/UI/Predict/components/PredictChipList/PredictChipList.tsx
@@ -23,7 +23,7 @@ import { useChipScrollList } from './useChipScrollList';
 export { calculateChipScrollX } from './calculateChipScrollX';
 
 const DEFAULT_CONTAINER_CLASS = 'pt-3 pb-3';
-const DEFAULT_CHIP_CLASS = 'rounded-xl px-4 py-2';
+const DEFAULT_CHIP_CLASS = 'rounded-full px-4 py-2';
 
 const PredictChipList: React.FC<PredictChipListProps> = ({
   chips,

--- a/app/components/UI/Predict/components/PredictDetailsChart/components/TimeframeSelector.tsx
+++ b/app/components/UI/Predict/components/PredictDetailsChart/components/TimeframeSelector.tsx
@@ -36,7 +36,7 @@ const TimeframeSelector: React.FC<TimeframeSelectorProps> = ({
           onPress={() => onTimeframeChange(timeframe)}
           style={({ pressed }) =>
             tw.style(
-              'flex-1 py-2 rounded-lg',
+              'flex-1 py-2 rounded-full',
               selectedTimeframe === timeframe ? 'bg-muted' : 'bg-default',
               pressed && 'bg-pressed',
             )

--- a/app/components/UI/Predict/components/PredictGameChart/TimeframeSelector.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/TimeframeSelector.tsx
@@ -42,7 +42,7 @@ const TimeframeSelector: React.FC<TimeframeSelectorProps> = ({
             disabled={disabled}
             style={({ pressed }) =>
               tw.style(
-                'px-4 py-2 rounded-md flex-1',
+                'px-4 py-2 rounded-full flex-1',
                 isSelected ? 'bg-background-pressed' : 'bg-transparent',
                 disabled && 'opacity-50',
                 pressed && !isSelected && 'bg-background-hover',


### PR DESCRIPTION
## Description

Updates Predict market detail controls to use fully rounded pill styling for the brand migration. This covers the game line chips and both timeframe selector implementations while preserving existing behavior and visual states.

## Related issues

- Fixes [DSYS-1107](https://consensyssoftware.atlassian.net/browse/DSYS-1107)
- Epic: [DSYS-1082](https://consensyssoftware.atlassian.net/browse/DSYS-1082)
- Figma: https://www.figma.com/design/aRyo0N82L0IoNlMVIKvSpc/Mobile-Papercuts?node-id=1485-16&t=S5OEwN4xh80CT0Oh-1

## Testing

- `yarn jest app/components/UI/Predict/components/PredictChipList app/components/UI/Predict/components/PredictGameChart/TimeframeSelector app/components/UI/Predict/components/PredictDetailsChart --runInBand`

## Screenshots

Not captured; styling-only change.

[DSYS-1107]: https://consensyssoftware.atlassian.net/browse/DSYS-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSYS-1082]: https://consensyssoftware.atlassian.net/browse/DSYS-1082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind border-radius class swaps only; no logic, data, or interaction changes.
> 
> **Overview**
> Updates Predict market-detail controls to **pill-shaped** corners as part of the brand migration, without changing selection, press, or disabled behavior.
> 
> `PredictChipList` default chip styling moves from `rounded-xl` to **`rounded-full`**. Both timeframe selectors—`PredictDetailsChart` (`rounded-lg` → `rounded-full`) and `PredictGameChart` (`rounded-md` → `rounded-full`)—get the same treatment so game-line chips and chart time ranges match the new control shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b1d57539320d3efc069238969784c601d85bb56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->