### PR TITLE
fix(watchlist): center empty-state copy when translations wrap

### DIFF
--- a/app/components/Views/Homepage/Sections/Watchlist/WatchlistSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Watchlist/WatchlistSection.test.tsx
@@ -192,6 +192,10 @@ describe('WatchlistSection', () => {
     expect(getByTestId('watchlist-empty-icon')).toBeDefined();
     expect(getAllByText('Watchlist').length).toBeGreaterThanOrEqual(1);
     expect(getByText('You have no watchlist items yet')).toBeDefined();
+    // Translations long enough to wrap fall back to left alignment without this.
+    expect(getByText('You have no watchlist items yet')).toHaveStyle({
+      textAlign: 'center',
+    });
   });
 
   it('renders up to 3 tokens when watchlist has items (newest first)', () => {

--- a/app/components/Views/Homepage/Sections/Watchlist/components/WatchlistEmptyState.tsx
+++ b/app/components/Views/Homepage/Sections/Watchlist/components/WatchlistEmptyState.tsx
@@ -29,10 +29,18 @@ const WatchlistEmptyState: React.FC = () => {
         height={78}
         testID="watchlist-empty-icon"
       />
-      <Text variant={TextVariant.HeadingSm} color={TextColor.TextDefault}>
+      <Text
+        variant={TextVariant.HeadingSm}
+        color={TextColor.TextDefault}
+        twClassName="text-center"
+      >
         {strings('token_watchlist.home_empty_title')}
       </Text>
-      <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+      <Text
+        variant={TextVariant.BodyMd}
+        color={TextColor.TextAlternative}
+        twClassName="text-center"
+      >
         {strings('token_watchlist.home_empty_subtitle')}
       </Text>
     </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The homepage watchlist empty state centered its children with `alignItems: center` on the wrapping `Box`, which only centers each `Text` as a block. English copy fits on one line, so it looked centered. Longer translations (Greek, and any other locale that wraps) fall back to left alignment inside the text block.

This sets `twClassName="text-center"` on both the title and description so wrapped lines stay centered in every language. The existing empty-state unit test now asserts `textAlign: 'center'` on the subtitle.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed watchlist empty-state copy not staying centered when translations wrap onto multiple lines

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Watchlist empty-state text alignment

  Background:
    Given I am logged into MetaMask Mobile
    And my watchlist has no items

  Scenario: wrapped empty-state copy stays centered
    Given the app language is set to Greek
    And I am on the Wallet home screen

    When the watchlist empty state is visible
    Then the title and description are horizontally centered
    And wrapped description lines stay centered rather than left-aligned

  Scenario: English empty state remains centered
    Given the app language is English
    And I am on the Wallet home screen

    When the watchlist empty state is visible
    Then the title and description remain centered
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="600" alt="Watchlist empty state in Greek with left-aligned wrapped description" src="https://github.com/user-attachments/assets/69c77893-6d19-4c56-85ff-53c94001dc69" />

### **After**

<!-- [screenshots/recordings] -->

<img width="600" alt="Watchlist empty state in Greek with centered wrapped description" src="https://github.com/user-attachments/assets/c432b341-46f2-4b59-a716-7e4c6c160535" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only text alignment on the watchlist empty state with a unit test; no auth, data, or navigation changes.
> 
> **Overview**
> **Centers watchlist empty-state copy when strings wrap** in locales with longer translations (e.g. Greek), where `Box` `alignItems: center` only centered each `Text` block but wrapped lines stayed left-aligned.
> 
> `WatchlistEmptyState` now applies `twClassName="text-center"` on the title and subtitle `Text` components (same pattern as other empty states). The watchlist section test asserts `textAlign: 'center'` on the empty subtitle string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16ecc83ba2a98728ad417ad0199e00c6a3e2ad3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->