### PR TITLE
Use pill styling for Predict market controls

### DIFF
--- a/app/components/UI/Predict/components/PredictChipList/PredictChipList.tsx
+++ b/app/components/UI/Predict/components/PredictChipList/PredictChipList.tsx
@@ -23,7 +23,7 @@ import { useChipScrollList } from './useChipScrollList';
 export { calculateChipScrollX } from './calculateChipScrollX';
 
 const DEFAULT_CONTAINER_CLASS = 'pt-3 pb-3';
-const DEFAULT_CHIP_CLASS = 'rounded-xl px-4 py-2';
+const DEFAULT_CHIP_CLASS = 'rounded-full px-4 py-2';
 
 const PredictChipList: React.FC<PredictChipListProps> = ({
   chips,

--- a/app/components/UI/Predict/components/PredictGameChart/TimeframeSelector.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/TimeframeSelector.tsx
@@ -42,7 +42,7 @@ const TimeframeSelector: React.FC<TimeframeSelectorProps> = ({
             disabled={disabled}
             style={({ pressed }) =>
               tw.style(
-                'px-4 py-2 rounded-md flex-1',
+                'px-4 py-2 rounded-full flex-1',
                 isSelected ? 'bg-background-pressed' : 'bg-transparent',
                 disabled && 'opacity-50',
                 pressed && !isSelected && 'bg-background-hover',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Updated the Predict market details timeframe selector and market-line chip controls to use fully rounded pill styling required by the brand migration. Existing interactions, spacing, colors, and selected states are unchanged.

Reference: [DSYS-1107](https://consensyssoftware.atlassian.net/browse/DSYS-1107)
Figma: [Mobile Papercuts — node 1485-16](https://www.figma.com/design/aRyo0N82L0IoNlMVIKvSpc/Mobile-Papercuts?node-id=1485-16&t=S5OEwN4xh80CT0Oh-1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [DSYS-1107](https://consensyssoftware.atlassian.net/browse/DSYS-1107)

## **Manual testing steps**

N/A — visual-only styling change. Device visual verification remains for reviewer validation.

## **Screenshots/Recordings**

### **Before**

See the image attached to the Jira ticket.

### **After**

N/A — no device capture available in this environment.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9960edc3-70d3-44aa-9cf7-c3e8a61b2c75?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9960edc3-70d3-44aa-9cf7-c3e8a61b2c75&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[DSYS-1107]: https://consensyssoftware.atlassian.net/browse/DSYS-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSYS-1107]: https://consensyssoftware.atlassian.net/browse/DSYS-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ