### PR TITLE
fix(perps): update triggered order type descriptions cp-8.11.0

### DIFF
--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.test.tsx
@@ -85,16 +85,17 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'perps.order.type.triggered': 'Triggered',
       'perps.order.type.advanced': 'Advanced',
       'perps.order.type.stop_limit.title': 'Stop limit',
-      'perps.order.type.stop_limit.description': 'Limit fills at trigger price',
+      'perps.order.type.stop_limit.description':
+        'Place a limit order if trigger price hits',
       'perps.order.type.stop_market.title': 'Stop market',
       'perps.order.type.stop_market.description':
-        'Market fills at trigger price',
+        'Place a market order if trigger price hits',
       'perps.order.type.take_profit_limit.title': 'Take limit',
       'perps.order.type.take_profit_limit.description':
-        'Limit take-profit at trigger price',
+        'Place a limit order if trigger price is reached',
       'perps.order.type.take_profit_market.title': 'Take market',
       'perps.order.type.take_profit_market.description':
-        'Market take-profit at trigger price',
+        'Place a market order if trigger price is reached',
       'perps.order.type.twap.title': 'TWAP',
       'perps.order.type.twap.description':
         'Split orders to execute at regular time interval',
@@ -203,16 +204,16 @@ describe('PerpsOrderTypeBottomSheet', () => {
       );
 
       expect(
-        screen.getByText('Limit fills at trigger price'),
+        screen.getByText('Place a limit order if trigger price hits'),
       ).toBeOnTheScreen();
       expect(
-        screen.getByText('Market fills at trigger price'),
+        screen.getByText('Place a market order if trigger price hits'),
       ).toBeOnTheScreen();
       expect(
-        screen.getByText('Limit take-profit at trigger price'),
+        screen.getByText('Place a limit order if trigger price is reached'),
       ).toBeOnTheScreen();
       expect(
-        screen.getByText('Market take-profit at trigger price'),
+        screen.getByText('Place a market order if trigger price is reached'),
       ).toBeOnTheScreen();
     });
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1920,19 +1920,19 @@
         },
         "stop_limit": {
           "title": "Stop limit",
-          "description": "Limit fills at trigger price"
+          "description": "Place a limit order if trigger price hits"
         },
         "stop_market": {
           "title": "Stop market",
-          "description": "Market fills at trigger price"
+          "description": "Place a market order if trigger price hits"
         },
         "take_profit_limit": {
           "title": "Take limit",
-          "description": "Limit take-profit at trigger price"
+          "description": "Place a limit order if trigger price is reached"
         },
         "take_profit_market": {
           "title": "Take market",
-          "description": "Market take-profit at trigger price"
+          "description": "Place a market order if trigger price is reached"
         },
         "twap": {
           "title": "TWAP",


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Triggered order type descriptions in the Perps order type bottom sheet were using outdated copy. This updates them to the approved Figma strings ([TAT-3954](https://consensyssoftware.atlassian.net/browse/TAT-3954)):

- **Stop limit:** Place a limit order if trigger price hits
- **Stop market:** Place a market order if trigger price hits
- **Take limit:** Place a limit order if trigger price is reached
- **Take market:** Place a market order if trigger price is reached

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Updated triggered order type descriptions in Perps

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3954

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Triggered order type descriptions

  Scenario: user views triggered order types
    Given the user is on a Perps market order form
    And triggered orders are enabled

    When the user opens the order type bottom sheet
    And the user selects the Triggered tab
    Then the Stop limit description reads "Place a limit order if trigger price hits"
    And the Stop market description reads "Place a market order if trigger price hits"
    And the Take limit description reads "Place a limit order if trigger price is reached"
    And the Take market description reads "Place a market order if trigger price is reached"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — copy-only change (previous: "Limit/Market fills at trigger price" variants).

### **After**

N/A — copy-only change matching [Figma](https://www.figma.com/design/RKxgK44BoVRyKtmjjP4SFc/PERPS---13-Jul---xx-Nov?node-id=11092-41481).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TAT-3954]: https://consensyssoftware.atlassian.net/browse/TAT-3954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only locale and test updates; no trading logic or component behavior changes.
> 
> **Overview**
> Updates **triggered** Perps order type helper text in English (`locales/languages/en.json`) to match approved Figma copy (TAT-3954). Descriptions for **Stop limit**, **Stop market**, **Take limit**, and **Take market** now explain that a limit or market order is placed when the trigger price hits or is reached, instead of the older “fills at trigger price” wording.
> 
> `PerpsOrderTypeBottomSheet.test.tsx` mock i18n strings and the Triggered-tab assertions are aligned with the new copy so UI tests still pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6c80936c47ae791c2f6891c825cfbb8a9993e85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->