### PR TITLE
feat(money): collapse the pushed Money header to match Perps

### DIFF
--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -1361,6 +1361,24 @@ describe('MoneyHomeView', () => {
     });
   });
 
+  describe('collapsing title', () => {
+    it('moves the title into the content when the stack was pushed', () => {
+      mockRouteParams = { showBackButton: true };
+
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      expect(getByTestId(MoneyBalanceSummaryTestIds.TITLE)).toBeOnTheScreen();
+    });
+
+    it('keeps the title in the header as the Money tab', () => {
+      const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      expect(
+        queryByTestId(MoneyBalanceSummaryTestIds.TITLE),
+      ).not.toBeOnTheScreen();
+    });
+  });
+
   it('opens the More sheet when menu button is pressed', () => {
     const { getByTestId } = renderWithProvider(<MoneyHomeView />);
 

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -1246,6 +1246,25 @@ describe('MoneyHomeView', () => {
       ).toHaveTextContent('$2,384.34');
     });
 
+    it('measures the banner as part of the collapsing title section', () => {
+      mockRouteParams = { showBackButton: true };
+      mockUseMoneyAccountBalance.mockReturnValue(unavailableMock('$2,384.34'));
+
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      const titleSection = within(
+        getByTestId(MoneyHomeViewTestIds.TITLE_SECTION),
+      );
+      expect(
+        titleSection.getByTestId(
+          MoneyHomeViewTestIds.BALANCE_UNAVAILABLE_BANNER,
+        ),
+      ).toBeOnTheScreen();
+      expect(
+        titleSection.getByTestId(MoneyBalanceSummaryTestIds.TITLE),
+      ).toBeOnTheScreen();
+    });
+
     it('hides the banner when the balance loads successfully', () => {
       const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
 
@@ -1376,6 +1395,22 @@ describe('MoneyHomeView', () => {
       expect(
         queryByTestId(MoneyBalanceSummaryTestIds.TITLE),
       ).not.toBeOnTheScreen();
+    });
+
+    it('measures the title section only when the stack was pushed', () => {
+      mockRouteParams = { showBackButton: true };
+      const pushed = renderWithProvider(<MoneyHomeView />);
+
+      expect(
+        pushed.getByTestId(MoneyHomeViewTestIds.TITLE_SECTION).props.onLayout,
+      ).toBeDefined();
+
+      mockRouteParams = undefined;
+      const tab = renderWithProvider(<MoneyHomeView />);
+
+      expect(
+        tab.getByTestId(MoneyHomeViewTestIds.TITLE_SECTION).props.onLayout,
+      ).toBeUndefined();
     });
   });
 

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.testIds.ts
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.testIds.ts
@@ -1,5 +1,6 @@
 export const MoneyHomeViewTestIds = {
   CONTAINER: 'money-home-view-container',
   SCROLL_VIEW: 'money-home-view-scroll-view',
+  TITLE_SECTION: 'money-home-view-title-section',
   BALANCE_UNAVAILABLE_BANNER: 'money-home-view-balance-unavailable-banner',
 } as const;

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -5,9 +5,10 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { RefreshControl, ScrollView } from 'react-native';
+import { RefreshControl, type LayoutChangeEvent } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import Animated from 'react-native-reanimated';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import {
   navigateWithDetails,
@@ -19,6 +20,7 @@ import {
   Box,
   BannerAlert,
   BannerAlertSeverity,
+  useHeaderStandardAnimated,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import Engine from '../../../../../core/Engine';
@@ -112,6 +114,12 @@ const ACTION_BUTTON_ROW_BUTTON_COUNT = 3;
 const MoneyHomeView = () => {
   const navigation = useNavigation<AppNavigationProp>();
   const { showBackButton, launchedFrom } = useParams<MoneyHomeParams>();
+  // Pushed over another stack (e.g. a Rewards campaign funding flow) rather
+  // than rooted in the tab bar, which is the only case that gets a back
+  // affordance and the title that collapses into the header on scroll.
+  const isPushed = Boolean(showBackButton);
+  const { scrollY, onScroll, titleSectionHeightSv, setTitleSectionHeight } =
+    useHeaderStandardAnimated();
   const insets = useSafeAreaInsets();
   const { styles } = useStyles(styleSheet, {});
   const { colors } = useTheme();
@@ -386,6 +394,13 @@ const MoneyHomeView = () => {
   const handleBackPress = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
+
+  const handleTitleSectionLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      setTitleSectionHeight(event.nativeEvent.layout.height);
+    },
+    [setTitleSectionHeight],
+  );
 
   const handleAddPress = useCallback(
     ({
@@ -903,12 +918,20 @@ const MoneyHomeView = () => {
       <MoneyHeader
         onMenuPress={handleMenuPress}
         onGetProPress={handleGetProPress}
-        onBack={showBackButton ? handleBackPress : undefined}
+        {...(isPushed
+          ? {
+              onBack: handleBackPress,
+              scrollY,
+              titleSectionHeight: titleSectionHeightSv,
+            }
+          : {})}
       />
-      <ScrollView
+      <Animated.ScrollView
         testID={MoneyHomeViewTestIds.SCROLL_VIEW}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
+        onScroll={onScroll}
+        scrollEventThrottle={16}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}
@@ -937,6 +960,7 @@ const MoneyHomeView = () => {
           onApyInfoPress={handleApyInfoPress}
           privacyMode={privacyMode}
           onBalancePress={handleBalancePress}
+          onTitleSectionLayout={isPushed ? handleTitleSectionLayout : undefined}
         />
         <MoneyActionButtonRow
           add={{
@@ -961,7 +985,7 @@ const MoneyHomeView = () => {
             {section.node}
           </React.Fragment>
         ))}
-      </ScrollView>
+      </Animated.ScrollView>
     </Box>
   );
 };

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -26,7 +26,9 @@ import { strings } from '../../../../../../locales/i18n';
 import Engine from '../../../../../core/Engine';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { useStyles } from '../../../../hooks/useStyles';
-import MoneyHeader from '../../components/MoneyHeader';
+import MoneyHeader, {
+  type MoneyHeaderProps,
+} from '../../components/MoneyHeader';
 import MoneyBalanceSummary from '../../components/MoneyBalanceSummary';
 import MoneyActionButtonRow from '../../components/MoneyActionButtonRow';
 import MoneyEarnings from '../../components/MoneyEarnings';
@@ -401,6 +403,21 @@ const MoneyHomeView = () => {
     },
     [setTitleSectionHeight],
   );
+
+  // Built as a whole object so each arm matches one side of the header's
+  // props union; spreading a partial would widen both arms to optional.
+  const headerProps: MoneyHeaderProps = isPushed
+    ? {
+        onMenuPress: handleMenuPress,
+        onGetProPress: handleGetProPress,
+        onBack: handleBackPress,
+        scrollY,
+        titleSectionHeight: titleSectionHeightSv,
+      }
+    : {
+        onMenuPress: handleMenuPress,
+        onGetProPress: handleGetProPress,
+      };
 
   const handleAddPress = useCallback(
     ({
@@ -915,17 +932,7 @@ const MoneyHomeView = () => {
       twClassName="flex-1 bg-default"
       testID={MoneyHomeViewTestIds.CONTAINER}
     >
-      <MoneyHeader
-        onMenuPress={handleMenuPress}
-        onGetProPress={handleGetProPress}
-        {...(isPushed
-          ? {
-              onBack: handleBackPress,
-              scrollY,
-              titleSectionHeight: titleSectionHeightSv,
-            }
-          : {})}
-      />
+      <MoneyHeader {...headerProps} />
       <Animated.ScrollView
         testID={MoneyHomeViewTestIds.SCROLL_VIEW}
         contentContainerStyle={styles.scrollContent}

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -948,27 +948,35 @@ const MoneyHomeView = () => {
           />
         }
       >
-        {showBalanceUnavailableBanner && (
-          <Box twClassName="px-4 pt-2">
-            <BannerAlert
-              severity={BannerAlertSeverity.Warning}
-              title={strings('money.balance_unavailable')}
-              description={strings(
-                'money.balance_unavailable_banner_description',
-              )}
-              style={styles.balanceUnavailableBanner}
-              testID={MoneyHomeViewTestIds.BALANCE_UNAVAILABLE_BANNER}
-            />
-          </Box>
-        )}
-        <MoneyBalanceSummary
-          apy={apyPercent}
-          displayState={displayState}
-          onApyInfoPress={handleApyInfoPress}
-          privacyMode={privacyMode}
-          onBalancePress={handleBalancePress}
-          onTitleSectionLayout={isPushed ? handleTitleSectionLayout : undefined}
-        />
+        {/* Everything above the action buttons is measured as one block: the
+            header's compact title should only appear once the large title has
+            scrolled away, which the banner pushes further down when shown. */}
+        <Box
+          testID={MoneyHomeViewTestIds.TITLE_SECTION}
+          onLayout={isPushed ? handleTitleSectionLayout : undefined}
+        >
+          {showBalanceUnavailableBanner && (
+            <Box twClassName="px-4 pt-2">
+              <BannerAlert
+                severity={BannerAlertSeverity.Warning}
+                title={strings('money.balance_unavailable')}
+                description={strings(
+                  'money.balance_unavailable_banner_description',
+                )}
+                style={styles.balanceUnavailableBanner}
+                testID={MoneyHomeViewTestIds.BALANCE_UNAVAILABLE_BANNER}
+              />
+            </Box>
+          )}
+          <MoneyBalanceSummary
+            apy={apyPercent}
+            displayState={displayState}
+            onApyInfoPress={handleApyInfoPress}
+            privacyMode={privacyMode}
+            onBalancePress={handleBalancePress}
+            showTitle={isPushed}
+          />
+        </Box>
         <MoneyActionButtonRow
           add={{
             onPress: () =>

--- a/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.test.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.test.tsx
@@ -301,7 +301,7 @@ describe('MoneyBalanceSummary', () => {
         <MoneyBalanceSummary
           apy={4}
           displayState={balanceState('$123.45')}
-          onTitleSectionLayout={jest.fn()}
+          showTitle
         />,
       );
 
@@ -316,7 +316,7 @@ describe('MoneyBalanceSummary', () => {
           apy={5.5}
           displayState={balanceState('$123.45')}
           onApyInfoPress={jest.fn()}
-          onTitleSectionLayout={jest.fn()}
+          showTitle
         />,
       );
 
@@ -329,23 +329,6 @@ describe('MoneyBalanceSummary', () => {
       expect(
         getByTestId(MoneyBalanceSummaryTestIds.APY_INFO_BUTTON),
       ).toBeOnTheScreen();
-    });
-
-    it('reports its height so the header can time the compact title', () => {
-      const mockTitleSectionLayout = jest.fn();
-      const { getByTestId } = render(
-        <MoneyBalanceSummary
-          apy={4}
-          displayState={balanceState('$123.45')}
-          onTitleSectionLayout={mockTitleSectionLayout}
-        />,
-      );
-
-      fireEvent(getByTestId(MoneyBalanceSummaryTestIds.CONTAINER), 'layout', {
-        nativeEvent: { layout: { height: 120 } },
-      });
-
-      expect(mockTitleSectionLayout).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.test.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.test.tsx
@@ -295,6 +295,70 @@ describe('MoneyBalanceSummary', () => {
     });
   });
 
+  describe('on the pushed Money screen', () => {
+    it('renders the Money title, which the tab leaves in the header', () => {
+      const { getByTestId } = render(
+        <MoneyBalanceSummary
+          apy={4}
+          displayState={balanceState('$123.45')}
+          onTitleSectionLayout={jest.fn()}
+        />,
+      );
+
+      expect(getByTestId(MoneyBalanceSummaryTestIds.TITLE)).toHaveTextContent(
+        strings('money.title'),
+      );
+    });
+
+    it('keeps the balance and the APY line under that title', () => {
+      const { getByTestId } = render(
+        <MoneyBalanceSummary
+          apy={5.5}
+          displayState={balanceState('$123.45')}
+          onApyInfoPress={jest.fn()}
+          onTitleSectionLayout={jest.fn()}
+        />,
+      );
+
+      expect(getByTestId(MoneyBalanceSummaryTestIds.BALANCE)).toHaveTextContent(
+        '$123.45',
+      );
+      expect(getByTestId(MoneyBalanceSummaryTestIds.APY)).toHaveTextContent(
+        '5.5% APY • mUSD',
+      );
+      expect(
+        getByTestId(MoneyBalanceSummaryTestIds.APY_INFO_BUTTON),
+      ).toBeOnTheScreen();
+    });
+
+    it('reports its height so the header can time the compact title', () => {
+      const mockTitleSectionLayout = jest.fn();
+      const { getByTestId } = render(
+        <MoneyBalanceSummary
+          apy={4}
+          displayState={balanceState('$123.45')}
+          onTitleSectionLayout={mockTitleSectionLayout}
+        />,
+      );
+
+      fireEvent(getByTestId(MoneyBalanceSummaryTestIds.CONTAINER), 'layout', {
+        nativeEvent: { layout: { height: 120 } },
+      });
+
+      expect(mockTitleSectionLayout).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('renders no title as the Money tab, which has one in its header', () => {
+    const { queryByTestId } = render(
+      <MoneyBalanceSummary apy={4} displayState={balanceState()} />,
+    );
+
+    expect(
+      queryByTestId(MoneyBalanceSummaryTestIds.TITLE),
+    ).not.toBeOnTheScreen();
+  });
+
   it('sits flush under the header, matching the Home page balance', () => {
     const { getByTestId } = render(
       <MoneyBalanceSummary apy={4} displayState={balanceState()} />,

--- a/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.testIds.ts
+++ b/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.testIds.ts
@@ -1,5 +1,6 @@
 export const MoneyBalanceSummaryTestIds = {
   CONTAINER: 'money-balance-summary-container',
+  TITLE: 'money-balance-summary-title',
   BALANCE: 'money-balance-summary-balance',
   BALANCE_PRESSABLE: 'money-balance-summary-balance-pressable',
   BALANCE_NO_ACCOUNT: 'money-balance-summary-balance-no-account',

--- a/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TouchableOpacity } from 'react-native';
+import { TouchableOpacity, type LayoutChangeEvent } from 'react-native';
 import {
   Box,
   BoxAlignItems,
@@ -15,6 +15,7 @@ import {
   Text,
   TextColor,
   TextVariant,
+  TitleHub,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import TextShimmer from '../TextShimmer';
@@ -41,6 +42,13 @@ interface MoneyBalanceSummaryProps {
    * balance is not pressable.
    */
   onBalancePress?: () => void;
+  /**
+   * Passed by the pushed Money screen only. It moves the title out of the
+   * header and into a `TitleHub` here, and reports that section's height so
+   * the header knows when to swap in its compact title. The Money tab leaves
+   * this unset and keeps its title in the header.
+   */
+  onTitleSectionLayout?: (event: LayoutChangeEvent) => void;
 }
 
 const MoneyBalanceSummary = ({
@@ -49,54 +57,51 @@ const MoneyBalanceSummary = ({
   onApyInfoPress,
   privacyMode = false,
   onBalancePress,
+  onTitleSectionLayout,
 }: MoneyBalanceSummaryProps) => {
   // APY + mUSD label stays visible alongside the balance and in the
   // unavailable states (dash / last known figure).
   const showApy =
     displayState.kind === 'balance' || displayState.kind === 'unavailable';
+  const hasApy = showApy && isPositiveNumberOrZero(apy);
 
-  const renderApySlot = () => {
-    if (!showApy || !isPositiveNumberOrZero(apy)) {
-      return null;
-    }
-    return (
-      <>
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          testID={MoneyBalanceSummaryTestIds.APY}
+  const apyLabel = hasApy ? (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      testID={MoneyBalanceSummaryTestIds.APY}
+    >
+      <TextShimmer>
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.SuccessDefault}
+          numberOfLines={1}
         >
-          <TextShimmer>
-            <Text
-              variant={TextVariant.BodyMd}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.SuccessDefault}
-              numberOfLines={1}
-            >
-              {strings('money.apy_label', { percentage: apy })}
-            </Text>
-          </TextShimmer>
-          <Text
-            variant={TextVariant.BodyMd}
-            fontWeight={FontWeight.Medium}
-            color={TextColor.TextAlternative}
-          >
-            {strings('money.apy_currency_suffix')}
-          </Text>
-        </Box>
-        {onApyInfoPress && (
-          <ButtonIcon
-            iconName={IconName.Info}
-            iconProps={{ color: IconColor.IconAlternative, size: IconSize.Sm }}
-            size={ButtonIconSize.Sm}
-            onPress={onApyInfoPress}
-            accessibilityLabel={strings('money.apy_info_label')}
-            testID={MoneyBalanceSummaryTestIds.APY_INFO_BUTTON}
-          />
-        )}
-      </>
-    );
-  };
+          {strings('money.apy_label', { percentage: apy })}
+        </Text>
+      </TextShimmer>
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
+        color={TextColor.TextAlternative}
+      >
+        {strings('money.apy_currency_suffix')}
+      </Text>
+    </Box>
+  ) : undefined;
+
+  const apyInfoButton =
+    hasApy && onApyInfoPress ? (
+      <ButtonIcon
+        iconName={IconName.Info}
+        iconProps={{ color: IconColor.IconAlternative, size: IconSize.Sm }}
+        size={ButtonIconSize.Sm}
+        onPress={onApyInfoPress}
+        accessibilityLabel={strings('money.apy_info_label')}
+        testID={MoneyBalanceSummaryTestIds.APY_INFO_BUTTON}
+      />
+    ) : undefined;
 
   const wrapPressable = (content: React.ReactNode) =>
     onBalancePress ? (
@@ -155,6 +160,21 @@ const MoneyBalanceSummary = ({
     }
   };
 
+  if (onTitleSectionLayout) {
+    return (
+      <TitleHub
+        testID={MoneyBalanceSummaryTestIds.CONTAINER}
+        twClassName="px-4 pb-3"
+        title={strings('money.title')}
+        titleProps={{ testID: MoneyBalanceSummaryTestIds.TITLE }}
+        amount={renderBalanceSlot()}
+        bottomLabel={apyLabel}
+        bottomLabelEndAccessory={apyInfoButton}
+        onLayout={onTitleSectionLayout}
+      />
+    );
+  }
+
   return (
     <Box twClassName="px-4 gap-1" testID={MoneyBalanceSummaryTestIds.CONTAINER}>
       {renderBalanceSlot()}
@@ -163,7 +183,8 @@ const MoneyBalanceSummary = ({
         alignItems={BoxAlignItems.Center}
         twClassName="gap-1"
       >
-        {renderApySlot()}
+        {apyLabel}
+        {apyInfoButton}
       </Box>
     </Box>
   );

--- a/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TouchableOpacity, type LayoutChangeEvent } from 'react-native';
+import { TouchableOpacity } from 'react-native';
 import {
   Box,
   BoxAlignItems,
@@ -43,12 +43,11 @@ interface MoneyBalanceSummaryProps {
    */
   onBalancePress?: () => void;
   /**
-   * Passed by the pushed Money screen only. It moves the title out of the
-   * header and into a `TitleHub` here, and reports that section's height so
-   * the header knows when to swap in its compact title. The Money tab leaves
-   * this unset and keeps its title in the header.
+   * Set by the pushed Money screen, which moves the title out of the header
+   * and into a `TitleHub` here so it can collapse on scroll. The Money tab
+   * leaves this unset and keeps its title in the header.
    */
-  onTitleSectionLayout?: (event: LayoutChangeEvent) => void;
+  showTitle?: boolean;
 }
 
 const MoneyBalanceSummary = ({
@@ -57,7 +56,7 @@ const MoneyBalanceSummary = ({
   onApyInfoPress,
   privacyMode = false,
   onBalancePress,
-  onTitleSectionLayout,
+  showTitle = false,
 }: MoneyBalanceSummaryProps) => {
   // APY + mUSD label stays visible alongside the balance and in the
   // unavailable states (dash / last known figure).
@@ -160,7 +159,7 @@ const MoneyBalanceSummary = ({
     }
   };
 
-  if (onTitleSectionLayout) {
+  if (showTitle) {
     return (
       <TitleHub
         testID={MoneyBalanceSummaryTestIds.CONTAINER}
@@ -170,7 +169,6 @@ const MoneyBalanceSummary = ({
         amount={renderBalanceSlot()}
         bottomLabel={apyLabel}
         bottomLabelEndAccessory={apyInfoButton}
-        onLayout={onTitleSectionLayout}
       />
     );
   }

--- a/app/components/UI/Money/components/MoneyHeader/MoneyHeader.test.tsx
+++ b/app/components/UI/Money/components/MoneyHeader/MoneyHeader.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import type { SharedValue } from 'react-native-reanimated';
 import MoneyHeader from './MoneyHeader';
 import { MoneyHeaderTestIds } from './MoneyHeader.testIds';
 import { strings } from '../../../../../../locales/i18n';
@@ -8,6 +9,16 @@ import { useProSubscriptionEnabled } from '../../../../../hooks/useProSubscripti
 jest.mock('../../../../../hooks/useProSubscriptionEnabled');
 
 const mockUseProSubscriptionEnabled = jest.mocked(useProSubscriptionEnabled);
+
+const sharedValue = (value: number): SharedValue<number> =>
+  ({ value }) as unknown as SharedValue<number>;
+
+// The pushed screen drives the collapsing title from its ScrollView, so its
+// header only renders with both scroll inputs.
+const pushedProps = {
+  scrollY: sharedValue(0),
+  titleSectionHeight: sharedValue(0),
+};
 
 describe('MoneyHeader', () => {
   beforeEach(() => {
@@ -77,6 +88,7 @@ describe('MoneyHeader', () => {
           onMenuPress={jest.fn()}
           onGetProPress={jest.fn()}
           onBack={jest.fn()}
+          {...pushedProps}
         />,
       );
 
@@ -90,6 +102,7 @@ describe('MoneyHeader', () => {
           onMenuPress={jest.fn()}
           onGetProPress={jest.fn()}
           onBack={mockOnBack}
+          {...pushedProps}
         />,
       );
 
@@ -104,12 +117,33 @@ describe('MoneyHeader', () => {
           onMenuPress={jest.fn()}
           onGetProPress={jest.fn()}
           onBack={jest.fn()}
+          {...pushedProps}
         />,
       );
 
       expect(getByTestId(MoneyHeaderTestIds.TITLE)).toHaveTextContent(
         strings('money.title'),
       );
+      expect(getByTestId(MoneyHeaderTestIds.MENU_BUTTON)).toBeOnTheScreen();
+    });
+
+    it('keeps the "Get Pro" button alongside the back button', () => {
+      mockUseProSubscriptionEnabled.mockReturnValue({
+        isProSubscriptionEnabled: true,
+        variantName: 'treatment',
+        isActive: true,
+      });
+
+      const { getByTestId } = render(
+        <MoneyHeader
+          onMenuPress={jest.fn()}
+          onGetProPress={jest.fn()}
+          onBack={jest.fn()}
+          {...pushedProps}
+        />,
+      );
+
+      expect(getByTestId(MoneyHeaderTestIds.GET_PRO_BUTTON)).toBeOnTheScreen();
       expect(getByTestId(MoneyHeaderTestIds.MENU_BUTTON)).toBeOnTheScreen();
     });
   });

--- a/app/components/UI/Money/components/MoneyHeader/MoneyHeader.tsx
+++ b/app/components/UI/Money/components/MoneyHeader/MoneyHeader.tsx
@@ -44,7 +44,7 @@ interface MoneyHeaderTabProps {
   titleSectionHeight?: never;
 }
 
-type MoneyHeaderProps = MoneyHeaderCommonProps &
+export type MoneyHeaderProps = MoneyHeaderCommonProps &
   (MoneyHeaderPushedProps | MoneyHeaderTabProps);
 
 const MoneyHeader = (props: MoneyHeaderProps) => {

--- a/app/components/UI/Money/components/MoneyHeader/MoneyHeader.tsx
+++ b/app/components/UI/Money/components/MoneyHeader/MoneyHeader.tsx
@@ -1,21 +1,19 @@
 import React from 'react';
 import {
   Box,
-  BoxAlignItems,
-  BoxFlexDirection,
   Button,
   ButtonIcon,
   ButtonSize,
   HeaderRoot,
+  HeaderStandardAnimated,
   IconName,
-  Text,
-  TextVariant,
 } from '@metamask/design-system-react-native';
+import type { SharedValue } from 'react-native-reanimated';
 import { strings } from '../../../../../../locales/i18n';
 import { MoneyHeaderTestIds } from './MoneyHeader.testIds';
 import { useProSubscriptionEnabled } from '../../../../../hooks/useProSubscriptionEnabled';
 
-interface MoneyHeaderProps {
+interface MoneyHeaderCommonProps {
   /**
    * Handler for the options menu button
    */
@@ -25,72 +23,95 @@ interface MoneyHeaderProps {
    * Only fired when the Pro subscription flow flag is enabled.
    */
   onGetProPress: () => void;
-  /**
-   * Handler for the back button. Omit it — as the Money tab does — to render
-   * the plain title with no back affordance.
-   */
-  onBack?: () => void;
 }
 
-const MoneyHeader = ({
-  onMenuPress,
-  onGetProPress,
-  onBack,
-}: MoneyHeaderProps) => {
+/**
+ * The pushed Money screen, which carries a back affordance and a title that
+ * collapses into the header as the page scrolls.
+ */
+interface MoneyHeaderPushedProps {
+  onBack: () => void;
+  /** Scroll offset of the page's animated ScrollView. */
+  scrollY: SharedValue<number>;
+  /** Measured height of the page's title section (its `TitleHub`). */
+  titleSectionHeight: SharedValue<number>;
+}
+
+/** The Money tab, which is rooted in the tab bar and has nothing to go back to. */
+interface MoneyHeaderTabProps {
+  onBack?: never;
+  scrollY?: never;
+  titleSectionHeight?: never;
+}
+
+type MoneyHeaderProps = MoneyHeaderCommonProps &
+  (MoneyHeaderPushedProps | MoneyHeaderTabProps);
+
+const MoneyHeader = (props: MoneyHeaderProps) => {
+  const { onMenuPress, onGetProPress } = props;
   const { isProSubscriptionEnabled } = useProSubscriptionEnabled();
+
+  const menuButtonProps = {
+    iconName: IconName.MoreVertical,
+    onPress: onMenuPress,
+    accessibilityLabel: 'Menu',
+    testID: MoneyHeaderTestIds.MENU_BUTTON,
+  };
+
+  // "Get Pro" is a text button, so it can only go in the end accessory, which
+  // takes the menu with it — the header slots the two ButtonIcon paths and the
+  // accessory as alternatives rather than siblings.
+  const endAccessory = isProSubscriptionEnabled ? (
+    <Box twClassName="flex-row items-center gap-1">
+      <Button
+        size={ButtonSize.Md}
+        onPress={onGetProPress}
+        testID={MoneyHeaderTestIds.GET_PRO_BUTTON}
+        accessibilityLabel={strings('pro_subscription.join_pro')}
+      >
+        {strings('pro_subscription.join_pro')}
+      </Button>
+      <ButtonIcon {...menuButtonProps} />
+    </Box>
+  ) : undefined;
+
+  if (props.onBack) {
+    return (
+      <HeaderStandardAnimated
+        testID={MoneyHeaderTestIds.CONTAINER}
+        title={strings('money.title')}
+        titleProps={{
+          testID: MoneyHeaderTestIds.TITLE,
+        }}
+        scrollY={props.scrollY}
+        titleSectionHeight={props.titleSectionHeight}
+        onBack={props.onBack}
+        backButtonProps={{
+          accessibilityLabel: strings('navigation.back'),
+          testID: MoneyHeaderTestIds.BACK_BUTTON,
+        }}
+        endAccessory={endAccessory}
+        endButtonIconProps={[menuButtonProps]}
+      />
+    );
+  }
 
   return (
     <HeaderRoot
       testID={MoneyHeaderTestIds.CONTAINER}
-      twClassName={onBack ? 'pl-1 pr-3' : 'pl-4 pr-3'}
+      twClassName="pl-4 pr-3"
       title={strings('money.title')}
       titleProps={{
         testID: MoneyHeaderTestIds.TITLE,
       }}
       endAccessory={
-        <Box twClassName="flex-row items-center gap-1">
-          {isProSubscriptionEnabled && (
-            <Button
-              size={ButtonSize.Md}
-              onPress={onGetProPress}
-              testID={MoneyHeaderTestIds.GET_PRO_BUTTON}
-              accessibilityLabel={strings('pro_subscription.join_pro')}
-            >
-              {strings('pro_subscription.join_pro')}
-            </Button>
-          )}
-          <ButtonIcon
-            iconName={IconName.MoreVertical}
-            onPress={onMenuPress}
-            accessibilityLabel="Menu"
-            testID={MoneyHeaderTestIds.MENU_BUTTON}
-          />
-        </Box>
+        endAccessory ?? (
+          <Box twClassName="flex-row items-center gap-1">
+            <ButtonIcon {...menuButtonProps} />
+          </Box>
+        )
       }
-    >
-      {/* `HeaderRoot` renders children in place of the title row, so this is
-          undefined without a back handler to leave the title path untouched. */}
-      {onBack ? (
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          twClassName="flex-1 gap-1"
-        >
-          <ButtonIcon
-            iconName={IconName.ArrowLeft}
-            onPress={onBack}
-            accessibilityLabel={strings('navigation.back')}
-            testID={MoneyHeaderTestIds.BACK_BUTTON}
-          />
-          <Text
-            variant={TextVariant.HeadingLg}
-            testID={MoneyHeaderTestIds.TITLE}
-          >
-            {strings('money.title')}
-          </Text>
-        </Box>
-      ) : undefined}
-    </HeaderRoot>
+    />
   );
 };
 

--- a/app/components/UI/Money/components/MoneyHeader/MoneyHeader.tsx
+++ b/app/components/UI/Money/components/MoneyHeader/MoneyHeader.tsx
@@ -33,7 +33,7 @@ interface MoneyHeaderPushedProps {
   onBack: () => void;
   /** Scroll offset of the page's animated ScrollView. */
   scrollY: SharedValue<number>;
-  /** Measured height of the page's title section (its `TitleHub`). */
+  /** Measured height of the page's leading section, title included. */
   titleSectionHeight: SharedValue<number>;
 }
 

--- a/app/components/UI/Money/components/MoneyHeader/index.ts
+++ b/app/components/UI/Money/components/MoneyHeader/index.ts
@@ -1,1 +1,2 @@
 export { default } from './MoneyHeader';
+export type { MoneyHeaderProps } from './MoneyHeader';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Design System asked Money to use the same stacked header as Perps (`HeaderStandardAnimated` + `TitleHub`) so pushed screens share one collapsing-title pattern.

After a sweepstakes Add Funds flow, Money is pushed with `showBackButton` (#35918). That screen still used `HeaderRoot` with a hand-rolled back row, which did not collapse the title on scroll and did not match Perps. The Money tab must stay as it is.

This PR applies the stacked header only when Money is pushed:

- `MoneyHeader` uses `HeaderStandardAnimated` with the Money title, a back button, and `endButtonIconProps` for the menu (Get Pro still uses `endAccessory` because it is a text button, which takes priority over the icon props).
- `MoneyBalanceSummary` uses `TitleHub` with title Money, the balance as `amount`, the APY line as `bottomLabel`, and the info icon as `bottomLabelEndAccessory`.
- The tab path keeps `HeaderRoot` and the existing balance layout. The gate is `showBackButton`, not `canGoBack()`, matching #35553: a tab navigator can report `canGoBack()` on a non-first tab.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated the Money header to match Perps when Money is opened as a pushed screen, with a back button and a title that collapses on scroll.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #35918
Refs: #35553

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money stacked header on the pushed screen

  Scenario: Money tab keeps its existing header
    Given the user is on the Money tab

    When they look at the header and balance
    Then there is no back button
    And the title stays in the header
    And the balance and APY line sit below it without a TitleHub title

  Scenario: pushed Money from sweepstakes Add Funds matches Perps
    Given the user is on the Money Account Sweepstakes campaign
    And they complete Add Funds so Money home is pushed with showBackButton

    When they land on Money home
    Then the header has a back button, the Money title, and the menu
    And the content TitleHub shows Money, the balance amount, and the APY line with the info icon
    And scrolling collapses the large title into the header
    And tapping back returns to the campaign

  Scenario: Get Pro stays available on the pushed header
    Given the Pro subscription flag is enabled
    And Money home is pushed with showBackButton

    When the user looks at the header
    Then Get Pro and the menu are both visible
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots or recordings to visualize the before and after of this change. -->

### **Before**

<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-09-08 at 14 27 30" src="https://github.com/user-attachments/assets/42098ba3-b960-43f1-87a9-9bb07ad27b5c" />

### **After**
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-09-10 at 15 30 24" src="https://github.com/user-attachments/assets/353b4584-c6e8-4ed8-a232-3b23dd9bf60c" />
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-09-10 at 15 31 10" src="https://github.com/user-attachments/assets/665dd878-32db-4eea-b173-21886ce7e2db" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only, gated by `showBackButton`; tab navigation and money logic are unchanged, with broad unit test coverage for both paths.
> 
> **Overview**
> Adds the **Perps-style collapsing header** only when Money home is **pushed** with `showBackButton` (e.g. post–Add Funds); the **Money tab** keeps `HeaderRoot` and the existing balance layout.
> 
> **`MoneyHeader`** now branches on a typed props union: pushed screens use **`HeaderStandardAnimated`** (back, compact title on scroll, menu via `endButtonIconProps` / Get Pro via `endAccessory`); the tab still uses **`HeaderRoot`**, without the old custom back+title row.
> 
> **`MoneyHomeView`** wires **`useHeaderStandardAnimated`**, swaps to **`Animated.ScrollView`**, and wraps the balance-unavailable banner plus **`MoneyBalanceSummary`** in a measured **`TITLE_SECTION`** so collapse timing includes the banner. **`showTitle`** moves the large “Money” title into content via **`TitleHub`** on pushed flows only.
> 
> **`MoneyBalanceSummary`** gains optional **`showTitle`** to render balance and APY through **`TitleHub`** when the title lives in the scroll content. Tests and test IDs cover title placement, layout measurement, and header accessories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83b555a888f04fd6f9329bad981e23c80574408d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->