### PR TITLE
fix(money): wrap no-fee tag so long translations don't overflow

### DIFF
--- a/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.test.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.test.tsx
@@ -172,6 +172,23 @@ describe('PotentialEarningsTokenRow', () => {
     ).toBeOnTheScreen();
   });
 
+  it('lets the "No fee" tag wrap below the token name instead of overflowing the row', () => {
+    const { getByTestId } = render(
+      <PotentialEarningsTokenRow
+        token={MOCK_USDC}
+        hasSubsidizedFee
+        apyDecimal={0.2}
+        onCardPress={jest.fn()}
+        onButtonPress={jest.fn()}
+      />,
+    );
+
+    // Without wrapping, longer translations of the tag render over the Add button.
+    expect(getByTestId(PotentialEarningsTokenRowTestIds.NAME_ROW)).toHaveStyle({
+      flexWrap: 'wrap',
+    });
+  });
+
   it('hides the "No fee" tag when hasSubsidizedFee is false', () => {
     const { queryByText } = render(
       <PotentialEarningsTokenRow

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.testIds.ts
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.testIds.ts
@@ -1,4 +1,5 @@
 export const PotentialEarningsTokenRowTestIds = {
   BALANCE: 'potential-earnings-token-row-balance',
   PROJECTED: 'potential-earnings-token-row-projected',
+  NAME_ROW: 'potential-earnings-token-row-name-row',
 } as const;

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.tsx
@@ -8,6 +8,7 @@ import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
+  BoxFlexWrap,
   Button,
   ButtonSize,
   ButtonVariant,
@@ -124,7 +125,9 @@ const PotentialEarningsTokenRow = ({
             <Box
               flexDirection={BoxFlexDirection.Row}
               alignItems={BoxAlignItems.Center}
+              flexWrap={BoxFlexWrap.Wrap}
               twClassName="gap-1"
+              testID={PotentialEarningsTokenRowTestIds.NAME_ROW}
             >
               <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
                 {token.name || token.symbol}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Money tab potential-earnings row puts the token name and the "No fee" tag in a single non-wrapping flex row. English copy ("No fee") fits beside the name. Longer translations (Greek: "Χωρίς τέλος συναλλαγής") overflow the row and paint over the Add button, because React Native flex children default to `flexShrink: 0` and overflow is visible.

This sets `flexWrap={BoxFlexWrap.Wrap}` on the name/tag row so the tag drops onto its own line when it no longer fits. Short translations stay inline; long ones wrap with the existing `gap-1`. A unit test asserts the wrap style so the overflow cannot regress silently.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Money tab "No fee" tag overflowing the Add button when translations are longer than English

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: No tracking issue; found during localized QA of the Money tab.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money tab no-fee tag wrapping

  Background:
    Given I am logged into MetaMask Mobile
    And I have a subsidized-fee token such as MetaMask USD in the Money tab list

  Scenario: long translation wraps the tag below the token name
    Given the app language is set to Greek
    And I am on the Money tab

    When the potential earnings list is visible
    Then the "No fee" tag sits on its own row under the token name
    And the tag does not overlap the Add button

  Scenario: short translation stays inline
    Given the app language is English
    And I am on the Money tab

    When the potential earnings list is visible
    Then the "No fee" tag remains on the same row as the token name
    And the Add button stays fully visible
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="600" alt="Greek Money tab row with the no-fee tag overflowing over the Add button" src="https://github.com/user-attachments/assets/a3ca376c-88c4-4d54-a2c5-d92d8e6c2dc0" />

### **After**

<!-- [screenshots/recordings] -->

<img width="600" alt="Greek Money tab row with the no-fee tag wrapped onto its own line" src="https://github.com/user-attachments/assets/8b5733b8-d9d8-4de5-8d36-ab23361583ef" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI layout change in one Money list row with a style assertion test; no auth, data, or payment logic touched.
> 
> **Overview**
> Fixes a **Money tab** layout bug where the subsidized **"No fee"** tag could draw over the **Add** button when localized strings are longer than English.
> 
> The token name and tag row in `PotentialEarningsTokenRow` now uses **`flexWrap`** so the tag can move to a second line while keeping the existing gap; a **`NAME_ROW`** test ID was added and a unit test locks in **`flexWrap: 'wrap'`** so the overflow cannot regress silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a7c9ebcc91a65adcb5693baa5d752d2bb0a775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->