### PR TITLE
ci: fix dead SonarCloud step in ci.yml (MCWP-740)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1740,6 +1740,7 @@ jobs:
         ${{
           (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
         }}
+      HAVE_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN != '' }}
     needs: merge-unit-and-component-view-tests
     # Run when merged coverage is ready even if optional integration shards failed upstream.
     if: ${{ always() && !cancelled() && needs.merge-unit-and-component-view-tests.result == 'success' && github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
@@ -1786,7 +1787,6 @@ jobs:
         # This is SonarSource/sonarqube-scan-action@v7.0.0
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
         env:
-          HAVE_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN != '' }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: Require clean working directory
         shell: bash


### PR DESCRIPTION
## **Description**

Fixes a dead CI step as part of MCWP-740 — CI workflow inventory and pruning.

**`ci.yml` — SonarCloud step never runs (fixed)**

The `SonarCloud Scan` step guards itself with `if: ${{ env.HAVE_SONAR_TOKEN == 'true' }}`, but `HAVE_SONAR_TOKEN` was defined in the step's own `env:` block — a value set at step level is not available to that same step's `if:` condition in GitHub Actions. The condition therefore always evaluates to `false` and SonarCloud never runs regardless of whether `SONAR_TOKEN` is set. Fix: move `HAVE_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN != '' }}` to the job-level `env:` block where it is visible to step `if:` expressions.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MCWP-740

## **Manual testing steps**

N/A — no app code or behavior is affected. The SonarCloud fix will cause SonarCloud to run where it was previously silently skipped.

## **Screenshots/Recordings**

### **Before**

N/A — CI workflow files only, no UI changes

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.