### PR TITLE
perf(confirmations): avoid decoding transaction calldata in render path

### DIFF
--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.test.tsx
@@ -64,7 +64,7 @@ const GAS_FEE_TOKEN_MOCK: ReturnType<typeof useSelectedGasFeeToken> = {
   metaMaskFee: '0x0',
   metamaskFeeFiat: '$0.00',
   fee: '0x0',
-  transferTransaction: {},
+  getTransferTransaction: () => ({}),
 };
 
 const SIMULATION_DATA_MOCK: SimulationData = {

--- a/app/components/Views/confirmations/constants/approve.ts
+++ b/app/components/Views/confirmations/constants/approve.ts
@@ -6,6 +6,10 @@ export const APPROVAL_4BYTE_SELECTORS = {
   PERMIT2_APPROVE: '0x87517c45',
 };
 
+export const APPROVAL_SELECTORS: Set<string> = new Set(
+  Object.values(APPROVAL_4BYTE_SELECTORS),
+);
+
 export const ZERO_AMOUNT = '0';
 
 export const TOKEN_VALUE_UNLIMITED_THRESHOLD = 10 ** 15;

--- a/app/components/Views/confirmations/hooks/gas/useGasFeeToken.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useGasFeeToken.test.ts
@@ -127,7 +127,7 @@ describe('useGasFeeToken', () => {
 
   it('returns token transfer transaction', () => {
     const result = runHook({ tokenAddress: GAS_FEE_TOKEN_MOCK.tokenAddress });
-    expect(result.transferTransaction).toStrictEqual({
+    expect(result.getTransferTransaction()).toStrictEqual({
       data: `0xa9059cbb000000000000000000000000${GAS_FEE_TOKEN_MOCK.recipient.slice(
         2,
       )}00000000000000000000000000000000000000000000000000000000000004d2`,
@@ -146,7 +146,7 @@ describe('useGasFeeToken', () => {
       ],
       tokenAddress: NATIVE_TOKEN_ADDRESS,
     });
-    expect(result.transferTransaction).toStrictEqual({
+    expect(result.getTransferTransaction()).toStrictEqual({
       gas: GAS_FEE_TOKEN_MOCK.gasTransfer,
       maxFeePerGas: GAS_FEE_TOKEN_MOCK.maxFeePerGas,
       maxPriorityFeePerGas: GAS_FEE_TOKEN_MOCK.maxPriorityFeePerGas,
@@ -180,7 +180,7 @@ describe('useGasFeeToken', () => {
 
   it('returns token transfer transaction when tokenAddress is not the native token address', () => {
     const result = runHook({ tokenAddress: GAS_FEE_TOKEN_MOCK.tokenAddress });
-    expect(result.transferTransaction).toEqual(
+    expect(result.getTransferTransaction()).toEqual(
       expect.objectContaining({
         to: GAS_FEE_TOKEN_MOCK.tokenAddress,
         data: expect.any(String),

--- a/app/components/Views/confirmations/hooks/gas/useGasFeeToken.ts
+++ b/app/components/Views/confirmations/hooks/gas/useGasFeeToken.ts
@@ -15,7 +15,7 @@ import { formatAmount } from '../../../../UI/SimulationDetails/formatAmount';
 import { useFeeCalculations } from './useFeeCalculations';
 import { useEthFiatAmount } from '../useEthFiatAmount';
 import { useAccountNativeBalance } from '../useAccountNativeBalance';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useNativeCurrencySymbol } from '../useNativeCurrencySymbol';
 
 export const RATE_WEI_NATIVE = '0xDE0B6B3A7640000'; // 1x10^18
@@ -67,7 +67,7 @@ export function useGasFeeToken({ tokenAddress }: { tokenAddress?: Hex }) {
   );
   const metamaskFeeFiat = useFiatTokenValue(gasFeeToken, metaMaskFee, chainId);
 
-  const transferTransaction = useMemo(
+  const getTransferTransaction = useCallback(
     () =>
       tokenAddress === NATIVE_TOKEN_ADDRESS
         ? getNativeTransferTransaction(gasFeeToken)
@@ -81,18 +81,18 @@ export function useGasFeeToken({ tokenAddress }: { tokenAddress?: Hex }) {
       amountFormatted,
       amountFiat,
       balanceFiat,
+      getTransferTransaction,
       metaMaskFee,
       metamaskFeeFiat,
-      transferTransaction,
     }),
     [
       gasFeeToken,
       amountFormatted,
       amountFiat,
       balanceFiat,
+      getTransferTransaction,
       metaMaskFee,
       metamaskFeeFiat,
-      transferTransaction,
     ],
   );
 }

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -114,11 +114,11 @@ const gasFeeToken = (
   ({
     tokenAddress: '0x90F79bf6EB2c4f870365E785982E1f101E93b906',
     symbol: 'USDC',
-    transferTransaction: {
+    getTransferTransaction: () => ({
       data: '0xabc',
       to: '0x90F79bf6EB2c4f870365E785982E1f101E93b906',
       value: '0x0',
-    },
+    }),
     gas: '0x5208',
     maxFeePerGas: '0x1',
     maxPriorityFeePerGas: '0x2',
@@ -824,7 +824,11 @@ describe('useTransactionConfirm', () => {
       });
       isSendBundleSupportedMock.mockReturnValue(Promise.resolve(true));
       useSelectedGasFeeTokenMock.mockReturnValue({
-        transferTransaction: { data: '0xabc', to: '0xdef', value: '0x0' },
+        getTransferTransaction: () => ({
+          data: '0xabc',
+          to: '0xdef',
+          value: '0x0',
+        }),
         gas: '0x5208',
         maxFeePerGas: '0x1',
         maxPriorityFeePerGas: '0x2',
@@ -923,7 +927,7 @@ describe('useTransactionConfirm', () => {
       isSendBundleSupportedMock.mockReturnValue(Promise.resolve(false));
 
       useSelectedGasFeeTokenMock.mockReturnValue({
-        transferTransaction: { data: '0xabc' },
+        getTransferTransaction: () => ({ data: '0xabc' }),
       } as unknown as ReturnType<typeof useSelectedGasFeeToken>);
 
       const { result } = renderHook();
@@ -943,7 +947,7 @@ describe('useTransactionConfirm', () => {
       isSendBundleSupportedMock.mockReturnValue(Promise.resolve(false));
 
       useSelectedGasFeeTokenMock.mockReturnValue({
-        transferTransaction: { data: '0xabc' },
+        getTransferTransaction: () => ({ data: '0xabc' }),
       } as unknown as ReturnType<typeof useSelectedGasFeeToken>);
 
       const { result } = renderHook();
@@ -979,7 +983,7 @@ describe('useTransactionConfirm', () => {
       isSendBundleSupportedMock.mockReturnValue(Promise.resolve(false));
 
       useSelectedGasFeeTokenMock.mockReturnValue({
-        transferTransaction: { data: '0xabc' },
+        getTransferTransaction: () => ({ data: '0xabc' }),
       } as unknown as ReturnType<typeof useSelectedGasFeeToken>);
 
       useTransactionMetadataRequestMock.mockReturnValue({

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -86,7 +86,7 @@ export function useTransactionConfirm() {
 
       updatedMetadata.batchTransactions = [
         ...(updatedMetadata.batchTransactions ?? []),
-        selectedGasFeeToken.transferTransaction,
+        selectedGasFeeToken.getTransferTransaction(),
       ];
 
       updatedMetadata.txParams.gas = selectedGasFeeToken.gas;

--- a/app/components/Views/confirmations/hooks/useApproveTransactionData.test.ts
+++ b/app/components/Views/confirmations/hooks/useApproveTransactionData.test.ts
@@ -409,4 +409,37 @@ describe('useApproveTransactionData', () => {
       expect(isLoading).toBe(true);
     });
   });
+
+  describe('non-approval transaction data', () => {
+    it.each([
+      [
+        'a token transfer',
+        `0xa9059cbb000000000000000000000000${mockedSpender.slice(
+          2,
+        )}0000000000000000000000000000000000000000000000000000000000000064`,
+      ],
+      ['an unrecognised method', '0xd0e30db0'],
+    ])('returns no approve method for %s', (_title, data) => {
+      const clonedState = cloneDeep(approveERC20TransactionStateMock);
+
+      clonedState.engine.backgroundState.TransactionController.transactions[0].txParams.data =
+        data;
+
+      const { result } = renderHookWithProvider(
+        () => useApproveTransactionData(),
+        {
+          state: clonedState,
+        },
+      );
+
+      const { isLoading, approveMethod, isRevoke, spender, amount } =
+        result.current;
+
+      expect(isLoading).toBe(false);
+      expect(approveMethod).toBeUndefined();
+      expect(isRevoke).toBe(false);
+      expect(spender).toBeUndefined();
+      expect(amount).toBeUndefined();
+    });
+  });
 });

--- a/app/components/Views/confirmations/hooks/useApproveTransactionData.ts
+++ b/app/components/Views/confirmations/hooks/useApproveTransactionData.ts
@@ -1,6 +1,10 @@
 import { useMemo } from 'react';
 
-import { APPROVAL_4BYTE_SELECTORS, ZERO_AMOUNT } from '../constants/approve';
+import {
+  APPROVAL_4BYTE_SELECTORS,
+  APPROVAL_SELECTORS,
+  ZERO_AMOUNT,
+} from '../constants/approve';
 import {
   get4ByteCode,
   parseStandardTokenTransactionData,
@@ -93,20 +97,31 @@ export const useApproveTransactionData = (): ApproveTransactionData => {
   const tokenStandard = details?.standard?.toUpperCase();
 
   // Memoize parsing operations
-  const { fourByteCode, parsedData } = useMemo(() => {
+  const { fourByteCode, isApproval, parsedData } = useMemo(() => {
     if (!data) {
-      return { fourByteCode: undefined, parsedData: undefined };
+      return {
+        fourByteCode: undefined,
+        isApproval: false,
+        parsedData: undefined,
+      };
     }
 
     const code = get4ByteCode(data);
-    const parsed = parseStandardTokenTransactionData(data);
 
-    return { fourByteCode: code, parsedData: parsed };
+    if (!APPROVAL_SELECTORS.has(code)) {
+      return { fourByteCode: code, isApproval: false, parsedData: undefined };
+    }
+
+    return {
+      fourByteCode: code,
+      isApproval: true,
+      parsedData: parseStandardTokenTransactionData(data),
+    };
   }, [data]);
 
   // Memoize the entire parsed approval data
   const parsedApproveData = useMemo((): ApproveTransactionData => {
-    if (!transactionMetadata || isTokenStandardPending || !parsedData) {
+    if (!transactionMetadata || isTokenStandardPending || !data) {
       return {
         isLoading: true,
       };
@@ -121,6 +136,16 @@ export const useApproveTransactionData = (): ApproveTransactionData => {
       tokenBalance: undefined,
       tokenSymbol: details?.symbol as string,
     };
+
+    if (!isApproval) {
+      return result;
+    }
+
+    if (!parsedData) {
+      return {
+        isLoading: true,
+      };
+    }
 
     switch (fourByteCode) {
       case APPROVAL_4BYTE_SELECTORS.APPROVE: {
@@ -207,11 +232,13 @@ export const useApproveTransactionData = (): ApproveTransactionData => {
 
     return result;
   }, [
+    data,
     details.decimalsNumber,
     details.symbol,
     isTokenStandardPending,
     tokenStandard,
     fourByteCode,
+    isApproval,
     parsedData,
     transactionMetadata,
     tokenBalance,

--- a/app/components/Views/confirmations/utils/approvals.ts
+++ b/app/components/Views/confirmations/utils/approvals.ts
@@ -3,7 +3,10 @@ import { Hex, add0x } from '@metamask/utils';
 import { Interface } from '@ethersproject/abi';
 
 import { strings } from '../../../../../locales/i18n';
-import { TOKEN_VALUE_UNLIMITED_THRESHOLD } from '../constants/approve';
+import {
+  APPROVAL_SELECTORS,
+  TOKEN_VALUE_UNLIMITED_THRESHOLD,
+} from '../constants/approve';
 import {
   APPROVALS_LIST,
   APPROVAL_TYPES,
@@ -12,7 +15,7 @@ import {
   SIGNATURE_PERMIT2,
 } from '../constants/approvals';
 import { ApproveMethod } from '../types/approve';
-import { parseStandardTokenTransactionData } from './transaction';
+import { get4ByteCode, parseStandardTokenTransactionData } from './transaction';
 
 export interface ParsedApprovalTransactionData {
   amountOrTokenId?: BigNumber;
@@ -25,6 +28,10 @@ export interface ParsedApprovalTransactionData {
 export function parseApprovalTransactionData(
   data: Hex,
 ): ParsedApprovalTransactionData | undefined {
+  if (!data || !APPROVAL_SELECTORS.has(get4ByteCode(data))) {
+    return undefined;
+  }
+
   const transactionDescription = parseStandardTokenTransactionData(data);
   const { args, name } = transactionDescription ?? { name: '' };
 


### PR DESCRIPTION
## **Description**

Confirmation load does a meaningful amount of ABI work on the render path whose result is then thrown away. This PR stops that work happening in the first place.

`parseStandardTokenTransactionData` tries the ERC20, ERC721, ERC1155 and USDC ABIs in sequence inside `try`/`catch`, returning on the first that matches. That makes calldata matching *none* of them the most expensive case, since it pays four failed parses plus four exception constructions — and that is exactly the calldata whose decoded result gets discarded.

- Three call sites decoded first and only afterwards decided whether they cared: `useApproveTransactionData` parsed every confirmation before switching on the 4 byte selector, `parseApprovalTransactionData` parsed before checking `APPROVALS_LIST`, and `extractSpenderFromApprovalData` then parsed a second time. All three now filter on the cheap 4 byte selector before decoding, via a shared `APPROVAL_SELECTORS` set.
- `useGasFeeToken` applies the same principle to the encoding direction. It constructed an ERC20 `Interface` on every render to build a transfer transaction that is only consumed when the user submits, so that now happens inside a `getTransferTransaction` callback.

The selector set is derived from the existing `APPROVAL_4BYTE_SELECTORS` and is a strict superset of `APPROVALS_LIST`, so the pre-filter cannot reject calldata that the downstream name checks would have accepted. Behaviour is otherwise unchanged, including the existing case where absent `txParams.data` leaves `useApproveTransactionData` in its loading state.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Token approval confirmations decode calldata correctly

  Scenario: user reviews an ERC20 approval
    Given a dapp requests an ERC20 approve
    When the confirmation opens
    Then the spender, token and approved amount are displayed as before
    And the approval alerts behave as before

  Scenario: user reviews a setApprovalForAll
    Given a dapp requests setApprovalForAll
    When the confirmation opens
    Then it is identified as an approve-all and the token details render as before

  Scenario: user submits a transaction paying gas with a token
    Given a transaction with a gas fee token selected
    When user submits the confirmation
    Then the gas fee token transfer is included and the transaction succeeds

  Scenario: user reviews a non-approval transaction
    Given a transaction whose calldata is not an approval
    When the confirmation opens
    Then it renders as before with no approval details
```

## **Screenshots/Recordings**

N/A — no visual change.

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Render-path optimization with selector gating and lazy gas-transfer encoding; intended behavior is unchanged and covered by new/updated tests, with submit-time gas batching still using the same transfer payload when invoked.
> 
> **Overview**
> Reduces confirmation render cost by **not** running full ABI calldata decoding unless the transaction looks like an approval.
> 
> Approval handling now checks a shared **`APPROVAL_SELECTORS`** set (from existing 4-byte selectors) before calling **`parseStandardTokenTransactionData`** in **`useApproveTransactionData`** and **`parseApprovalTransactionData`**. Non-approval calldata (e.g. transfers or unknown methods) returns empty approval fields without parsing. Tests cover those cases.
> 
> Gas-fee token payment encoding moves off the render path: **`useGasFeeToken`** exposes **`getTransferTransaction()`** (built via **`useCallback`**) instead of a memoized **`transferTransaction`**, and **`useTransactionConfirm`** invokes it when batching smart transactions. Related mocks and tests were updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9982b998e6dd0e96502c408c3a0d38691d4c4dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->