### PR TITLE
perf(confirmations): gate expensive hooks behind visibility and loading checks

### DIFF
--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -166,33 +166,28 @@ interface ConfirmProps {
   fullscreenStyle?: StyleProp<ViewStyle>;
 }
 
+interface ConfirmInternalProps extends ConfirmProps {
+  approvalRequestType?: string;
+}
+
 export const Confirm = ({
   route,
   disableSafeArea = false,
   fullscreenStyle,
 }: ConfirmProps) => {
   const { approvalRequest } = useApprovalRequest();
-  const { isFullScreenConfirmation } = useFullScreenConfirmation();
   const navigation = useNavigation<AppNavigationProp>();
-  const { onReject } = useConfirmActions();
-  const { onFirstPaint } = useConfirmationLoadMetrics();
-  const { styles } = useStyles(styleSheet, {
-    isFullScreenConfirmation,
-    disableSafeArea,
-  });
 
+  // While there is no approval request, keep the loading state in place and
+  // disable the back gesture. The approvalRequest-present nav options
+  // (headerShown / gestureEnabled) are set by ConfirmInternal so this effect
+  // stays independent of the expensive isFullScreenConfirmation hook.
   useEffect(() => {
-    const options: NativeStackNavigationOptions = {
-      // If not, keep the loading state in place until there is a request that can be rejected.
-      gestureEnabled: Boolean(approvalRequest),
-    };
-
-    if (approvalRequest) {
-      options.headerShown = Boolean(isFullScreenConfirmation);
+    if (!approvalRequest) {
+      const options: NativeStackNavigationOptions = { gestureEnabled: false };
+      navigation.setOptions(options);
     }
-
-    navigation.setOptions(options);
-  }, [approvalRequest, isFullScreenConfirmation, navigation]);
+  }, [approvalRequest, navigation]);
 
   useEffect(() => {
     if (!approvalRequest) {
@@ -208,10 +203,53 @@ export const Confirm = ({
     }
   }, [approvalRequest]);
 
-  // Show spinner if there is no approvalRequest
+  // Show spinner if there is no approvalRequest. Crucially, none of the
+  // expensive confirmation hooks (useConfirmActions -> useTransactionConfirm,
+  // useFullScreenConfirmation -> useTransactionMetadataRequest, etc.) run on
+  // this path — they are gated behind ConfirmInternal below.
   if (!approvalRequest) {
     return <Loader />;
   }
+
+  return (
+    <ConfirmInternal
+      approvalRequestType={approvalRequest.type}
+      disableSafeArea={disableSafeArea}
+      fullscreenStyle={fullscreenStyle}
+      route={route}
+    />
+  );
+};
+
+/**
+ * The confirmation shell that mounts only once an approval request exists.
+ * Everything expensive lives here — `useConfirmActions`,
+ * `useFullScreenConfirmation`, styles — so none of it runs during the loader
+ * phase.
+ */
+function ConfirmInternal({
+  approvalRequestType,
+  route,
+  disableSafeArea = false,
+  fullscreenStyle,
+}: ConfirmInternalProps) {
+  const navigation = useNavigation<AppNavigationProp>();
+  const { isFullScreenConfirmation } = useFullScreenConfirmation();
+  const { onReject } = useConfirmActions();
+  const { onFirstPaint } = useConfirmationLoadMetrics();
+  const { styles } = useStyles(styleSheet, {
+    isFullScreenConfirmation,
+    disableSafeArea,
+  });
+
+  useEffect(() => {
+    const options: NativeStackNavigationOptions = {
+      gestureEnabled: true,
+      headerShown: Boolean(isFullScreenConfirmation),
+    };
+
+    navigation.setOptions(options);
+  }, [isFullScreenConfirmation, navigation]);
 
   // Show confirmation in a flat container if the confirmation is full screen
   if (isFullScreenConfirmation) {
@@ -230,7 +268,7 @@ export const Confirm = ({
   return (
     <BottomSheet onClose={() => onReject()} testID={ConfirmationUIType.MODAL}>
       <View
-        testID={approvalRequest?.type}
+        testID={approvalRequestType}
         style={styles.confirmContainer}
         onLayout={onFirstPaint}
       >
@@ -238,7 +276,7 @@ export const Confirm = ({
       </View>
     </BottomSheet>
   );
-};
+}
 
 function ConfirmationAlerts({ children }: { children: ReactNode }) {
   const alerts = useConfirmationAlerts();

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -166,10 +166,6 @@ interface ConfirmProps {
   fullscreenStyle?: StyleProp<ViewStyle>;
 }
 
-interface ConfirmInternalProps extends ConfirmProps {
-  approvalRequestType?: string;
-}
-
 export const Confirm = ({
   route,
   disableSafeArea = false,
@@ -178,12 +174,9 @@ export const Confirm = ({
   const { approvalRequest } = useApprovalRequest();
   const navigation = useNavigation<AppNavigationProp>();
 
-  // While there is no approval request, keep the loading state in place and
-  // disable the back gesture. The approvalRequest-present nav options
-  // (headerShown / gestureEnabled) are set by ConfirmInternal so this effect
-  // stays independent of the expensive isFullScreenConfirmation hook.
   useEffect(() => {
     if (!approvalRequest) {
+      // Keep the loading state in place until there is a request that can be rejected.
       const options: NativeStackNavigationOptions = { gestureEnabled: false };
       navigation.setOptions(options);
     }
@@ -203,17 +196,13 @@ export const Confirm = ({
     }
   }, [approvalRequest]);
 
-  // Show spinner if there is no approvalRequest. Crucially, none of the
-  // expensive confirmation hooks (useConfirmActions -> useTransactionConfirm,
-  // useFullScreenConfirmation -> useTransactionMetadataRequest, etc.) run on
-  // this path — they are gated behind ConfirmInternal below.
+  // Show spinner if there is no approvalRequest
   if (!approvalRequest) {
     return <Loader />;
   }
 
   return (
     <ConfirmInternal
-      approvalRequestType={approvalRequest.type}
       disableSafeArea={disableSafeArea}
       fullscreenStyle={fullscreenStyle}
       route={route}
@@ -221,18 +210,12 @@ export const Confirm = ({
   );
 };
 
-/**
- * The confirmation shell that mounts only once an approval request exists.
- * Everything expensive lives here — `useConfirmActions`,
- * `useFullScreenConfirmation`, styles — so none of it runs during the loader
- * phase.
- */
 function ConfirmInternal({
-  approvalRequestType,
   route,
   disableSafeArea = false,
   fullscreenStyle,
-}: ConfirmInternalProps) {
+}: ConfirmProps) {
+  const { approvalRequest } = useApprovalRequest();
   const navigation = useNavigation<AppNavigationProp>();
   const { isFullScreenConfirmation } = useFullScreenConfirmation();
   const { onReject } = useConfirmActions();
@@ -268,7 +251,7 @@ function ConfirmInternal({
   return (
     <BottomSheet onClose={() => onReject()} testID={ConfirmationUIType.MODAL}>
       <View
-        testID={approvalRequestType}
+        testID={approvalRequest?.type}
         style={styles.confirmContainer}
         onLayout={onFirstPaint}
       >

--- a/app/components/Views/confirmations/components/footer/footer.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.tsx
@@ -62,27 +62,15 @@ const HIDE_FOOTER_BY_DEFAULT_TYPES = [
   TransactionType.predictWithdraw,
 ];
 
-/**
- * Thin visibility gate for the confirmation footer.
- *
- * Runs ONLY the cheap hooks needed to decide whether the footer renders at all.
- * For the types in `HIDE_FOOTER_BY_DEFAULT_TYPES` (e.g. `moneyAccountDeposit`)
- * the footer renders `null`, and gating here avoids paying for the heavy hook
- * chain in `FooterInternal` (`useConfirmActions` -> `useTransactionConfirm` ->
- * `useHandleHwSend` -> gas subtree, plus alerts/pay/gasless hooks). Because
- * hooks cannot be conditional, keeping those in this wrapper would run them and
- * throw the result away on every hidden-footer render.
- */
 export function Footer() {
   const transactionMetadata = useTransactionMetadataRequest();
-  const { isFooterVisible: isFooterVisibleFlag } = useConfirmationContext();
+  const { isFooterVisible } = useConfirmationContext();
 
-  const isFooterVisible =
-    isFooterVisibleFlag ??
-    (!transactionMetadata ||
-      !hasTransactionType(transactionMetadata, HIDE_FOOTER_BY_DEFAULT_TYPES));
-
-  if (!isFooterVisible) {
+  if (
+    isFooterVisible === false ||
+    (isFooterVisible === undefined &&
+      hasTransactionType(transactionMetadata, HIDE_FOOTER_BY_DEFAULT_TYPES))
+  ) {
     return null;
   }
 

--- a/app/components/Views/confirmations/components/footer/footer.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.tsx
@@ -62,7 +62,34 @@ const HIDE_FOOTER_BY_DEFAULT_TYPES = [
   TransactionType.predictWithdraw,
 ];
 
-export const Footer = () => {
+/**
+ * Thin visibility gate for the confirmation footer.
+ *
+ * Runs ONLY the cheap hooks needed to decide whether the footer renders at all.
+ * For the types in `HIDE_FOOTER_BY_DEFAULT_TYPES` (e.g. `moneyAccountDeposit`)
+ * the footer renders `null`, and gating here avoids paying for the heavy hook
+ * chain in `FooterInternal` (`useConfirmActions` -> `useTransactionConfirm` ->
+ * `useHandleHwSend` -> gas subtree, plus alerts/pay/gasless hooks). Because
+ * hooks cannot be conditional, keeping those in this wrapper would run them and
+ * throw the result away on every hidden-footer render.
+ */
+export function Footer() {
+  const transactionMetadata = useTransactionMetadataRequest();
+  const { isFooterVisible: isFooterVisibleFlag } = useConfirmationContext();
+
+  const isFooterVisible =
+    isFooterVisibleFlag ??
+    (!transactionMetadata ||
+      !hasTransactionType(transactionMetadata, HIDE_FOOTER_BY_DEFAULT_TYPES));
+
+  if (!isFooterVisible) {
+    return null;
+  }
+
+  return <FooterInternal />;
+}
+
+function FooterInternal() {
   const {
     alerts,
     fieldAlerts,
@@ -93,8 +120,7 @@ export const Footer = () => {
   );
   const isPayAmountStale = useIsTransactionPayAmountStale();
   const { isGaslessLoading } = useIsGaslessLoading();
-  const { isFooterVisible: isFooterVisibleFlag, isTransactionValueUpdating } =
-    useConfirmationContext();
+  const { isTransactionValueUpdating } = useConfirmationContext();
 
   const navigation = useNavigation<AppNavigationProp>();
 
@@ -205,15 +231,6 @@ export const Footer = () => {
     (isPayTokenRequiredTransaction && !isPaySubmitReady) ||
     isGaslessLoading;
 
-  const isFooterVisible =
-    isFooterVisibleFlag ??
-    (!transactionMetadata ||
-      !hasTransactionType(transactionMetadata, HIDE_FOOTER_BY_DEFAULT_TYPES));
-
-  if (!isFooterVisible) {
-    return null;
-  }
-
   if (
     transactionMetadata &&
     hasTransactionType(transactionMetadata, [TransactionType.predictClaim])
@@ -297,7 +314,7 @@ export const Footer = () => {
       )}
     </>
   );
-};
+}
 
 export function FooterSkeleton() {
   const { isFullScreenConfirmation } = useFullScreenConfirmation();


### PR DESCRIPTION
## **Description**

React hooks cannot be conditional, so a component that early-returns `null` still pays for every hook declared above that return. Both `Footer` and `Confirm` ran their full hook chains before deciding whether they had anything to render.

- `Footer` becomes a thin visibility gate that runs only the cheap hooks needed to decide whether the footer renders at all, with the heavy chain moved into `FooterInternal`. Confirmation types in `HIDE_FOOTER_BY_DEFAULT_TYPES` now render `null` without first running `useConfirmActions` → `useTransactionConfirm` → `useHandleHwSend`.
- `Confirm` is split into a loader shell and `ConfirmInternal`. While no approval request exists, the loader renders without running `useConfirmActions`, `useFullScreenConfirmation` or `useStyles`.

Gating inside each component, rather than at each call site, means every parent that mounts them benefits without the parents changing.

This is not a behavioural change: the visibility and loading conditions are unchanged, only the point at which they are evaluated moves. The effects that *maintain* the loading state (blocking hardware back-press, disabling the back gesture) deliberately stay in the outer `Confirm`, since they must run precisely when it early-returns.

## **Changelog**

CHANGELOG entry: Improved confirmation screen load performance

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Confirmation footer visibility

  Scenario: user opens a confirmation whose footer is hidden by default
    Given the user is on the wallet home screen
    When user starts a flow whose type is in HIDE_FOOTER_BY_DEFAULT_TYPES
    Then the confirmation renders without a footer
    And the confirmation can still be completed and rejected as before

  Scenario: user opens a confirmation with a visible footer
    Given the user is on the wallet home screen
    When user starts a send transaction
    Then the confirmation renders with Cancel and Confirm buttons
    And both buttons behave as before

  Scenario: confirmation is opened before the approval request resolves
    Given the user triggers a confirmation
    When the approval request has not yet arrived
    Then a loader is shown
    And the hardware back button does not dismiss the loader
    And the confirmation renders normally once the request arrives
```

## **Screenshots/Recordings**

N/A

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only structural split with preserved conditions; main risk is accidental hook-order or nav-option regressions on the confirmation screen.
> 
> **Overview**
> **Refactors confirmation `Confirm` and `Footer` so expensive hooks run only when those surfaces actually render**, without changing visibility or loading rules.
> 
> `Confirm` is now a thin shell: while there is no `approvalRequest`, it only shows the loader and keeps back-gesture/back-press blocking; `useConfirmActions`, fullscreen styling, and the main UI move into `ConfirmInternal` once a request exists. Navigation options are split so the loader path disables gestures only when needed, and the loaded path always enables gestures and toggles the header for fullscreen confirmations.
> 
> `Footer` early-returns `null` from a small wrapper after the same visibility checks (`isFooterVisible` and `HIDE_FOOTER_BY_DEFAULT_TYPES`); confirm/cancel logic, pay/gasless guards, and alerts live in `FooterInternal` so hidden-footer flows skip that hook chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74b5534ee8bff66a85c41a5f95d8bbb6d97ee6be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->