### PR TITLE
perf(confirmations): extract useConfirmReject so reject-only consumers skip the confirm path

### DIFF
--- a/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
@@ -16,12 +16,16 @@ import { ConfirmationUIType } from '../../ConfirmationView.testIds';
 import { TraceName, endTrace, trace } from '../../../../../util/trace';
 import { Confirm, ConfirmationLoader } from './confirm-component';
 import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
+import { useConfirmActions } from '../../hooks/useConfirmActions';
 import { useConfirmReject } from '../../hooks/useConfirmReject';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import useConfirmationAlerts from '../../hooks/alerts/useConfirmationAlerts';
 import { useFullScreenConfirmation } from '../../hooks/ui/useFullScreenConfirmation';
 
 jest.mock('../../hooks/useConfirmReject');
+// Confirm renders the footer, which still depends on the full useConfirmActions
+// chain (useTransactionConfirm -> useFiatConfirm -> ramps -> react-query).
+jest.mock('../../hooks/useConfirmActions');
 
 jest.mock('../../../../../util/trace', () => ({
   ...jest.requireActual('../../../../../util/trace'),
@@ -161,6 +165,7 @@ jest.mock('../../../../../core/redux/slices/bridge', () => ({
 }));
 
 describe('Confirm', () => {
+  const useConfirmActionsMock = jest.mocked(useConfirmActions);
   const useConfirmRejectMock = jest.mocked(useConfirmReject);
   const mockOnReject = jest.fn();
   const useParamsMock = jest.mocked(useParams);
@@ -168,6 +173,10 @@ describe('Confirm', () => {
   beforeEach(() => {
     useConfirmRejectMock.mockReturnValue({
       onReject: mockOnReject,
+    });
+    useConfirmActionsMock.mockReturnValue({
+      onReject: jest.fn(),
+      onConfirm: jest.fn(),
     });
 
     jest.mocked(useConfirmationAlerts).mockReturnValue([]);

--- a/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
@@ -16,12 +16,12 @@ import { ConfirmationUIType } from '../../ConfirmationView.testIds';
 import { TraceName, endTrace, trace } from '../../../../../util/trace';
 import { Confirm, ConfirmationLoader } from './confirm-component';
 import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
-import { useConfirmActions } from '../../hooks/useConfirmActions';
+import { useConfirmReject } from '../../hooks/useConfirmReject';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import useConfirmationAlerts from '../../hooks/alerts/useConfirmationAlerts';
 import { useFullScreenConfirmation } from '../../hooks/ui/useFullScreenConfirmation';
 
-jest.mock('../../hooks/useConfirmActions');
+jest.mock('../../hooks/useConfirmReject');
 
 jest.mock('../../../../../util/trace', () => ({
   ...jest.requireActual('../../../../../util/trace'),
@@ -161,14 +161,13 @@ jest.mock('../../../../../core/redux/slices/bridge', () => ({
 }));
 
 describe('Confirm', () => {
-  const useConfirmActionsMock = jest.mocked(useConfirmActions);
+  const useConfirmRejectMock = jest.mocked(useConfirmReject);
   const mockOnReject = jest.fn();
   const useParamsMock = jest.mocked(useParams);
 
   beforeEach(() => {
-    useConfirmActionsMock.mockReturnValue({
+    useConfirmRejectMock.mockReturnValue({
       onReject: mockOnReject,
-      onConfirm: jest.fn(),
     });
 
     jest.mocked(useConfirmationAlerts).mockReturnValue([]);

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -20,7 +20,7 @@ import useApprovalRequest from '../../hooks/useApprovalRequest';
 import { AlertsContextProvider } from '../../context/alert-system-context';
 import { ConfirmationContextProvider } from '../../context/confirmation-context';
 import { QRHardwareContextProvider } from '../../context/qr-hardware-context';
-import { useConfirmActions } from '../../hooks/useConfirmActions';
+import { useConfirmReject } from '../../hooks/useConfirmReject';
 import { useConfirmationLoadMetrics } from '../../hooks/metrics/useConfirmationLoadMetrics';
 import { useFullScreenConfirmation } from '../../hooks/ui/useFullScreenConfirmation';
 import { ConfirmationAssetPollingProvider } from '../confirmation-asset-polling-provider/confirmation-asset-polling-provider';
@@ -218,7 +218,7 @@ function ConfirmInternal({
   const { approvalRequest } = useApprovalRequest();
   const navigation = useNavigation<AppNavigationProp>();
   const { isFullScreenConfirmation } = useFullScreenConfirmation();
-  const { onReject } = useConfirmActions();
+  const { onReject } = useConfirmReject();
   const { onFirstPaint } = useConfirmationLoadMetrics();
   const { styles } = useStyles(styleSheet, {
     isFullScreenConfirmation,

--- a/app/components/Views/confirmations/components/info/transaction-batch/transaction-batch.test.tsx
+++ b/app/components/Views/confirmations/components/info/transaction-batch/transaction-batch.test.tsx
@@ -3,6 +3,7 @@ import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { generateStablecoinLendingDepositConfirmationState } from '../../../__mocks__/controllers/transaction-batch-mock';
 import { useConfirmationMetricEvents } from '../../../hooks/metrics/useConfirmationMetricEvents';
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
+import { useConfirmReject } from '../../../hooks/useConfirmReject';
 import { getNavbar } from '../../UI/navbar/navbar';
 import TransactionBatch from './transaction-batch';
 
@@ -36,6 +37,10 @@ jest.mock('../../../../../../core/Engine', () => ({
 
 jest.mock('../../../hooks/useConfirmActions', () => ({
   useConfirmActions: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useConfirmReject', () => ({
+  useConfirmReject: jest.fn(),
 }));
 
 jest.mock('../../../components/UI/navbar/navbar', () => ({
@@ -81,6 +86,7 @@ describe('BatchTransaction', () => {
   const mockSetConfirmationMetric = jest.fn();
   const mockGetNavbar = jest.mocked(getNavbar);
   const mockUseConfirmActions = jest.mocked(useConfirmActions);
+  const mockUseConfirmReject = jest.mocked(useConfirmReject);
   const mockUseConfirmationMetricEvents = jest.mocked(
     useConfirmationMetricEvents,
   );
@@ -91,6 +97,7 @@ describe('BatchTransaction', () => {
       onReject: jest.fn(),
       onConfirm: jest.fn(),
     });
+    mockUseConfirmReject.mockReturnValue({ onReject: jest.fn() });
 
     mockUseConfirmationMetricEvents.mockReturnValue({
       trackAdvancedDetailsToggledEvent: mockTrackAdvancedDetailsToggledEvent,
@@ -105,6 +112,7 @@ describe('BatchTransaction', () => {
       onConfirm: jest.fn(),
       onReject: mockOnReject,
     }));
+    mockUseConfirmReject.mockImplementation(() => ({ onReject: mockOnReject }));
 
     renderWithProvider(<TransactionBatch />, {
       state: generateStablecoinLendingDepositConfirmationState,

--- a/app/components/Views/confirmations/components/info/transfer/transfer.test.tsx
+++ b/app/components/Views/confirmations/components/info/transfer/transfer.test.tsx
@@ -3,6 +3,7 @@ import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { transferConfirmationState } from '../../../../../../util/test/confirm-data-helpers';
 import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
+import { useConfirmReject } from '../../../hooks/useConfirmReject';
 import { useConfirmationMetricEvents } from '../../../hooks/metrics/useConfirmationMetricEvents';
 import { getNavbar } from '../../UI/navbar/navbar';
 import Transfer from './transfer';
@@ -67,6 +68,10 @@ jest.mock('../../../hooks/useConfirmActions', () => ({
   useConfirmActions: jest.fn(),
 }));
 
+jest.mock('../../../hooks/useConfirmReject', () => ({
+  useConfirmReject: jest.fn(),
+}));
+
 jest.mock('../../UI/navbar/navbar', () => ({
   getNavbar: jest.fn(),
 }));
@@ -104,6 +109,7 @@ describe('Transfer', () => {
   );
   const mockTrackPageViewedEvent = jest.fn();
   const mockUseConfirmActions = jest.mocked(useConfirmActions);
+  const mockUseConfirmReject = jest.mocked(useConfirmReject);
   const mockUseConfirmationMetricEvents = jest.mocked(
     useConfirmationMetricEvents,
   );
@@ -115,6 +121,7 @@ describe('Transfer', () => {
       onReject: jest.fn(),
       onConfirm: jest.fn(),
     });
+    mockUseConfirmReject.mockReturnValue({ onReject: jest.fn() });
 
     mockUseConfirmationMetricEvents.mockReturnValue({
       trackPageViewedEvent: mockTrackPageViewedEvent,
@@ -128,6 +135,7 @@ describe('Transfer', () => {
       onConfirm: jest.fn(),
       onReject: mockOnReject,
     }));
+    mockUseConfirmReject.mockImplementation(() => ({ onReject: mockOnReject }));
 
     const { getByText } = renderWithProvider(<Transfer />, {
       state: transferConfirmationState,

--- a/app/components/Views/confirmations/external/staking/info/staking-claim/staking-claim.test.tsx
+++ b/app/components/Views/confirmations/external/staking/info/staking-claim/staking-claim.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { stakingClaimConfirmationState } from '../../../../../../../util/test/confirm-data-helpers';
 import renderWithProvider from '../../../../../../../util/test/renderWithProvider';
 import { useConfirmActions } from '../../../../hooks/useConfirmActions';
+import { useConfirmReject } from '../../../../hooks/useConfirmReject';
 import { getNavbar } from '../../../../components/UI/navbar/navbar';
 import StakingClaim from './staking-claim';
 import { endTrace, TraceName } from '../../../../../../../util/trace';
@@ -47,6 +48,10 @@ jest.mock('../../../../hooks/useConfirmActions', () => ({
   useConfirmActions: jest.fn(),
 }));
 
+jest.mock('../../../../hooks/useConfirmReject', () => ({
+  useConfirmReject: jest.fn(),
+}));
+
 jest.mock('../../../../components/UI/animated-pulse', () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -77,6 +82,7 @@ jest.mock('../../../../../../../util/trace', () => ({
 describe('StakingClaim', () => {
   const mockGetNavbar = jest.mocked(getNavbar);
   const mockUseConfirmActions = jest.mocked(useConfirmActions);
+  const mockUseConfirmReject = jest.mocked(useConfirmReject);
   const mockEndTrace = jest.mocked(endTrace);
 
   beforeEach(() => {
@@ -85,6 +91,7 @@ describe('StakingClaim', () => {
       onReject: jest.fn(),
       onConfirm: jest.fn(),
     });
+    mockUseConfirmReject.mockReturnValue({ onReject: jest.fn() });
   });
 
   it('should render correctly', () => {
@@ -93,6 +100,7 @@ describe('StakingClaim', () => {
       onConfirm: jest.fn(),
       onReject: mockOnReject,
     }));
+    mockUseConfirmReject.mockImplementation(() => ({ onReject: mockOnReject }));
 
     const mockRoute: RouteProp<{ params: { amountWei: string } }, 'params'> = {
       key: 'test',

--- a/app/components/Views/confirmations/external/staking/info/staking-deposit/staking-deposit.test.tsx
+++ b/app/components/Views/confirmations/external/staking/info/staking-deposit/staking-deposit.test.tsx
@@ -5,6 +5,7 @@ import renderWithProvider from '../../../../../../../util/test/renderWithProvide
 import { stakingDepositConfirmationState } from '../../../../../../../util/test/confirm-data-helpers';
 import { EVENT_PROVIDERS } from '../../../../../../UI/Stake/constants/events';
 import { useConfirmActions } from '../../../../hooks/useConfirmActions';
+import { useConfirmReject } from '../../../../hooks/useConfirmReject';
 import { useConfirmationMetricEvents } from '../../../../hooks/metrics/useConfirmationMetricEvents';
 import { getNavbar } from '../../../../components/UI/navbar/navbar';
 import { endTrace, TraceName } from '../../../../../../../util/trace';
@@ -50,6 +51,10 @@ jest.mock('../../../../hooks/useConfirmActions', () => ({
   useConfirmActions: jest.fn(),
 }));
 
+jest.mock('../../../../hooks/useConfirmReject', () => ({
+  useConfirmReject: jest.fn(),
+}));
+
 jest.mock('../../../../components/UI/navbar/navbar', () => ({
   getNavbar: jest.fn(),
 }));
@@ -82,6 +87,7 @@ describe('StakingDeposit', () => {
   const mockSetConfirmationMetric = jest.fn();
   const mockGetNavbar = jest.mocked(getNavbar);
   const mockUseConfirmActions = jest.mocked(useConfirmActions);
+  const mockUseConfirmReject = jest.mocked(useConfirmReject);
   const mockUseConfirmationMetricEvents = jest.mocked(
     useConfirmationMetricEvents,
   );
@@ -93,6 +99,7 @@ describe('StakingDeposit', () => {
       onReject: jest.fn(),
       onConfirm: jest.fn(),
     });
+    mockUseConfirmReject.mockReturnValue({ onReject: jest.fn() });
 
     mockUseConfirmationMetricEvents.mockReturnValue({
       trackAdvancedDetailsToggledEvent: mockTrackAdvancedDetailsToggledEvent,
@@ -107,6 +114,7 @@ describe('StakingDeposit', () => {
       onConfirm: jest.fn(),
       onReject: mockOnReject,
     }));
+    mockUseConfirmReject.mockImplementation(() => ({ onReject: mockOnReject }));
 
     const { getByText } = renderWithProvider(<StakingDeposit />, {
       state: stakingDepositConfirmationState,

--- a/app/components/Views/confirmations/external/staking/info/staking-withdrawal/staking-withdrawal.test.tsx
+++ b/app/components/Views/confirmations/external/staking/info/staking-withdrawal/staking-withdrawal.test.tsx
@@ -4,6 +4,7 @@ import { stakingWithdrawalConfirmationState } from '../../../../../../../util/te
 import renderWithProvider from '../../../../../../../util/test/renderWithProvider';
 import { EVENT_PROVIDERS } from '../../../../../../UI/Stake/constants/events';
 import { useConfirmActions } from '../../../../hooks/useConfirmActions';
+import { useConfirmReject } from '../../../../hooks/useConfirmReject';
 import { useConfirmationMetricEvents } from '../../../../hooks/metrics/useConfirmationMetricEvents';
 import { getNavbar } from '../../../../components/UI/navbar/navbar';
 import StakingWithdrawal from './staking-withdrawal';
@@ -53,6 +54,10 @@ jest.mock('../../../../hooks/useConfirmActions', () => ({
   useConfirmActions: jest.fn(),
 }));
 
+jest.mock('../../../../hooks/useConfirmReject', () => ({
+  useConfirmReject: jest.fn(),
+}));
+
 jest.mock('../../../../components/UI/navbar/navbar', () => ({
   getNavbar: jest.fn(),
 }));
@@ -85,6 +90,7 @@ describe('StakingWithdrawal', () => {
   const mockSetConfirmationMetric = jest.fn();
   const mockGetNavbar = jest.mocked(getNavbar);
   const mockUseConfirmActions = jest.mocked(useConfirmActions);
+  const mockUseConfirmReject = jest.mocked(useConfirmReject);
   const mockUseConfirmationMetricEvents = jest.mocked(
     useConfirmationMetricEvents,
   );
@@ -96,6 +102,7 @@ describe('StakingWithdrawal', () => {
       onReject: jest.fn(),
       onConfirm: jest.fn(),
     });
+    mockUseConfirmReject.mockReturnValue({ onReject: jest.fn() });
 
     mockUseConfirmationMetricEvents.mockReturnValue({
       trackPageViewedEvent: mockTrackPageViewedEvent,
@@ -109,6 +116,7 @@ describe('StakingWithdrawal', () => {
       onConfirm: jest.fn(),
       onReject: mockOnReject,
     }));
+    mockUseConfirmReject.mockImplementation(() => ({ onReject: mockOnReject }));
 
     const { getByText } = renderWithProvider(
       <StakingWithdrawal

--- a/app/components/Views/confirmations/hooks/alerts/useGasSponsorshipWarningAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasSponsorshipWarningAlert.test.ts
@@ -14,14 +14,14 @@ import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { Severity } from '../../types/alerts';
 import { NETWORKS_CHAIN_ID } from '../../../../../constants/network';
 import { useRampNavigation } from '../../../../UI/Ramp/hooks/useRampNavigation';
-import { useConfirmActions } from '../useConfirmActions';
+import { useConfirmReject } from '../useConfirmReject';
 import { useIsGasSponsored } from '../gas/useIsGasSponsored';
 
 jest.mock('../../../../UI/Ramp/hooks/useRampNavigation', () => ({
   useRampNavigation: jest.fn(),
 }));
-jest.mock('../useConfirmActions', () => ({
-  useConfirmActions: jest.fn(),
+jest.mock('../useConfirmReject', () => ({
+  useConfirmReject: jest.fn(),
 }));
 jest.mock('../transactions/useTransactionMetadataRequest');
 jest.mock('../gas/useIsGasSponsored');
@@ -62,14 +62,13 @@ describe('useGasSponsorshipWarningAlert', () => {
     useTransactionMetadataRequest,
   );
   const mockUseRampNavigation = jest.mocked(useRampNavigation);
-  const mockUseConfirmActions = jest.mocked(useConfirmActions);
+  const mockUseConfirmReject = jest.mocked(useConfirmReject);
   const mockUseIsGasSponsored = jest.mocked(useIsGasSponsored);
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseConfirmActions.mockReturnValue({
+    mockUseConfirmReject.mockReturnValue({
       onReject: jest.fn(),
-      onConfirm: jest.fn(),
     });
     mockUseRampNavigation.mockReturnValue({
       goToBuy: jest.fn(),

--- a/app/components/Views/confirmations/hooks/alerts/useGasSponsorshipWarningAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasSponsorshipWarningAlert.ts
@@ -14,7 +14,7 @@ import { useTransactionMetadataRequest } from '../transactions/useTransactionMet
 import { NETWORKS_CHAIN_ID } from '../../../../../constants/network';
 import { useRampNavigation } from '../../../../UI/Ramp/hooks/useRampNavigation';
 import { RAMPS_BUY_CUF_SURFACE } from '../../../../UI/Ramp/constants/rampsBuyCufTags';
-import { useConfirmActions } from '../useConfirmActions';
+import { useConfirmReject } from '../useConfirmReject';
 import { useIsGasSponsored } from '../gas/useIsGasSponsored';
 
 /**
@@ -99,7 +99,7 @@ export const useGasSponsorshipWarningAlert = (): Alert[] => {
   const transactionMetadata = useTransactionMetadataRequest();
   const isGasSponsored = useIsGasSponsored();
   const { goToBuy } = useRampNavigation();
-  const { onReject } = useConfirmActions();
+  const { onReject } = useConfirmReject();
 
   const { chainId, simulationData } = transactionMetadata ?? {};
 

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
@@ -10,7 +10,7 @@ import { strings } from '../../../../../../locales/i18n';
 import { AlertKeys } from '../../constants/alerts';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { Severity } from '../../types/alerts';
-import { useConfirmActions } from '../useConfirmActions';
+import { useConfirmReject } from '../useConfirmReject';
 import { useConfirmationContext } from '../../context/confirmation-context';
 import { useRampNavigation } from '../../../../UI/Ramp/hooks/useRampNavigation';
 import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
@@ -49,7 +49,7 @@ jest.mock('@react-navigation/native', () => {
 
 jest.mock('../../../../../selectors/preferencesController');
 jest.mock('../useHasInsufficientBalance');
-jest.mock('../useConfirmActions');
+jest.mock('../useConfirmReject');
 jest.mock('../transactions/useTransactionMetadataRequest');
 jest.mock('../useAccountNativeBalance');
 jest.mock('../../../../../../locales/i18n');
@@ -67,7 +67,7 @@ describe('useInsufficientBalanceAlert', () => {
     useTransactionMetadataRequest,
   );
   const mockUseAccountNativeBalance = jest.mocked(useAccountNativeBalance);
-  const mockUseConfirmActions = jest.mocked(useConfirmActions);
+  const mockUseConfirmReject = jest.mocked(useConfirmReject);
   const mockSelectUseTransactionSimulations = jest.mocked(
     selectUseTransactionSimulations,
   );
@@ -125,9 +125,8 @@ describe('useInsufficientBalanceAlert', () => {
       }
       return key;
     });
-    mockUseConfirmActions.mockReturnValue({
+    mockUseConfirmReject.mockReturnValue({
       onReject: jest.fn(),
-      onConfirm: jest.fn(),
     });
     mockUseConfirmationContext.mockReturnValue({
       isTransactionValueUpdating: false,
@@ -227,9 +226,8 @@ describe('useInsufficientBalanceAlert', () => {
 
   it('onReject is called when callback is called', () => {
     const onRejectMock = jest.fn();
-    mockUseConfirmActions.mockReturnValue({
+    mockUseConfirmReject.mockReturnValue({
       onReject: onRejectMock,
-      onConfirm: jest.fn(),
     });
     const { result } = renderHook(() => useInsufficientBalanceAlert());
 

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -7,7 +7,7 @@ import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { AlertKeys } from '../../constants/alerts';
 import { Alert, Severity } from '../../types/alerts';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import { useConfirmActions } from '../useConfirmActions';
+import { useConfirmReject } from '../useConfirmReject';
 import { useConfirmationContext } from '../../context/confirmation-context';
 import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 import {
@@ -37,7 +37,7 @@ export const useInsufficientBalanceAlert = ({
   const { goToBuy } = useRampNavigation();
   const transactionMetadata = useTransactionMetadataRequest();
   const { isTransactionValueUpdating } = useConfirmationContext();
-  const { onReject } = useConfirmActions();
+  const { onReject } = useConfirmReject();
   const { isSupported: isGaslessSupported, pending: isGaslessCheckPending } =
     useIsGaslessSupported();
   const isUsingPay = useTransactionPayHasSourceAmount();

--- a/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.test.ts
+++ b/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useNavigation } from '@react-navigation/native';
 import { BackHandler } from 'react-native';
 import Device from '../../../../../util/device';
-import { useConfirmActions } from '../useConfirmActions';
+import { useConfirmReject } from '../useConfirmReject';
 import { useFullScreenConfirmation } from './useFullScreenConfirmation';
 import useClearConfirmationOnBackSwipe from './useClearConfirmationOnBackSwipe';
 import { useConfirmationContext } from '../../context/confirmation-context';
@@ -11,8 +11,8 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
 }));
 
-jest.mock('../useConfirmActions', () => ({
-  useConfirmActions: jest.fn(),
+jest.mock('../useConfirmReject', () => ({
+  useConfirmReject: jest.fn(),
 }));
 
 jest.mock('../../../../../util/device', () => ({
@@ -42,7 +42,7 @@ describe('useClearConfirmationOnBackSwipe', () => {
       goBack: jest.fn(),
     });
 
-    (useConfirmActions as jest.Mock).mockReturnValue({
+    (useConfirmReject as jest.Mock).mockReturnValue({
       onReject: mockOnReject,
     });
 

--- a/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.ts
+++ b/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.ts
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/native';
 import { useCallback, useEffect, useRef } from 'react';
 import { BackHandler } from 'react-native';
 import Device from '../../../../../util/device';
-import { useConfirmActions } from '../useConfirmActions';
+import { useConfirmReject } from '../useConfirmReject';
 import { useFullScreenConfirmation } from './useFullScreenConfirmation';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import { useConfirmationContext } from '../../context/confirmation-context';
@@ -10,7 +10,7 @@ import { useConfirmationContext } from '../../context/confirmation-context';
 const useClearConfirmationOnBackSwipe = () => {
   const navigation = useNavigation<AppNavigationProp>();
   const { isFullScreenConfirmation } = useFullScreenConfirmation();
-  const { onReject } = useConfirmActions();
+  const { onReject } = useConfirmReject();
   const { mmPayRequestInProgressNavHandler, isConfirmationSubmittingRef } =
     useConfirmationContext();
   const hasRejectedRef = useRef(false);

--- a/app/components/Views/confirmations/hooks/ui/useNavbar.test.ts
+++ b/app/components/Views/confirmations/hooks/ui/useNavbar.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useNavigation } from '@react-navigation/native';
 import { Theme } from '../../../../../util/theme/models';
 import { getNavbar } from '../../components/UI/navbar/navbar';
-import { useConfirmActions } from '../useConfirmActions';
+import { useConfirmReject } from '../useConfirmReject';
 import { useFullScreenConfirmation } from './useFullScreenConfirmation';
 import { useConfirmationContext } from '../../context/confirmation-context';
 import useNavbar from './useNavbar';
@@ -16,8 +16,8 @@ jest.mock('../../components/UI/navbar/navbar', () => ({
   getNavbar: jest.fn(),
 }));
 
-jest.mock('../useConfirmActions', () => ({
-  useConfirmActions: jest.fn(),
+jest.mock('../useConfirmReject', () => ({
+  useConfirmReject: jest.fn(),
 }));
 
 jest.mock('./useFullScreenConfirmation', () => ({
@@ -43,7 +43,7 @@ describe('useNavbar', () => {
       setOptions: mockSetOptions,
     });
 
-    (useConfirmActions as jest.Mock).mockReturnValue({
+    (useConfirmReject as jest.Mock).mockReturnValue({
       onReject: mockOnReject,
     });
 
@@ -70,7 +70,7 @@ describe('useNavbar', () => {
     renderHook(() => useNavbar(mockTitle));
 
     expect(useNavigation).toHaveBeenCalled();
-    expect(useConfirmActions).toHaveBeenCalled();
+    expect(useConfirmReject).toHaveBeenCalled();
     expect(useFullScreenConfirmation).toHaveBeenCalled();
     expect(getNavbar).toHaveBeenCalledWith({
       title: mockTitle,
@@ -91,7 +91,7 @@ describe('useNavbar', () => {
     renderHook(() => useNavbar(mockTitle));
 
     expect(useNavigation).toHaveBeenCalled();
-    expect(useConfirmActions).toHaveBeenCalled();
+    expect(useConfirmReject).toHaveBeenCalled();
     expect(useFullScreenConfirmation).toHaveBeenCalled();
     expect(mockSetOptions).not.toHaveBeenCalled();
     expect(getNavbar).not.toHaveBeenCalled();
@@ -105,7 +105,7 @@ describe('useNavbar', () => {
     renderHook(() => useNavbar(mockTitle));
 
     expect(useNavigation).toHaveBeenCalled();
-    expect(useConfirmActions).toHaveBeenCalled();
+    expect(useConfirmReject).toHaveBeenCalled();
     expect(useFullScreenConfirmation).toHaveBeenCalled();
     expect(mockSetOptions).not.toHaveBeenCalled();
     expect(getNavbar).not.toHaveBeenCalled();
@@ -137,7 +137,7 @@ describe('useNavbar', () => {
 
   it('updates navigation options when onReject changes for full screen confirmations', () => {
     const newOnReject = jest.fn();
-    (useConfirmActions as jest.Mock).mockReturnValue({
+    (useConfirmReject as jest.Mock).mockReturnValue({
       onReject: newOnReject,
     });
     (useFullScreenConfirmation as jest.Mock).mockReturnValue({

--- a/app/components/Views/confirmations/hooks/ui/useNavbar.ts
+++ b/app/components/Views/confirmations/hooks/ui/useNavbar.ts
@@ -7,7 +7,7 @@ import {
   getNavbar,
   NavbarOverrides,
 } from '../../components/UI/navbar/navbar';
-import { useConfirmActions } from '../useConfirmActions';
+import { useConfirmReject } from '../useConfirmReject';
 import { useFullScreenConfirmation } from './useFullScreenConfirmation';
 import { useConfirmationContext } from '../../context/confirmation-context';
 
@@ -17,7 +17,7 @@ const useNavbar = (
   overrides?: NavbarOverrides,
 ) => {
   const navigation = useNavigation<AppNavigationProp>();
-  const { onReject } = useConfirmActions();
+  const { onReject } = useConfirmReject();
   const theme = useTheme();
   const { isFullScreenConfirmation } = useFullScreenConfirmation();
   const { mmPayRequestInProgressNavHandler } = useConfirmationContext();
@@ -50,7 +50,7 @@ const useNavbar = (
 export function useModalNavbar() {
   const navigation = useNavigation<AppNavigationProp>();
 
-  const { onReject } = useConfirmActions();
+  const { onReject } = useConfirmReject();
 
   useEffect(() => {
     navigation.setOptions(getModalNavigationOptions());

--- a/app/components/Views/confirmations/hooks/useConfirmActions.test.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmActions.test.ts
@@ -284,62 +284,6 @@ describe('useConfirmAction', () => {
     expect(clearSecurityAlertResponseSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('does not call signature related methods when onReject is called if confirmation is not of type signature', async () => {
-    const clearSecurityAlertResponseSpy = jest.spyOn(
-      PPOMUtil,
-      'clearSignatureSecurityAlertResponse',
-    );
-    const mockCancelQRScanRequestIfPresent = jest
-      .fn()
-      .mockResolvedValue(undefined);
-    jest.spyOn(QRHardwareHook, 'useQRHardwareContext').mockReturnValue({
-      cancelQRScanRequestIfPresent: mockCancelQRScanRequestIfPresent,
-    } as unknown as QRHardwareHook.QRHardwareContextType);
-    const { result } = renderHookWithProvider(() => useConfirmActions(), {
-      state: stakingDepositConfirmationState,
-    });
-    result?.current?.onReject();
-    expect(mockCancelQRScanRequestIfPresent).toHaveBeenCalledTimes(1);
-    await flushPromises();
-    expect(Engine.rejectPendingApproval).toHaveBeenCalledTimes(1);
-    expect(mockCaptureSignatureMetrics).not.toHaveBeenCalled();
-    expect(clearSecurityAlertResponseSpy).not.toHaveBeenCalled();
-  });
-
-  it('call required callbacks when reject button is clicked', async () => {
-    const clearSecurityAlertResponseSpy = jest.spyOn(
-      PPOMUtil,
-      'clearSignatureSecurityAlertResponse',
-    );
-    const mockCancelQRScanRequestIfPresent = jest
-      .fn()
-      .mockResolvedValue(undefined);
-    jest.spyOn(QRHardwareHook, 'useQRHardwareContext').mockReturnValue({
-      cancelQRScanRequestIfPresent: mockCancelQRScanRequestIfPresent,
-    } as unknown as QRHardwareHook.QRHardwareContextType);
-    const { result } = renderHookWithProvider(() => useConfirmActions(), {
-      state: personalSignatureConfirmationState,
-    });
-    result?.current?.onReject();
-    expect(mockCancelQRScanRequestIfPresent).toHaveBeenCalledTimes(1);
-    await flushPromises();
-    expect(Engine.rejectPendingApproval).toHaveBeenCalledTimes(1);
-    expect(mockCaptureSignatureMetrics).toHaveBeenCalledTimes(1);
-    expect(clearSecurityAlertResponseSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not navigate back when onReject is called with skipNavigation as true', async () => {
-    const goBackSpy = jest.fn();
-    useNavigationMock.mockReturnValue({
-      goBack: goBackSpy,
-    } as unknown as ReturnType<typeof useNavigation>);
-    const { result } = renderHookWithProvider(() => useConfirmActions(), {
-      state: personalSignatureConfirmationState,
-    });
-    result?.current?.onReject(undefined, true);
-    expect(goBackSpy).not.toHaveBeenCalled();
-  });
-
   it('sets waitForResult to false when approvalType is TransactionBatch', async () => {
     const transactionBatchState = {
       engine: {

--- a/app/components/Views/confirmations/hooks/useConfirmActions.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmActions.ts
@@ -8,13 +8,13 @@ import {
 } from '@metamask/transaction-controller';
 
 import PPOMUtil from '../../../../lib/ppom/ppom-util';
-import Routes from '../../../../constants/navigation/Routes';
 import { navigateToActivityAfterConfirmation } from '../../../../util/navigation/navigateToActivityAfterConfirmation';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 
 import { isSignatureRequest } from '../utils/confirm';
 import { useQRHardwareContext } from '../context/qr-hardware-context';
 import useApprovalRequest from './useApprovalRequest';
+import { useConfirmReject } from './useConfirmReject';
 import { useSignatureMetrics } from './signatures/useSignatureMetrics';
 import { useTransactionConfirm } from './transactions/useTransactionConfirm';
 import { useTransactionMetadataRequest } from './transactions/useTransactionMetadataRequest';
@@ -25,23 +25,16 @@ import { useLedgerConfirm } from './useLedgerConfirm';
 import { useQrConfirm } from '../../../../core/HardwareWallet/hooks/useQrConfirm';
 
 export const useConfirmActions = () => {
-  const {
-    onConfirm: onRequestConfirm,
-    onReject: onRequestReject,
-    approvalRequest,
-  } = useApprovalRequest();
+  const { onConfirm: onRequestConfirm, approvalRequest } = useApprovalRequest();
+  const { onReject } = useConfirmReject();
   const {
     navigateOnConfirm: onTransactionSigningComplete,
     onConfirm: onTransactionConfirm,
   } = useTransactionConfirm();
   const transactionMetadata = useTransactionMetadataRequest();
   const { captureSignatureMetrics } = useSignatureMetrics();
-  const {
-    cancelQRScanRequestIfPresent,
-    isSigningQRObject,
-    setScannerVisible,
-    setSigningConfirmed,
-  } = useQRHardwareContext();
+  const { isSigningQRObject, setScannerVisible, setSigningConfirmed } =
+    useQRHardwareContext();
   const navigation = useNavigation<AppNavigationProp>();
   const approvalType = approvalRequest?.type;
   const isSignatureReq = approvalType && isSignatureRequest(approvalType);
@@ -58,31 +51,6 @@ export const useConfirmActions = () => {
     ])
       ? transactionMetadata.id
       : undefined;
-
-  const onReject = useCallback(
-    async (error?: Error, skipNavigation = false, navigateToHome = false) => {
-      await cancelQRScanRequestIfPresent();
-      onRequestReject(error);
-      if (!skipNavigation) {
-        navigation.goBack();
-      }
-      if (navigateToHome) {
-        navigation.navigate(Routes.WALLET_VIEW);
-      }
-      if (isSignatureReq && approvalRequest?.id) {
-        captureSignatureMetrics(MetaMetricsEvents.SIGNATURE_REJECTED);
-        PPOMUtil.clearSignatureSecurityAlertResponse(approvalRequest.id);
-      }
-    },
-    [
-      cancelQRScanRequestIfPresent,
-      captureSignatureMetrics,
-      navigation,
-      onRequestReject,
-      isSignatureReq,
-      approvalRequest?.id,
-    ],
-  );
 
   const executeApproval = useCallback(async () => {
     const waitForResult = approvalType !== ApprovalType.TransactionBatch;

--- a/app/components/Views/confirmations/hooks/useConfirmReject.test.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmReject.test.ts
@@ -1,0 +1,134 @@
+import { useNavigation } from '@react-navigation/native';
+
+import Engine from '../../../../core/Engine';
+import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
+import {
+  personalSignatureConfirmationState,
+  stakingDepositConfirmationState,
+} from '../../../../util/test/confirm-data-helpers';
+import PPOMUtil from '../../../../lib/ppom/ppom-util';
+// eslint-disable-next-line import-x/no-namespace
+import * as QRHardwareHook from '../context/qr-hardware-context/qr-hardware-context';
+import { useConfirmReject } from './useConfirmReject';
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: jest.fn(),
+}));
+
+jest.mock('../../../../core/Engine', () => ({
+  acceptPendingApproval: jest.fn(),
+  rejectPendingApproval: jest.fn(),
+  context: {
+    KeyringController: {
+      state: {
+        keyrings: [
+          {
+            accounts: ['0x0000000000000000000000000000000000000000'],
+          },
+        ],
+      },
+    },
+  },
+}));
+
+const mockCaptureSignatureMetrics = jest.fn();
+jest.mock('./signatures/useSignatureMetrics', () => ({
+  useSignatureMetrics: () => ({
+    captureSignatureMetrics: mockCaptureSignatureMetrics,
+  }),
+}));
+
+const flushPromises = async () => await new Promise(process.nextTick);
+
+describe('useConfirmReject', () => {
+  const useNavigationMock = jest.mocked(useNavigation);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useNavigationMock.mockReturnValue({
+      goBack: jest.fn(),
+      navigate: jest.fn(),
+    } as unknown as ReturnType<typeof useNavigation>);
+  });
+
+  it('rejects the pending approval and cancels any pending QR scan', async () => {
+    const mockCancelQRScanRequestIfPresent = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    jest.spyOn(QRHardwareHook, 'useQRHardwareContext').mockReturnValue({
+      cancelQRScanRequestIfPresent: mockCancelQRScanRequestIfPresent,
+    } as unknown as QRHardwareHook.QRHardwareContextType);
+
+    const { result } = renderHookWithProvider(() => useConfirmReject(), {
+      state: personalSignatureConfirmationState,
+    });
+
+    result?.current?.onReject();
+
+    expect(mockCancelQRScanRequestIfPresent).toHaveBeenCalledTimes(1);
+    await flushPromises();
+    expect(Engine.rejectPendingApproval).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures signature reject metrics for signature confirmations', async () => {
+    const clearSecurityAlertResponseSpy = jest.spyOn(
+      PPOMUtil,
+      'clearSignatureSecurityAlertResponse',
+    );
+    jest.spyOn(QRHardwareHook, 'useQRHardwareContext').mockReturnValue({
+      cancelQRScanRequestIfPresent: jest.fn().mockResolvedValue(undefined),
+    } as unknown as QRHardwareHook.QRHardwareContextType);
+
+    const { result } = renderHookWithProvider(() => useConfirmReject(), {
+      state: personalSignatureConfirmationState,
+    });
+
+    result?.current?.onReject();
+    await flushPromises();
+
+    expect(mockCaptureSignatureMetrics).toHaveBeenCalledTimes(1);
+    expect(clearSecurityAlertResponseSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not capture signature metrics for non-signature confirmations', async () => {
+    const clearSecurityAlertResponseSpy = jest.spyOn(
+      PPOMUtil,
+      'clearSignatureSecurityAlertResponse',
+    );
+    jest.spyOn(QRHardwareHook, 'useQRHardwareContext').mockReturnValue({
+      cancelQRScanRequestIfPresent: jest.fn().mockResolvedValue(undefined),
+    } as unknown as QRHardwareHook.QRHardwareContextType);
+
+    const { result } = renderHookWithProvider(() => useConfirmReject(), {
+      state: stakingDepositConfirmationState,
+    });
+
+    result?.current?.onReject();
+    await flushPromises();
+
+    expect(Engine.rejectPendingApproval).toHaveBeenCalledTimes(1);
+    expect(mockCaptureSignatureMetrics).not.toHaveBeenCalled();
+    expect(clearSecurityAlertResponseSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate back when skipNavigation is true', () => {
+    const goBackSpy = jest.fn();
+    useNavigationMock.mockReturnValue({
+      goBack: goBackSpy,
+      navigate: jest.fn(),
+    } as unknown as ReturnType<typeof useNavigation>);
+    jest.spyOn(QRHardwareHook, 'useQRHardwareContext').mockReturnValue({
+      cancelQRScanRequestIfPresent: jest.fn().mockResolvedValue(undefined),
+    } as unknown as QRHardwareHook.QRHardwareContextType);
+
+    const { result } = renderHookWithProvider(() => useConfirmReject(), {
+      state: personalSignatureConfirmationState,
+    });
+
+    result?.current?.onReject(undefined, true);
+
+    expect(goBackSpy).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/Views/confirmations/hooks/useConfirmReject.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmReject.ts
@@ -1,0 +1,63 @@
+import { useCallback } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import type { AppNavigationProp } from '../../../../core/NavigationService/types';
+
+import PPOMUtil from '../../../../lib/ppom/ppom-util';
+import Routes from '../../../../constants/navigation/Routes';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
+
+import { isSignatureRequest } from '../utils/confirm';
+import { useQRHardwareContext } from '../context/qr-hardware-context';
+import useApprovalRequest from './useApprovalRequest';
+import { useSignatureMetrics } from './signatures/useSignatureMetrics';
+
+/**
+ * Provides the confirmation `onReject` handler in isolation.
+ *
+ * Extracted from `useConfirmActions` so that consumers which only need to
+ * reject a confirmation (alerts, navbar, back-swipe handler) don't drag in the
+ * entire confirm path — `useTransactionConfirm`, `useTransactionMetadataRequest`,
+ * `useLedgerConfirm`, `useQrConfirm`, ledger/QR account detection — none of
+ * which `onReject` depends on. Those hooks are expensive and re-run on the
+ * confirmation critical path; keeping them out of the reject-only consumers is
+ * a meaningful perf win (`useTransactionAlerts` instantiated the full tree
+ * twice just to grab this one callback).
+ *
+ * `useConfirmActions` re-exports the `onReject` returned here, so this remains
+ * the single source of truth for reject behaviour.
+ */
+export const useConfirmReject = () => {
+  const { onReject: onRequestReject, approvalRequest } = useApprovalRequest();
+  const { captureSignatureMetrics } = useSignatureMetrics();
+  const { cancelQRScanRequestIfPresent } = useQRHardwareContext();
+  const navigation = useNavigation<AppNavigationProp>();
+  const approvalType = approvalRequest?.type;
+  const isSignatureReq = approvalType && isSignatureRequest(approvalType);
+
+  const onReject = useCallback(
+    async (error?: Error, skipNavigation = false, navigateToHome = false) => {
+      await cancelQRScanRequestIfPresent();
+      onRequestReject(error);
+      if (!skipNavigation) {
+        navigation.goBack();
+      }
+      if (navigateToHome) {
+        navigation.navigate(Routes.WALLET_VIEW);
+      }
+      if (isSignatureReq && approvalRequest?.id) {
+        captureSignatureMetrics(MetaMetricsEvents.SIGNATURE_REJECTED);
+        PPOMUtil.clearSignatureSecurityAlertResponse(approvalRequest.id);
+      }
+    },
+    [
+      cancelQRScanRequestIfPresent,
+      captureSignatureMetrics,
+      navigation,
+      onRequestReject,
+      isSignatureReq,
+      approvalRequest?.id,
+    ],
+  );
+
+  return { onReject };
+};


### PR DESCRIPTION
## **Description**

`useConfirmActions` returns both `onConfirm` and `onReject`. A hook instantiates all of its dependencies regardless of which fields the caller destructures, so consumers that only need to reject still ran the entire confirm path — `useTransactionConfirm`, `useTransactionMetadataRequest`, `useLedgerConfirm`, `useQrConfirm` and the ledger/QR account detection behind them. `onReject` depends on none of it.

- Reject logic moves into a new `useConfirmReject`, and `useConfirmActions` re-exports its `onReject`, so behaviour keeps a single source of truth and no consumer signature changes.
- The five reject-only consumers — `useGasSponsorshipWarningAlert`, `useInsufficientBalanceAlert`, `useClearConfirmationOnBackSwipe`, `useNavbar` and `Confirm` — now call `useConfirmReject` directly.
- The reject unit tests move with the logic, leaving `useConfirmActions` covering the confirm path only.

Each of those consumers re-instantiated the confirm chain on every render pass of a confirmation load, so gating by capability rather than by render path removes that work several times over.

This is not a behavioural change: `onReject` is the same function, only the set of hooks a caller must instantiate to obtain it changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Rejecting a confirmation

  Scenario: user rejects a transaction from the confirmation footer
    Given the user has a pending transaction confirmation open

    When user taps Cancel
    Then the confirmation is dismissed and the transaction is rejected

  Scenario: user dismisses a modal confirmation by swiping
    Given the user has a pending modal confirmation open

    When user swipes the bottom sheet down
    Then the confirmation is dismissed and the transaction is rejected

  Scenario: user rejects via the navigation bar
    Given the user has a pending full-screen confirmation open

    When user taps the navigation bar reject control
    Then the confirmation is dismissed and the transaction is rejected

  Scenario: user rejects from an insufficient balance alert
    Given the user has a transaction with insufficient balance to cover gas

    When user taps the reject action on the alert
    Then the confirmation is dismissed and the transaction is rejected
```

## **Screenshots/Recordings**

N/A

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with preserved reject behavior via shared hook; confirm path unchanged for footer/actions consumers.
> 
> **Overview**
> Extracts confirmation **reject** handling into a dedicated **`useConfirmReject`** hook so callers that only need `onReject` no longer instantiate the heavy confirm stack (`useTransactionConfirm`, ledger/QR confirm paths, etc.).
> 
> **`useConfirmActions`** now delegates to **`useConfirmReject`** for `onReject` (same behavior, single source of truth) and keeps confirm-only logic. Reject-only surfaces—**`Confirm`** (modal dismiss), balance/gas sponsorship alerts, **`useNavbar`**, and **`useClearConfirmationOnBackSwipe`**—import **`useConfirmReject`** directly.
> 
> Reject unit tests move to **`useConfirmReject.test.ts`**; related component/hook tests add mocks for the new hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 580d1aaa5489084d8eb83df23e4879408db63501. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->