### PR TITLE
fix: remove custom title color from Manage connections header

### DIFF
--- a/app/components/Views/SDK/SDKSessionsManager/SDKSessionsManager.tsx
+++ b/app/components/Views/SDK/SDKSessionsManager/SDKSessionsManager.tsx
@@ -12,7 +12,6 @@ import {
   Button,
   ButtonVariant,
   HeaderStandard,
-  TextColor,
 } from '@metamask/design-system-react-native';
 import Icon, {
   IconName,
@@ -145,7 +144,6 @@ const SDKSessionsManager = () => {
     >
       <HeaderStandard
         title={strings('app_settings.manage_sdk_connections_title')}
-        titleProps={{ color: TextColor.PrimaryDefault }}
         onBack={handleBack}
         includesTopInset
         testID={SDKSelectorsIDs.SESSION_MANAGER_HEADER}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

The "Manage connections" screen (SDK sessions manager) rendered its header title in the primary/accent color because it explicitly passed `titleProps={{ color: TextColor.PrimaryDefault }}` to `HeaderStandard`. Every other screen using `HeaderStandard` relies on the component's default title color, so this one stood out as purple against the rest of the app.

This change removes the `titleProps` override (and the now-unused `TextColor` import) so the title uses the design system's default header title color.

## **Changelog**

CHANGELOG entry: Fixed the "Manage connections" screen title being rendered in the accent color instead of the default header color

## **Related issues**

Fixes: N/A — visual fix reported directly via screenshot

## **Manual testing steps**

```gherkin
Feature: Manage connections header title color

  Scenario: user opens the Manage connections screen
    Given the user has the app open
    When the user navigates to Settings and opens "Manage connections"
    Then the "Manage connections" header title is rendered in the default header text color
    And it is no longer rendered in the purple/primary accent color
```

## **Screenshots/Recordings**

### **Before**

The reported screenshot shows the "Manage connections" title rendered in purple at the top of the SDK sessions screen.

### **After**

Not captured — this change only removes a color override, so the title now renders in the same default color used by every other `HeaderStandard` screen. No simulator was available in this environment to capture a device screenshot.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Not applicable — this is a styling-only change with no runtime or rendering cost implications.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e04a05fb-6b74-4e7e-b178-ba9645df9b77?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e04a05fb-6b74-4e7e-b178-ba9645df9b77&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

