### PR TITLE
feat: TSA-1131 add Social V1 leaderboard tab with metrics-first trader rows

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
@@ -61,6 +61,7 @@ const mockTraders = [
     pnlValue: 963000,
     winRatePercent: 92,
     pnlPerChain: { base: 963000 },
+    followerCount: 1200,
     isFollowing: false,
   },
 ];

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
@@ -16,6 +16,7 @@ const baseTrader: TopTrader = {
   pnlValue: 963146.8,
   winRatePercent: 92,
   pnlPerChain: { base: 963146.8 },
+  followerCount: 48707,
   isFollowing: false,
 };
 

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
@@ -18,6 +18,7 @@ const baseTrader: TopTrader = {
   pnlValue: 963146.8,
   winRatePercent: 92,
   pnlPerChain: { base: 963146.8 },
+  followerCount: 48707,
   isFollowing: false,
 };
 
@@ -171,6 +172,68 @@ describe('TraderRow', () => {
       />,
     );
     expect(screen.getByTestId('custom-test-id')).toBeOnTheScreen();
+  });
+
+  describe('Social V1 variant', () => {
+    it('renders the win rate, follower count, PnL, and ROI without a follow action', () => {
+      renderWithProvider(
+        <TraderRow
+          trader={baseTrader}
+          variant="socialV1"
+          onFollowPress={mockOnFollowPress}
+        />,
+      );
+
+      expect(screen.getByText('alpha.eth')).toBeOnTheScreen();
+      expect(screen.getByText('92% WR')).toBeOnTheScreen();
+      expect(screen.getByText('48,707 followers')).toBeOnTheScreen();
+      expect(screen.getByText('+$963,146.80')).toBeOnTheScreen();
+      expect(screen.getByText('+43.0%')).toBeOnTheScreen();
+      expect(screen.queryByText('Follow')).toBeNull();
+    });
+
+    it('renders the singular follower label for a single follower', () => {
+      renderWithProvider(
+        <TraderRow
+          trader={{ ...baseTrader, followerCount: 1 }}
+          variant="socialV1"
+          onFollowPress={mockOnFollowPress}
+        />,
+      );
+
+      expect(screen.getByText('1 follower')).toBeOnTheScreen();
+    });
+
+    it('omits the win rate tag when the window has no win-rate data', () => {
+      renderWithProvider(
+        <TraderRow
+          trader={{ ...baseTrader, winRatePercent: null }}
+          variant="socialV1"
+          onFollowPress={mockOnFollowPress}
+        />,
+      );
+
+      expect(screen.queryByText(/WR$/)).toBeNull();
+    });
+
+    it('keeps the row and podium medal interactive', () => {
+      renderWithProvider(
+        <TraderRow
+          trader={baseTrader}
+          variant="socialV1"
+          onFollowPress={mockOnFollowPress}
+          onTraderPress={mockOnTraderPress}
+        />,
+      );
+
+      expect(screen.getByTestId('rank-medal-1')).toBeOnTheScreen();
+      fireEvent.press(screen.getByTestId('trader-row-trader-1'));
+      expect(mockOnTraderPress).toHaveBeenCalledWith(
+        'trader-1',
+        'alpha.eth',
+        1,
+      );
+    });
   });
 
   describe('layout stability', () => {

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
@@ -174,68 +174,6 @@ describe('TraderRow', () => {
     expect(screen.getByTestId('custom-test-id')).toBeOnTheScreen();
   });
 
-  describe('Social V1 variant', () => {
-    it('renders the win rate, follower count, PnL, and ROI without a follow action', () => {
-      renderWithProvider(
-        <TraderRow
-          trader={baseTrader}
-          variant="socialV1"
-          onFollowPress={mockOnFollowPress}
-        />,
-      );
-
-      expect(screen.getByText('alpha.eth')).toBeOnTheScreen();
-      expect(screen.getByText('92% WR')).toBeOnTheScreen();
-      expect(screen.getByText('48,707 followers')).toBeOnTheScreen();
-      expect(screen.getByText('+$963,146.80')).toBeOnTheScreen();
-      expect(screen.getByText('+43.0%')).toBeOnTheScreen();
-      expect(screen.queryByText('Follow')).toBeNull();
-    });
-
-    it('renders the singular follower label for a single follower', () => {
-      renderWithProvider(
-        <TraderRow
-          trader={{ ...baseTrader, followerCount: 1 }}
-          variant="socialV1"
-          onFollowPress={mockOnFollowPress}
-        />,
-      );
-
-      expect(screen.getByText('1 follower')).toBeOnTheScreen();
-    });
-
-    it('omits the win rate tag when the window has no win-rate data', () => {
-      renderWithProvider(
-        <TraderRow
-          trader={{ ...baseTrader, winRatePercent: null }}
-          variant="socialV1"
-          onFollowPress={mockOnFollowPress}
-        />,
-      );
-
-      expect(screen.queryByText(/WR$/)).toBeNull();
-    });
-
-    it('keeps the row and podium medal interactive', () => {
-      renderWithProvider(
-        <TraderRow
-          trader={baseTrader}
-          variant="socialV1"
-          onFollowPress={mockOnFollowPress}
-          onTraderPress={mockOnTraderPress}
-        />,
-      );
-
-      expect(screen.getByTestId('rank-medal-1')).toBeOnTheScreen();
-      fireEvent.press(screen.getByTestId('trader-row-trader-1'));
-      expect(mockOnTraderPress).toHaveBeenCalledWith(
-        'trader-1',
-        'alpha.eth',
-        1,
-      );
-    });
-  });
-
   describe('layout stability', () => {
     const findAncestor = (
       start: ReactTestInstance | null,

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -7,26 +7,18 @@ import {
   ButtonSize,
   ButtonVariant,
   FontWeight,
-  IconName,
-  Tag,
-  TagSeverity,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
-import { TouchableOpacity } from 'react-native';
+import { TouchableOpacity, View } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import { RankMedal, isTopRank } from '../topRank';
-import type { TopTrader } from '../types';
-/* eslint-disable import-x/no-restricted-paths -- TODO(ADR-0020): reuses the leaderboard number formatters; route-isolation backlog */
-import {
-  formatCount,
-  formatPercent,
-  formatSignedUsd,
-} from '../../../../SocialLeaderboard/utils/formatters';
-/* eslint-enable import-x/no-restricted-paths */
+import type { TraderRowProps } from '../types';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import { formatSignedUsd } from '../../../../SocialLeaderboard/utils/formatters';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import TraderMuteChip from '../../../../SocialLeaderboard/components/TraderMuteChip';
 import TraderAvatar from './TraderAvatar';
@@ -34,53 +26,9 @@ import TraderAvatar from './TraderAvatar';
 const MUTE_CHIP_DIAMETER = 40;
 
 const AVATAR_SIZE = 40;
-// Medal height that keeps the badge tucked into the avatar's bottom-right
-// corner rather than dominating it (the default 30 is sized for a standalone
-// podium).
-const SOCIAL_V1_MEDAL_HEIGHT = 24;
-// At or above this win rate the tag switches to the highlighted treatment.
-const ELITE_WIN_RATE_PERCENT = 90;
 // Fixed row height so the skeleton placeholder can match it exactly without
 // drifting due to font-scale or button-size differences.
 export const TRADER_ROW_HEIGHT = 71;
-export const SOCIAL_V1_TRADER_ROW_HEIGHT = 72;
-
-/**
- * The figure shown under the username. Callers that rank by something other
- * than PnL (e.g. the leaderboard's Sort by control) pass the ranked value here
- * so the row shows what the list is ordered by.
- */
-export interface TraderRowMetric {
-  /** Pre-formatted value, e.g. `+$45,900.89`, `+43.00%` or `92%`. */
-  label: string;
-  /** Renders the value in success green rather than error red. */
-  isPositive: boolean;
-}
-
-export interface TraderRowProps {
-  trader: TopTrader;
-  /** Opts into the denser, metrics-first Social V1 leaderboard treatment. */
-  variant?: 'default' | 'socialV1';
-  /** Defaults to the trader's PnL for the loaded window. */
-  metric?: TraderRowMetric;
-  onFollowPress: (traderId: string) => void;
-  onTraderPress?: (
-    traderId: string,
-    traderName: string,
-    /* Used downstream for podium decoration */
-    overallRank: number,
-  ) => void;
-  /** Whether this trader's alerts are paused. Only used when muting is shown. */
-  isMuted?: boolean;
-  /**
-   * When true (and the trader is followed), render the inline mute chip beside
-   * the Follow button. Gated by the caller on push-notification availability.
-   */
-  showMute?: boolean;
-  /** Toggles the muted state for this trader. */
-  onMuteToggle?: (traderId: string) => void;
-  testID?: string;
-}
 
 /**
  * TraderRow -- a single row in the Top Traders leaderboard.
@@ -90,7 +38,6 @@ export interface TraderRowProps {
  */
 const TraderRow: React.FC<TraderRowProps> = ({
   trader,
-  variant = 'default',
   metric,
   onFollowPress,
   onTraderPress,
@@ -105,123 +52,10 @@ const TraderRow: React.FC<TraderRowProps> = ({
   const isMetricPositive = metric?.isPositive ?? trader.pnlValue >= 0;
   const showMedal = isTopRank(trader.rank);
   const canShowMuteChip = showMute && Boolean(onMuteToggle);
-  const isSocialV1 = variant === 'socialV1';
 
   const handleMutePress = React.useCallback(() => {
     onMuteToggle?.(trader.id);
   }, [onMuteToggle, trader.id]);
-
-  if (isSocialV1) {
-    const isEliteWinRate =
-      (trader.winRatePercent ?? 0) >= ELITE_WIN_RATE_PERCENT;
-    const winRateLabel = strings('social_leaderboard.win_rate_tag', {
-      winRate: formatPercent(trader.winRatePercent, {
-        showSign: false,
-        decimals: 0,
-      }),
-    });
-    const followerLabel = strings(
-      trader.followerCount === 1
-        ? 'social_leaderboard.trader_profile.followers_count'
-        : 'social_leaderboard.trader_profile.followers_count_plural',
-      { count: formatCount(trader.followerCount) },
-    );
-    const roi = formatPercent(trader.percentageChange, { decimals: 1 });
-
-    return (
-      <TouchableOpacity
-        activeOpacity={onTraderPress ? 0.7 : 1}
-        onPress={
-          onTraderPress
-            ? () =>
-                onTraderPress(trader.id, trader.username, trader.overallRank)
-            : undefined
-        }
-        disabled={!onTraderPress}
-        testID={testID ?? `trader-row-${trader.id}`}
-      >
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          gap={3}
-          twClassName="px-4"
-          style={{ height: SOCIAL_V1_TRADER_ROW_HEIGHT }}
-        >
-          <Box>
-            <TraderAvatar
-              imageUrl={trader.avatarUri}
-              address={trader.address}
-              size={AVATAR_SIZE}
-              recyclingKey={trader.id}
-            />
-            {showMedal ? (
-              <Box twClassName="absolute -bottom-1 -right-2">
-                <RankMedal rank={trader.rank} size={SOCIAL_V1_MEDAL_HEIGHT} />
-              </Box>
-            ) : null}
-          </Box>
-
-          {/* `min-w-0` lets the name truncate inside the row instead of
-              pushing the metrics column off the right edge. */}
-          <Box twClassName="flex-1 min-w-0">
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              gap={2}
-            >
-              <Text
-                variant={TextVariant.BodyLg}
-                fontWeight={FontWeight.Bold}
-                color={TextColor.TextDefault}
-                numberOfLines={1}
-                twClassName="shrink"
-              >
-                {trader.username}
-              </Text>
-              {trader.winRatePercent !== null && (
-                <Tag
-                  severity={
-                    isEliteWinRate ? TagSeverity.Warning : TagSeverity.Neutral
-                  }
-                  startIconName={isEliteWinRate ? IconName.Trophy : undefined}
-                  twClassName="shrink-0"
-                >
-                  {winRateLabel}
-                </Tag>
-              )}
-            </Box>
-            <Text
-              variant={TextVariant.BodyMd}
-              color={TextColor.TextAlternative}
-              numberOfLines={1}
-            >
-              {followerLabel}
-            </Text>
-          </Box>
-
-          <Box alignItems={BoxAlignItems.End} twClassName="shrink-0">
-            <Text
-              variant={TextVariant.BodyLg}
-              fontWeight={FontWeight.Medium}
-              numberOfLines={1}
-              twClassName={
-                isMetricPositive ? 'text-success-default' : 'text-error-default'
-              }
-            >
-              {metricText}
-            </Text>
-            <Text
-              variant={TextVariant.BodyMd}
-              color={TextColor.TextAlternative}
-              numberOfLines={1}
-            >
-              {roi}
-            </Text>
-          </Box>
-        </Box>
-      </TouchableOpacity>
-    );
-  }
 
   return (
     <Box
@@ -248,7 +82,7 @@ const TraderRow: React.FC<TraderRowProps> = ({
           alignItems={BoxAlignItems.Center}
           gap={4}
         >
-          <Box>
+          <View>
             <TraderAvatar
               imageUrl={trader.avatarUri}
               address={trader.address}
@@ -258,11 +92,11 @@ const TraderRow: React.FC<TraderRowProps> = ({
             {showMedal ? (
               // Offset so the medal bottom (incl. its 2px border) sits ~10px
               // below the avatar's bottom edge.
-              <Box twClassName="absolute -bottom-[10px] -right-2">
+              <View style={tw.style('absolute -bottom-[10px] -right-2')}>
                 <RankMedal rank={trader.rank} />
-              </Box>
+              </View>
             ) : null}
-          </Box>
+          </View>
 
           <Box twClassName="flex-1 min-w-0">
             <Text

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -7,18 +7,26 @@ import {
   ButtonSize,
   ButtonVariant,
   FontWeight,
+  IconName,
+  Tag,
+  TagSeverity,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import { TouchableOpacity } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import { RankMedal, isTopRank } from '../topRank';
 import type { TopTrader } from '../types';
-// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import { formatSignedUsd } from '../../../../SocialLeaderboard/utils/formatters';
+/* eslint-disable import-x/no-restricted-paths -- TODO(ADR-0020): reuses the leaderboard number formatters; route-isolation backlog */
+import {
+  formatCount,
+  formatPercent,
+  formatSignedUsd,
+} from '../../../../SocialLeaderboard/utils/formatters';
+/* eslint-enable import-x/no-restricted-paths */
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import TraderMuteChip from '../../../../SocialLeaderboard/components/TraderMuteChip';
 import TraderAvatar from './TraderAvatar';
@@ -26,9 +34,16 @@ import TraderAvatar from './TraderAvatar';
 const MUTE_CHIP_DIAMETER = 40;
 
 const AVATAR_SIZE = 40;
+// Medal height that keeps the badge tucked into the avatar's bottom-right
+// corner rather than dominating it (the default 30 is sized for a standalone
+// podium).
+const SOCIAL_V1_MEDAL_HEIGHT = 24;
+// At or above this win rate the tag switches to the highlighted treatment.
+const ELITE_WIN_RATE_PERCENT = 90;
 // Fixed row height so the skeleton placeholder can match it exactly without
 // drifting due to font-scale or button-size differences.
 export const TRADER_ROW_HEIGHT = 71;
+export const SOCIAL_V1_TRADER_ROW_HEIGHT = 72;
 
 /**
  * The figure shown under the username. Callers that rank by something other
@@ -44,6 +59,8 @@ export interface TraderRowMetric {
 
 export interface TraderRowProps {
   trader: TopTrader;
+  /** Opts into the denser, metrics-first Social V1 leaderboard treatment. */
+  variant?: 'default' | 'socialV1';
   /** Defaults to the trader's PnL for the loaded window. */
   metric?: TraderRowMetric;
   onFollowPress: (traderId: string) => void;
@@ -73,6 +90,7 @@ export interface TraderRowProps {
  */
 const TraderRow: React.FC<TraderRowProps> = ({
   trader,
+  variant = 'default',
   metric,
   onFollowPress,
   onTraderPress,
@@ -87,10 +105,123 @@ const TraderRow: React.FC<TraderRowProps> = ({
   const isMetricPositive = metric?.isPositive ?? trader.pnlValue >= 0;
   const showMedal = isTopRank(trader.rank);
   const canShowMuteChip = showMute && Boolean(onMuteToggle);
+  const isSocialV1 = variant === 'socialV1';
 
   const handleMutePress = React.useCallback(() => {
     onMuteToggle?.(trader.id);
   }, [onMuteToggle, trader.id]);
+
+  if (isSocialV1) {
+    const isEliteWinRate =
+      (trader.winRatePercent ?? 0) >= ELITE_WIN_RATE_PERCENT;
+    const winRateLabel = strings('social_leaderboard.win_rate_tag', {
+      winRate: formatPercent(trader.winRatePercent, {
+        showSign: false,
+        decimals: 0,
+      }),
+    });
+    const followerLabel = strings(
+      trader.followerCount === 1
+        ? 'social_leaderboard.trader_profile.followers_count'
+        : 'social_leaderboard.trader_profile.followers_count_plural',
+      { count: formatCount(trader.followerCount) },
+    );
+    const roi = formatPercent(trader.percentageChange, { decimals: 1 });
+
+    return (
+      <TouchableOpacity
+        activeOpacity={onTraderPress ? 0.7 : 1}
+        onPress={
+          onTraderPress
+            ? () =>
+                onTraderPress(trader.id, trader.username, trader.overallRank)
+            : undefined
+        }
+        disabled={!onTraderPress}
+        testID={testID ?? `trader-row-${trader.id}`}
+      >
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={3}
+          twClassName="px-4"
+          style={{ height: SOCIAL_V1_TRADER_ROW_HEIGHT }}
+        >
+          <Box>
+            <TraderAvatar
+              imageUrl={trader.avatarUri}
+              address={trader.address}
+              size={AVATAR_SIZE}
+              recyclingKey={trader.id}
+            />
+            {showMedal ? (
+              <Box twClassName="absolute -bottom-1 -right-2">
+                <RankMedal rank={trader.rank} size={SOCIAL_V1_MEDAL_HEIGHT} />
+              </Box>
+            ) : null}
+          </Box>
+
+          {/* `min-w-0` lets the name truncate inside the row instead of
+              pushing the metrics column off the right edge. */}
+          <Box twClassName="flex-1 min-w-0">
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              gap={2}
+            >
+              <Text
+                variant={TextVariant.BodyLg}
+                fontWeight={FontWeight.Bold}
+                color={TextColor.TextDefault}
+                numberOfLines={1}
+                twClassName="shrink"
+              >
+                {trader.username}
+              </Text>
+              {trader.winRatePercent !== null && (
+                <Tag
+                  severity={
+                    isEliteWinRate ? TagSeverity.Warning : TagSeverity.Neutral
+                  }
+                  startIconName={isEliteWinRate ? IconName.Trophy : undefined}
+                  twClassName="shrink-0"
+                >
+                  {winRateLabel}
+                </Tag>
+              )}
+            </Box>
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+              numberOfLines={1}
+            >
+              {followerLabel}
+            </Text>
+          </Box>
+
+          <Box alignItems={BoxAlignItems.End} twClassName="shrink-0">
+            <Text
+              variant={TextVariant.BodyLg}
+              fontWeight={FontWeight.Medium}
+              numberOfLines={1}
+              twClassName={
+                isMetricPositive ? 'text-success-default' : 'text-error-default'
+              }
+            >
+              {metricText}
+            </Text>
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+              numberOfLines={1}
+            >
+              {roi}
+            </Text>
+          </Box>
+        </Box>
+      </TouchableOpacity>
+    );
+  }
 
   return (
     <Box
@@ -117,7 +248,7 @@ const TraderRow: React.FC<TraderRowProps> = ({
           alignItems={BoxAlignItems.Center}
           gap={4}
         >
-          <View>
+          <Box>
             <TraderAvatar
               imageUrl={trader.avatarUri}
               address={trader.address}
@@ -127,11 +258,11 @@ const TraderRow: React.FC<TraderRowProps> = ({
             {showMedal ? (
               // Offset so the medal bottom (incl. its 2px border) sits ~10px
               // below the avatar's bottom edge.
-              <View style={tw.style('absolute -bottom-[10px] -right-2')}>
+              <Box twClassName="absolute -bottom-[10px] -right-2">
                 <RankMedal rank={trader.rank} />
-              </View>
+              </Box>
             ) : null}
-          </View>
+          </Box>
 
           <Box twClassName="flex-1 min-w-0">
             <Text

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRowSkeleton.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRowSkeleton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { View } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { Box } from '@metamask/design-system-react-native';
 import { useTheme } from '../../../../../../util/theme';
-import { TRADER_ROW_HEIGHT } from './TraderRow';
+import { SOCIAL_V1_TRADER_ROW_HEIGHT, TRADER_ROW_HEIGHT } from './TraderRow';
 
 /**
  * TraderRowSkeleton — loading placeholder that mirrors the TraderRow layout.
@@ -14,37 +14,55 @@ import { TRADER_ROW_HEIGHT } from './TraderRow';
  * Outer wrapper height is locked to `TRADER_ROW_HEIGHT` so the skeleton
  * occupies the exact same vertical space as a rendered <TraderRow />.
  */
-const TraderRowSkeleton: React.FC = () => {
+interface TraderRowSkeletonProps {
+  variant?: 'default' | 'socialV1';
+}
+
+const TraderRowSkeleton: React.FC<TraderRowSkeletonProps> = ({
+  variant = 'default',
+}) => {
   const tw = useTailwind();
   const { colors } = useTheme();
+  const isSocialV1 = variant === 'socialV1';
+  const rowHeight = isSocialV1
+    ? SOCIAL_V1_TRADER_ROW_HEIGHT
+    : TRADER_ROW_HEIGHT;
 
   return (
-    <View
-      style={[tw.style('px-4 justify-center'), { height: TRADER_ROW_HEIGHT }]}
-    >
+    <Box style={[tw.style('px-4 justify-center'), { height: rowHeight }]}>
       <SkeletonPlaceholder
         backgroundColor={colors.background.section}
         highlightColor={colors.background.subsection}
       >
-        <View style={tw.style('flex-row items-center')}>
+        <Box style={tw.style('flex-row items-center')}>
           {/* Avatar placeholder */}
-          <View style={tw.style('w-10 h-10 rounded-full mr-3')} />
+          <Box style={tw.style('w-10 h-10 rounded-full mr-3')} />
 
-          {/* Text info placeholder — total height matches the avatar (40px)
-              so the two bars line up with the actual BodyMd + BodySm text rows
-              (~20px + ~16px) and don't appear vertically centered with gaps. */}
-          <View style={tw.style('flex-1 gap-1')}>
-            <View style={tw.style('w-24 h-5 rounded')} />
-            <View style={tw.style('w-40 h-4 rounded')} />
-          </View>
+          {/* Text info placeholder — two bars matching the name and the
+              follower / stats line beneath it. */}
+          <Box style={tw.style('flex-1 gap-1')}>
+            <Box style={tw.style('w-24 h-5 rounded')} />
+            <Box
+              style={tw.style(
+                isSocialV1 ? 'w-20 h-4 rounded' : 'w-40 h-4 rounded',
+              )}
+            />
+          </Box>
 
-          {/* Button placeholder — 80×40 (ButtonSize.Md) matches the real
-              button so the row's right edge stays stable when the button
-              toggles between Follow and Following. */}
-          <View style={tw.style('w-20 h-10 rounded-xl ml-3')} />
-        </View>
+          {isSocialV1 ? (
+            // Right-aligned metric bars replace the follow action on the
+            // Social V1 leaderboard.
+            <Box style={tw.style('items-end gap-1 ml-3')}>
+              <Box style={tw.style('w-28 h-5 rounded')} />
+              <Box style={tw.style('w-12 h-4 rounded')} />
+            </Box>
+          ) : (
+            // 80×40 matches the real ButtonSize.Md follow action.
+            <Box style={tw.style('w-20 h-10 rounded-xl ml-3')} />
+          )}
+        </Box>
       </SkeletonPlaceholder>
-    </View>
+    </Box>
   );
 };
 

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRowSkeleton.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRowSkeleton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
+import { View } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { Box } from '@metamask/design-system-react-native';
 import { useTheme } from '../../../../../../util/theme';
-import { SOCIAL_V1_TRADER_ROW_HEIGHT, TRADER_ROW_HEIGHT } from './TraderRow';
+import { TRADER_ROW_HEIGHT } from './TraderRow';
 
 /**
  * TraderRowSkeleton — loading placeholder that mirrors the TraderRow layout.
@@ -14,55 +14,37 @@ import { SOCIAL_V1_TRADER_ROW_HEIGHT, TRADER_ROW_HEIGHT } from './TraderRow';
  * Outer wrapper height is locked to `TRADER_ROW_HEIGHT` so the skeleton
  * occupies the exact same vertical space as a rendered <TraderRow />.
  */
-interface TraderRowSkeletonProps {
-  variant?: 'default' | 'socialV1';
-}
-
-const TraderRowSkeleton: React.FC<TraderRowSkeletonProps> = ({
-  variant = 'default',
-}) => {
+const TraderRowSkeleton: React.FC = () => {
   const tw = useTailwind();
   const { colors } = useTheme();
-  const isSocialV1 = variant === 'socialV1';
-  const rowHeight = isSocialV1
-    ? SOCIAL_V1_TRADER_ROW_HEIGHT
-    : TRADER_ROW_HEIGHT;
 
   return (
-    <Box style={[tw.style('px-4 justify-center'), { height: rowHeight }]}>
+    <View
+      style={[tw.style('px-4 justify-center'), { height: TRADER_ROW_HEIGHT }]}
+    >
       <SkeletonPlaceholder
         backgroundColor={colors.background.section}
         highlightColor={colors.background.subsection}
       >
-        <Box style={tw.style('flex-row items-center')}>
+        <View style={tw.style('flex-row items-center')}>
           {/* Avatar placeholder */}
-          <Box style={tw.style('w-10 h-10 rounded-full mr-3')} />
+          <View style={tw.style('w-10 h-10 rounded-full mr-3')} />
 
-          {/* Text info placeholder — two bars matching the name and the
-              follower / stats line beneath it. */}
-          <Box style={tw.style('flex-1 gap-1')}>
-            <Box style={tw.style('w-24 h-5 rounded')} />
-            <Box
-              style={tw.style(
-                isSocialV1 ? 'w-20 h-4 rounded' : 'w-40 h-4 rounded',
-              )}
-            />
-          </Box>
+          {/* Text info placeholder — total height matches the avatar (40px)
+              so the two bars line up with the actual BodyMd + BodySm text rows
+              (~20px + ~16px) and don't appear vertically centered with gaps. */}
+          <View style={tw.style('flex-1 gap-1')}>
+            <View style={tw.style('w-24 h-5 rounded')} />
+            <View style={tw.style('w-40 h-4 rounded')} />
+          </View>
 
-          {isSocialV1 ? (
-            // Right-aligned metric bars replace the follow action on the
-            // Social V1 leaderboard.
-            <Box style={tw.style('items-end gap-1 ml-3')}>
-              <Box style={tw.style('w-28 h-5 rounded')} />
-              <Box style={tw.style('w-12 h-4 rounded')} />
-            </Box>
-          ) : (
-            // 80×40 matches the real ButtonSize.Md follow action.
-            <Box style={tw.style('w-20 h-10 rounded-xl ml-3')} />
-          )}
-        </Box>
+          {/* Button placeholder — 80×40 (ButtonSize.Md) matches the real
+              button so the row's right edge stays stable when the button
+              toggles between Follow and Following. */}
+          <View style={tw.style('w-20 h-10 rounded-xl ml-3')} />
+        </View>
       </SkeletonPlaceholder>
-    </Box>
+    </View>
   );
 };
 

--- a/app/components/Views/Homepage/Sections/TopTraders/components/index.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/index.ts
@@ -1,5 +1,5 @@
 export { default as TraderRow } from './TraderRow';
-export type { TraderRowProps } from './TraderRow';
+export type { TraderRowProps } from '../types';
 
 export { default as TraderRowSkeleton } from './TraderRowSkeleton';
 

--- a/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.test.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.test.ts
@@ -41,6 +41,7 @@ const mockTraders = [
     pnl7d: 963146.8,
     roiPercent7d: 43,
     pnlPerChain: { base: 963146.8 },
+    followerCount: 48707,
   },
   {
     rank: 2,
@@ -51,6 +52,7 @@ const mockTraders = [
     pnl7d: 474751.45,
     roiPercent7d: 359,
     pnlPerChain: { ethereum: 474751.45 },
+    followerCount: 21999,
   },
   {
     rank: 3,
@@ -61,6 +63,7 @@ const mockTraders = [
     pnl7d: 374735.16,
     roiPercent7d: 617,
     pnlPerChain: { solana: 374735.16 },
+    followerCount: 11772,
   },
 ];
 
@@ -140,6 +143,7 @@ describe('useTopTraders', () => {
         pnlValue: first.pnl7d,
         winRatePercent: null,
         pnlPerChain: first.pnlPerChain ?? {},
+        followerCount: first.followerCount,
         isFollowing: false,
       });
     });

--- a/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.ts
@@ -125,6 +125,7 @@ export const useTopTraders = (
         is30d ? entry.winRate30d : entry.winRate7d,
       ),
       pnlPerChain: entry.pnlPerChain ?? {},
+      followerCount: entry.followerCount ?? 0,
       isFollowing: isFollowing(entry.profileId),
     }));
   }, [data, isFollowing, timeframe]);

--- a/app/components/Views/Homepage/Sections/TopTraders/types.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/types.ts
@@ -32,6 +32,8 @@ export interface TopTrader {
   winRatePercent: number | null;
   /** PnL broken down by chain. Used for client-side chain filtering. */
   pnlPerChain: Record<string, number>;
+  /** Followers this trader has, as reported by the leaderboard. */
+  followerCount: number;
   /** Whether the current user is following this trader. */
   isFollowing: boolean;
 }

--- a/app/components/Views/Homepage/Sections/TopTraders/types.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/types.ts
@@ -39,6 +39,48 @@ export interface TopTrader {
 }
 
 /**
+ * The figure shown under the username on a trader row. Callers that rank by
+ * something other than PnL (e.g. the leaderboard's Sort by control) pass the
+ * ranked value here so the row shows what the list is ordered by.
+ *
+ * Lives here rather than beside a single row component because every trader
+ * row variant renders it and `traderMetric.ts` builds it.
+ */
+export interface TraderRowMetric {
+  /** Pre-formatted value, e.g. `+$45,900.89`, `+43.00%` or `92%`. */
+  label: string;
+  /** Renders the value in success green rather than error red. */
+  isPositive: boolean;
+}
+
+/**
+ * Props shared by every trader row variant, so a list can accept one as an
+ * injected `RowComponent` without knowing which variant it received.
+ */
+export interface TraderRowProps {
+  trader: TopTrader;
+  /** Defaults to the trader's PnL for the loaded window. */
+  metric?: TraderRowMetric;
+  onFollowPress: (traderId: string) => void;
+  onTraderPress?: (
+    traderId: string,
+    traderName: string,
+    /* Used downstream for podium decoration */
+    overallRank: number,
+  ) => void;
+  /** Whether this trader's alerts are paused. Only used when muting is shown. */
+  isMuted?: boolean;
+  /**
+   * When true (and the trader is followed), render the inline mute chip beside
+   * the Follow button. Gated by the caller on push-notification availability.
+   */
+  showMute?: boolean;
+  /** Toggles the muted state for this trader. */
+  onMuteToggle?: (traderId: string) => void;
+  testID?: string;
+}
+
+/**
  * Network filter selection for the leaderboard.
  * null means "All networks".
  */

--- a/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.test.tsx
+++ b/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.test.tsx
@@ -159,6 +159,7 @@ const makeTrader = (overrides: Partial<TopTrader> = {}): TopTrader => ({
   pnlValue: 456900,
   winRatePercent: 92,
   pnlPerChain: {},
+  followerCount: 1200,
   isFollowing: false,
   ...overrides,
 });

--- a/app/components/Views/SocialLeaderboard/SocialV1View/SocialV1View.test.tsx
+++ b/app/components/Views/SocialLeaderboard/SocialV1View/SocialV1View.test.tsx
@@ -58,6 +58,16 @@ jest.mock('../../../../util/haptics', () => ({
   playSelection: () => mockPlaySelection(),
 }));
 
+jest.mock('../TopTradersView', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () =>
+      ReactActual.createElement(View, { testID: 'top-traders-view' }),
+  };
+});
+
 jest.mock(
   '../../../../util/notifications/services/NotificationService',
   () => ({
@@ -99,7 +109,7 @@ describe('SocialV1View', () => {
     ).toHaveTextContent('social_leaderboard.feed.tabs.leaderboard');
   });
 
-  it('renders each tab subnav over an empty scroll surface', () => {
+  it('renders every tab subnav', () => {
     renderWithProvider(<SocialV1View />);
 
     expect(
@@ -114,6 +124,18 @@ describe('SocialV1View', () => {
     expect(
       screen.getByTestId(getSubnavPillTestId('topTraders')),
     ).toBeOnTheScreen();
+  });
+
+  it('mounts the leaderboard list once the Leaderboard tab is opened', () => {
+    renderWithProvider(<SocialV1View />);
+
+    expect(screen.queryByTestId('top-traders-view')).toBeNull();
+
+    fireEvent.press(
+      screen.getByTestId(`${SocialV1ViewSelectorsIDs.TABS}-tab-2`),
+    );
+
+    expect(screen.getByTestId('top-traders-view')).toBeOnTheScreen();
   });
 
   it('emits TSA-1122 exposure when the v1 home opens', () => {

--- a/app/components/Views/SocialLeaderboard/SocialV1View/SocialV1View.tsx
+++ b/app/components/Views/SocialLeaderboard/SocialV1View/SocialV1View.tsx
@@ -54,6 +54,7 @@ import {
   SOCIAL_V1_VARIANTS,
 } from './abTestConfig';
 import EmptyShellTabPage from '../shell/EmptyShellTabPage';
+import LeaderboardShellTabPage from '../shell/LeaderboardShellTabPage';
 import {
   SOCIAL_V1_TAB_ORDER,
   SOCIAL_SHELL_TAB_CONFIG,
@@ -121,6 +122,7 @@ const SocialV1View: React.FC = () => {
   const tabOrder = SOCIAL_V1_TAB_ORDER;
   const feedIndex = tabOrder.indexOf('feed');
   const liveTradesIndex = tabOrder.indexOf('liveTrades');
+  const leaderboardIndex = tabOrder.indexOf('leaderboard');
   // The landing tab is the first one, so the surface always opens on index 0.
   const [activeIndex, setActiveIndex] = useState(LANDING_INDEX);
 
@@ -486,13 +488,22 @@ const SocialV1View: React.FC = () => {
                   collapsable={false}
                   testID={testIds.page}
                 >
-                  <EmptyShellTabPage
-                    tab={tab}
-                    onScroll={scrollHandlers[tab]}
-                    pageRef={pageRef}
-                    containerTestID={testIds.container}
-                    scrollTestID={testIds.scroll}
-                  />
+                  {tab === 'leaderboard' ? (
+                    <LeaderboardShellTabPage
+                      isActive={activeIndex === leaderboardIndex}
+                      onScroll={scrollHandlers[tab]}
+                      pageRef={pageRef}
+                      containerTestID={testIds.container}
+                    />
+                  ) : (
+                    <EmptyShellTabPage
+                      tab={tab}
+                      onScroll={scrollHandlers[tab]}
+                      pageRef={pageRef}
+                      containerTestID={testIds.container}
+                      scrollTestID={testIds.scroll}
+                    />
+                  )}
                 </View>
               );
             })}

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, screen } from '@testing-library/react-native';
 import React from 'react';
-import { FlatList } from 'react-native';
+import { FlatList, Text } from 'react-native';
 import { DEFAULT_SOCIAL_AI_PREFERENCES } from '@metamask/notification-services-controller/notification-services';
 import Logger from '../../../../util/Logger';
 import { loadingSet } from '../../../../actions/user';
@@ -9,7 +9,12 @@ import renderWithProvider from '../../../../util/test/renderWithProvider';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import type { UseTopTradersResult } from '../../Homepage/Sections/TopTraders/hooks/useTopTraders';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import type { TopTrader } from '../../Homepage/Sections/TopTraders/types';
+/* eslint-disable import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog */
+import type {
+  TopTrader,
+  TraderRowProps,
+} from '../../Homepage/Sections/TopTraders/types';
+/* eslint-enable import-x/no-restricted-paths */
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { ImpactMoment } from '../../../../util/haptics';
 import TopTradersView from './TopTradersView';
@@ -863,6 +868,63 @@ describe('TopTradersView', () => {
       screen.queryByTestId(TopTradersViewSelectorsIDs.TYPE_SELECTOR),
     ).toBeOnTheScreen();
     expect(screen.queryByText('alpha.eth')).not.toBeOnTheScreen();
+  });
+
+  describe('injected row components', () => {
+    it('renders the legacy follow-button row by default', () => {
+      renderWithProvider(<TopTradersView />);
+
+      expect(screen.getAllByText('Follow').length).toBeGreaterThan(0);
+    });
+
+    it('renders an injected RowComponent with the trader and ranked metric', () => {
+      const InjectedRow: React.FC<TraderRowProps> = ({ trader, metric }) => (
+        <Text testID={`injected-row-${trader.id}`}>{metric?.label}</Text>
+      );
+
+      renderWithProvider(<TopTradersView RowComponent={InjectedRow} />);
+
+      expect(screen.getByTestId('injected-row-trader-1')).toBeOnTheScreen();
+      expect(screen.getByText('+$963,146.80')).toBeOnTheScreen();
+      expect(screen.queryByText('Follow')).toBeNull();
+    });
+
+    it('renders an injected SkeletonComponent while loading', () => {
+      setTabResult(LANDING_TAB, { isLoading: true, traders: [] });
+      const InjectedSkeleton: React.FC = () => (
+        <Text testID="injected-skeleton">loading</Text>
+      );
+
+      renderWithProvider(
+        <TopTradersView SkeletonComponent={InjectedSkeleton} />,
+      );
+
+      expect(screen.getAllByTestId('injected-skeleton').length).toBeGreaterThan(
+        0,
+      );
+    });
+
+    it('sizes the skeleton count off the injected rowHeight', () => {
+      setTabResult(LANDING_TAB, { isLoading: true, traders: [] });
+      const InjectedSkeleton: React.FC = () => (
+        <Text testID="injected-skeleton">loading</Text>
+      );
+
+      const renderWithRowHeight = (rowHeight: number) => {
+        const { unmount } = renderWithProvider(
+          <TopTradersView
+            SkeletonComponent={InjectedSkeleton}
+            rowHeight={rowHeight}
+          />,
+        );
+        const count = screen.getAllByTestId('injected-skeleton').length;
+        unmount();
+        return count;
+      };
+
+      // Taller rows cover the viewport with fewer placeholders.
+      expect(renderWithRowHeight(200)).toBeLessThan(renderWithRowHeight(50));
+    });
   });
 
   describe('performance', () => {

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -156,6 +156,7 @@ const fixtureTraders: TopTrader[] = [
     pnlValue: 963146.8,
     winRatePercent: 92,
     pnlPerChain: { base: 500000, ethereum: 463146.8 },
+    followerCount: 48707,
     isFollowing: false,
   },
   {
@@ -169,6 +170,7 @@ const fixtureTraders: TopTrader[] = [
     pnlValue: 474751.45,
     winRatePercent: 61,
     pnlPerChain: { base: 474751.45 },
+    followerCount: 21999,
     isFollowing: false,
   },
   {
@@ -182,6 +184,7 @@ const fixtureTraders: TopTrader[] = [
     pnlValue: 374735.16,
     winRatePercent: 48,
     pnlPerChain: { solana: 374735.16 },
+    followerCount: 11772,
     isFollowing: false,
   },
 ];
@@ -697,6 +700,65 @@ describe('TopTradersView', () => {
       all: false,
       tokens: true,
       perps: true,
+    });
+  });
+
+  describe('pinned type filter', () => {
+    it('scopes the queries to the pinned type and hides the type pill', () => {
+      renderWithProvider(<TopTradersView pinnedTypeFilter="all" />);
+
+      expect(
+        screen.queryByTestId(TopTradersViewSelectorsIDs.TYPE_SELECTOR),
+      ).toBeNull();
+      expectLatestQueryEnabledStates({
+        all: true,
+        tokens: false,
+        perps: false,
+      });
+    });
+
+    it('does not prefetch the other type queries', () => {
+      jest.useFakeTimers();
+      try {
+        setTabResult('all', { isFetching: false });
+        const { rerender } = renderWithProvider(
+          <TopTradersView pinnedTypeFilter="all" />,
+        );
+
+        rerender(<TopTradersView pinnedTypeFilter="all" />);
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
+
+        expectLatestQueryEnabledStates({
+          all: true,
+          tokens: false,
+          perps: false,
+        });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('keeps the pinned type enabled when the sort changes', () => {
+      renderWithProvider(<TopTradersView pinnedTypeFilter="all" />);
+
+      selectSort('winRate');
+
+      expectLatestQueryEnabledStates({
+        all: true,
+        tokens: false,
+        perps: false,
+      });
+    });
+
+    it('reports the pinned type as the analytics chain filter', () => {
+      renderWithProvider(<TopTradersView pinnedTypeFilter="all" />);
+
+      expect(mockTrack).toHaveBeenCalledWith(
+        MetaMetricsEvents.SOCIAL_TRADER_LEADERBOARD_SCREEN_VIEWED,
+        expect.objectContaining({ chain_filter: 'all' }),
+      );
     });
   });
 

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
@@ -51,18 +51,18 @@ import {
   TraderRow,
   TraderRowSkeleton,
 } from '../../Homepage/Sections/TopTraders/components';
-import {
-  SOCIAL_V1_TRADER_ROW_HEIGHT,
-  TRADER_ROW_HEIGHT,
-  type TraderRowMetric,
-} from '../../Homepage/Sections/TopTraders/components/TraderRow';
+import { TRADER_ROW_HEIGHT } from '../../Homepage/Sections/TopTraders/components/TraderRow';
+import type {
+  TopTrader,
+  TraderRowMetric,
+  TraderRowProps,
+} from '../../Homepage/Sections/TopTraders/types';
 import { useTopTraders } from '../../Homepage/Sections/TopTraders/hooks';
 import {
   ALL_CHAINS,
   PERP_CHAINS,
   SPOT_CHAINS,
 } from '../../shared/top-traders-constants';
-import type { TopTrader } from '../../Homepage/Sections/TopTraders/types';
 import type { SocialTabPageHandle } from '../shared/tabPageScroll';
 import { TopTradersViewSelectorsIDs } from './TopTradersView.testIds';
 import { getTraderMetricDisplay, rankTradersByMetric } from './traderMetric';
@@ -163,8 +163,19 @@ export interface TopTradersViewProps {
    * landing list has loaded, so those requests never contend with it.
    */
   onVisibleLeaderboardSettled?: () => void;
-  /** Visual treatment used for each trader row and its loading skeleton. */
-  rowVariant?: 'default' | 'socialV1';
+  /**
+   * Row component rendered for each trader. Defaults to the legacy
+   * Follow-button row; the Social V1 leaderboard injects its metrics-first row
+   * instead. Pass `SkeletonComponent` and `rowHeight` to match.
+   */
+  RowComponent?: React.ComponentType<TraderRowProps>;
+  /** Loading placeholder matching `RowComponent`. */
+  SkeletonComponent?: React.ComponentType;
+  /**
+   * Height of a single `RowComponent`, used to size the skeleton count to the
+   * viewport. Must match the injected row or the placeholder count drifts.
+   */
+  rowHeight?: number;
   /**
    * Pins the position type to a single value and hides its filter pill, so the
    * host owns that axis. Used by the Social V1 leaderboard tab, whose subnav
@@ -182,7 +193,9 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
   onScroll,
   pageRef,
   onVisibleLeaderboardSettled,
-  rowVariant = 'default',
+  RowComponent = TraderRow,
+  SkeletonComponent = TraderRowSkeleton,
+  rowHeight = TRADER_ROW_HEIGHT,
   pinnedTypeFilter,
 }) => {
   const navigation = useNavigation<AppNavigationProp>();
@@ -247,13 +260,9 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
   // Render enough skeleton rows to cover the visible list area. Add a couple of
   // extras so users can see the shimmer continue past the fold while scrolling.
   const skeletonKeys = useMemo(() => {
-    const rowHeight =
-      rowVariant === 'socialV1'
-        ? SOCIAL_V1_TRADER_ROW_HEIGHT
-        : TRADER_ROW_HEIGHT;
     const count = Math.ceil(windowHeight / rowHeight) + 2;
     return Array.from({ length: count }, (_, i) => `top-trader-skeleton-${i}`);
-  }, [rowVariant, windowHeight]);
+  }, [rowHeight, windowHeight]);
 
   const allChains = isPerpsEnabled ? ALL_CHAINS : SPOT_CHAINS;
 
@@ -509,9 +518,8 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
 
   const renderTraderRow = useCallback(
     ({ item }: { item: RankedTrader }) => (
-      <TraderRow
+      <RowComponent
         trader={item}
-        variant={rowVariant}
         metric={item.displayMetric}
         onFollowPress={handleFollowPress}
         onTraderPress={handleTraderPress}
@@ -521,9 +529,9 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
       />
     ),
     [
+      RowComponent,
       handleFollowPress,
       handleTraderPress,
-      rowVariant,
       showMuteChip,
       isChipMuted,
       onMutePress,
@@ -598,7 +606,7 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
         >
           {listHeader}
           {skeletonKeys.map((key) => (
-            <TraderRowSkeleton key={key} variant={rowVariant} />
+            <SkeletonComponent key={key} />
           ))}
         </Animated.ScrollView>
       ) : (

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
@@ -52,6 +52,7 @@ import {
   TraderRowSkeleton,
 } from '../../Homepage/Sections/TopTraders/components';
 import {
+  SOCIAL_V1_TRADER_ROW_HEIGHT,
   TRADER_ROW_HEIGHT,
   type TraderRowMetric,
 } from '../../Homepage/Sections/TopTraders/components/TraderRow';
@@ -162,6 +163,14 @@ export interface TopTradersViewProps {
    * landing list has loaded, so those requests never contend with it.
    */
   onVisibleLeaderboardSettled?: () => void;
+  /** Visual treatment used for each trader row and its loading skeleton. */
+  rowVariant?: 'default' | 'socialV1';
+  /**
+   * Pins the position type to a single value and hides its filter pill, so the
+   * host owns that axis. Used by the Social V1 leaderboard tab, whose subnav
+   * sits above this list. `tokens` and `perps` still require the perps flag.
+   */
+  pinnedTypeFilter?: SocialTypeFilter;
 }
 
 /**
@@ -173,6 +182,8 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
   onScroll,
   pageRef,
   onVisibleLeaderboardSettled,
+  rowVariant = 'default',
+  pinnedTypeFilter,
 }) => {
   const navigation = useNavigation<AppNavigationProp>();
   const route = useRoute<RouteProp<RootStackParamList, 'SocialV0View'>>();
@@ -186,13 +197,19 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
   const { track } = useSocialLeaderboardAnalytics();
   const source = route.params?.source ?? 'nav_tab';
 
-  const [renderedTab, setRenderedTab] = useState<TabFilter>(DEFAULT_TYPE_TAB);
+  const [renderedTab, setRenderedTab] = useState<TabFilter>(
+    pinnedTypeFilter ?? DEFAULT_TYPE_TAB,
+  );
   // Only the landing tab's query starts enabled; the others are switched on
   // when the user picks them, or by the idle prefetch below. Perps being off
   // pins the whole screen to the spot-only "all" query.
   const [queryEnabledTabs, setQueryEnabledTabs] = useState<
     Record<TabFilter, boolean>
-  >(() => buildQueryEnabledTabs(isPerpsEnabled ? DEFAULT_TYPE_TAB : 'all'));
+  >(() =>
+    buildQueryEnabledTabs(
+      pinnedTypeFilter ?? (isPerpsEnabled ? DEFAULT_TYPE_TAB : 'all'),
+    ),
+  );
   const [timeframe, setTimeframe] =
     useState<SocialTimeframe>(DEFAULT_TIMEFRAME);
   const [sort, setSort] = useState<LeaderboardSort>(DEFAULT_LEADERBOARD_SORT);
@@ -204,7 +221,9 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
   // Tracks whether we've already emitted the screen-viewed event this mount.
   // Avoids re-firing if the user changes filters or refreshes.
   const hasFiredScreenViewedRef = useRef(false);
-  const selectedTabRef = useRef<TabFilter>(DEFAULT_TYPE_TAB);
+  const selectedTabRef = useRef<TabFilter>(
+    pinnedTypeFilter ?? DEFAULT_TYPE_TAB,
+  );
   // Tracks whether the user has explicitly chosen a tab. Once they have, late
   // feature-flag hydration must not override their selection with the default.
   const hasUserSelectedTabRef = useRef(false);
@@ -228,9 +247,13 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
   // Render enough skeleton rows to cover the visible list area. Add a couple of
   // extras so users can see the shimmer continue past the fold while scrolling.
   const skeletonKeys = useMemo(() => {
-    const count = Math.ceil(windowHeight / TRADER_ROW_HEIGHT) + 2;
+    const rowHeight =
+      rowVariant === 'socialV1'
+        ? SOCIAL_V1_TRADER_ROW_HEIGHT
+        : TRADER_ROW_HEIGHT;
+    const count = Math.ceil(windowHeight / rowHeight) + 2;
     return Array.from({ length: count }, (_, i) => `top-trader-skeleton-${i}`);
-  }, [windowHeight]);
+  }, [rowVariant, windowHeight]);
 
   const allChains = isPerpsEnabled ? ALL_CHAINS : SPOT_CHAINS;
 
@@ -265,7 +288,7 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
     [allResult, tokensResult, perpsResult],
   );
 
-  const activeTab = isPerpsEnabled ? renderedTab : 'all';
+  const activeTab = pinnedTypeFilter ?? (isPerpsEnabled ? renderedTab : 'all');
   const activeResult = resultsByTab[activeTab];
   const { traders: loadedTraders, isLoading, toggleFollow } = activeResult;
   // The API ranks on its own (30-day) window, so the selected time frame is
@@ -283,7 +306,9 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
   // `isLoading`: arriving with a warm cache (the homepage carousel shares the
   // Tokens query key) leaves `isLoading` false while the tab still revalidates,
   // which would let the secondary fetches ride along instead of waiting.
+  // A pinned instance can never switch type, so there is nothing to warm.
   const shouldPrefetchSecondaryTabs =
+    !pinnedTypeFilter &&
     isEnabled &&
     isPerpsEnabled &&
     !activeResult.isFetching &&
@@ -304,6 +329,9 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
   }, [isEnabled, navigation]);
 
   useEffect(() => {
+    if (pinnedTypeFilter) {
+      return;
+    }
     if (!isPerpsEnabled) {
       if (selectedTabRef.current !== 'all') {
         selectedTabRef.current = 'all';
@@ -327,7 +355,7 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
       setRenderedTab(DEFAULT_TYPE_TAB);
       setQueryEnabledTabs(buildQueryEnabledTabs(DEFAULT_TYPE_TAB));
     }
-  }, [isPerpsEnabled]);
+  }, [isPerpsEnabled, pinnedTypeFilter]);
 
   useEffect(() => {
     if (!isEnabled || hasFiredScreenViewedRef.current) return;
@@ -385,10 +413,12 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
     (next: LeaderboardSort) => {
       setSort(next);
       setQueryEnabledTabs(
-        buildQueryEnabledTabs(isPerpsEnabled ? selectedTabRef.current : 'all'),
+        buildQueryEnabledTabs(
+          pinnedTypeFilter ?? (isPerpsEnabled ? selectedTabRef.current : 'all'),
+        ),
       );
     },
-    [isPerpsEnabled],
+    [isPerpsEnabled, pinnedTypeFilter],
   );
 
   const openTypeSheet = useCallback(() => setIsTypeSheetOpen(true), []);
@@ -481,6 +511,7 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
     ({ item }: { item: RankedTrader }) => (
       <TraderRow
         trader={item}
+        variant={rowVariant}
         metric={item.displayMetric}
         onFollowPress={handleFollowPress}
         onTraderPress={handleTraderPress}
@@ -492,6 +523,7 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
     [
       handleFollowPress,
       handleTraderPress,
+      rowVariant,
       showMuteChip,
       isChipMuted,
       onMutePress,
@@ -509,7 +541,7 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
         twClassName="px-4 pt-4 pb-4"
       >
         <Box flexDirection={BoxFlexDirection.Row} gap={2}>
-          {isPerpsEnabled && (
+          {isPerpsEnabled && !pinnedTypeFilter && (
             <TypeFilterSelector
               value={activeTab}
               onPress={openTypeSheet}
@@ -535,6 +567,7 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
       openSortSheet,
       openTimeframeSheet,
       openTypeSheet,
+      pinnedTypeFilter,
       sort,
       timeframe,
     ],
@@ -565,7 +598,7 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
         >
           {listHeader}
           {skeletonKeys.map((key) => (
-            <TraderRowSkeleton key={key} />
+            <TraderRowSkeleton key={key} variant={rowVariant} />
           ))}
         </Animated.ScrollView>
       ) : (
@@ -594,12 +627,14 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
         />
       )}
 
-      <TypeFilterSheet
-        isOpen={isTypeSheetOpen}
-        value={activeTab}
-        onChange={handleTabPress}
-        onClose={closeTypeSheet}
-      />
+      {!pinnedTypeFilter && (
+        <TypeFilterSheet
+          isOpen={isTypeSheetOpen}
+          value={activeTab}
+          onChange={handleTabPress}
+          onClose={closeTypeSheet}
+        />
+      )}
 
       <TimeframeFilterSheet
         isOpen={isTimeframeSheetOpen}

--- a/app/components/Views/SocialLeaderboard/TopTradersView/components/SocialV1TraderRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/components/SocialV1TraderRow.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, screen } from '@testing-library/react-native';
+import React from 'react';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import type { TopTrader } from '../../../Homepage/Sections/TopTraders/types';
+import SocialV1TraderRow from './SocialV1TraderRow';
+
+const baseTrader: TopTrader = {
+  id: 'trader-1',
+  address: '0x0000000000000000000000000000000000000001',
+  rank: 1,
+  overallRank: 1,
+  username: 'alpha.eth',
+  avatarUri: 'https://example.com/avatar.png',
+  percentageChange: 43,
+  pnlValue: 963146.8,
+  winRatePercent: 92,
+  pnlPerChain: { base: 963146.8 },
+  followerCount: 48707,
+  isFollowing: false,
+};
+
+const mockOnFollowPress = jest.fn();
+const mockOnTraderPress = jest.fn();
+
+describe('SocialV1TraderRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the win rate, follower count, PnL, and ROI without a follow action', () => {
+    renderWithProvider(
+      <SocialV1TraderRow
+        trader={baseTrader}
+        onFollowPress={mockOnFollowPress}
+      />,
+    );
+
+    expect(screen.getByText('alpha.eth')).toBeOnTheScreen();
+    expect(screen.getByText('92% WR')).toBeOnTheScreen();
+    expect(screen.getByText('48,707 followers')).toBeOnTheScreen();
+    expect(screen.getByText('+$963,146.80')).toBeOnTheScreen();
+    expect(screen.getByText('+43.0%')).toBeOnTheScreen();
+    expect(screen.queryByText('Follow')).toBeNull();
+  });
+
+  it('renders the singular follower label for a single follower', () => {
+    renderWithProvider(
+      <SocialV1TraderRow
+        trader={{ ...baseTrader, followerCount: 1 }}
+        onFollowPress={mockOnFollowPress}
+      />,
+    );
+
+    expect(screen.getByText('1 follower')).toBeOnTheScreen();
+  });
+
+  it('omits the win rate tag when the window has no win-rate data', () => {
+    renderWithProvider(
+      <SocialV1TraderRow
+        trader={{ ...baseTrader, winRatePercent: null }}
+        onFollowPress={mockOnFollowPress}
+      />,
+    );
+
+    expect(screen.queryByText(/WR$/)).toBeNull();
+  });
+
+  it('keeps the row and podium medal interactive', () => {
+    renderWithProvider(
+      <SocialV1TraderRow
+        trader={baseTrader}
+        onFollowPress={mockOnFollowPress}
+        onTraderPress={mockOnTraderPress}
+      />,
+    );
+
+    expect(screen.getByTestId('rank-medal-1')).toBeOnTheScreen();
+    fireEvent.press(screen.getByTestId('trader-row-trader-1'));
+    expect(mockOnTraderPress).toHaveBeenCalledWith('trader-1', 'alpha.eth', 1);
+  });
+
+  it('ignores the mute props this surface has no inline actions for', () => {
+    const mockOnMuteToggle = jest.fn();
+    renderWithProvider(
+      <SocialV1TraderRow
+        trader={{ ...baseTrader, isFollowing: true }}
+        onFollowPress={mockOnFollowPress}
+        showMute
+        onMuteToggle={mockOnMuteToggle}
+      />,
+    );
+
+    expect(screen.queryByTestId('trader-row-mute-chip-trader-1')).toBeNull();
+  });
+
+  it('renders the ranked metric passed by the list instead of PnL', () => {
+    renderWithProvider(
+      <SocialV1TraderRow
+        trader={baseTrader}
+        metric={{ label: '92%', isPositive: true }}
+        onFollowPress={mockOnFollowPress}
+      />,
+    );
+
+    expect(screen.getByText('92%')).toBeOnTheScreen();
+    expect(screen.queryByText('+$963,146.80')).toBeNull();
+  });
+
+  it('uses a custom testID when provided', () => {
+    renderWithProvider(
+      <SocialV1TraderRow
+        trader={baseTrader}
+        onFollowPress={mockOnFollowPress}
+        testID="custom-test-id"
+      />,
+    );
+
+    expect(screen.getByTestId('custom-test-id')).toBeOnTheScreen();
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TopTradersView/components/SocialV1TraderRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/components/SocialV1TraderRow.tsx
@@ -1,0 +1,168 @@
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  FontWeight,
+  IconName,
+  Tag,
+  TagSeverity,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import { strings } from '../../../../../../locales/i18n';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import TraderAvatar from '../../../Homepage/Sections/TopTraders/components/TraderAvatar';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import { RankMedal, isTopRank } from '../../../Homepage/Sections/TopTraders/topRank';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import type { TraderRowProps } from '../../../Homepage/Sections/TopTraders/types';
+import { formatCount, formatPercent, formatSignedUsd } from '../../utils/formatters';
+
+const AVATAR_SIZE = 40;
+// Medal height that keeps the badge tucked into the avatar's bottom-right
+// corner rather than dominating it (the default 30 is sized for a standalone
+// podium).
+const MEDAL_HEIGHT = 24;
+// At or above this win rate the tag switches to the highlighted treatment.
+const ELITE_WIN_RATE_PERCENT = 90;
+/**
+ * Fixed row height so the skeleton placeholder can match it exactly without
+ * drifting due to font-scale differences.
+ */
+export const SOCIAL_V1_TRADER_ROW_HEIGHT = 72;
+
+/**
+ * SocialV1TraderRow -- a single row in the Social Bundle V1 leaderboard.
+ *
+ * Metrics-first counterpart to the legacy `TraderRow`: instead of leading with
+ * a Follow action and one PnL figure, it pairs the trader's identity (avatar
+ * with podium medal, username, win-rate tag, follower count) with a
+ * right-aligned column showing the ranked metric over ROI.
+ *
+ * Accepts the shared `TraderRowProps` so it can be injected into
+ * `TopTradersView` interchangeably with the legacy row, but deliberately
+ * ignores the follow and mute callbacks -- this surface has no inline actions.
+ */
+const SocialV1TraderRow: React.FC<TraderRowProps> = ({
+  trader,
+  metric,
+  onTraderPress,
+  testID,
+}) => {
+  const metricText = metric?.label ?? formatSignedUsd(trader.pnlValue);
+  const isMetricPositive = metric?.isPositive ?? trader.pnlValue >= 0;
+  const showMedal = isTopRank(trader.rank);
+  const isEliteWinRate = (trader.winRatePercent ?? 0) >= ELITE_WIN_RATE_PERCENT;
+
+  const winRateLabel = strings('social_leaderboard.win_rate_tag', {
+    winRate: formatPercent(trader.winRatePercent, {
+      showSign: false,
+      decimals: 0,
+    }),
+  });
+  const followerLabel = strings(
+    trader.followerCount === 1
+      ? 'social_leaderboard.trader_profile.followers_count'
+      : 'social_leaderboard.trader_profile.followers_count_plural',
+    { count: formatCount(trader.followerCount) },
+  );
+  const roi = formatPercent(trader.percentageChange, { decimals: 1 });
+
+  return (
+    <TouchableOpacity
+      activeOpacity={onTraderPress ? 0.7 : 1}
+      onPress={
+        onTraderPress
+          ? () => onTraderPress(trader.id, trader.username, trader.overallRank)
+          : undefined
+      }
+      disabled={!onTraderPress}
+      testID={testID ?? `trader-row-${trader.id}`}
+    >
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={3}
+        twClassName="px-4"
+        style={{ height: SOCIAL_V1_TRADER_ROW_HEIGHT }}
+      >
+        <Box>
+          <TraderAvatar
+            imageUrl={trader.avatarUri}
+            address={trader.address}
+            size={AVATAR_SIZE}
+            recyclingKey={trader.id}
+          />
+          {showMedal ? (
+            <Box twClassName="absolute -bottom-1 -right-2">
+              <RankMedal rank={trader.rank} size={MEDAL_HEIGHT} />
+            </Box>
+          ) : null}
+        </Box>
+
+        {/* `min-w-0` lets the name truncate inside the row instead of
+            pushing the metrics column off the right edge. */}
+        <Box twClassName="flex-1 min-w-0">
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            gap={2}
+          >
+            <Text
+              variant={TextVariant.BodyLg}
+              fontWeight={FontWeight.Bold}
+              color={TextColor.TextDefault}
+              numberOfLines={1}
+              twClassName="shrink"
+            >
+              {trader.username}
+            </Text>
+            {trader.winRatePercent !== null && (
+              <Tag
+                severity={
+                  isEliteWinRate ? TagSeverity.Warning : TagSeverity.Neutral
+                }
+                startIconName={isEliteWinRate ? IconName.Trophy : undefined}
+                twClassName="shrink-0"
+              >
+                {winRateLabel}
+              </Tag>
+            )}
+          </Box>
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
+            numberOfLines={1}
+          >
+            {followerLabel}
+          </Text>
+        </Box>
+
+        <Box alignItems={BoxAlignItems.End} twClassName="shrink-0">
+          <Text
+            variant={TextVariant.BodyLg}
+            fontWeight={FontWeight.Medium}
+            numberOfLines={1}
+            twClassName={
+              isMetricPositive ? 'text-success-default' : 'text-error-default'
+            }
+          >
+            {metricText}
+          </Text>
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
+            numberOfLines={1}
+          >
+            {roi}
+          </Text>
+        </Box>
+      </Box>
+    </TouchableOpacity>
+  );
+};
+
+export default React.memo(SocialV1TraderRow);

--- a/app/components/Views/SocialLeaderboard/TopTradersView/components/SocialV1TraderRowSkeleton.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/components/SocialV1TraderRowSkeleton.tsx
@@ -1,0 +1,53 @@
+import { Box } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import React from 'react';
+import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
+import { useTheme } from '../../../../../util/theme';
+import { SOCIAL_V1_TRADER_ROW_HEIGHT } from './SocialV1TraderRow';
+
+/**
+ * SocialV1TraderRowSkeleton -- loading placeholder mirroring
+ * `SocialV1TraderRow`.
+ *
+ * Bar widths trace the real row: avatar, then the username and follower lines,
+ * then the right-aligned metric / ROI pair. Outer wrapper height is locked to
+ * `SOCIAL_V1_TRADER_ROW_HEIGHT` so the skeleton occupies the exact same
+ * vertical space as a rendered row.
+ */
+const SocialV1TraderRowSkeleton: React.FC = () => {
+  const tw = useTailwind();
+  const { colors } = useTheme();
+
+  return (
+    <Box
+      style={[
+        tw.style('px-4 justify-center'),
+        { height: SOCIAL_V1_TRADER_ROW_HEIGHT },
+      ]}
+    >
+      <SkeletonPlaceholder
+        backgroundColor={colors.background.section}
+        highlightColor={colors.background.subsection}
+      >
+        <Box style={tw.style('flex-row items-center')}>
+          {/* Avatar placeholder */}
+          <Box style={tw.style('w-10 h-10 rounded-full mr-3')} />
+
+          {/* Username + follower-count lines */}
+          <Box style={tw.style('flex-1 gap-1')}>
+            <Box style={tw.style('w-24 h-5 rounded')} />
+            <Box style={tw.style('w-20 h-4 rounded')} />
+          </Box>
+
+          {/* Right-aligned metric / ROI pair */}
+          <Box style={tw.style('items-end gap-1 ml-3')}>
+            <Box style={tw.style('w-28 h-5 rounded')} />
+            <Box style={tw.style('w-12 h-4 rounded')} />
+          </Box>
+        </Box>
+      </SkeletonPlaceholder>
+    </Box>
+  );
+};
+
+export default SocialV1TraderRowSkeleton;

--- a/app/components/Views/SocialLeaderboard/TopTradersView/components/index.ts
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/components/index.ts
@@ -1,0 +1,4 @@
+export { default as SocialV1TraderRow } from './SocialV1TraderRow';
+export { SOCIAL_V1_TRADER_ROW_HEIGHT } from './SocialV1TraderRow';
+
+export { default as SocialV1TraderRowSkeleton } from './SocialV1TraderRowSkeleton';

--- a/app/components/Views/SocialLeaderboard/TopTradersView/traderMetric.test.ts
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/traderMetric.test.ts
@@ -12,6 +12,7 @@ const buildTrader = (overrides: Partial<TopTrader> = {}): TopTrader => ({
   pnlValue: 45900.89,
   winRatePercent: 92,
   pnlPerChain: {},
+  followerCount: 1200,
   isFollowing: false,
   ...overrides,
 });

--- a/app/components/Views/SocialLeaderboard/TopTradersView/traderMetric.ts
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/traderMetric.ts
@@ -1,7 +1,5 @@
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import type { TraderRowMetric } from '../../Homepage/Sections/TopTraders/components/TraderRow';
-// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import type { TopTrader } from '../../Homepage/Sections/TopTraders/types';
+import type { TopTrader, TraderRowMetric } from '../../Homepage/Sections/TopTraders/types';
 import type { LeaderboardSort } from '../components/Filters';
 import { formatPercent, formatSignedUsd } from '../utils/formatters';
 

--- a/app/components/Views/SocialLeaderboard/shell/LeaderboardShellTabPage.test.tsx
+++ b/app/components/Views/SocialLeaderboard/shell/LeaderboardShellTabPage.test.tsx
@@ -3,6 +3,11 @@ import { screen } from '@testing-library/react-native';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import LeaderboardShellTabPage from './LeaderboardShellTabPage';
 import { getSubnavPillTestId } from './SubnavPills';
+import {
+  SOCIAL_V1_TRADER_ROW_HEIGHT,
+  SocialV1TraderRow,
+  SocialV1TraderRowSkeleton,
+} from '../TopTradersView/components';
 
 const TOP_TRADERS_TEST_ID = 'top-traders-view';
 
@@ -49,9 +54,20 @@ describe('LeaderboardShellTabPage', () => {
     );
 
     expect(mockTopTradersProps).toHaveBeenCalledWith(
+      expect.objectContaining({ pinnedTypeFilter: 'all' }),
+    );
+  });
+
+  it('injects the Social V1 row, skeleton, and matching row height', () => {
+    renderWithProvider(
+      <LeaderboardShellTabPage containerTestID="leaderboard-page" />,
+    );
+
+    expect(mockTopTradersProps).toHaveBeenCalledWith(
       expect.objectContaining({
-        pinnedTypeFilter: 'all',
-        rowVariant: 'socialV1',
+        RowComponent: SocialV1TraderRow,
+        SkeletonComponent: SocialV1TraderRowSkeleton,
+        rowHeight: SOCIAL_V1_TRADER_ROW_HEIGHT,
       }),
     );
   });

--- a/app/components/Views/SocialLeaderboard/shell/LeaderboardShellTabPage.test.tsx
+++ b/app/components/Views/SocialLeaderboard/shell/LeaderboardShellTabPage.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { screen } from '@testing-library/react-native';
+import renderWithProvider from '../../../../util/test/renderWithProvider';
+import LeaderboardShellTabPage from './LeaderboardShellTabPage';
+import { getSubnavPillTestId } from './SubnavPills';
+
+const TOP_TRADERS_TEST_ID = 'top-traders-view';
+
+const mockTopTradersProps = jest.fn();
+
+jest.mock('../TopTradersView', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: (props: Record<string, unknown>) => {
+      mockTopTradersProps(props);
+      return ReactActual.createElement(View, { testID: 'top-traders-view' });
+    },
+  };
+});
+
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+describe('LeaderboardShellTabPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the leaderboard subnav pills', () => {
+    renderWithProvider(
+      <LeaderboardShellTabPage containerTestID="leaderboard-page" />,
+    );
+
+    expect(
+      screen.getByTestId(getSubnavPillTestId('topTraders')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(getSubnavPillTestId('topPerps')),
+    ).toBeOnTheScreen();
+    expect(screen.getByTestId(getSubnavPillTestId('kols'))).toBeOnTheScreen();
+  });
+
+  it('scopes the list to every position type', () => {
+    renderWithProvider(
+      <LeaderboardShellTabPage containerTestID="leaderboard-page" />,
+    );
+
+    expect(mockTopTradersProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pinnedTypeFilter: 'all',
+        rowVariant: 'socialV1',
+      }),
+    );
+  });
+
+  it('holds the list back until the tab is opened', () => {
+    const { rerender } = renderWithProvider(
+      <LeaderboardShellTabPage
+        isActive={false}
+        containerTestID="leaderboard-page"
+      />,
+    );
+
+    expect(screen.queryByTestId(TOP_TRADERS_TEST_ID)).toBeNull();
+
+    rerender(
+      <LeaderboardShellTabPage isActive containerTestID="leaderboard-page" />,
+    );
+
+    expect(screen.getByTestId(TOP_TRADERS_TEST_ID)).toBeOnTheScreen();
+  });
+
+  it('keeps the list mounted once the tab has been opened', () => {
+    const { rerender } = renderWithProvider(
+      <LeaderboardShellTabPage isActive containerTestID="leaderboard-page" />,
+    );
+
+    rerender(
+      <LeaderboardShellTabPage
+        isActive={false}
+        containerTestID="leaderboard-page"
+      />,
+    );
+
+    expect(screen.getByTestId(TOP_TRADERS_TEST_ID)).toBeOnTheScreen();
+  });
+});

--- a/app/components/Views/SocialLeaderboard/shell/LeaderboardShellTabPage.tsx
+++ b/app/components/Views/SocialLeaderboard/shell/LeaderboardShellTabPage.tsx
@@ -1,0 +1,77 @@
+import { Box } from '@metamask/design-system-react-native';
+import React, { useEffect, useState } from 'react';
+import TopTradersView from '../TopTradersView';
+import type { SocialTabPageHandle } from '../shared/tabPageScroll';
+import SubnavPills from './SubnavPills';
+import { SOCIAL_SHELL_TAB_CONFIG } from './tabConfig';
+import type { LeaderboardSubnavId } from './types';
+
+const LEADERBOARD_CONFIG = SOCIAL_SHELL_TAB_CONFIG.leaderboard;
+
+export interface LeaderboardShellTabPageProps {
+  /**
+   * Whether this page is the visible tab. The pager mounts every page up
+   * front, so the list is held back until the tab is first opened — otherwise
+   * opening the home would fetch the leaderboard and emit its screen-viewed
+   * event while the user is still on Feed. Defaults to `true` for standalone
+   * use.
+   */
+  isActive?: boolean;
+  /**
+   * Scroll handler forwarded by the tabs container so the page's scroll drives
+   * the parent's collapsing title.
+   */
+  onScroll?: React.ComponentProps<typeof TopTradersView>['onScroll'];
+  /**
+   * Lets the tabs container drive this page's scroll offset so the collapsing
+   * title stays put when the user switches tabs.
+   */
+  pageRef?: React.Ref<SocialTabPageHandle>;
+  containerTestID: string;
+}
+
+/**
+ * Leaderboard tab page for Social Bundle V1: the leaderboard subnav pinned
+ * above the ranked trader list shared with the legacy home. The list covers
+ * every position type; the per-subnav rankings (top perps, KOLs) land in later
+ * tickets, so until then the pills only carry their own selected state.
+ */
+const LeaderboardShellTabPage: React.FC<LeaderboardShellTabPageProps> = ({
+  isActive = true,
+  onScroll,
+  pageRef,
+  containerTestID,
+}) => {
+  const [selectedSubnav, setSelectedSubnav] = useState<LeaderboardSubnavId>(
+    LEADERBOARD_CONFIG.defaultSubnav,
+  );
+  // Latches on: once the list has loaded, leaving the tab must not tear it down
+  // and refetch on the way back.
+  const [hasBeenActive, setHasBeenActive] = useState(isActive);
+
+  useEffect(() => {
+    if (isActive) {
+      setHasBeenActive(true);
+    }
+  }, [isActive]);
+
+  return (
+    <Box twClassName="flex-1 bg-default" testID={containerTestID}>
+      <SubnavPills
+        items={LEADERBOARD_CONFIG.subnav}
+        value={selectedSubnav}
+        onChange={setSelectedSubnav}
+      />
+      {hasBeenActive && (
+        <TopTradersView
+          pinnedTypeFilter="all"
+          rowVariant="socialV1"
+          onScroll={onScroll}
+          pageRef={pageRef}
+        />
+      )}
+    </Box>
+  );
+};
+
+export default LeaderboardShellTabPage;

--- a/app/components/Views/SocialLeaderboard/shell/LeaderboardShellTabPage.tsx
+++ b/app/components/Views/SocialLeaderboard/shell/LeaderboardShellTabPage.tsx
@@ -1,6 +1,11 @@
 import { Box } from '@metamask/design-system-react-native';
 import React, { useEffect, useState } from 'react';
 import TopTradersView from '../TopTradersView';
+import {
+  SOCIAL_V1_TRADER_ROW_HEIGHT,
+  SocialV1TraderRow,
+  SocialV1TraderRowSkeleton,
+} from '../TopTradersView/components';
 import type { SocialTabPageHandle } from '../shared/tabPageScroll';
 import SubnavPills from './SubnavPills';
 import { SOCIAL_SHELL_TAB_CONFIG } from './tabConfig';
@@ -65,7 +70,9 @@ const LeaderboardShellTabPage: React.FC<LeaderboardShellTabPageProps> = ({
       {hasBeenActive && (
         <TopTradersView
           pinnedTypeFilter="all"
-          rowVariant="socialV1"
+          RowComponent={SocialV1TraderRow}
+          SkeletonComponent={SocialV1TraderRowSkeleton}
+          rowHeight={SOCIAL_V1_TRADER_ROW_HEIGHT}
           onScroll={onScroll}
           pageRef={pageRef}
         />

--- a/app/components/Views/SocialLeaderboard/utils/formatters.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.ts
@@ -9,11 +9,23 @@ import {
 } from '../../../../util/number';
 import { DAY, HOUR, MINUTE } from '../../../../constants/time';
 import { toDateFormat, formatTimestampToYYYYMMDD } from '../../../../util/date';
-import { strings } from '../../../../../locales/i18n';
+import { getIntlNumberFormatter } from '../../../../util/intl';
+import I18n, { strings } from '../../../../../locales/i18n';
 import { tradeTimestampToMs } from './tradeTimestamp';
 
 /** Placeholder rendered wherever a numeric value is unavailable. */
 export const EM_DASH = '\u2014';
+
+/**
+ * Whole count with locale digit grouping (e.g. `48,707`). Use for tallies such
+ * as follower counts, where there is no currency, sign or decimal component.
+ */
+export function formatCount(value: number | null | undefined): string {
+  if (value == null) return EM_DASH;
+  return getIntlNumberFormatter(I18n.locale, {
+    maximumFractionDigits: 0,
+  }).format(value);
+}
 
 /**
  * USD for social leaderboard rows/cards: match perps-style fiat (always two

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1269,6 +1269,7 @@
     },
     "follow": "Follow",
     "following": "Following",
+    "win_rate_tag": "{{winRate}} WR",
     "mute": {
       "on_accessibility_label": "Notifications on. Tap to mute this trader",
       "muted_accessibility_label": "Muted. Tap to turn notifications back on",

--- a/tests/component-view/api-mocking/socialLeaderboard.ts
+++ b/tests/component-view/api-mocking/socialLeaderboard.ts
@@ -32,6 +32,7 @@ export interface MockLeaderboardEntry {
   winRate7d: number;
   winRate30d: number;
   pnlPerChain: Record<string, number>;
+  followerCount: number;
 }
 
 /**
@@ -59,6 +60,7 @@ export const mockLeaderboardTraders: MockLeaderboardEntry[] = [
     winRate7d: 0.92,
     winRate30d: 0.88,
     pnlPerChain: { base: 500_000, ethereum: 463_146.8 },
+    followerCount: 48_707,
   },
   {
     profileId: 'trader-2',
@@ -73,6 +75,7 @@ export const mockLeaderboardTraders: MockLeaderboardEntry[] = [
     winRate7d: 0.61,
     winRate30d: 0.58,
     pnlPerChain: { base: 474_751.45 },
+    followerCount: 21_999,
   },
   {
     profileId: 'trader-3',
@@ -87,6 +90,7 @@ export const mockLeaderboardTraders: MockLeaderboardEntry[] = [
     winRate7d: 0.48,
     winRate30d: 0.52,
     pnlPerChain: { hyperliquid: 374_735.16 },
+    followerCount: 11_772,
   },
 ];
 


### PR DESCRIPTION
## **Description**

Fills in the **Leaderboard** tab of the Social Bundle V1 shell. It was rendering
an empty placeholder; it now shows the real ranked trader list, with a row
design built for this surface.

### What you get

Opening Follow Trading → **Leaderboard** now shows:

- The leaderboard subnav pills (Top traders / Top perps / KOLs) pinned above the
  list. The list itself covers every position type — the per-subnav rankings
  land in later tickets, so for now the pills only carry their selected state.
- A ranked trader list using a new, denser row: avatar with rank medal,
  username, a win-rate tag (trophy treatment at ≥90% WR), follower count
  underneath, and a right-aligned column with the ranked metric over ROI.
- No Follow button or mute chip — this surface is read-only, unlike the legacy
  leaderboard row.

The Time frame and Sort by filters work as they do today. The position-type
filter is hidden here, because the subnav above the list owns that axis.

The list is only mounted once you actually open the tab, so landing on Feed
doesn't fetch the leaderboard or fire its screen-viewed event. Once opened it
stays mounted, so tabbing away and back doesn't refetch.

### How it's fenced

Everything here lives behind the existing **`socialAiTSA1122AbtestSocialBundleV1`**
A/B flag (LaunchDarkly, `control` | `treatment`). No new flag is introduced.

```
navigateToSocialLeaderboard()
   └── isSocialV1Treatment()
         ├── treatment → Routes.SOCIAL.V1 → SocialV1View   ← all new code lives here
         └── control   → Routes.SOCIAL.V0 → SocialV0View   ← untouched
```

`LeaderboardShellTabPage` and the new row components are only ever rendered from
`SocialV1View`, which control users never reach. The whole feature also stays
behind `selectSocialLeaderboardEnabled`, as before.

**The legacy V0 leaderboard is unchanged.** `TraderRowSkeleton.tsx` isn't touched
at all, and `TraderRow.tsx`'s only change is that two type definitions moved to
`types.ts` — no render-tree change.

### Structure

```
SocialV1View                             (existing 3-tab shell)
└── LeaderboardShellTabPage              NEW — the leaderboard tab
    ├── SubnavPills                      (existing)
    └── TopTradersView                   (shared with V0)
        ├── RowComponent      ─────────► SocialV1TraderRow           NEW
        ├── SkeletonComponent ─────────► SocialV1TraderRowSkeleton   NEW
        └── rowHeight         ─────────► SOCIAL_V1_TRADER_ROW_HEIGHT
```

The V1 rows are **separate components**, not a variant flag on the V0 row — the
two layouts share almost no markup, and keeping them apart means V1 changes
can't regress the live V0 surface.

`TopTradersView` is deliberately **shared** rather than forked: the filter state,
tab queries, follow/mute wiring and analytics are genuinely common, and
duplicating them would be the expensive half. It takes the presentation as
props instead:

```ts
RowComponent?: React.ComponentType<TraderRowProps>;  // default: TraderRow
SkeletonComponent?: React.ComponentType;             // default: TraderRowSkeleton
rowHeight?: number;                                  // default: TRADER_ROW_HEIGHT
pinnedTypeFilter?: SocialTypeFilter;                 // default: unpinned
```

V0 passes none of these and keeps today's behavior. `LeaderboardShellTabPage`
passes the V1 trio plus `pinnedTypeFilter="all"`, which hides the type pill and
sheet, seeds the query state, and skips the secondary-tab prefetch and
perps-flag reconciliation (a pinned list can never switch type, so there's
nothing to warm).

#### New files

| File | Role |
| --- | --- |
| `SocialLeaderboard/shell/LeaderboardShellTabPage.tsx` | The leaderboard tab: subnav + list |
| `SocialLeaderboard/TopTradersView/components/SocialV1TraderRow.tsx` | The V1 row; owns `SOCIAL_V1_TRADER_ROW_HEIGHT` |
| `SocialLeaderboard/TopTradersView/components/SocialV1TraderRowSkeleton.tsx` | Loading placeholder matching that row |

#### Supporting changes

- `TraderRowMetric` and `TraderRowProps` moved to `TopTraders/types.ts`. They're
  shared vocabulary — `traderMetric.ts` builds the metric and both rows consume
  it — and `TraderRowProps` is the contract that lets a row be injected.
- `followerCount` added to `TopTrader`, mapped in `useTopTraders`.
- New `formatCount` helper for locale-grouped whole numbers (e.g. `48,707`).
- New `social_leaderboard.win_rate_tag` string.

> [!NOTE]
> `followerCount` is non-optional on `TopTrader` and falls back to `0`, so the V1
> rows would read "0 followers" if the leaderboard API isn't returning the field
> yet. Worth confirming it's live before merge. V0 never renders it.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TSA-1131](https://consensyssoftware.atlassian.net/browse/TSA-1131)

## **Manual testing steps**

```gherkin
Feature: Social Bundle V1 leaderboard tab

  Scenario: user opens the Leaderboard tab and sees the ranked list
    Given the user is in the Social V1 treatment and lands on the Feed tab
    When user taps the "Leaderboard" tab
    Then the leaderboard subnav pills render pinned above the list
    And the ranked trader list loads with the denser Social V1 rows
    And each row shows the avatar with rank medal, username, win-rate tag,
        follower count, and the ranked metric over ROI right-aligned
    And no Follow button or mute chip appears on any row

  Scenario: user sees no position-type filter on the leaderboard tab
    Given the user is on the Leaderboard tab of the Social V1 shell
    Then the Time frame and Sort by pills are shown
    And the position-type pill is not shown
    And the list covers every position type

  Scenario: user leaves and returns to the Leaderboard tab
    Given the user has opened the Leaderboard tab and the list has loaded
    When user switches to another tab and back to "Leaderboard"
    Then the list is still populated and does not refetch from scratch
    And the collapsing title keeps its scroll offset

  Scenario: user never opens the Leaderboard tab
    Given the Social V1 shell has just opened on the Feed tab
    Then no leaderboard request is issued
    And no leaderboard screen-viewed analytics event is emitted

  Scenario: loading placeholders match the rows they replace
    Given the Leaderboard tab is opened with a cold cache
    Then the skeleton rows match the Social V1 row height and layout
    And the list does not shift when the real rows arrive

  Scenario: high win-rate trader is highlighted
    Given the leaderboard contains a trader with a win rate of 90% or more
    Then that trader's win-rate tag uses the trophy treatment

  Scenario: control users are unaffected
    Given the user is in the Social V1 control group
    When user opens Follow Trading
    Then the legacy two-tab leaderboard opens
    And rows render with the original Follow-button treatment and 71px height
    And the position-type filter pill and sheet still work
```

## **Screenshots/Recordings**

### **Before**

<!-- Leaderboard tab rendering the empty placeholder — recording pending. -->

### **After**

<!-- Leaderboard tab with pinned subnav + Social V1 rows — recording pending. -->

> [!NOTE]
> Recordings still to be attached before this leaves draft.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TSA-1131]: https://consensyssoftware.atlassian.net/browse/TSA-1131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shared TopTradersView query/filter logic changed for pinned-type mode; V0 defaults unchanged but regression risk on the live leaderboard. followerCount falls back to 0 if the API omits the field, which would show misleading counts on V1 rows.
> 
> **Overview**
> The **Social V1 Leaderboard tab** no longer uses an empty shell: it renders **`LeaderboardShellTabPage`** with subnav pills above the shared **`TopTradersView`** list. The list mounts only after the tab is first opened (avoiding fetch and screen-viewed analytics on Feed landing) and stays mounted when you switch away.
> 
> **`TopTradersView`** now accepts injectable **`RowComponent`**, **`SkeletonComponent`**, **`rowHeight`**, and **`pinnedTypeFilter`**. V0 keeps the legacy Follow-button row; V1 injects **`SocialV1TraderRow`** (win-rate tag with trophy at ≥90%, follower count, ranked metric + ROI, no Follow/mute) and hides the position-type filter when type is pinned to **`all`**.
> 
> Data and shared types: **`followerCount`** on **`TopTrader`** (mapped in **`useTopTraders`**, default `0`), **`TraderRowProps`** / **`TraderRowMetric`** moved to **`types.ts`**, plus **`formatCount`** and **`social_leaderboard.win_rate_tag`** for the new row copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fee361a97a585fbb4ee9e5d65ef1ca6287cf1ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->