### PR TITLE
perf: trace every measurable cold-start stage

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useRef } from 'react';
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { FullWindowOverlay } from 'react-native-screens';
 import { useRoute } from '@react-navigation/native';
 import {
@@ -135,7 +135,17 @@ import TooltipModal from '../../Views/TooltipModal';
 import OptionsSheet from '../../UI/SelectOptionSheet/OptionsSheet';
 import FoxLoader from '../../UI/FoxLoader';
 import MultiRpcModal from '../../Views/MultiRpcModal/MultiRpcModal';
-import { endTrace, TraceName } from '../../../util/trace';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../util/trace';
+import getUIStartupSpan from '../../../core/Performance/UIStartup';
+import {
+  endPostInitGap,
+  startAppStartToUnlockInteractive,
+} from '../../../core/Performance/startupStageSpans';
 import { selectExistingUser } from '../../../reducers/user/selectors';
 import { Performance } from '../../../core/Performance';
 import { queueColdHomepageReadyTrace } from '../../../core/Performance/HomepageReady';
@@ -1157,7 +1167,35 @@ const ModalSwitchAccountType = () => (
   </NativeStack.Navigator>
 );
 
+// Module-scoped so a remount cannot reopen the span. This is a once-per-launch
+// measurement, not a per-mount one.
+let hasMeasuredRootNavigatorRender = false;
+
 const AppFlow = () => {
+  // A lazy `useState` initialiser rather than a ref write during render: the
+  // initialiser runs exactly once, before children evaluate, and stays
+  // compatible with React Compiler (this directory is opted in).
+  useState(() => {
+    if (hasMeasuredRootNavigatorRender) {
+      return null;
+    }
+    trace({
+      name: TraceName.RootNavigatorFirstRender,
+      op: TraceOperation.UIStartup,
+      parentContext: getUIStartupSpan(),
+    });
+    return null;
+  });
+
+  useEffect(() => {
+    if (hasMeasuredRootNavigatorRender) {
+      return;
+    }
+    hasMeasuredRootNavigatorRender = true;
+    endTrace({ name: TraceName.RootNavigatorFirstRender });
+    endPostInitGap();
+  }, []);
+
   const { colors, themeAppearance } = useTheme();
   const onboardingCanvasColor =
     themeAppearance === 'dark'
@@ -1570,6 +1608,7 @@ const App: React.FC = () => {
   const existingUser = useSelector(selectExistingUser);
   const isUnlocked = useSelector(selectIsUnlocked);
   const hasQueuedColdHomepageReadyTrace = useRef(false);
+  const hasStartedUnlockInteractiveTrace = useRef(false);
 
   useEffect(() => {
     if (
@@ -1582,6 +1621,23 @@ const App: React.FC = () => {
 
     hasQueuedColdHomepageReadyTrace.current = true;
     queueColdHomepageReadyTrace(Performance.appLaunchTime);
+  }, [existingUser, isUnlocked]);
+
+  // The mirror of the effect above, for the locked cold start — which is the
+  // common case and the one nothing measured. `HomepageReady` only starts at
+  // unlock submit on this path, so the entire wait before the user can begin
+  // typing was untracked.
+  useEffect(() => {
+    if (
+      hasStartedUnlockInteractiveTrace.current ||
+      !existingUser ||
+      isUnlocked
+    ) {
+      return;
+    }
+
+    hasStartedUnlockInteractiveTrace.current = true;
+    startAppStartToUnlockInteractive();
   }, [existingUser, isUnlocked]);
 
   useEffect(() => {

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -144,7 +144,7 @@ import {
 import getUIStartupSpan from '../../../core/Performance/UIStartup';
 import {
   endPostInitGap,
-  startAppStartToUnlockInteractive,
+  startAppStartToUnlockLaidOut,
 } from '../../../core/Performance/startupStageSpans';
 import { selectExistingUser } from '../../../reducers/user/selectors';
 import { Performance } from '../../../core/Performance';
@@ -1608,7 +1608,7 @@ const App: React.FC = () => {
   const existingUser = useSelector(selectExistingUser);
   const isUnlocked = useSelector(selectIsUnlocked);
   const hasQueuedColdHomepageReadyTrace = useRef(false);
-  const hasStartedUnlockInteractiveTrace = useRef(false);
+  const hasStartedUnlockLaidOutTrace = useRef(false);
 
   useEffect(() => {
     if (
@@ -1628,16 +1628,12 @@ const App: React.FC = () => {
   // unlock submit on this path, so the entire wait before the user can begin
   // typing was untracked.
   useEffect(() => {
-    if (
-      hasStartedUnlockInteractiveTrace.current ||
-      !existingUser ||
-      isUnlocked
-    ) {
+    if (hasStartedUnlockLaidOutTrace.current || !existingUser || isUnlocked) {
       return;
     }
 
-    hasStartedUnlockInteractiveTrace.current = true;
-    startAppStartToUnlockInteractive();
+    hasStartedUnlockLaidOutTrace.current = true;
+    startAppStartToUnlockLaidOut();
   }, [existingUser, isUnlocked]);
 
   useEffect(() => {

--- a/app/components/Nav/ControllersGate/ControllersGate.tsx
+++ b/app/components/Nav/ControllersGate/ControllersGate.tsx
@@ -4,6 +4,12 @@ import { ControllersGateProps } from './types';
 import { useSelector } from 'react-redux';
 import { selectAppServicesReady } from '../../../reducers/user/selectors';
 import FoxLoader from '../../UI/FoxLoader';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../util/trace';
 /**
  * A higher order component that gate keeps the children until the app services are finished loaded
  * and the splash animation has completed.
@@ -25,8 +31,28 @@ const ControllersGate: React.FC<ControllersGateProps> = ({
       toValue: 0,
       duration: 300,
       useNativeDriver: true,
-    }).start(() => setLoaderDone(true));
+    }).start(() => {
+      // Closes the reveal-tax span: children have been rendering underneath
+      // since `appServicesReady` flipped, so everything between that moment and
+      // here is perceived latency the user pays with nothing to show for it.
+      endTrace({ name: TraceName.SplashRevealTax });
+      setLoaderDone(true);
+    });
   }, [loaderOpacity]);
+
+  // Open the reveal-tax span the moment the gate unblocks. Neither `UIStartup`
+  // (ends at App's first render) nor Sentry's `app_start_cold` (ends at root
+  // mount) covers this window, so without an explicit span the fixed
+  // 800ms + 250ms + 300ms below is invisible to every shipped metric.
+  useEffect(() => {
+    if (!appServicesReady) {
+      return;
+    }
+    trace({
+      name: TraceName.SplashRevealTax,
+      op: TraceOperation.UIStartup,
+    });
+  }, [appServicesReady]);
 
   // Only fade out once BOTH the animation is done AND app services are ready.
   // This prevents a blank screen when Rive fails or times out before services finish.

--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -62,7 +62,7 @@ import {
   TraceOperation,
   endTrace,
 } from '../../../util/trace';
-import { endAppStartToUnlockInteractive } from '../../../core/Performance/startupStageSpans';
+import { endAppStartToUnlockLaidOut } from '../../../core/Performance/startupStageSpans';
 import HelpText, {
   HelpTextSeverity,
 } from '../../../component-library/components/Form/HelpText';
@@ -614,10 +614,12 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
               <TextField
                 placeholder={strings('login.password_placeholder')}
                 // Fires on the password field's NATIVE layout — the first
-                // moment the user can actually type. A mount or effect fires
-                // before the field accepts input and would measure ~zero.
+                // moment it would accept input. A mount or effect fires before
+                // that and would measure ~zero. Note this is when the field
+                // *works*, not when it is *visible*: the splash may still be
+                // covering it, and that gap is `SplashRevealTax`.
                 // Guarded internally, so repeated layouts are harmless.
-                onLayout={endAppStartToUnlockInteractive}
+                onLayout={endAppStartToUnlockLaidOut}
                 inputRef={fieldRef}
                 onChangeText={handlePasswordChange}
                 value={password}

--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -62,6 +62,7 @@ import {
   TraceOperation,
   endTrace,
 } from '../../../util/trace';
+import { endAppStartToUnlockInteractive } from '../../../core/Performance/startupStageSpans';
 import HelpText, {
   HelpTextSeverity,
 } from '../../../component-library/components/Form/HelpText';
@@ -612,6 +613,11 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
             >
               <TextField
                 placeholder={strings('login.password_placeholder')}
+                // Fires on the password field's NATIVE layout — the first
+                // moment the user can actually type. A mount or effect fires
+                // before the field accepts input and would measure ~zero.
+                // Guarded internally, so repeated layouts are harmless.
+                onLayout={endAppStartToUnlockInteractive}
                 inputRef={fieldRef}
                 onChangeText={handlePasswordChange}
                 value={password}

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -18,6 +18,7 @@ import {
 import { getTraceTags } from '../../util/sentry/tags';
 import { trace, endTrace, TraceName, TraceOperation } from '../../util/trace';
 import getUIStartupSpan from '../Performance/UIStartup';
+import { startPostInitGap } from '../Performance/startupStageSpans';
 
 import ReduxService from '../redux';
 import NavigationService from '../NavigationService';
@@ -145,7 +146,17 @@ export class EngineService {
    */
   start = async () => {
     const reduxState = ReduxService.store.getState();
+    // Separately spanned because this is ~70 filesystem reads + JSON.parse
+    // before a single controller can be constructed, and it needs to be
+    // attributable independently of Engine.init() to know whether startup is
+    // I/O-bound or CPU-bound here.
+    trace({
+      name: TraceName.ControllerStateRehydration,
+      op: TraceOperation.StorageRehydration,
+      parentContext: getUIStartupSpan(),
+    });
     const persistedState = await ControllerStorage.getAllPersistedState();
+    endTrace({ name: TraceName.ControllerStateRehydration });
 
     if (reduxState?.user?.existingUser) {
       Logger.log(
@@ -209,6 +220,9 @@ export class EngineService {
       }, 150);
     }
     endTrace({ name: TraceName.EngineInitialization });
+    // The window from here to the navigator's first render is where
+    // fire-and-forget startup work runs. See startupStageSpans.ts.
+    startPostInitGap();
   };
 
   /**

--- a/app/core/Performance/startupStageSpans.test.ts
+++ b/app/core/Performance/startupStageSpans.test.ts
@@ -1,0 +1,95 @@
+import { endTrace, trace, TraceName } from '../../util/trace';
+import {
+  endAppStartToUnlockInteractive,
+  endPostInitGap,
+  resetStartupStageSpansForTesting,
+  startAppStartToUnlockInteractive,
+  startPostInitGap,
+} from './startupStageSpans';
+
+jest.mock('../../util/trace', () => ({
+  ...jest.requireActual('../../util/trace'),
+  trace: jest.fn(),
+  endTrace: jest.fn(),
+}));
+
+jest.mock('.', () => ({
+  Performance: { appLaunchTime: 1_700_000_000_000 },
+}));
+
+const mockTrace = trace as jest.Mock;
+const mockEndTrace = endTrace as jest.Mock;
+
+describe('startupStageSpans', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetStartupStageSpansForTesting();
+  });
+
+  describe('post-init gap', () => {
+    it('opens and closes the span once', () => {
+      startPostInitGap();
+      endPostInitGap();
+
+      expect(mockTrace).toHaveBeenCalledTimes(1);
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({ name: TraceName.PostInitGap }),
+      );
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reopen on a second start', () => {
+      // A remount must not restart a once-per-launch measurement.
+      startPostInitGap();
+      startPostInitGap();
+
+      expect(mockTrace).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not close twice', () => {
+      startPostInitGap();
+      endPostInitGap();
+      endPostInitGap();
+
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not close a span that never opened', () => {
+      // Ending an unopened span would emit a stray measurement.
+      endPostInitGap();
+
+      expect(mockEndTrace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('app start to unlock interactive', () => {
+    it('anchors the span on the native launch timestamp', () => {
+      // Anchoring on `Date.now()` would silently exclude everything before the
+      // component mounted, which is most of the window being measured.
+      startAppStartToUnlockInteractive();
+
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.AppStartToUnlockInteractive,
+          startTime: 1_700_000_000_000,
+        }),
+      );
+    });
+
+    it('closes only on the first native layout', () => {
+      // `onLayout` fires repeatedly; only the first is the moment the field
+      // became interactive.
+      startAppStartToUnlockInteractive();
+      endAppStartToUnlockInteractive();
+      endAppStartToUnlockInteractive();
+      endAppStartToUnlockInteractive();
+
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.AppStartToUnlockInteractive,
+        }),
+      );
+    });
+  });
+});

--- a/app/core/Performance/startupStageSpans.test.ts
+++ b/app/core/Performance/startupStageSpans.test.ts
@@ -1,9 +1,9 @@
 import { endTrace, trace, TraceName } from '../../util/trace';
 import {
-  endAppStartToUnlockInteractive,
+  endAppStartToUnlockLaidOut,
   endPostInitGap,
   resetStartupStageSpansForTesting,
-  startAppStartToUnlockInteractive,
+  startAppStartToUnlockLaidOut,
   startPostInitGap,
 } from './startupStageSpans';
 
@@ -62,15 +62,15 @@ describe('startupStageSpans', () => {
     });
   });
 
-  describe('app start to unlock interactive', () => {
+  describe('app start to unlock laid out', () => {
     it('anchors the span on the native launch timestamp', () => {
       // Anchoring on `Date.now()` would silently exclude everything before the
       // component mounted, which is most of the window being measured.
-      startAppStartToUnlockInteractive();
+      startAppStartToUnlockLaidOut();
 
       expect(mockTrace).toHaveBeenCalledWith(
         expect.objectContaining({
-          name: TraceName.AppStartToUnlockInteractive,
+          name: TraceName.AppStartToUnlockLaidOut,
           startTime: 1_700_000_000_000,
         }),
       );
@@ -78,16 +78,16 @@ describe('startupStageSpans', () => {
 
     it('closes only on the first native layout', () => {
       // `onLayout` fires repeatedly; only the first is the moment the field
-      // became interactive.
-      startAppStartToUnlockInteractive();
-      endAppStartToUnlockInteractive();
-      endAppStartToUnlockInteractive();
-      endAppStartToUnlockInteractive();
+      // finished laying out and could accept input.
+      startAppStartToUnlockLaidOut();
+      endAppStartToUnlockLaidOut();
+      endAppStartToUnlockLaidOut();
+      endAppStartToUnlockLaidOut();
 
       expect(mockEndTrace).toHaveBeenCalledTimes(1);
       expect(mockEndTrace).toHaveBeenCalledWith(
         expect.objectContaining({
-          name: TraceName.AppStartToUnlockInteractive,
+          name: TraceName.AppStartToUnlockLaidOut,
         }),
       );
     });

--- a/app/core/Performance/startupStageSpans.ts
+++ b/app/core/Performance/startupStageSpans.ts
@@ -1,0 +1,81 @@
+import { Performance } from '.';
+import { endTrace, trace, TraceName, TraceOperation } from '../../util/trace';
+
+/**
+ * Owns the two startup spans whose start and end live in different files.
+ *
+ * Both are once-per-launch measurements, so the guards are module-scoped: a
+ * remount must not reopen a span, and a repeated native `onLayout` must not
+ * close one twice.
+ */
+let postInitGapOpen = false;
+let postInitGapClosed = false;
+let unlockInteractiveClosed = false;
+
+/**
+ * Opens the window between `Engine.init()` finishing and the navigator's first
+ * render.
+ *
+ * Nothing the user can see happens here, which is exactly why it needs a span:
+ * it is where fire-and-forget startup work lands. It measured 1,102 ms before
+ * a single call site (4,107 `new URL()` parses for analytics labelling) was
+ * fixed, and 152 ms after. A regression of that class is otherwise invisible,
+ * because it sits between two spans rather than inside either.
+ */
+export function startPostInitGap(): void {
+  if (postInitGapOpen) {
+    return;
+  }
+  postInitGapOpen = true;
+  trace({
+    name: TraceName.PostInitGap,
+    op: TraceOperation.UIStartup,
+  });
+}
+
+/** Closes the post-init window when the navigator first renders. */
+export function endPostInitGap(): void {
+  if (!postInitGapOpen || postInitGapClosed) {
+    return;
+  }
+  postInitGapClosed = true;
+  endTrace({ name: TraceName.PostInitGap });
+}
+
+/**
+ * Opens the app-start-to-unlock-interactive CUF, anchored on the native launch
+ * timestamp so it covers the same window the user experiences.
+ *
+ * `UIStartup` ends at `App`'s first render, and `HomepageReady` only starts at
+ * unlock submit on the locked path, so for a locked cold start — the common
+ * case — nothing measures the wait before the user can even begin typing.
+ */
+export function startAppStartToUnlockInteractive(): void {
+  trace({
+    name: TraceName.AppStartToUnlockInteractive,
+    op: TraceOperation.UIStartup,
+    startTime: Performance.appLaunchTime,
+  });
+}
+
+/**
+ * Closes the CUF the first time the password field reports native layout.
+ *
+ * Anchored on layout rather than mount or an effect: those fire before the
+ * field can accept input and would measure close to zero. Measured on a
+ * Galaxy A14, the field became interactive 1,402 ms before it was visible.
+ */
+export function endAppStartToUnlockInteractive(): void {
+  if (unlockInteractiveClosed) {
+    return;
+  }
+  unlockInteractiveClosed = true;
+  endTrace({ name: TraceName.AppStartToUnlockInteractive });
+}
+
+/** @internal Reset between tests. Do not call in production code. */
+export function resetStartupStageSpansForTesting(): void {
+  postInitGapOpen = false;
+  postInitGapClosed = false;
+  unlockInteractiveClosed = false;
+}

--- a/app/core/Performance/startupStageSpans.ts
+++ b/app/core/Performance/startupStageSpans.ts
@@ -10,7 +10,7 @@ import { endTrace, trace, TraceName, TraceOperation } from '../../util/trace';
  */
 let postInitGapOpen = false;
 let postInitGapClosed = false;
-let unlockInteractiveClosed = false;
+let unlockLaidOutClosed = false;
 
 /**
  * Opens the window between `Engine.init()` finishing and the navigator's first
@@ -43,16 +43,16 @@ export function endPostInitGap(): void {
 }
 
 /**
- * Opens the app-start-to-unlock-interactive CUF, anchored on the native launch
+ * Opens the app-start-to-unlock-laid-out CUF, anchored on the native launch
  * timestamp so it covers the same window the user experiences.
  *
  * `UIStartup` ends at `App`'s first render, and `HomepageReady` only starts at
  * unlock submit on the locked path, so for a locked cold start — the common
  * case — nothing measures the wait before the user can even begin typing.
  */
-export function startAppStartToUnlockInteractive(): void {
+export function startAppStartToUnlockLaidOut(): void {
   trace({
-    name: TraceName.AppStartToUnlockInteractive,
+    name: TraceName.AppStartToUnlockLaidOut,
     op: TraceOperation.UIStartup,
     startTime: Performance.appLaunchTime,
   });
@@ -62,20 +62,24 @@ export function startAppStartToUnlockInteractive(): void {
  * Closes the CUF the first time the password field reports native layout.
  *
  * Anchored on layout rather than mount or an effect: those fire before the
- * field can accept input and would measure close to zero. Measured on a
- * Galaxy A14, the field became interactive 1,402 ms before it was visible.
+ * field can accept input and would measure close to zero.
+ *
+ * This is the moment the field *works*, not the moment it is *visible* — on a
+ * Galaxy A14 the splash covered it for a further 1,402 ms. That gap is
+ * deliberately left in `SplashRevealTax` rather than folded in here, so the two
+ * are separable; a single "user can unlock" number would hide it.
  */
-export function endAppStartToUnlockInteractive(): void {
-  if (unlockInteractiveClosed) {
+export function endAppStartToUnlockLaidOut(): void {
+  if (unlockLaidOutClosed) {
     return;
   }
-  unlockInteractiveClosed = true;
-  endTrace({ name: TraceName.AppStartToUnlockInteractive });
+  unlockLaidOutClosed = true;
+  endTrace({ name: TraceName.AppStartToUnlockLaidOut });
 }
 
 /** @internal Reset between tests. Do not call in production code. */
 export function resetStartupStageSpansForTesting(): void {
   postInitGapOpen = false;
   postInitGapClosed = false;
-  unlockInteractiveClosed = false;
+  unlockLaidOutClosed = false;
 }

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -41,16 +41,22 @@ export enum TraceName {
    * Despite the name, this ends at `App`'s **first render** — not when startup
    * is over and not when anything is on screen. The splash still covers the UI
    * and the user cannot interact yet. Kept as-is because it has shipped
-   * history; use `AppStartToUnlockInteractive` for the full cold-start journey.
+   * history; use `AppStartToUnlockLaidOut` for the full cold-start journey.
    */
   UIStartup = 'UI Startup',
   HomepageReady = 'Homepage Ready',
   /**
-   * Process start -> the unlock screen genuinely accepts input. The app's
-   * most-executed cold path, previously untracked in production: `UIStartup`
-   * ends at `App`'s first render, before the splash reveal and unlock paint.
+   * Process start -> the unlock password field completes native layout, i.e.
+   * the first moment it would accept input. The app's most-executed cold path,
+   * previously untracked in production: `UIStartup` ends at `App`'s first
+   * render, before the splash reveal and unlock paint.
+   *
+   * **"Laid out", not "visible".** The splash can still be covering the field
+   * when this ends — measured at 1,402 ms of further wait on a Galaxy A14.
+   * Add `SplashRevealTax` to get the moment the user can actually unlock; the
+   * two are kept separate so that gap stays attributable.
    */
-  AppStartToUnlockInteractive = 'App Start To Unlock Interactive',
+  AppStartToUnlockLaidOut = 'App Start To Unlock Laid Out',
   /**
    * `appServicesReady` -> splash overlay removed. Fixed animation cost paid
    * after the UI is already rendered underneath, so it is pure perceived

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -37,8 +37,39 @@ export enum TraceName {
   LoginBiometricAuthentication = 'Login Biometrics Authentication',
   AppStartBiometricAuthentication = 'App start Biometrics Authentication',
   EngineInitialization = 'Engine Initialization',
+  /**
+   * Despite the name, this ends at `App`'s **first render** — not when startup
+   * is over and not when anything is on screen. The splash still covers the UI
+   * and the user cannot interact yet. Kept as-is because it has shipped
+   * history; use `AppStartToUnlockInteractive` for the full cold-start journey.
+   */
   UIStartup = 'UI Startup',
   HomepageReady = 'Homepage Ready',
+  /**
+   * Process start -> the unlock screen genuinely accepts input. The app's
+   * most-executed cold path, previously untracked in production: `UIStartup`
+   * ends at `App`'s first render, before the splash reveal and unlock paint.
+   */
+  AppStartToUnlockInteractive = 'App Start To Unlock Interactive',
+  /**
+   * `appServicesReady` -> splash overlay removed. Fixed animation cost paid
+   * after the UI is already rendered underneath, so it is pure perceived
+   * latency. Should trend to zero.
+   */
+  SplashRevealTax = 'Splash Reveal Tax',
+  /**
+   * `AppFlow`'s first render — the synchronous navigator module-evaluation
+   * burst. Splits "engine init" from "screen graph evaluation" inside startup.
+   */
+  RootNavigatorFirstRender = 'Root Navigator First Render',
+  /** Reading and parsing every `persist:<Controller>` blob before Engine init. */
+  ControllerStateRehydration = 'Controller State Rehydration',
+  /**
+   * `Engine.init()` finishing -> the navigator's first render. Nothing visible
+   * happens here, which is why it needs a span: it is where fire-and-forget
+   * startup work lands, and it sits between two spans rather than inside either.
+   */
+  PostInitGap = 'Post Init Gap',
   UiSlotsLoad = 'UI Slots Load',
   DeeplinkProcessed = 'Deeplink Processed',
   DeeplinkNavigated = 'Deeplink Navigated',


### PR DESCRIPTION
## **Description**

Cold start was measured end to end on a low-tier Android device: **9,723 ms from icon tap to a usable wallet**. Almost none of it is visible in production telemetry.

`UIStartup` — the one span that sounds like it covers startup — **ends at `App`'s first render**, roughly 2.1 s into that 9.7 s. Everything after it is unmeasured: the splash reveal, the unlock screen becoming usable, and a **1,102 ms gap** between `Engine.init()` finishing and the navigator rendering that had no span at either end.

So the three largest stages of cold start were invisible, and there was no way to tell a regression in "engine init" from one in "screen graph evaluation" from one in "splash animation" — they all landed outside every shipped span.

This PR adds five spans so every stage of the ladder is separately attributable. **Instrumentation only — no behaviour change, no new dependency**, all five go through the existing `trace()`/`endTrace()` layer per the repo convention.

### The stages, and where each span lands

Galaxy A14 5G, Android 15, `production` release build, populated wallet, cold starts, n=5 medians. "After" shows where a separate PR has since moved the number.

| Stage | Span | Starts at | Ends at | Before → After | |
|---|---|---|---|---:|---|
| S1 | `nativeLaunchStart/End` | process fork | native handoff | 53 → 53 | mark only, no span |
| S1b | **none** | `nativeLaunchEnd` | `runJsBundleStart` | 589 → 507 | ⚠️ **untraceable from JS** |
| S2 | `runJsBundle` marks | bundle load | eval end | 1,288 → 1,085 | mark only, no span |
| S1–S2 | `LoadScripts` | `appLaunchTime` | observer `now` | reports 1,288 → 1,085 | ⚠️ see below |
| S3 | **none** | eval end | rehydrate start | 200 → 200 | diffuse, deliberately skipped |
| S4a | **`ControllerStateRehydration`** | before `getAllPersistedState()` | after it resolves | 88 → 88 | ✅ **new** |
| S4b | `EngineInitialization` | Engine init | init done | 778 → 778 | existed |
| S4c | **`PostInitGap`** | `Engine.init()` returns | navigator first-render effect | 1,102 → **152** | ✅ **new** — was invisible |
| S4d | **`RootNavigatorFirstRender`** | `AppFlow` render | `AppFlow` mount effect | 24 → 24 | ✅ **new** |
| — | `UIStartup` | `appLaunchTime` | `App` first-render effect | ≈2,130 | existed, misnamed |
| S5 | **`AppStartToUnlockLaidOut`** | `Performance.appLaunchTime` | password field native `onLayout` | **≈4,475** | ✅ **new** |
| F1 | **`SplashRevealTax`** | `appServicesReady` | fade-out callback | 1,752 → **1,527** | ✅ **new** — was invisible |
| S6 | `HomepageReady` | unlock submit | homepage usable | 3,846 → **2,050** | existed |

**Do not sum these.** `AppStartToUnlockLaidOut` contains S1–F1 and `UIStartup` contains S4a–S4d. The only disjoint pair spanning the whole journey is S5 + S6 = 4,475 + 1,402 covered + 3,846 = **9,723 ms**.

### `LoadScripts` does not measure the pre-JS window

Worth knowing before you read the table above as complete. `Performance.ts:95-104` opens `LoadScripts` at `appLaunchTime` and ends it immediately at `now`, so its duration *is* `Math.max(nativeLaunchDuration, jsBundleDuration)` — a synthetic value, not a real window:

```
reported:  max(53, 1288)      = 1,288 ms
actual:    53 + 589 + 1288    = 1,930 ms
```

That **642 ms under-report** is what #35986 fixes. S1b is not "folded into `LoadScripts`" — it is simply absent from every shipped metric, and this PR does not change that (see below).

### Design decisions worth reviewing

**`AppStartToUnlockLaidOut` closes on the password field's *native layout*, not on mount or an effect.** This is the whole reason the span is trustworthy. A mount or `useEffect` fires before the field can accept input and would report a duration close to zero — measuring the wrong moment is worse than not measuring, because it looks fine. It is anchored on `Performance.appLaunchTime` (process start) via `startTime`, not on when the component happened to mount.

**The name says "laid out", not "interactive", and that distinction is the point.** The field finishes layout at ≈4,475 ms but the splash keeps covering it for a further **1,402 ms**, so the user cannot actually unlock until ≈5,877 ms. Naming it "interactive" would have overclaimed by exactly the gap this instrumentation exists to expose. Collapsing both into one "user can unlock" number was the alternative and was rejected — it hides the 1,402 ms. `AppStartToUnlockLaidOut` + `SplashRevealTax` decompose the wait into **when it worked** and **when you could see it**.

**`SplashRevealTax` is deliberately top-level, not nested under the unlock CUF.** It also fires on the already-unlocked path, where that CUF never starts, so parenting it would drop the span exactly on one of the two paths.

**`UIStartup` is left alone.** It ships today and has history, so rather than change its meaning I documented what it actually covers and added a doc comment warning that the name overpromises.

**S1b (507 ms) is not traced.** Bridgeless emits no `ReactMarker` for host/context setup, so there is no JS-observable boundary. It was attributed offline with `atrace` instead. Closing it needs native code and is out of scope here — flagging it rather than shipping a span that guesses.

**The two spans whose start and end live in different files** (`PostInitGap`, `AppStartToUnlockLaidOut`) are owned by a small dedicated module, `app/core/Performance/startupStageSpans.ts`, rather than leaving a `trace()` in one file and a matching `endTrace()` in another with nothing tying them together.

### Once-per-launch guarding

Every span here is a once-per-launch measurement, so each is idempotent:

- `PostInitGap` will not reopen on a second start, will not close twice, and **will not close if it never opened** — an unmatched `endTrace` would otherwise emit a span with a bogus start.
- `RootNavigatorFirstRender` is guarded by a **module-scoped** flag, not a ref, so a remount cannot restart it.
- It opens from a lazy `useState` initialiser rather than a write during render — runs exactly once, before children evaluate, and stays React Compiler compatible (`app/components/Nav` is opted in).
- `AppStartToUnlockLaidOut` closes only on the first of many `onLayout` calls.

### Note for whoever dashboards these

A span abandoned mid-flight — the gate unmounting during the fade, or the app backgrounded before the unlock screen paints — is **not** silently wrong. The existing `trace()` infrastructure finishes it at the `TRACES_CLEANUP_INTERVAL` cap with `status: deadline_exceeded` and `trace.timed_out: true`. **Filter on `trace.timed_out` when building panels**, or those capped spans will distort p90/max.

### Sampling

Nothing special is done here: `tracesSampleRate` is 0.03 in production and child spans inherit the parent's sampling decision, so these ride the existing configuration.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related: #35986 — fixes the `LoadScripts` / `appLaunchTime` bug described above. **That bug makes every span here start ~642 ms too late**, including `AppStartToUnlockLaidOut`, which anchors on `Performance.appLaunchTime` directly. This PR is still correct and useful without it — stage *durations* and their relative sizes are unaffected — but the absolute process-start-anchored numbers are only right once #35986 lands. Kept separate because it is a correctness fix to existing behaviour, not instrumentation.

Startup fixes measured with this instrumentation: #36036, #36044, #36041.

## **Manual testing steps**

```gherkin
Feature: Startup stage spans

  Scenario: cold start on a locked wallet
    Given a build with dev/E2E trace sampling
    And the app has been force-stopped

    When user launches the app
    And user waits for the unlock screen to appear
    Then a trace exists for each of ControllerStateRehydration,
      EngineInitialization, PostInitGap and RootNavigatorFirstRender
    And AppStartToUnlockLaidOut ends when the password field finishes layout
    And SplashRevealTax ends when the splash overlay disappears
    And no span is reported twice

  Scenario: cold start on an already-unlocked path
    When user launches the app without a lock
    Then SplashRevealTax is still reported
    And AppStartToUnlockLaidOut is absent rather than empty

  Scenario: no user-visible change
    When user launches, unlocks and uses the wallet
    Then the app behaves exactly as it does on main
```

## **Screenshots/Recordings**

### **Before**

N/A — no UI change. The spans above are the output; stage numbers are in the table.

### **After**

N/A — no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
  - `startupStageSpans.test.ts` — 6 cases covering the guards above, including that ending a never-opened span is a no-op and that the CUF anchors on the native launch timestamp rather than `Date.now()`. Full sweep of the touched areas: **473 tests, 15 suites, all passing**; `tsc` clean; ESLint 0 errors. `startupStageSpans.ts` and `ControllersGate.tsx` at 100% coverage; every new line in `App.tsx` verified as exercised, locked-path branch included.
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - Every new `TraceName` carries a doc comment saying what it covers and why it needs its own span; `UIStartup` gained one saying what it does *not* cover.
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Samsung Galaxy A14 5G (SM-A146P), Android 15, `production` release build — a mid-range physical device. All stage numbers above are n=5 cold-start medians from it.
- [x] I've tested with a power user scenario
  - Populated wallet with several imported accounts, cold starts only.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - That is what this PR is.
- **Cost of the instrumentation itself**: five `trace()`/`endTrace()` pairs, no timers, no polling, no new render work, and no always-on sampling loop. An earlier version of this work (#35985, closed) was rejected for adding real work to the path it measured; this one deliberately does not.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
