### PR TITLE
fix(confirmations): patch transaction pay controller for predict deposit-order

### DIFF
--- a/.yarn/patches/@metamask-transaction-pay-controller-npm-27.1.1-predict-deposit-order-exact-output.patch
+++ b/.yarn/patches/@metamask-transaction-pay-controller-npm-27.1.1-predict-deposit-order-exact-output.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/strategy/relay/relay-quotes.cjs b/dist/strategy/relay/relay-quotes.cjs
+--- a/dist/strategy/relay/relay-quotes.cjs
++++ b/dist/strategy/relay/relay-quotes.cjs
+@@ -196,7 +196,8 @@
+         }
+         const hasTransactions = Boolean(body.txs?.length);
+         const requiresExactOutput = hasTransactions ||
+-            transaction.type === transaction_controller_1.TransactionType.perpsDepositAndOrder;
++            transaction.type === transaction_controller_1.TransactionType.perpsDepositAndOrder ||
++            transaction.type === transaction_controller_1.TransactionType.predictDepositAndOrder;
+         const finalBody = {
+             ...body,
+             amount: body.amount ??
+diff --git a/dist/strategy/relay/relay-quotes.mjs b/dist/strategy/relay/relay-quotes.mjs
+--- a/dist/strategy/relay/relay-quotes.mjs
++++ b/dist/strategy/relay/relay-quotes.mjs
+@@ -193,7 +193,8 @@
+         }
+         const hasTransactions = Boolean(body.txs?.length);
+         const requiresExactOutput = hasTransactions ||
+-            transaction.type === TransactionType.perpsDepositAndOrder;
++            transaction.type === TransactionType.perpsDepositAndOrder ||
++            transaction.type === TransactionType.predictDepositAndOrder;
+         const finalBody = {
+             ...body,
+             amount: body.amount ??

--- a/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
@@ -95,14 +95,16 @@ describe('TotalRow', () => {
       expect(getByText(TOTAL_FIAT_MOCK)).toBeDefined();
     });
 
-    it('renders the total amount for an explicitly output-based quote', () => {
+    it('renders the total amount for predictDepositAndOrder output-based quotes', () => {
       useTransactionPayTotalsMock.mockReturnValue({
         isInputBased: false,
         total: { usd: '123.456' },
         targetAmount: { usd: '99.38', fiat: '99.38' },
       } as unknown as TransactionPayTotals);
 
-      const { getByTestId, getByText } = render();
+      const { getByTestId, getByText } = render({
+        type: TransactionType.predictDepositAndOrder,
+      });
 
       expect(getByTestId('total-row')).toBeOnTheScreen();
       expect(getByText(TOTAL_FIAT_MOCK)).toBeDefined();
@@ -149,14 +151,16 @@ describe('TotalRow', () => {
       expect(queryByTestId('total-row')).toBeNull();
     });
 
-    it('renders the receive row for input-based quotes', () => {
+    it('renders the receive row for plain predict deposits that stay input-based', () => {
       useTransactionPayTotalsMock.mockReturnValue({
         isInputBased: true,
         total: { usd: '100', fiat: '100' },
         targetAmount: { usd: '99.38', fiat: '99.38' },
       } as unknown as TransactionPayTotals);
 
-      const { getByTestId, getByText, queryByTestId } = render();
+      const { getByTestId, getByText, queryByTestId } = render({
+        type: TransactionType.predictDeposit,
+      });
 
       expect(getByTestId('receive-row')).toBeOnTheScreen();
       expect(getByText(RECEIVE_FIAT_MOCK)).toBeOnTheScreen();

--- a/package.json
+++ b/package.json
@@ -403,7 +403,7 @@
     "@metamask/superstruct": "^3.2.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/transaction-controller": "^69.7.0",
-    "@metamask/transaction-pay-controller": "^27.1.1",
+    "@metamask/transaction-pay-controller": "patch:@metamask/transaction-pay-controller@npm%3A27.1.1#~/.yarn/patches/@metamask-transaction-pay-controller-npm-27.1.1-predict-deposit-order-exact-output.patch",
     "@metamask/tron-wallet-snap": "^3.2.0",
     "@metamask/utils": "^11.11.0",
     "@metamask/wallet": "^12.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12392,7 +12392,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:^27.1.1":
+"@metamask/transaction-pay-controller@npm:27.1.1":
   version: 27.1.1
   resolution: "@metamask/transaction-pay-controller@npm:27.1.1"
   dependencies:
@@ -12418,6 +12418,35 @@ __metadata:
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
   checksum: 10/d4ae68fb02011cfc730dcea823e2dc2e2f198eb2e1bbe6c4f9e0fc716815d4c8b3ad26d0da760e0bbce84d1d46a142118306ea920a3c7f84297cb82c33743c8a
+  languageName: node
+  linkType: hard
+
+"@metamask/transaction-pay-controller@patch:@metamask/transaction-pay-controller@npm%3A27.1.1#~/.yarn/patches/@metamask-transaction-pay-controller-npm-27.1.1-predict-deposit-order-exact-output.patch":
+  version: 27.1.1
+  resolution: "@metamask/transaction-pay-controller@patch:@metamask/transaction-pay-controller@npm%3A27.1.1#~/.yarn/patches/@metamask-transaction-pay-controller-npm-27.1.1-predict-deposit-order-exact-output.patch::version=27.1.1&hash=56d3b8"
+  dependencies:
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/assets-controller": "npm:^14.0.3"
+    "@metamask/assets-controllers": "npm:^111.1.3"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/gas-fee-controller": "npm:^26.3.2"
+    "@metamask/keyring-controller": "npm:^27.1.1"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/network-controller": "npm:^36.0.0"
+    "@metamask/ramps-controller": "npm:^20.2.0"
+    "@metamask/remote-feature-flag-controller": "npm:^6.1.0"
+    "@metamask/sentinel-api-service": "npm:^1.0.1"
+    "@metamask/transaction-controller": "npm:^69.7.0"
+    "@metamask/utils": "npm:^11.11.0"
+    bignumber.js: "npm:^9.1.2"
+    bn.js: "npm:^5.2.1"
+    immer: "npm:^9.0.6"
+    lodash: "npm:^4.17.21"
+  checksum: 10/431bd1fb0138e8e93a2891d81f0b64586ed6453270f6a377c5afa865a6e2b6190c5745d44d5b5fdc478e59de1408ecfba31e02c414bedaf8ab54ec4e581815b6
   languageName: node
   linkType: hard
 
@@ -39837,7 +39866,7 @@ __metadata:
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/tooling-insight": "npm:^1.0.1"
     "@metamask/transaction-controller": "npm:^69.7.0"
-    "@metamask/transaction-pay-controller": "npm:^27.1.1"
+    "@metamask/transaction-pay-controller": "patch:@metamask/transaction-pay-controller@npm%3A27.1.1#~/.yarn/patches/@metamask-transaction-pay-controller-npm-27.1.1-predict-deposit-order-exact-output.patch"
     "@metamask/tron-wallet-snap": "npm:^3.2.0"
     "@metamask/utils": "npm:^11.11.0"
     "@metamask/wallet": "npm:^12.0.3"


### PR DESCRIPTION
# fix(confirmations): patch transaction pay controller for predict deposit-order

## **Description**

This backports the `predictDepositAndOrder` Relay quoting fix from MetaMask/core PR #10173 as a Yarn patch on the 8.11.0 release branch instead of bumping `@metamask/transaction-pay-controller` to a newer version.

That keeps the scope focused while restoring `EXACT_OUTPUT` quoting for Predict deposit-and-order flows and leaving plain `predictDeposit` flows on `EXACT_INPUT`.

## **Changelog**

CHANGELOG entry: Fixed Predict deposit-and-order Relay quotes to preserve exact-output sizing

## **Related issues**

Refs: MetaMask/core#10173

## **Manual testing steps**

```gherkin
Feature: Predict deposit-and-order Relay quotes

  Scenario: request exact output for deposit-and-order flows
    Given the patched transaction pay controller is installed on the 8.11.0 release branch
    When the relay quote strategy evaluates a predictDepositAndOrder transaction
    Then it requests EXACT_OUTPUT with targetAmountMinimum
    And plain predictDeposit transactions continue to request EXACT_INPUT
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Relay quote sizing for Predict deposit-and-order flows (money movement), though the logic mirrors existing perps deposit-and-order behavior and scope is limited to a targeted dependency patch.
> 
> **Overview**
> Backports the **Predict deposit-and-order** Relay quoting fix (MetaMask/core#10173) by **Yarn-patching** `@metamask/transaction-pay-controller@27.1.1` instead of bumping the package on the 8.11.0 release branch.
> 
> The patch treats `TransactionType.predictDepositAndOrder` like `perpsDepositAndOrder` when building Relay quote bodies, so those flows request **EXACT_OUTPUT** (with target minimum sizing). Plain **`predictDeposit`** flows are unchanged and stay **EXACT_INPUT**.
> 
> `package.json` / `yarn.lock` now resolve the controller through the new patch file. **`TotalRow`** tests are tightened to pass explicit transaction types so output-based deposit-and-order vs input-based plain deposit expectations stay documented.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6fece46b185fdad5830e066e228dd2dc692fe67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->