### PR TITLE
feat: limit orders dest amount and default buy/sell selection

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.test.tsx
@@ -109,17 +109,21 @@ jest.mock('./BridgeLimitOrderFooterView', () => ({
 
 jest.mock('../../../components/SwapsInputs', () => {
   const ReactActual = jest.requireActual('react');
-  const { View, TextInput } = jest.requireActual('react-native');
+  const { View, Text, TextInput } = jest.requireActual('react-native');
 
   return {
     SwapsInputs: ({
       sourceTokenAreaTestID,
       destTokenAreaTestID,
+      destTokenAmount,
       onSourceInputPress,
+      onFlipPress,
     }: {
       sourceTokenAreaTestID?: string;
       destTokenAreaTestID?: string;
+      destTokenAmount?: string;
       onSourceInputPress?: () => void;
+      onFlipPress?: () => void;
     }) => (
       <View>
         <TextInput
@@ -129,6 +133,8 @@ jest.mock('../../../components/SwapsInputs', () => {
         <View testID={sourceTokenAreaTestID} />
         <View testID={destTokenAreaTestID} />
         <TextInput testID="limit-dest-token-area-input" />
+        <Text testID="limit-dest-token-amount">{destTokenAmount}</Text>
+        <View testID="limit-flip-tokens" onTouchEnd={onFlipPress} />
       </View>
     ),
   };
@@ -246,6 +252,7 @@ const mockHandleCustomPress = jest.fn();
 const mockFocusCustomPercent = jest.fn();
 const mockFocusAmount = jest.fn();
 const mockFocusLimitPrice = jest.fn();
+const mockHandleFlipTokensPress = jest.fn();
 
 let mockIsAmountFocused = false;
 let mockIsCustomPercentFocused = false;
@@ -254,11 +261,9 @@ let mockSourceAmount = '';
 function buildSwapInputsMock() {
   return {
     destToken: mockDestToken,
-    // Limit orders do not quote a destination amount.
-    destTokenAmount: '',
     enabledChainIds: ['eip155:1'] as CaipChainId[],
     handleDestTokenPress: jest.fn(),
-    handleFlipTokensPress: jest.fn(),
+    handleFlipTokensPress: mockHandleFlipTokensPress,
     handleSourceMaxPress: jest.fn(),
     handleSourcePresetAmountSelect: jest.fn(),
     handleSourceTokenPress: jest.fn(),
@@ -290,6 +295,7 @@ function buildSwapInputsMock() {
 function buildPriceAdjustMock() {
   return {
     commitCustomPercent: mockCommitCustomPercent,
+    counterFiatRate: undefined,
     counterToken: mockSourceToken,
     customValue: '',
     handleCustomPress: mockHandleCustomPress,
@@ -390,6 +396,51 @@ describe('BridgeLimitOrderView', () => {
     expect(
       getByTestId(BridgeViewSelectorsIDs.LIMIT_DEST_TOKEN_INPUT),
     ).toBeOnTheScreen();
+  });
+
+  it('renders the destination amount the source amount buys at the limit price', () => {
+    mockSourceAmount = '2';
+    jest.mocked(useSwapsLimitOrderPriceAdjust).mockImplementation(() => ({
+      ...buildPriceAdjustMock(),
+      limitPrice: '3000',
+    }));
+
+    const { getByTestId } = renderLimitOrderView();
+
+    // 2 * 3000 = 6000, minus the 0.875% quote fee.
+    expect(getByTestId('limit-dest-token-amount')).toHaveTextContent('5947.5');
+  });
+
+  it('renders a zero destination amount before a source amount is entered', () => {
+    mockSourceAmount = '';
+
+    const { getByTestId } = renderLimitOrderView();
+
+    expect(getByTestId('limit-dest-token-amount')).toHaveTextContent('0');
+  });
+
+  it('flips the tokens with the destination amount as the new source amount', () => {
+    mockSourceAmount = '2';
+    jest.mocked(useSwapsLimitOrderPriceAdjust).mockImplementation(() => ({
+      ...buildPriceAdjustMock(),
+      limitPrice: '3000',
+    }));
+
+    const { getByTestId } = renderLimitOrderView();
+
+    fireEvent(getByTestId('limit-flip-tokens'), 'touchEnd');
+
+    expect(mockHandleFlipTokensPress).toHaveBeenCalledWith('5947.5');
+  });
+
+  it('flips the tokens without an amount when the destination amount is zero', () => {
+    mockSourceAmount = '';
+
+    const { getByTestId } = renderLimitOrderView();
+
+    fireEvent(getByTestId('limit-flip-tokens'), 'touchEnd');
+
+    expect(mockHandleFlipTokensPress).toHaveBeenCalledWith(undefined);
   });
 
   it('does not render recurring You get copy on the dest token row', () => {

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { ScrollView, type LayoutChangeEvent } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
@@ -52,6 +58,7 @@ import {
   getCurrencySymbol,
 } from '../../../utils/currencyUtils';
 import { formatAmountWithLocaleSeparators } from '../../../utils/formatAmountWithLocaleSeparators';
+import { getSwapsLimitOrderDestTokenAmount } from '../../../utils/limitOrders/getSwapsLimitOrderDestTokenAmount';
 import { strings } from '../../../../../../../locales/i18n';
 import { useHasMissingAssetsPriceData } from '../../../hooks/useHasMissingAssetsPriceData';
 import { useIsHardwareWalletForBridge } from '../../../hooks/useIsHardwareWalletForBridge';
@@ -78,7 +85,6 @@ const BridgeLimitOrderViewContent = ({
   const customPercentInputRef = useRef<ButtonPricePresetsSectionRef>(null);
   const {
     destToken,
-    destTokenAmount,
     enabledChainIds,
     handleDestTokenPress,
     handleFlipTokensPress,
@@ -93,6 +99,7 @@ const BridgeLimitOrderViewContent = ({
   } = useLimitOrderSwapInputs({ latestSourceBalance });
   const {
     commitCustomPercent,
+    counterFiatRate,
     counterToken,
     customValue,
     handleCustomPress,
@@ -138,6 +145,38 @@ const BridgeLimitOrderViewContent = ({
     onLimitPriceChange: handleLimitPriceChange,
     sourceAmountInput,
   });
+
+  // Limit orders are not quoted, so the destination amount is derived from the
+  // amount being paid and the price the order would trigger at.
+  const destTokenAmount = useMemo(
+    () =>
+      getSwapsLimitOrderDestTokenAmount({
+        counterFiatRate,
+        destTokenDecimals: destToken?.decimals,
+        executionType,
+        isLimitFiatMode,
+        limitPrice,
+        sourceAmount,
+      }),
+    [
+      counterFiatRate,
+      destToken?.decimals,
+      executionType,
+      isLimitFiatMode,
+      limitPrice,
+      sourceAmount,
+    ],
+  );
+
+  const handleFlipPress = useCallback(() => {
+    // A zero estimate is nothing to carry over, so the source input is cleared
+    // rather than seeded with it.
+    handleFlipTokensPress(
+      destTokenAmount && Number(destTokenAmount) > 0
+        ? destTokenAmount
+        : undefined,
+    );
+  }, [destTokenAmount, handleFlipTokensPress]);
 
   const isHardwareWallet = useIsHardwareWalletForBridge();
 
@@ -312,7 +351,7 @@ const BridgeLimitOrderViewContent = ({
               onSourceInputPress={onSourceInputPress}
               onSourceTokenPress={handleSourceTokenPress}
               onSourceMaxPress={handleSourceMaxPress}
-              onFlipPress={handleFlipTokensPress}
+              onFlipPress={handleFlipPress}
               onDestInputPress={closeKeypad}
               onDestTokenPress={handleDestTokenPress}
               sourceTokenAreaTestID={

--- a/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.test.ts
@@ -279,8 +279,8 @@ describe('useLimitOrderSwapInputs', () => {
     });
   });
 
-  describe('destination amount', () => {
-    it('is empty because limit orders do not quote a destination amount', () => {
+  describe('handleFlipTokensPress', () => {
+    it('switches the tokens with the destination amount so it becomes the source amount', () => {
       const { result } = renderLimitOrderSwapInputsHook(
         {
           sourceToken: getNativeSourceToken('eip155:1'),
@@ -290,12 +290,14 @@ describe('useLimitOrderSwapInputs', () => {
         ENABLED_CHAIN_IDS,
       );
 
-      expect(result.current.destTokenAmount).toBe('');
-    });
-  });
+      result.current.handleFlipTokensPress('3000');
 
-  describe('handleFlipTokensPress', () => {
-    it('switches the tokens with an empty amount so the source input is cleared', () => {
+      expect(mockResetToTokenMode).toHaveBeenCalledTimes(1);
+      expect(mockHandleSwitchTokens).toHaveBeenCalledWith('3000');
+      expect(mockSwitchTokens).toHaveBeenCalledTimes(1);
+    });
+
+    it('switches the tokens without an amount so the source input is cleared', () => {
       const { result } = renderLimitOrderSwapInputsHook(
         {
           sourceToken: getNativeSourceToken('eip155:1'),
@@ -307,8 +309,7 @@ describe('useLimitOrderSwapInputs', () => {
 
       result.current.handleFlipTokensPress();
 
-      expect(mockResetToTokenMode).toHaveBeenCalledTimes(1);
-      expect(mockHandleSwitchTokens).toHaveBeenCalledWith('');
+      expect(mockHandleSwitchTokens).toHaveBeenCalledWith(undefined);
       expect(mockSwitchTokens).toHaveBeenCalledTimes(1);
     });
   });

--- a/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.ts
+++ b/app/components/UI/Bridge/hooks/useLimitOrderSwapsInput/index.ts
@@ -88,7 +88,6 @@ export const useLimitOrderSwapInputs = ({
     onSourceAmountChange: handleSourceAmountChange,
     featureId: FeatureId.LIMIT_ORDER,
   });
-  const destTokenAmount: string | undefined = '';
   const { resetToTokenMode, syncFiatAmountToTokenAmount } = sourceAmountInput;
 
   const { handleSwitchTokens } = useSwitchTokens();
@@ -125,12 +124,15 @@ export const useLimitOrderSwapInputs = ({
     [dispatch, syncFiatAmountToTokenAmount],
   );
 
-  const handleFlipTokensPress = useCallback(() => {
-    resetToTokenMode();
-    handleSwitchTokens(destTokenAmount)().catch((error) => {
-      console.error('Error switching swap tokens:', error);
-    });
-  }, [destTokenAmount, handleSwitchTokens, resetToTokenMode]);
+  const handleFlipTokensPress = useCallback(
+    (destTokenAmount?: string) => {
+      resetToTokenMode();
+      handleSwitchTokens(destTokenAmount)().catch((error) => {
+        console.error('Error switching swap tokens:', error);
+      });
+    },
+    [handleSwitchTokens, resetToTokenMode],
+  );
 
   const handleSourceTokenPress = useCallback(() => {
     navigation.navigate(Routes.BRIDGE.TOKEN_SELECTOR, {
@@ -155,7 +157,6 @@ export const useLimitOrderSwapInputs = ({
   return {
     enabledChainIds,
     destToken,
-    destTokenAmount,
     handleDestTokenPress,
     handleFlipTokensPress,
     handleSourceMaxPress,

--- a/app/components/UI/Bridge/hooks/useStablecoinsDefaultSlippage/index.ts
+++ b/app/components/UI/Bridge/hooks/useStablecoinsDefaultSlippage/index.ts
@@ -10,10 +10,12 @@ export const StablecoinsByChainId: Partial<Record<Hex, Set<string>>> = {
   [CHAIN_IDS.MAINNET]: new Set([
     '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
     '0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
+    '0xaca92e438df0b2401ff60da7e4337b687a2435da', // mUSD
   ]),
   [CHAIN_IDS.LINEA_MAINNET]: new Set([
     '0x176211869cA2b568f2A7D4EE941E073a821EE1ff', // USDC
     '0xA219439258ca9da29E9Cc4cE5596924745e12B93', // USDT
+    '0xaca92e438df0b2401ff60da7e4337b687a2435da', // mUSD
   ]),
   [CHAIN_IDS.POLYGON]: new Set([
     '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359', // USDC

--- a/app/components/UI/Bridge/hooks/useStablecoinsDefaultSlippage/index.ts
+++ b/app/components/UI/Bridge/hooks/useStablecoinsDefaultSlippage/index.ts
@@ -65,6 +65,17 @@ export const StablecoinsByChainId: Partial<Record<Hex, Set<string>>> = {
   ]),
 };
 
+export const getIsStablecoin = (tokenAddress: string, chainId: Hex) => {
+  const stablecoins = StablecoinsByChainId[chainId];
+
+  if (!stablecoins) return false;
+
+  return (
+    stablecoins.has(tokenAddress.toLowerCase()) ||
+    stablecoins.has(toChecksumHexAddress(tokenAddress))
+  );
+};
+
 /**
  * This function checks if the source and destination tokens are both stablecoins.
  * @param sourceTokenAddress - The address of the source token.
@@ -76,18 +87,9 @@ export const getIsStablecoinPair = (
   sourceTokenAddress: string,
   destTokenAddress: string,
   chainId: Hex,
-) => {
-  const stablecoins = StablecoinsByChainId[chainId];
-
-  if (!stablecoins) return false;
-
-  return (
-    (stablecoins.has(sourceTokenAddress.toLowerCase()) ||
-      stablecoins.has(toChecksumHexAddress(sourceTokenAddress))) &&
-    (stablecoins.has(destTokenAddress.toLowerCase()) ||
-      stablecoins.has(toChecksumHexAddress(destTokenAddress)))
-  );
-};
+) =>
+  getIsStablecoin(sourceTokenAddress, chainId) &&
+  getIsStablecoin(destTokenAddress, chainId);
 
 /**
  * This function handles the slippage for stablecoins swaps.

--- a/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.test.ts
@@ -33,9 +33,23 @@ const sourceToken = createMockToken({
   decimals: 18,
 });
 
+// Neither token is a stablecoin, so this pair defaults to a buy priced in
+// fiat. Pairs holding a stablecoin have their own describe block below.
 const destToken = createMockToken({
+  address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+  symbol: 'LINK',
+  decimals: 18,
+});
+
+const usdc = createMockToken({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
   symbol: 'USDC',
+  decimals: 6,
+});
+
+const usdt = createMockToken({
+  address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+  symbol: 'USDT',
   decimals: 6,
 });
 
@@ -50,7 +64,7 @@ function mockFiatRates({
     if (token?.symbol === 'ETH') {
       return sourceRate;
     }
-    if (token?.symbol === 'USDC') {
+    if (token?.symbol === 'LINK') {
       return destRate;
     }
     return undefined;
@@ -87,20 +101,20 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
     expect(result.current.executionType).toBe(LimitOrderExecutionType.BUY);
     expect(result.current.isLimitFiatMode).toBe(true);
     expect(result.current.limitPrice).toBe('1');
-    expect(result.current.quotedSymbol).toBe('USDC');
+    expect(result.current.quotedSymbol).toBe('LINK');
     expect(result.current.counterToken).toEqual(sourceToken);
   });
 
   it('reseeds market price after flipping quote unit when source and dest fiat rates match', () => {
-    const usdt = createMockToken({
-      address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
-      symbol: 'USDT',
-      decimals: 6,
+    const uni = createMockToken({
+      address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+      symbol: 'UNI',
+      decimals: 18,
     });
     mockUseLiveTokenFiatRate.mockImplementation(() => 1);
 
     const { result } = renderPriceAdjustHook({
-      sourceToken: usdt,
+      sourceToken: uni,
     });
 
     expect(result.current.limitPrice).toBe('1');
@@ -111,7 +125,7 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
 
     expect(result.current.executionType).toBe(LimitOrderExecutionType.SELL);
     expect(result.current.limitPrice).toBe('1');
-    expect(result.current.quotedSymbol).toBe('USDT');
+    expect(result.current.quotedSymbol).toBe('UNI');
   });
 
   it('does not reseed market price after the user edits the limit price', () => {
@@ -316,19 +330,18 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
 
     expect(result.current.limitPrice).toBe('1');
 
-    const usdc = destToken;
     mockUseLiveTokenFiatRate.mockImplementation((token) => {
       if (token?.symbol === 'ETH') {
         return 2000;
       }
-      if (token?.symbol === 'USDC') {
+      if (token?.symbol === 'LINK') {
         return 1.5;
       }
       return undefined;
     });
 
     rerender({
-      destToken: usdc,
+      destToken,
       sourceToken,
     });
 
@@ -360,19 +373,26 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
     expect(result.current.onAmountTypeTogglePress).toBeUndefined();
   });
 
-  describe('live market tracking', () => {
-    it('suppresses market comparison while tracking market, even if the raw comparison would show one', () => {
-      // Simulates the one-render lag right after a market data update, where
-      // limitPrice hasn't resynced yet and the raw comparison would report a
-      // false divergence. isTrackingMarket must suppress it unconditionally.
+  describe('market price seeding', () => {
+    it('surfaces the market comparison even right after the market preset, when the raw comparison would show one', () => {
+      // Once seeded, the limit price no longer follows the market, so the
+      // comparison must not be suppressed just because the price sits at
+      // market immediately after pressing "Market".
       mockGetSwapsLimitOrderPriceMarketComparison.mockReturnValue({
-        label: 'stale comparison',
+        label: 'real comparison',
         isNegative: true,
       });
 
       const { result } = renderPriceAdjustHook();
 
-      expect(result.current.marketComparison).toBeUndefined();
+      act(() => {
+        result.current.handleMarketPress();
+      });
+
+      expect(result.current.marketComparison).toEqual({
+        label: 'real comparison',
+        isNegative: true,
+      });
     });
 
     it('surfaces the market comparison once tracking market stops', () => {
@@ -393,7 +413,7 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
       });
     });
 
-    it('follows the market rate while the price sits at market', () => {
+    it('seeds the limit price from the market rate on mount, but does not keep following it', () => {
       const { result, rerender } = renderPriceAdjustHook();
 
       expect(result.current.limitPrice).toBe('1');
@@ -401,10 +421,10 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
       mockFiatRates({ destRate: 1.2 });
       rerender({ destToken, sourceToken });
 
-      expect(result.current.limitPrice).toBe('1.2');
+      expect(result.current.limitPrice).toBe('1');
     });
 
-    it('stops following the market after a percent preset, and resumes after the market preset', () => {
+    it('does not follow the market after a percent preset or after the market preset', () => {
       const { result, rerender } = renderPriceAdjustHook();
 
       act(() => {
@@ -427,10 +447,10 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
       mockFiatRates({ destRate: 1.5 });
       rerender({ destToken, sourceToken });
 
-      expect(result.current.limitPrice).toBe('1.5');
+      expect(result.current.limitPrice).toBe('1.2');
     });
 
-    it('follows the market after a zero custom percent is committed', () => {
+    it('does not follow the market after a zero custom percent is committed', () => {
       const { result, rerender } = renderPriceAdjustHook();
 
       act(() => {
@@ -442,14 +462,16 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
         result.current.commitCustomPercent();
       });
 
+      expect(result.current.limitPrice).toBe('1');
+
       mockFiatRates({ destRate: 1.2 });
       rerender({ destToken, sourceToken });
 
-      expect(result.current.limitPrice).toBe('1.2');
+      expect(result.current.limitPrice).toBe('1');
       expect(result.current.isCustomActive).toBe(true);
     });
 
-    it('stops following the market after a non-zero custom percent is committed', () => {
+    it('does not follow the market after a non-zero custom percent is committed', () => {
       const { result, rerender } = renderPriceAdjustHook();
 
       act(() => {
@@ -469,7 +491,7 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
       expect(result.current.limitPrice).toBe('0.95');
     });
 
-    it('stops following the market after the denomination is toggled', () => {
+    it('does not follow the market after the denomination is toggled', () => {
       const { result, rerender } = renderPriceAdjustHook();
 
       act(() => {
@@ -484,7 +506,7 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
       expect(result.current.limitPrice).toBe('0.0005');
     });
 
-    it('follows the market in counter-token denomination after the market preset', () => {
+    it('seeds the market price in counter-token denomination after the market preset, but does not keep following it', () => {
       const { result, rerender } = renderPriceAdjustHook();
 
       act(() => {
@@ -501,15 +523,15 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
       mockFiatRates({ destRate: 2 });
       rerender({ destToken, sourceToken });
 
-      expect(result.current.limitPrice).toBe('0.001');
+      expect(result.current.limitPrice).toBe('0.0005');
     });
   });
 
   it('seeds the market price for a new pair sharing the same quoted fiat rate and counter decimals', () => {
-    const usdt = createMockToken({
-      address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
-      symbol: 'USDT',
-      decimals: 6,
+    const uni = createMockToken({
+      address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+      symbol: 'UNI',
+      decimals: 18,
     });
     mockUseLiveTokenFiatRate.mockImplementation((token) =>
       token?.symbol === 'ETH' ? 2000 : 1,
@@ -520,11 +542,111 @@ describe('useSwapsLimitOrderPriceAdjust', () => {
     expect(result.current.limitPrice).toBe('1');
 
     rerender({
-      destToken: usdt,
+      destToken: uni,
       sourceToken,
     });
 
     expect(result.current.limitPrice).toBe('1');
+  });
+
+  describe('stablecoin pairs', () => {
+    beforeEach(() => {
+      mockUseLiveTokenFiatRate.mockImplementation((token) =>
+        token?.symbol === 'ETH' ? 2000 : 1,
+      );
+    });
+
+    it('buys the destination token priced in the source stablecoin', () => {
+      const { result } = renderPriceAdjustHook({
+        sourceToken: usdc,
+        destToken: sourceToken,
+      });
+
+      expect(result.current.executionType).toBe(LimitOrderExecutionType.BUY);
+      expect(result.current.isLimitFiatMode).toBe(false);
+      expect(result.current.quotedSymbol).toBe('ETH');
+      expect(result.current.counterToken).toEqual(usdc);
+      expect(result.current.limitPrice).toBe('2000');
+    });
+
+    it('sells the source token priced in the destination stablecoin', () => {
+      const { result } = renderPriceAdjustHook({ destToken: usdc });
+
+      expect(result.current.executionType).toBe(LimitOrderExecutionType.SELL);
+      expect(result.current.isLimitFiatMode).toBe(false);
+      expect(result.current.quotedSymbol).toBe('ETH');
+      expect(result.current.counterToken).toEqual(usdc);
+      expect(result.current.limitPrice).toBe('2000');
+    });
+
+    it('buys the destination stablecoin priced in the source stablecoin', () => {
+      const { result } = renderPriceAdjustHook({
+        sourceToken: usdc,
+        destToken: usdt,
+      });
+
+      expect(result.current.executionType).toBe(LimitOrderExecutionType.BUY);
+      expect(result.current.isLimitFiatMode).toBe(false);
+      expect(result.current.quotedSymbol).toBe('USDT');
+      expect(result.current.counterToken).toEqual(usdc);
+      expect(result.current.limitPrice).toBe('1');
+    });
+
+    it('keeps pricing in the stablecoin after the tokens are flipped', () => {
+      const { result, rerender } = renderPriceAdjustHook({ destToken: usdc });
+
+      expect(result.current.executionType).toBe(LimitOrderExecutionType.SELL);
+
+      rerender({ destToken: sourceToken, sourceToken: usdc });
+
+      expect(result.current.executionType).toBe(LimitOrderExecutionType.BUY);
+      expect(result.current.isLimitFiatMode).toBe(false);
+      expect(result.current.counterToken).toEqual(usdc);
+      expect(result.current.limitPrice).toBe('2000');
+    });
+
+    it('prices in fiat again once a flip leaves no stablecoin in the pair', () => {
+      const { result, rerender } = renderPriceAdjustHook({
+        sourceToken: usdc,
+        destToken: sourceToken,
+      });
+
+      expect(result.current.isLimitFiatMode).toBe(false);
+
+      rerender({ destToken, sourceToken });
+
+      expect(result.current.executionType).toBe(LimitOrderExecutionType.BUY);
+      expect(result.current.isLimitFiatMode).toBe(true);
+      expect(result.current.limitPrice).toBe('1');
+    });
+
+    it('keeps pricing in the stablecoin when the quote unit is flipped onto the other stablecoin', () => {
+      const { result } = renderPriceAdjustHook({
+        sourceToken: usdc,
+        destToken: usdt,
+      });
+
+      act(() => {
+        result.current.onQuoteUnitPress?.();
+      });
+
+      expect(result.current.executionType).toBe(LimitOrderExecutionType.SELL);
+      expect(result.current.isLimitFiatMode).toBe(false);
+      expect(result.current.counterToken).toEqual(usdt);
+    });
+
+    it('prices in fiat when the quote unit is flipped onto a non-stablecoin', () => {
+      const { result } = renderPriceAdjustHook({ destToken: usdc });
+
+      act(() => {
+        result.current.onQuoteUnitPress?.();
+      });
+
+      expect(result.current.executionType).toBe(LimitOrderExecutionType.BUY);
+      expect(result.current.isLimitFiatMode).toBe(true);
+      expect(result.current.counterToken).toEqual(sourceToken);
+      expect(result.current.limitPrice).toBe('1');
+    });
   });
 
   it('resets price fields when the token pair changes', () => {

--- a/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapsLimitOrderPriceAdjust/index.ts
@@ -6,11 +6,15 @@ import { useLiveTokenFiatRate } from '../useLiveTokenFiatRate';
 import type { BridgeToken } from '../../types';
 import { formatTokenInputAmountFromFiat } from '../../utils/sourceAmountInputMode';
 import { formatLimitOrderFiatPriceFromTokenAmount } from '../../utils/limitOrders/formatLimitOrderFiatPrice';
+import {
+  getIsSwapsLimitOrderStablecoin,
+  getSwapsLimitOrderDefaultPriceMode,
+} from '../../utils/limitOrders/getSwapsLimitOrderDefaultPriceMode';
 import { getSwapsLimitOrderPriceFromMarketPercent } from '../../utils/limitOrders/getSwapsLimitOrderPriceFromMarketPercent';
 import { getSwapsLimitOrderPriceMarketComparison } from '../../utils/limitOrders/getSwapsLimitOrderPriceMarketComparison';
 import { getSwapsLimitOrderSecondaryValue } from '../../utils/limitOrders/getSwapsLimitOrderSecondaryValue';
 import {
-  initialLimitOrderPriceAdjustState,
+  getInitialLimitOrderPriceAdjustState,
   limitOrderPriceAdjustReducer,
 } from '../../reducers/limitOrderPriceAdjustReducer';
 import {
@@ -28,9 +32,17 @@ export const useSwapsLimitOrderPriceAdjust = ({
   sourceToken,
 }: Params) => {
   const currentCurrency = useSelector(selectCurrentCurrency);
+  const {
+    executionType: defaultExecutionType,
+    isLimitFiatMode: defaultIsLimitFiatMode,
+  } = getSwapsLimitOrderDefaultPriceMode({ destToken, sourceToken });
   const [state, dispatch] = useReducer(
     limitOrderPriceAdjustReducer,
-    initialLimitOrderPriceAdjustState,
+    {
+      executionType: defaultExecutionType,
+      isLimitFiatMode: defaultIsLimitFiatMode,
+    },
+    getInitialLimitOrderPriceAdjustState,
   );
   const {
     customValue,
@@ -119,7 +131,7 @@ export const useSwapsLimitOrderPriceAdjust = ({
       return;
     }
 
-    // A 0% offset is market, so the price keeps following the live rate.
+    // A 0% offset is market, so it's treated the same as the market preset.
     dispatch({
       type: 'commitCustomPercent',
       limitPrice: nextLimitPrice,
@@ -128,20 +140,30 @@ export const useSwapsLimitOrderPriceAdjust = ({
     });
   }, [customValue, getLimitPriceFromSignedPercent, isCustomActive, isSell]);
 
+  // A new pair starts over on the side and denomination that pair defaults to,
+  // which is also what makes a source/dest flip land on the right ones.
   useEffect(() => {
-    dispatch({ type: 'reset' });
+    dispatch({
+      type: 'reset',
+      executionType: defaultExecutionType,
+      isLimitFiatMode: defaultIsLimitFiatMode,
+    });
   }, [
+    defaultExecutionType,
+    defaultIsLimitFiatMode,
     destToken?.address,
     destToken?.chainId,
     sourceToken?.address,
     sourceToken?.chainId,
   ]);
 
-  // Keeps the limit price on the live market rate for as long as it sits at
-  // market, so it refreshes with every market data update instead of only
-  // being seeded once.
+  // Seeds the limit price from the live market rate exactly once whenever
+  // there isn't one yet (initial mount, a new token pair, or after flipping
+  // sides). Once seeded, the price stays put even as the market rate keeps
+  // moving; only the market-comparison label below keeps reflecting the live
+  // difference between the fixed price and the current market rate.
   useEffect(() => {
-    if (!isTrackingMarket) {
+    if (!isTrackingMarket || limitPrice !== undefined) {
       return;
     }
 
@@ -154,23 +176,21 @@ export const useSwapsLimitOrderPriceAdjust = ({
       type: 'seedFromMarket',
       limitPrice: nextLimitPrice,
     });
-  }, [
-    destToken?.address,
-    destToken?.chainId,
-    executionType, // flipSide clears limitPrice even when quotedFiatRate is unchanged
-    getLimitPriceFromSignedPercent,
-    isTrackingMarket,
-    sourceToken?.address,
-    sourceToken?.chainId,
-  ]);
+  }, [getLimitPriceFromSignedPercent, isTrackingMarket, limitPrice]);
 
   const canToggleLimitPrice = Boolean(
     destFiatRate && destFiatRate > 0 && sourceFiatRate && sourceFiatRate > 0,
   );
 
   const handleQuoteUnitPress = useCallback(() => {
-    dispatch({ type: 'flipSide' });
-  }, []);
+    // Flipping the side swaps which token the price is expressed in, so the
+    // denomination follows whichever token becomes the counter token.
+    const nextCounterToken = isSell ? sourceToken : destToken;
+    dispatch({
+      type: 'flipSide',
+      isLimitFiatMode: !getIsSwapsLimitOrderStablecoin(nextCounterToken),
+    });
+  }, [destToken, isSell, sourceToken]);
 
   const handleAmountTypeTogglePress = useCallback(() => {
     if (!canToggleLimitPrice) {
@@ -210,17 +230,16 @@ export const useSwapsLimitOrderPriceAdjust = ({
   const limitFiat = isLimitFiatMode
     ? limitPrice
     : formatLimitOrderFiatPriceFromTokenAmount(limitPrice, counterFiatRate);
-  const marketComparison = isTrackingMarket
-    ? undefined
-    : getSwapsLimitOrderPriceMarketComparison({
-        limitFiat,
-        marketFiat: quotedFiatRate,
-        executionType,
-        threshold: 0,
-      });
+  const marketComparison = getSwapsLimitOrderPriceMarketComparison({
+    limitFiat,
+    marketFiat: quotedFiatRate,
+    executionType,
+    threshold: 0,
+  });
 
   return {
     commitCustomPercent,
+    counterFiatRate,
     counterToken,
     customValue: customValue ?? '',
     handleCustomPress,

--- a/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.test.ts
+++ b/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.test.ts
@@ -1,6 +1,6 @@
 import { LimitOrderExecutionType } from '../constants/limitOrders';
 import {
-  initialLimitOrderPriceAdjustState,
+  getInitialLimitOrderPriceAdjustState,
   limitOrderPriceAdjustReducer,
   type LimitOrderPriceAdjustState,
 } from './limitOrderPriceAdjustReducer';
@@ -14,12 +14,33 @@ const modifiedState: LimitOrderPriceAdjustState = {
   customValue: '8',
 };
 
+const initialLimitOrderPriceAdjustState = getInitialLimitOrderPriceAdjustState({
+  executionType: LimitOrderExecutionType.BUY,
+  isLimitFiatMode: true,
+});
+
 describe('limitOrderPriceAdjustReducer', () => {
-  it('matches the expected initial state', () => {
+  it('starts price fields unset on the side and denomination it is given', () => {
     expect(initialLimitOrderPriceAdjustState).toEqual({
       executionType: LimitOrderExecutionType.BUY,
       limitPrice: undefined,
       isLimitFiatMode: true,
+      isTrackingMarket: true,
+      isCustomActive: false,
+      customValue: undefined,
+    });
+  });
+
+  it('starts on the counter-token denomination when it is given one', () => {
+    expect(
+      getInitialLimitOrderPriceAdjustState({
+        executionType: LimitOrderExecutionType.SELL,
+        isLimitFiatMode: false,
+      }),
+    ).toEqual({
+      executionType: LimitOrderExecutionType.SELL,
+      limitPrice: undefined,
+      isLimitFiatMode: false,
       isTrackingMarket: true,
       isCustomActive: false,
       customValue: undefined,
@@ -243,9 +264,10 @@ describe('limitOrderPriceAdjustReducer', () => {
   });
 
   describe('flipSide', () => {
-    it('flips buy to sell and resets price fields', () => {
+    it('flips sell to buy and resets price fields onto the given denomination', () => {
       const result = limitOrderPriceAdjustReducer(modifiedState, {
         type: 'flipSide',
+        isLimitFiatMode: true,
       });
 
       expect(result).toEqual({
@@ -258,19 +280,20 @@ describe('limitOrderPriceAdjustReducer', () => {
       });
     });
 
-    it('flips sell to buy and resets price fields', () => {
+    it('flips buy to sell and resets price fields onto the given denomination', () => {
       const result = limitOrderPriceAdjustReducer(
         {
           ...modifiedState,
           executionType: LimitOrderExecutionType.BUY,
+          isLimitFiatMode: true,
         },
-        { type: 'flipSide' },
+        { type: 'flipSide', isLimitFiatMode: false },
       );
 
       expect(result).toEqual({
         executionType: LimitOrderExecutionType.SELL,
         limitPrice: undefined,
-        isLimitFiatMode: true,
+        isLimitFiatMode: false,
         isTrackingMarket: true,
         isCustomActive: false,
         customValue: undefined,
@@ -279,15 +302,37 @@ describe('limitOrderPriceAdjustReducer', () => {
   });
 
   describe('reset', () => {
-    it('resets price fields while preserving execution type', () => {
+    it('resets price fields onto the given side and denomination', () => {
       const result = limitOrderPriceAdjustReducer(modifiedState, {
         type: 'reset',
+        executionType: LimitOrderExecutionType.BUY,
+        isLimitFiatMode: true,
       });
+
+      expect(result).toEqual({
+        executionType: LimitOrderExecutionType.BUY,
+        limitPrice: undefined,
+        isLimitFiatMode: true,
+        isTrackingMarket: true,
+        isCustomActive: false,
+        customValue: undefined,
+      });
+    });
+
+    it('resets price fields onto the counter-token denomination of a sell', () => {
+      const result = limitOrderPriceAdjustReducer(
+        { ...modifiedState, executionType: LimitOrderExecutionType.BUY },
+        {
+          type: 'reset',
+          executionType: LimitOrderExecutionType.SELL,
+          isLimitFiatMode: false,
+        },
+      );
 
       expect(result).toEqual({
         executionType: LimitOrderExecutionType.SELL,
         limitPrice: undefined,
-        isLimitFiatMode: true,
+        isLimitFiatMode: false,
         isTrackingMarket: true,
         isCustomActive: false,
         customValue: undefined,

--- a/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.ts
+++ b/app/components/UI/Bridge/reducers/limitOrderPriceAdjustReducer.ts
@@ -26,21 +26,34 @@ export type LimitOrderPriceAdjustAction =
       type: 'toggleFiatMode';
       convertLimitPrice: (limitPrice: string | undefined) => string | undefined;
     }
-  | { type: 'flipSide' }
-  | { type: 'reset' };
+  | { type: 'flipSide'; isLimitFiatMode: boolean }
+  | {
+      type: 'reset';
+      executionType: LimitOrderExecutionType;
+      isLimitFiatMode: boolean;
+    };
 
 const PRICE_FIELDS_RESET = {
   limitPrice: undefined,
-  isLimitFiatMode: true,
   isTrackingMarket: true,
   isCustomActive: false,
   customValue: undefined,
-} as const satisfies Omit<LimitOrderPriceAdjustState, 'executionType'>;
+} as const satisfies Omit<
+  LimitOrderPriceAdjustState,
+  'executionType' | 'isLimitFiatMode'
+>;
 
-export const initialLimitOrderPriceAdjustState: LimitOrderPriceAdjustState = {
-  executionType: LimitOrderExecutionType.BUY,
+export const getInitialLimitOrderPriceAdjustState = ({
+  executionType,
+  isLimitFiatMode,
+}: {
+  executionType: LimitOrderExecutionType;
+  isLimitFiatMode: boolean;
+}): LimitOrderPriceAdjustState => ({
+  executionType,
+  isLimitFiatMode,
   ...PRICE_FIELDS_RESET,
-};
+});
 
 export const limitOrderPriceAdjustReducer = (
   state: LimitOrderPriceAdjustState,
@@ -104,6 +117,7 @@ export const limitOrderPriceAdjustReducer = (
     case 'flipSide':
       return {
         ...PRICE_FIELDS_RESET,
+        isLimitFiatMode: action.isLimitFiatMode,
         executionType:
           state.executionType === LimitOrderExecutionType.BUY
             ? LimitOrderExecutionType.SELL
@@ -113,6 +127,8 @@ export const limitOrderPriceAdjustReducer = (
       return {
         ...state,
         ...PRICE_FIELDS_RESET,
+        executionType: action.executionType,
+        isLimitFiatMode: action.isLimitFiatMode,
       };
     default: {
       const exhaustiveCheck: never = action;

--- a/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderDefaultPriceMode.test.ts
+++ b/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderDefaultPriceMode.test.ts
@@ -1,0 +1,155 @@
+import { SolScope } from '@metamask/keyring-api';
+import { CaipChainId } from '@metamask/utils';
+import { createMockToken } from '../../testUtils/fixtures';
+import { LimitOrderExecutionType } from '../../constants/limitOrders';
+import {
+  getIsSwapsLimitOrderStablecoin,
+  getSwapsLimitOrderDefaultPriceMode,
+} from './getSwapsLimitOrderDefaultPriceMode';
+
+const eth = createMockToken({
+  address: '0x0000000000000000000000000000000000000000',
+  symbol: 'ETH',
+  decimals: 18,
+});
+
+const link = createMockToken({
+  address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+  symbol: 'LINK',
+  decimals: 18,
+});
+
+const usdc = createMockToken({
+  address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  symbol: 'USDC',
+  decimals: 6,
+});
+
+const usdt = createMockToken({
+  address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+  symbol: 'USDT',
+  decimals: 6,
+});
+
+describe('getIsSwapsLimitOrderStablecoin', () => {
+  it('detects a stablecoin from a lowercase address', () => {
+    expect(getIsSwapsLimitOrderStablecoin(usdc)).toBe(true);
+  });
+
+  it('detects a stablecoin from a checksum address', () => {
+    expect(
+      getIsSwapsLimitOrderStablecoin(
+        createMockToken({
+          address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          symbol: 'USDC',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('detects a stablecoin on a chain identified by its CAIP chain id', () => {
+    expect(
+      getIsSwapsLimitOrderStablecoin(
+        createMockToken({
+          address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+          symbol: 'USDC',
+          chainId: 'eip155:8453' as CaipChainId,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not detect a stablecoin outside the configured chain', () => {
+    expect(
+      getIsSwapsLimitOrderStablecoin(
+        createMockToken({ ...usdc, chainId: '0x89' }),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not detect a stablecoin on a chain with no configured stablecoins', () => {
+    expect(
+      getIsSwapsLimitOrderStablecoin(
+        createMockToken({ ...usdc, chainId: '0x270f' }),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not detect a stablecoin on a non-EVM chain', () => {
+    expect(
+      getIsSwapsLimitOrderStablecoin(
+        createMockToken({
+          address: `${SolScope.Mainnet}/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`,
+          symbol: 'USDC',
+          chainId: SolScope.Mainnet,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not detect a stablecoin for a missing token', () => {
+    expect(getIsSwapsLimitOrderStablecoin(undefined)).toBe(false);
+  });
+});
+
+describe('getSwapsLimitOrderDefaultPriceMode', () => {
+  it('prices the destination token in fiat when neither token is a stablecoin', () => {
+    expect(
+      getSwapsLimitOrderDefaultPriceMode({
+        sourceToken: eth,
+        destToken: link,
+      }),
+    ).toEqual({
+      executionType: LimitOrderExecutionType.BUY,
+      isLimitFiatMode: true,
+    });
+  });
+
+  it('prices the destination token in the source stablecoin when only the source is a stablecoin', () => {
+    expect(
+      getSwapsLimitOrderDefaultPriceMode({
+        sourceToken: usdc,
+        destToken: eth,
+      }),
+    ).toEqual({
+      executionType: LimitOrderExecutionType.BUY,
+      isLimitFiatMode: false,
+    });
+  });
+
+  it('prices the source token in the destination stablecoin when only the destination is a stablecoin', () => {
+    expect(
+      getSwapsLimitOrderDefaultPriceMode({
+        sourceToken: eth,
+        destToken: usdc,
+      }),
+    ).toEqual({
+      executionType: LimitOrderExecutionType.SELL,
+      isLimitFiatMode: false,
+    });
+  });
+
+  it('prices the destination token in the source stablecoin when both tokens are stablecoins', () => {
+    expect(
+      getSwapsLimitOrderDefaultPriceMode({
+        sourceToken: usdc,
+        destToken: usdt,
+      }),
+    ).toEqual({
+      executionType: LimitOrderExecutionType.BUY,
+      isLimitFiatMode: false,
+    });
+  });
+
+  it('prices the destination token in fiat while the pair is incomplete', () => {
+    expect(
+      getSwapsLimitOrderDefaultPriceMode({
+        sourceToken: undefined,
+        destToken: undefined,
+      }),
+    ).toEqual({
+      executionType: LimitOrderExecutionType.BUY,
+      isLimitFiatMode: true,
+    });
+  });
+});

--- a/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderDefaultPriceMode.test.ts
+++ b/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderDefaultPriceMode.test.ts
@@ -31,6 +31,12 @@ const usdt = createMockToken({
   decimals: 6,
 });
 
+const musd = createMockToken({
+  address: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+  symbol: 'mUSD',
+  decimals: 6,
+});
+
 describe('getIsSwapsLimitOrderStablecoin', () => {
   it('detects a stablecoin from a lowercase address', () => {
     expect(getIsSwapsLimitOrderStablecoin(usdc)).toBe(true);
@@ -54,6 +60,22 @@ describe('getIsSwapsLimitOrderStablecoin', () => {
           address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
           symbol: 'USDC',
           chainId: 'eip155:8453' as CaipChainId,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('detects mUSD as a stablecoin on Ethereum mainnet', () => {
+    expect(getIsSwapsLimitOrderStablecoin(musd)).toBe(true);
+  });
+
+  it('detects mUSD as a stablecoin on Linea', () => {
+    expect(
+      getIsSwapsLimitOrderStablecoin(
+        createMockToken({
+          address: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+          symbol: 'mUSD',
+          chainId: '0xe708',
         }),
       ),
     ).toBe(true);
@@ -122,6 +144,18 @@ describe('getSwapsLimitOrderDefaultPriceMode', () => {
       getSwapsLimitOrderDefaultPriceMode({
         sourceToken: eth,
         destToken: usdc,
+      }),
+    ).toEqual({
+      executionType: LimitOrderExecutionType.SELL,
+      isLimitFiatMode: false,
+    });
+  });
+
+  it('sells ETH priced in mUSD for the default Ethereum limit order pair', () => {
+    expect(
+      getSwapsLimitOrderDefaultPriceMode({
+        sourceToken: eth,
+        destToken: musd,
       }),
     ).toEqual({
       executionType: LimitOrderExecutionType.SELL,

--- a/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderDefaultPriceMode.ts
+++ b/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderDefaultPriceMode.ts
@@ -1,0 +1,74 @@
+import { formatChainIdToHex } from '@metamask/bridge-controller';
+import {
+  isCaipChainId,
+  KnownCaipNamespace,
+  parseCaipChainId,
+  type CaipChainId,
+  type Hex,
+} from '@metamask/utils';
+import { LimitOrderExecutionType } from '../../constants/limitOrders';
+import { getIsStablecoin } from '../../hooks/useStablecoinsDefaultSlippage';
+import type { BridgeToken } from '../../types';
+
+const getEvmHexChainId = (chainId: Hex | CaipChainId): Hex | undefined => {
+  if (!isCaipChainId(chainId)) {
+    return chainId;
+  }
+
+  return parseCaipChainId(chainId).namespace === KnownCaipNamespace.Eip155
+    ? formatChainIdToHex(chainId)
+    : undefined;
+};
+
+export const getIsSwapsLimitOrderStablecoin = (
+  token: BridgeToken | undefined,
+): boolean => {
+  if (!token) {
+    return false;
+  }
+
+  const hexChainId = getEvmHexChainId(token.chainId);
+
+  return hexChainId ? getIsStablecoin(token.address, hexChainId) : false;
+};
+
+/**
+ * Order side and price denomination a limit order pair starts on.
+ *
+ * A limit price is quoted per unit of the quoted token, expressed in the
+ * counter token: the source token on a buy and the destination token on a
+ * sell. A stablecoin is a meaningful unit to quote against, so whichever side
+ * holds one becomes the counter token, and the price is then expressed as a
+ * rate in it rather than in fiat:
+ *
+ * - neither token is a stablecoin: buy the destination token, priced in fiat
+ * - only the source is a stablecoin: buy the destination token, priced in it
+ * - only the destination is a stablecoin: sell the source token, priced in it
+ * - both are stablecoins: buy the destination token, priced in the source one
+ */
+export const getSwapsLimitOrderDefaultPriceMode = ({
+  destToken,
+  sourceToken,
+}: {
+  destToken: BridgeToken | undefined;
+  sourceToken: BridgeToken | undefined;
+}): {
+  executionType: LimitOrderExecutionType;
+  isLimitFiatMode: boolean;
+} => {
+  const isSourceStablecoin = getIsSwapsLimitOrderStablecoin(sourceToken);
+  const isDestStablecoin = getIsSwapsLimitOrderStablecoin(destToken);
+
+  return {
+    // Selling is only the better framing when the destination is the sole
+    // stablecoin, which makes it the counter token; a stablecoin source is
+    // already the counter token of a buy.
+    executionType:
+      isDestStablecoin && !isSourceStablecoin
+        ? LimitOrderExecutionType.SELL
+        : LimitOrderExecutionType.BUY,
+    // Given the side above, the counter token is the stablecoin whenever the
+    // pair has one, so a rate can replace the fiat price.
+    isLimitFiatMode: !isSourceStablecoin && !isDestStablecoin,
+  };
+};

--- a/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderDestTokenAmount.test.ts
+++ b/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderDestTokenAmount.test.ts
@@ -1,0 +1,193 @@
+import { LimitOrderExecutionType } from '../../constants/limitOrders';
+import { getSwapsLimitOrderDestTokenAmount } from './getSwapsLimitOrderDestTokenAmount';
+
+// Sells quote the price per source token and buys quote it per destination
+// token, so each side pairs with the counter token on the opposite end of the
+// trade: mUSD (6 decimals) when selling ETH, ETH (18 decimals) when buying it.
+const sellTokenModeDefaults = {
+  counterFiatRate: 1,
+  destTokenDecimals: 6,
+  executionType: LimitOrderExecutionType.SELL,
+  isLimitFiatMode: false,
+  limitPrice: '3000',
+  sourceAmount: '2',
+};
+
+const buyTokenModeDefaults = {
+  counterFiatRate: 1,
+  destTokenDecimals: 18,
+  executionType: LimitOrderExecutionType.BUY,
+  isLimitFiatMode: false,
+  limitPrice: '3000',
+  sourceAmount: '6000',
+};
+
+describe('getSwapsLimitOrderDestTokenAmount', () => {
+  describe('limit price denominated in a token', () => {
+    it('multiplies the source amount by a sell price quoted in destination tokens, minus the quote fee', () => {
+      const result = getSwapsLimitOrderDestTokenAmount(sellTokenModeDefaults);
+
+      // 2 * 3000 = 6000, minus the 0.875% quote fee.
+      expect(result).toBe('5947.5');
+    });
+
+    it('divides the source amount by a buy price quoted in source tokens, minus the quote fee', () => {
+      const result = getSwapsLimitOrderDestTokenAmount(buyTokenModeDefaults);
+
+      // 6000 / 3000 = 2, minus the 0.875% quote fee.
+      expect(result).toBe('1.9825');
+    });
+
+    it('ignores the counter token fiat rate', () => {
+      const result = getSwapsLimitOrderDestTokenAmount({
+        ...sellTokenModeDefaults,
+        counterFiatRate: 4321,
+      });
+
+      expect(result).toBe('5947.5');
+    });
+  });
+
+  describe('limit price denominated in fiat', () => {
+    it('converts a sell price in fiat through the live destination token price', () => {
+      const result = getSwapsLimitOrderDestTokenAmount({
+        counterFiatRate: 80000,
+        destTokenDecimals: 8,
+        executionType: LimitOrderExecutionType.SELL,
+        isLimitFiatMode: true,
+        limitPrice: '2400',
+        sourceAmount: '1',
+      });
+
+      // 1 * 2400 / 80000 = 0.03, minus the 0.875% quote fee.
+      expect(result).toBe('0.0297375');
+    });
+
+    it('converts a buy price in fiat through the live source token price', () => {
+      const result = getSwapsLimitOrderDestTokenAmount({
+        counterFiatRate: 2000,
+        destTokenDecimals: 8,
+        executionType: LimitOrderExecutionType.BUY,
+        isLimitFiatMode: true,
+        limitPrice: '80000',
+        sourceAmount: '40',
+      });
+
+      // 40 / (80000 / 2000) = 1, minus the 0.875% quote fee.
+      expect(result).toBe('0.99125');
+    });
+
+    it.each([
+      { counterFiatRate: undefined },
+      { counterFiatRate: 0 },
+      { counterFiatRate: -1 },
+    ])(
+      'returns undefined when the counter token fiat rate is $counterFiatRate',
+      ({ counterFiatRate }) => {
+        const result = getSwapsLimitOrderDestTokenAmount({
+          ...sellTokenModeDefaults,
+          counterFiatRate,
+          isLimitFiatMode: true,
+        });
+
+        expect(result).toBeUndefined();
+      },
+    );
+  });
+
+  describe('rounding', () => {
+    it('rounds down to the destination token decimals', () => {
+      const result = getSwapsLimitOrderDestTokenAmount({
+        ...buyTokenModeDefaults,
+        destTokenDecimals: 6,
+        limitPrice: '3',
+        sourceAmount: '1',
+      });
+
+      // (1 / 3) * (1 - 0.00875) = 0.33041666..., rounded down to 6 decimals.
+      expect(result).toBe('0.330416');
+    });
+
+    it('returns zero when the amount rounds below the smallest destination unit', () => {
+      const result = getSwapsLimitOrderDestTokenAmount({
+        ...sellTokenModeDefaults,
+        destTokenDecimals: 2,
+        limitPrice: '0.001',
+        sourceAmount: '1',
+      });
+
+      expect(result).toBe('0');
+    });
+
+    it('drops trailing zeros', () => {
+      const result = getSwapsLimitOrderDestTokenAmount({
+        ...sellTokenModeDefaults,
+        limitPrice: '2.5',
+        sourceAmount: '1',
+      });
+
+      // 1 * 2.5 * (1 - 0.00875) = 2.478125
+      expect(result).toBe('2.478125');
+    });
+  });
+
+  describe('quote fee', () => {
+    it('reduces the destination amount by 0.875%', () => {
+      const result = getSwapsLimitOrderDestTokenAmount({
+        ...sellTokenModeDefaults,
+        destTokenDecimals: 18,
+        limitPrice: '1',
+        sourceAmount: '1',
+      });
+
+      expect(result).toBe('0.99125');
+    });
+  });
+
+  describe('amounts that produce no destination value', () => {
+    it.each([
+      { sourceAmount: undefined },
+      { sourceAmount: '' },
+      { sourceAmount: '0' },
+      { sourceAmount: '-1' },
+      { sourceAmount: 'abc' },
+    ])(
+      'returns zero when the source amount is $sourceAmount',
+      ({ sourceAmount }) => {
+        const result = getSwapsLimitOrderDestTokenAmount({
+          ...sellTokenModeDefaults,
+          sourceAmount,
+        });
+
+        expect(result).toBe('0');
+      },
+    );
+
+    it.each([
+      { limitPrice: undefined },
+      { limitPrice: '' },
+      { limitPrice: '0' },
+      { limitPrice: '-1' },
+      { limitPrice: 'abc' },
+    ])(
+      'returns undefined when the limit price is $limitPrice',
+      ({ limitPrice }) => {
+        const result = getSwapsLimitOrderDestTokenAmount({
+          ...sellTokenModeDefaults,
+          limitPrice,
+        });
+
+        expect(result).toBeUndefined();
+      },
+    );
+
+    it('returns undefined when the destination token decimals are unavailable', () => {
+      const result = getSwapsLimitOrderDestTokenAmount({
+        ...sellTokenModeDefaults,
+        destTokenDecimals: undefined,
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderDestTokenAmount.ts
+++ b/app/components/UI/Bridge/utils/limitOrders/getSwapsLimitOrderDestTokenAmount.ts
@@ -1,0 +1,86 @@
+import { BigNumber } from 'bignumber.js';
+import { LimitOrderExecutionType } from '../../constants/limitOrders';
+import { trimTrailingZeros } from '../trimTrailingZeros';
+
+// Estimated MetaMask fee taken from the swap that fills the order, expressed
+// as a fraction of the destination amount (0.875%).
+const QUOTE_BPS_FEE = 0.00875;
+
+/**
+ * Destination amount the order would produce if it filled at its limit price.
+ *
+ * The limit price is quoted per unit of the quoted token, which is the source
+ * token on a sell and the destination token on a buy, and is denominated
+ * either in the counter token or in fiat. Expressing it as counter tokens per
+ * quoted token first collapses those four combinations into one multiplication
+ * or division of the source amount:
+ *
+ * - sell priced in destination tokens: sourceAmount * limitPrice
+ * - buy priced in source tokens: sourceAmount / limitPrice
+ * - sell priced in fiat: sourceAmount * limitPrice / destination fiat rate
+ * - buy priced in fiat: sourceAmount * source fiat rate / limitPrice
+ *
+ * The fiat cases are estimates: they value the counter token at its live
+ * market rate, which keeps moving until the order fills. The result is also
+ * reduced by {@link QUOTE_BPS_FEE} to approximate the fee the fill would incur.
+ */
+export const getSwapsLimitOrderDestTokenAmount = ({
+  counterFiatRate,
+  destTokenDecimals,
+  executionType,
+  isLimitFiatMode,
+  limitPrice,
+  sourceAmount,
+}: {
+  counterFiatRate: number | undefined;
+  destTokenDecimals: number | undefined;
+  executionType: LimitOrderExecutionType;
+  isLimitFiatMode: boolean;
+  limitPrice: string | undefined;
+  sourceAmount: string | undefined;
+}): string | undefined => {
+  if (destTokenDecimals === undefined) {
+    return undefined;
+  }
+
+  const price = new BigNumber(limitPrice ?? '');
+  if (!price.isFinite() || price.lte(0)) {
+    return undefined;
+  }
+
+  let counterPerQuoted = price;
+  if (isLimitFiatMode) {
+    if (!counterFiatRate || counterFiatRate <= 0) {
+      return undefined;
+    }
+    counterPerQuoted = price.dividedBy(counterFiatRate);
+  }
+
+  if (!counterPerQuoted.isFinite() || counterPerQuoted.lte(0)) {
+    return undefined;
+  }
+
+  const amount = new BigNumber(sourceAmount ?? '');
+  if (!amount.isFinite() || amount.lte(0)) {
+    return '0';
+  }
+
+  const destTokenAmountBeforeFee =
+    executionType === LimitOrderExecutionType.SELL
+      ? amount.multipliedBy(counterPerQuoted)
+      : amount.dividedBy(counterPerQuoted);
+
+  const destTokenAmount = destTokenAmountBeforeFee.multipliedBy(
+    new BigNumber(1).minus(QUOTE_BPS_FEE),
+  );
+
+  if (!destTokenAmount.isFinite()) {
+    return undefined;
+  }
+
+  return trimTrailingZeros(
+    destTokenAmount
+      .decimalPlaces(destTokenDecimals, BigNumber.ROUND_DOWN)
+      .toFixed(),
+  );
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Implement destination amount calculations on limit order and update buy/sell default selection on limit order input.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:  Implement destination amount calculations on limit order and update buy/sell default selection on limit order input.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-5057

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Please check official acceptance criteria for tests.
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

<!-- [screenshots/recordings] -->

### **After**

N/A

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes limit-order pricing defaults, market-tracking semantics, and displayed fill estimates users may rely on when placing orders; logic is well-tested but affects core swap/limit-order UX.
> 
> **Overview**
> Limit orders now show an **estimated destination amount** derived from the source amount, limit price, buy/sell side, and fiat vs token denomination (via `getSwapsLimitOrderDestTokenAmount`), including a **0.875% quote fee** and rounding to destination decimals. **Flipping tokens** passes that estimate into the source field when it is positive; otherwise the source amount is cleared.
> 
> **Default buy/sell and price unit** are chosen from the token pair: stablecoin pairs (including newly listed **mUSD** on Ethereum/Linea) default to pricing in the stablecoin counter token and the appropriate execution side; non-stable pairs stay on buy-in-fiat. Price-adjust state **reseeds** to those defaults when the pair changes or the quote side flips.
> 
> **Limit price behavior** changes from continuously tracking the live market to **seeding market once** when there is no price yet; the market-vs-limit comparison is shown even right after tapping Market. The swap-input hook no longer returns a fixed empty destination amount—computation lives in the limit order view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a90e3be97b56dd735f500418c4d8b98809fd9e97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->