### PR TITLE
fix(perps): tag deposit and withdrawal Sentry errors

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -765,7 +765,12 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
             Logger.error(
               ensureError(err, 'PerpsMarketDetailsView.handleAddFunds'),
               {
-                tags: { feature: PERPS_CONSTANTS.FeatureName },
+                tags: {
+                  feature: PERPS_CONSTANTS.FeatureName,
+                  component: 'PerpsMarketDetailsView',
+                  action: 'financial_deposit',
+                  operation: 'financial_operations',
+                },
               },
             );
           },
@@ -773,7 +778,12 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = ({
       );
     } catch (err) {
       Logger.error(ensureError(err, 'PerpsMarketDetailsView.handleAddFunds'), {
-        tags: { feature: PERPS_CONSTANTS.FeatureName },
+        tags: {
+          feature: PERPS_CONSTANTS.FeatureName,
+          component: 'PerpsMarketDetailsView',
+          action: 'financial_deposit',
+          operation: 'financial_operations',
+        },
       });
     }
   }, [

--- a/app/components/UI/Perps/Views/PerpsOrderRedirect.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderRedirect.test.tsx
@@ -10,6 +10,7 @@ import { usePerpsConnection } from '../hooks/usePerpsConnection';
 import { usePerpsTrading } from '../hooks/usePerpsTrading';
 import usePerpsToasts from '../hooks/usePerpsToasts';
 import Routes from '../../../../constants/navigation/Routes';
+import Logger from '../../../../util/Logger';
 import { CONFIRMATION_HEADER_CONFIG } from '../constants/perpsConfig';
 
 jest.mock('@react-navigation/native', () => ({
@@ -166,6 +167,15 @@ describe('PerpsOrderRedirect', () => {
       expect(mockGoBack).toHaveBeenCalled();
     });
     expect(mockDepositWithOrder).toHaveBeenCalled();
+    expect(Logger.error).toHaveBeenCalledWith(expect.any(Error), {
+      tags: {
+        feature: 'perps',
+        component: 'PerpsOrderRedirect',
+        action: 'financial_deposit',
+        operation: 'financial_operations',
+      },
+      context: { name: 'PerpsOrderRedirect.depositWithOrder', data: {} },
+    });
   });
 
   it('calls depositWithOrder and navigates to confirmation on success', async () => {

--- a/app/components/UI/Perps/Views/PerpsOrderRedirect.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderRedirect.tsx
@@ -88,7 +88,12 @@ const PerpsOrderRedirect: React.FC = () => {
       } catch (error: unknown) {
         const err = ensureError(error, 'PerpsOrderRedirect.depositWithOrder');
         Logger.error(err, {
-          tags: { feature: PERPS_CONSTANTS.FeatureName },
+          tags: {
+            feature: PERPS_CONSTANTS.FeatureName,
+            component: 'PerpsOrderRedirect',
+            action: 'financial_deposit',
+            operation: 'financial_operations',
+          },
           context: { name: 'PerpsOrderRedirect.depositWithOrder', data: {} },
         });
         showToast(
@@ -101,7 +106,12 @@ const PerpsOrderRedirect: React.FC = () => {
 
     runDepositFlow().catch((error: unknown) => {
       Logger.error(ensureError(error, 'PerpsOrderRedirect.runDepositFlow'), {
-        tags: { feature: PERPS_CONSTANTS.FeatureName },
+        tags: {
+          feature: PERPS_CONSTANTS.FeatureName,
+          component: 'PerpsOrderRedirect',
+          action: 'financial_deposit',
+          operation: 'financial_operations',
+        },
         context: { name: 'PerpsOrderRedirect.runDepositFlow', data: {} },
       });
     });

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
@@ -7,6 +7,7 @@ import { usePerpsHomeActions } from './usePerpsHomeActions';
 import { usePerpsTrading } from './usePerpsTrading';
 import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
 import Routes from '../../../../constants/navigation/Routes';
+import Logger from '../../../../util/Logger';
 import { MetaMetricsEvents } from '../../../../core/Analytics/MetaMetrics.events';
 import {
   PERPS_EVENT_PROPERTY,
@@ -56,6 +57,11 @@ jest.mock('../../../Views/confirmations/hooks/useConfirmNavigation', () => ({
 
 jest.mock('@sentry/react-native', () => ({
   captureException: jest.fn(),
+}));
+
+jest.mock('../../../../util/Logger', () => ({
+  error: jest.fn(),
+  log: jest.fn(),
 }));
 
 const mockTrack = jest.fn();
@@ -324,6 +330,14 @@ describe('usePerpsHomeActions', () => {
         expect(onError).toHaveBeenCalledWith(depositError, 'deposit');
         expect(result.current.error).toEqual(depositError);
         expect(mockNavigation.goBack).toHaveBeenCalledTimes(1);
+        expect(Logger.error).toHaveBeenCalledWith(depositError, {
+          tags: {
+            feature: 'perps',
+            component: 'usePerpsHomeActions',
+            action: 'financial_deposit',
+            operation: 'financial_operations',
+          },
+        });
       });
     });
   });
@@ -551,6 +565,14 @@ describe('usePerpsHomeActions', () => {
       await waitFor(() => {
         expect(result.current.error).toEqual(new Error('Withdraw failed'));
         expect(onError).toHaveBeenCalledWith(expect.any(Error), 'withdraw');
+      });
+      expect(Logger.error).toHaveBeenCalledWith(expect.any(Error), {
+        tags: {
+          feature: 'perps',
+          component: 'usePerpsHomeActions',
+          action: 'financial_withdrawal',
+          operation: 'financial_operations',
+        },
       });
     });
 

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
@@ -184,6 +184,9 @@ export const usePerpsHomeActions = (
             Logger.error(errorObj, {
               tags: {
                 feature: PERPS_CONSTANTS.FeatureName,
+                component: 'usePerpsHomeActions',
+                action: 'financial_deposit',
+                operation: 'financial_operations',
               },
             });
 
@@ -253,6 +256,9 @@ export const usePerpsHomeActions = (
       Logger.error(errorObj, {
         tags: {
           feature: PERPS_CONSTANTS.FeatureName,
+          component: 'usePerpsHomeActions',
+          action: 'financial_withdrawal',
+          operation: 'financial_operations',
         },
       });
 

--- a/app/components/UI/Perps/hooks/useWithdrawalRequests.test.ts
+++ b/app/components/UI/Perps/hooks/useWithdrawalRequests.test.ts
@@ -685,7 +685,12 @@ describe('useWithdrawalRequests', () => {
         expect.objectContaining({ message: 'API Error' }),
       );
       expect(mockLoggerError.mock.calls[0][1]).toMatchObject({
-        tags: { feature: expect.any(String) },
+        tags: {
+          feature: expect.any(String),
+          component: 'useWithdrawalRequests',
+          action: 'financial_withdrawal',
+          operation: 'financial_operations',
+        },
         context: {
           name: 'useWithdrawalRequests.executeWithdrawalCompletionCheck',
           data: {

--- a/app/components/UI/Perps/hooks/useWithdrawalRequests.ts
+++ b/app/components/UI/Perps/hooks/useWithdrawalRequests.ts
@@ -175,6 +175,9 @@ export const useWithdrawalRequests = (
       Logger.error(errorInstance, {
         tags: {
           feature: PERPS_CONSTANTS.FeatureName,
+          component: 'useWithdrawalRequests',
+          action: 'financial_withdrawal',
+          operation: 'financial_operations',
         },
         context: {
           name: 'useWithdrawalRequests.executeWithdrawalCompletionCheck',

--- a/docs/perps/perps-sentry-reference.md
+++ b/docs/perps/perps-sentry-reference.md
@@ -704,6 +704,23 @@ Use this to isolate genuine perps connection failures. You can also use `feature
 
 Fires on initial `connect()` failures and programmatic `reconnectWithNewContext()` calls. User-initiated retries from the error screen only add a Sentry breadcrumb (no new event) to avoid noise.
 
+## Deposit and withdrawal errors
+
+Live on [Perps - Health](https://metamask.sentry.io/dashboard/314902/).
+
+```
+feature:perps action:financial_deposit
+feature:perps action:financial_withdrawal
+```
+
+Deposit widgets also include pre-tag Relay failures:
+
+```
+event.type:error feature:perps (action:financial_deposit OR message:"*HyperLiquid deposit*" OR message:"*Missing post-quote deposit*")
+```
+
+Do not use `message:*withdraw*` — it matches deposit errors such as `Insufficient balance for withdrawal`.
+
 ### MixPanel
 
 | Event                  | Key Properties                                                                        |


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Deposit and withdrawal failures were logged to Sentry without consistent `action` tags, so the [Perps - Health](https://metamask.sentry.io/dashboard/314902/) dashboard could not separate those flows from other `financial_operations` errors.

This adds `action: financial_deposit` and `action: financial_withdrawal` (plus `component` and `operation: financial_operations`) on the existing `Logger.error` sites in home add-funds/withdraw, market-details add funds, order-redirect deposit, and withdrawal-request completion. User-facing deposit/withdraw behavior is unchanged. Query notes live in `docs/perps/perps-sentry-reference.md`. Do not use `message:*withdraw*` — it matches deposit errors such as `Insufficient balance for withdrawal`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: telemetry-only change with no linked ticket

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps deposit and withdrawal Sentry error tags

  Background:
    Given I am logged into MetaMask Mobile
    And I am eligible for Perps

  Scenario: failed add funds still surfaces the existing error
    Given I am on Perps Home or a Perps market detail screen
    When add funds fails
    Then the user-facing error handling is unchanged
    And Sentry receives the error with action financial_deposit

  Scenario: failed withdraw still surfaces the existing error
    Given I am on Perps Home
    When withdraw fails
    Then the user-facing error handling is unchanged
    And Sentry receives the error with action financial_withdrawal
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)