### PR TITLE
perf(confirmations): rely on reference equality in confirmation selectors

### DIFF
--- a/app/components/Views/confirmations/hooks/gas/useGasFeeEstimates.ts
+++ b/app/components/Views/confirmations/hooks/gas/useGasFeeEstimates.ts
@@ -1,4 +1,3 @@
-import isEqual from 'lodash/isEqual';
 import { useSelector } from 'react-redux';
 import { useEffect, useState } from 'react';
 
@@ -29,9 +28,8 @@ export function useGasFeeEstimates(networkClientId: string | undefined) {
     ? networkClientId
     : undefined;
 
-  const gasFeeEstimates = useSelector(
-    (state: RootState) => selectGasFeeEstimatesByChainId(state, chainId),
-    isEqual,
+  const gasFeeEstimates = useSelector((state: RootState) =>
+    selectGasFeeEstimatesByChainId(state, chainId),
   );
   const { NetworkController } = Engine.context;
 

--- a/app/components/Views/confirmations/hooks/metrics/useConfirmationLoadMetrics.ts
+++ b/app/components/Views/confirmations/hooks/metrics/useConfirmationLoadMetrics.ts
@@ -23,30 +23,11 @@ const meansByTransactionType = new Map<
  * Records how long a transaction confirmation took to become visible, spanning
  * transaction creation to the confirmation body's first paint.
  *
- * Reports the duration twice: as the `confirmation_time_to_open_ms` metric
- * property, and as a standalone `Transaction Confirmation Load` Sentry
- * transaction.
- *
- * This is generic to every redesigned confirmation. It lives on the shared
- * `Confirm` component rather than on any feature-specific surface, so sends,
- * swaps, approvals, dapp transactions, stake, earn, predict and MetaMask Pay
- * all report the same span.
- *
  * Non-transaction confirmations (for example signature requests) have no
  * creation timestamp to anchor against and are skipped.
  *
- * Additionally logs a session-scoped running mean (`averageMs`) grouped by
- * transaction type, alongside the sample count it is drawn from, so a slow
- * type is not masked by a fast one. This is diagnostic output only — the mean
- * is never dispatched as a metric property nor attached to the Sentry trace,
- * both of which stay per-confirmation.
- *
- * A second mean (`warmAverageMs`) excludes each type's first sample. That first
- * confirmation absorbs one-off module evaluation and cache warming, so it can
- * sit hundreds of milliseconds above the steady state and drag `averageMs` with
- * it — enough to swamp the effect being measured when comparing builds. The
- * warm mean is the figure to compare; it is `undefined` until a type has at
- * least two samples.
+ * Running means are logged per transaction type for diagnostics only, and are
+ * never dispatched as metric properties.
  *
  * @returns An object with an `onFirstPaint` callback, to be passed to the root
  * confirmation container's `onLayout`.

--- a/app/components/Views/confirmations/hooks/metrics/useConfirmationLoadMetrics.ts
+++ b/app/components/Views/confirmations/hooks/metrics/useConfirmationLoadMetrics.ts
@@ -11,7 +11,12 @@ const log = createProjectLogger('confirmation-load-metrics');
 
 const meansByTransactionType = new Map<
   string,
-  { sampleCount: number; totalDurationMs: number }
+  {
+    sampleCount: number;
+    totalDurationMs: number;
+    warmSampleCount: number;
+    warmTotalDurationMs: number;
+  }
 >();
 
 /**
@@ -35,6 +40,13 @@ const meansByTransactionType = new Map<
  * type is not masked by a fast one. This is diagnostic output only — the mean
  * is never dispatched as a metric property nor attached to the Sentry trace,
  * both of which stay per-confirmation.
+ *
+ * A second mean (`warmAverageMs`) excludes each type's first sample. That first
+ * confirmation absorbs one-off module evaluation and cache warming, so it can
+ * sit hundreds of milliseconds above the steady state and drag `averageMs` with
+ * it — enough to swamp the effect being measured when comparing builds. The
+ * warm mean is the figure to compare; it is `undefined` until a type has at
+ * least two samples.
  *
  * @returns An object with an `onFirstPaint` callback, to be passed to the root
  * confirmation container's `onLayout`.
@@ -99,10 +111,22 @@ export function useConfirmationLoadMetrics() {
     const stats = meansByTransactionType.get(transactionType) ?? {
       sampleCount: 0,
       totalDurationMs: 0,
+      warmSampleCount: 0,
+      warmTotalDurationMs: 0,
     };
+
+    // Counted before the increment below, so the first sample of each type is
+    // treated as cold and excluded from the warm mean.
+    const isWarmSample = stats.sampleCount > 0;
 
     stats.sampleCount += 1;
     stats.totalDurationMs += durationMs;
+
+    if (isWarmSample) {
+      stats.warmSampleCount += 1;
+      stats.warmTotalDurationMs += durationMs;
+    }
+
     meansByTransactionType.set(transactionType, stats);
 
     log('First paint', durationMs, {
@@ -110,6 +134,10 @@ export function useConfirmationLoadMetrics() {
       sampleCount: stats.sampleCount,
       transactionId,
       transactionType,
+      warmAverageMs: stats.warmSampleCount
+        ? Math.round(stats.warmTotalDurationMs / stats.warmSampleCount)
+        : undefined,
+      warmSampleCount: stats.warmSampleCount,
     });
   }, [canMeasure, createdAtMs, dispatch, transactionId, transactionType]);
 

--- a/app/components/Views/confirmations/hooks/metrics/useConfirmationLoadMetrics.ts
+++ b/app/components/Views/confirmations/hooks/metrics/useConfirmationLoadMetrics.ts
@@ -9,6 +9,11 @@ import { createProjectLogger } from '@metamask/utils';
 
 const log = createProjectLogger('confirmation-load-metrics');
 
+const meansByTransactionType = new Map<
+  string,
+  { sampleCount: number; totalDurationMs: number }
+>();
+
 /**
  * Records how long a transaction confirmation took to become visible, spanning
  * transaction creation to the confirmation body's first paint.
@@ -24,6 +29,12 @@ const log = createProjectLogger('confirmation-load-metrics');
  *
  * Non-transaction confirmations (for example signature requests) have no
  * creation timestamp to anchor against and are skipped.
+ *
+ * Additionally logs a session-scoped running mean (`averageMs`) grouped by
+ * transaction type, alongside the sample count it is drawn from, so a slow
+ * type is not masked by a fast one. This is diagnostic output only — the mean
+ * is never dispatched as a metric property nor attached to the Sentry trace,
+ * both of which stay per-confirmation.
  *
  * @returns An object with an `onFirstPaint` callback, to be passed to the root
  * confirmation container's `onLayout`.
@@ -85,7 +96,18 @@ export function useConfirmationLoadMetrics() {
       timestamp: paintedAtMs,
     });
 
+    const stats = meansByTransactionType.get(transactionType) ?? {
+      sampleCount: 0,
+      totalDurationMs: 0,
+    };
+
+    stats.sampleCount += 1;
+    stats.totalDurationMs += durationMs;
+    meansByTransactionType.set(transactionType, stats);
+
     log('First paint', durationMs, {
+      averageMs: Math.round(stats.totalDurationMs / stats.sampleCount),
+      sampleCount: stats.sampleCount,
       transactionId,
       transactionType,
     });

--- a/app/components/Views/confirmations/hooks/useApprovalRequest.test.ts
+++ b/app/components/Views/confirmations/hooks/useApprovalRequest.test.ts
@@ -54,11 +54,20 @@ const PAGE_META_MOCK = {
   test: 'value',
 };
 
+// Runs the real selector against a minimal state, rather than stubbing its
+// result, so `selectFirstPendingApproval` is actually exercised.
 const mockSelector = (
   approvalRequests: ApprovalControllerState['pendingApprovals'],
 ) => {
-  (useSelector as jest.MockedFn<typeof useSelector>).mockReturnValue(
-    approvalRequests,
+  (useSelector as jest.MockedFn<typeof useSelector>).mockImplementation(
+    (selector) =>
+      selector({
+        engine: {
+          backgroundState: {
+            ApprovalController: { pendingApprovals: approvalRequests },
+          },
+        },
+      }),
   );
 };
 

--- a/app/components/Views/confirmations/hooks/useApprovalRequest.ts
+++ b/app/components/Views/confirmations/hooks/useApprovalRequest.ts
@@ -1,27 +1,18 @@
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { cloneDeep, isEqual } from 'lodash';
 import { ApprovalRequest } from '@metamask/approval-controller';
 import { providerErrors } from '@metamask/rpc-errors';
 import Engine from '../../../../core/Engine';
-import { selectPendingApprovals } from '../../../../selectors/approvalController';
+import { selectFirstPendingApproval } from '../../../../selectors/approvalController';
 
 // TODO: Replace "any" with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ApprovalRequestType = ApprovalRequest<any>;
 
 const useApprovalRequest = () => {
-  const pendingApprovals = useSelector(selectPendingApprovals, isEqual);
-  const pendingApprovalList = Object.values(pendingApprovals ?? {});
-
-  const firstPendingApproval = pendingApprovalList[0] as
+  const approvalRequest = useSelector(selectFirstPendingApproval) as
     | ApprovalRequestType
     | undefined;
-
-  const approvalRequest = useMemo(
-    () => cloneDeep(firstPendingApproval),
-    [firstPendingApproval],
-  );
 
   const onConfirm = useCallback(
     async (

--- a/app/selectors/approvalController.ts
+++ b/app/selectors/approvalController.ts
@@ -2,6 +2,8 @@ import { createSelector } from 'reselect';
 import { RootState } from '../reducers';
 import { ApprovalControllerState } from '@metamask/approval-controller';
 
+const DEFAULT_APPROVALS = {};
+
 const selectApprovalControllerState = (state: RootState) =>
   state?.engine?.backgroundState?.ApprovalController;
 
@@ -15,4 +17,9 @@ export const selectApprovalFlows = createSelector(
   selectApprovalControllerState,
   (approvalControllerState: ApprovalControllerState) =>
     approvalControllerState?.approvalFlows,
+);
+
+export const selectFirstPendingApproval = createSelector(
+  selectPendingApprovals,
+  (pendingApprovals) => Object.values(pendingApprovals ?? DEFAULT_APPROVALS)[0],
 );

--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -26,10 +26,6 @@ interface MetaMaskPayToken {
 type LocalTransaction = TransactionMeta | SmartTransaction;
 const MONEY_DEPOSIT_TYPES = [TransactionType.moneyAccountDeposit];
 const MONEY_WITHDRAW_TYPES = [TransactionType.moneyAccountWithdraw];
-
-// Hoisted so the empty-state fallback keeps a stable reference. A fresh `[]`
-// per evaluation would change identity on every call and defeat memoisation in
-// every selector derived from `selectTransactions`.
 const EMPTY_TRANSACTIONS: TransactionMeta[] = [];
 
 function isTerminalFailedStatus(status: unknown): boolean {

--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -27,6 +27,11 @@ type LocalTransaction = TransactionMeta | SmartTransaction;
 const MONEY_DEPOSIT_TYPES = [TransactionType.moneyAccountDeposit];
 const MONEY_WITHDRAW_TYPES = [TransactionType.moneyAccountWithdraw];
 
+// Hoisted so the empty-state fallback keeps a stable reference. A fresh `[]`
+// per evaluation would change identity on every call and defeat memoisation in
+// every selector derived from `selectTransactions`.
+const EMPTY_TRANSACTIONS: TransactionMeta[] = [];
+
 function isTerminalFailedStatus(status: unknown): boolean {
   return (
     status === TransactionStatus.failed ||
@@ -135,7 +140,7 @@ const selectTransactionControllerState = (state: RootState) =>
 export const selectTransactions = createSelector(
   selectTransactionControllerState,
   (transactionControllerState) =>
-    transactionControllerState?.transactions ?? [],
+    transactionControllerState?.transactions ?? EMPTY_TRANSACTIONS,
 );
 
 const selectTransactionBatchesStrict = createSelector(

--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -1,6 +1,5 @@
 import { createSelector } from 'reselect';
 import { RootState } from '../reducers';
-import { createDeepEqualSelector } from './util';
 import {
   selectPendingSmartTransactionsBySender,
   selectPendingSmartTransactionsForSelectedAccountGroup,
@@ -133,7 +132,7 @@ function matchesTransactionType(
 const selectTransactionControllerState = (state: RootState) =>
   state.engine.backgroundState.TransactionController;
 
-const selectTransactionsStrict = createSelector(
+export const selectTransactions = createSelector(
   selectTransactionControllerState,
   (transactionControllerState) =>
     transactionControllerState?.transactions ?? [],
@@ -146,13 +145,13 @@ const selectTransactionBatchesStrict = createSelector(
 );
 
 export const selectRequiredTransactionIds = createSelector(
-  selectTransactionsStrict,
+  selectTransactions,
   (transactions) =>
     new Set(transactions.flatMap((tx) => tx.requiredTransactionIds ?? [])),
 );
 
 export const selectRequiredTransactions = createSelector(
-  [selectTransactionsStrict, selectRequiredTransactionIds],
+  [selectTransactions, selectRequiredTransactionIds],
   (transactions, requiredTransactionIds) =>
     transactions.filter((tx) => requiredTransactionIds.has(tx.id)),
 );
@@ -172,7 +171,7 @@ export const selectRequiredTransactionHashes = createSelector(
  * the user action. Redesigned Activity hides them as separate rows (TMCU-1064).
  */
 export const selectGasPaymentTransactions = createSelector(
-  selectTransactionsStrict,
+  selectTransactions,
   (transactions) =>
     transactions.filter((tx) => tx.type === TransactionType.gasPayment),
 );
@@ -205,7 +204,7 @@ export const selectExcludedActivityTransactionHashes = createSelector(
 );
 
 export const selectRelatedChainIdsByTransactionId = createSelector(
-  selectTransactionsStrict,
+  selectTransactions,
   (transactions) => {
     const transactionsById = new Map<string, TransactionMeta>(
       transactions.map((tx) => [tx.id, tx]),
@@ -258,7 +257,7 @@ function getMoneyWithdrawRecipients(transaction: TransactionMeta): string[] {
  * receiving a Money withdrawal.
  */
 const selectRelatedAddressesByTransactionId = createSelector(
-  selectTransactionsStrict,
+  selectTransactions,
   (transactions) => {
     const transactionsById = new Map<string, TransactionMeta>(
       transactions.map((transaction) => [transaction.id, transaction]),
@@ -303,18 +302,8 @@ const selectRelatedAddressesByTransactionId = createSelector(
   },
 );
 
-export const selectTransactions = createDeepEqualSelector(
-  selectTransactionsStrict,
-  (transactions) => transactions,
-  {
-    devModeChecks: {
-      identityFunctionCheck: 'never',
-    },
-  },
-);
-
 export const selectHasUnapprovedTransactions = createSelector(
-  selectTransactionsStrict,
+  selectTransactions,
   (transactions) =>
     transactions.some((tx) => tx.status === TransactionStatus.unapproved),
 );
@@ -349,13 +338,13 @@ function belongsToActiveAccount(
   );
 }
 
-export const selectNonReplacedTransactions = createDeepEqualSelector(
-  selectTransactionsStrict,
+export const selectNonReplacedTransactions = createSelector(
+  selectTransactions,
   (transactions) =>
     transactions.filter((transaction) => !isReplacedTransaction(transaction)),
 );
 
-export const selectSortedTransactions = createDeepEqualSelector(
+export const selectSortedTransactions = createSelector(
   [selectNonReplacedTransactions, selectPendingSmartTransactionsBySender],
   (nonReplacedTransactions, pendingSmartTransactions) =>
     [...nonReplacedTransactions, ...pendingSmartTransactions].sort(
@@ -423,7 +412,7 @@ export const selectLastUsedPaymentMethod = createSelector(
 );
 
 export const selectSortedEVMTransactionsForSelectedAccountGroup =
-  createDeepEqualSelector(
+  createSelector(
     [
       selectNonReplacedTransactions,
       selectPendingSmartTransactionsForSelectedAccountGroup,
@@ -434,7 +423,7 @@ export const selectSortedEVMTransactionsForSelectedAccountGroup =
       ),
   );
 
-export const selectLocalTransactions = createDeepEqualSelector(
+export const selectLocalTransactions = createSelector(
   [
     selectNonReplacedTransactions,
     selectPendingSmartTransactionsForSelectedAccountGroup,
@@ -489,9 +478,9 @@ export const selectLocalTransactions = createDeepEqualSelector(
  * type and amount (its live replacement drives the status). Address/required
  * filtering mirrors {@link selectLocalTransactions} so the two align by nonce.
  */
-export const selectReplacedLocalTransactions = createDeepEqualSelector(
+export const selectReplacedLocalTransactions = createSelector(
   [
-    selectTransactionsStrict,
+    selectTransactions,
     selectSelectedAccountGroupEvmInternalAccount,
     selectEvmAddress,
     selectRequiredTransactionIds,
@@ -534,8 +523,8 @@ export const selectSwapsTransactions = createSelector(
     transactionControllerState?.swapsTransactions ?? {},
 );
 
-export const selectTransactionMetadataById = createDeepEqualSelector(
-  selectTransactionsStrict,
+export const selectTransactionMetadataById = createSelector(
+  selectTransactions,
   (_: RootState, id: string) => id,
   (transactions, id) => transactions.find((tx) => tx.id === id),
 );
@@ -550,7 +539,7 @@ export const makeSelectTransactionMetadataById =
  * carries the tx hash but none of the local metadata.
  */
 export const selectTransactionMetadataByHash = createSelector(
-  selectTransactionsStrict,
+  selectTransactions,
   (_: RootState, hash: string | undefined) => hash,
   (transactions, hash) =>
     hash
@@ -560,14 +549,14 @@ export const selectTransactionMetadataByHash = createSelector(
       : undefined,
 );
 
-export const selectTransactionBatchMetadataById = createDeepEqualSelector(
+export const selectTransactionBatchMetadataById = createSelector(
   selectTransactionBatchesStrict,
   (_: RootState, id: string) => id,
   (transactionBatches, id) => transactionBatches?.find((tx) => tx.id === id),
 );
 
 export const selectTransactionsByIds = createSelector(
-  selectTransactionsStrict,
+  selectTransactions,
   (_: RootState, ids: string[]) => ids,
   (transactions, ids) =>
     ids
@@ -576,7 +565,7 @@ export const selectTransactionsByIds = createSelector(
 );
 
 export const selectTransactionsByBatchId = createSelector(
-  selectTransactionsStrict,
+  selectTransactions,
   (_: RootState, batchId: string) => batchId,
   (transactions, batchId) =>
     transactions.filter((tx) => tx.batchId === batchId),


### PR DESCRIPTION
## **Description**

Several hooks on the confirmation path compared Redux state by deep equality before deciding whether to re-render. Controller state reaches Redux through Immer-produced updates, which preserve the identity of any subtree that did not change, so reference equality already carries the same information — the deep comparisons were re-deriving a guarantee the state layer provides, on every store update, proportional to the size of the state being compared.

- `useApprovalRequest` now reads a memoized `selectFirstPendingApproval` selector instead of deep-comparing the whole pending-approvals map, rebuilding an array from it on each render, and deep-cloning the result.
- The transaction and gas-fee selector paths use `createSelector` in place of `createDeepEqualSelector`, and `useGasFeeEstimates` drops its `isEqual` comparator.
- `selectTransactions` is exported directly rather than being re-wrapped, so consumers share one memoized instance.
- The empty-state fallbacks for transactions and pending approvals are hoisted to module-level constants, so the no-data case keeps a stable reference instead of allocating a fresh empty value per evaluation.

The confirmation load logger additionally reports a running mean that excludes each transaction type's first sample, since that sample absorbs one-off module evaluation and cache warming and is not representative of steady-state behaviour.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Confirmation display

  Scenario: user opens a transaction confirmation
    Given the user has a wallet with funds
    When the user initiates a send, swap, or dapp transaction
    Then the confirmation is displayed with the correct details
    And gas fee estimates populate and update

  Scenario: user acts on a confirmation
    Given a confirmation is displayed
    When the user confirms or rejects it
    Then the confirmation is dismissed and the action is applied

  Scenario: user opens consecutive confirmations
    Given the user has completed one confirmation
    When the user initiates another transaction
    Then the new confirmation displays its own details rather than the previous request's
```

## **Screenshots/Recordings**

N/A

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Memoization and equality semantics change on hot confirmation paths; extra re-renders are possible if controller updates break reference stability, and approval objects are no longer deep-cloned before use.
> 
> **Overview**
> This PR speeds up the confirmation path by **dropping deep equality checks** where Immer already keeps stable references for unchanged Redux subtrees.
> 
> **Approvals:** `useApprovalRequest` now subscribes via memoized `selectFirstPendingApproval` instead of deep-comparing the full pending-approvals map, rebuilding `Object.values` each render, and `cloneDeep` on the first item. Empty pending state uses a module-level `DEFAULT_APPROVALS` constant for a stable fallback reference.
> 
> **Transactions & gas:** Transaction selectors switch from `createDeepEqualSelector` to `createSelector`, with `selectTransactions` exported as the single memoized source and `EMPTY_TRANSACTIONS` hoisted for empty lists. `useGasFeeEstimates` removes the `useSelector` `isEqual` comparator.
> 
> **Diagnostics:** `useConfirmationLoadMetrics` logs per–transaction-type running averages (overall and “warm,” excluding each type’s first cold sample); docs clarify these are log-only, not dispatched metrics.
> 
> Tests for `useApprovalRequest` invoke the real `selectFirstPendingApproval` against minimal state instead of stubbing selector output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fd43fadb09dfe27e212a74c71a429198bd928a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->