### PR TITLE
fix: trending wash trading token filter

### DIFF
--- a/app/components/UI/Trending/utils/filterTrendingTokens.test.ts
+++ b/app/components/UI/Trending/utils/filterTrendingTokens.test.ts
@@ -191,7 +191,8 @@ describe('filterLowQualityTokens', () => {
             {
               featureId: 'UNSTABLE_TOKEN_PRICE',
               type: 'Warning',
-              description: 'Tokens with limited liquidity in liquidity pools - could potentially become illiquid',
+              description:
+                'Tokens with limited liquidity in liquidity pools - could potentially become illiquid',
             },
           ],
         } as TrendingAsset['securityData'],

--- a/app/components/UI/Trending/utils/filterTrendingTokens.test.ts
+++ b/app/components/UI/Trending/utils/filterTrendingTokens.test.ts
@@ -110,7 +110,7 @@ describe('filterLowQualityTokens', () => {
     expect(filterLowQualityTokens(tokens)).toHaveLength(0);
   });
 
-  it('only filters out tokens missing symbol/name, keeps risky tokens', () => {
+  it('only filters out tokens missing symbol/name or manipulated volume, keeps other risky tokens', () => {
     const tokens = [
       buildToken({ symbol: 'GOOD', name: 'Good Token' }),
       buildToken({ symbol: '', name: 'No Ticker' }),
@@ -132,6 +132,74 @@ describe('filterLowQualityTokens', () => {
       'GOOD',
       'RISKY',
       'SAFE',
+    ]);
+  });
+
+  it('removes tokens whose security features include WASH_TRADING', () => {
+    const tokens = [
+      buildToken({
+        symbol: 'WASH',
+        securityData: {
+          resultType: 'Warning',
+          features: [
+            {
+              featureId: 'WASH_TRADING',
+              type: 'Warning',
+              description: 'Wash trading detected',
+            },
+          ],
+        } as TrendingAsset['securityData'],
+      }),
+      buildToken({ symbol: 'KEEP' }),
+    ];
+
+    expect(filterLowQualityTokens(tokens).map((t) => t.symbol)).toEqual([
+      'KEEP',
+    ]);
+  });
+
+  it('removes tokens whose security features include FAKE_VOLUME', () => {
+    const tokens = [
+      buildToken({
+        symbol: 'FAKE',
+        securityData: {
+          resultType: 'Warning',
+          features: [
+            {
+              featureId: 'FAKE_VOLUME',
+              type: 'Warning',
+              description: 'Fake volume detected',
+            },
+          ],
+        } as TrendingAsset['securityData'],
+      }),
+      buildToken({ symbol: 'KEEP' }),
+    ];
+
+    expect(filterLowQualityTokens(tokens).map((t) => t.symbol)).toEqual([
+      'KEEP',
+    ]);
+  });
+
+  it('keeps tokens with other security features', () => {
+    const tokens = [
+      buildToken({
+        symbol: 'UNSTABLE',
+        securityData: {
+          resultType: 'Warning',
+          features: [
+            {
+              featureId: 'UNSTABLE_TOKEN_PRICE',
+              type: 'Warning',
+              description: 'Tokens with limited liquidity in liquidity pools - could potentially become illiquid',
+            },
+          ],
+        } as TrendingAsset['securityData'],
+      }),
+    ];
+
+    expect(filterLowQualityTokens(tokens).map((t) => t.symbol)).toEqual([
+      'UNSTABLE',
     ]);
   });
 

--- a/app/components/UI/Trending/utils/filterTrendingTokens.ts
+++ b/app/components/UI/Trending/utils/filterTrendingTokens.ts
@@ -1,5 +1,7 @@
 import type { TrendingAsset } from '@metamask/assets-controllers';
 
+const MANIPULATED_VOLUME_FEATURE_IDS = new Set(['WASH_TRADING', 'FAKE_VOLUME']);
+
 /**
  * Returns true when a token lacks a meaningful ticker (symbol) or display name.
  * Tokens without these render blank placeholders in the UI.
@@ -8,10 +10,22 @@ const lacksTickerOrName = (token: TrendingAsset): boolean =>
   !token.symbol?.trim() || !token.name?.trim();
 
 /**
- * Filters out tokens that lack a meaningful symbol or name.
- * Risky tokens (Warning/Spam/Malicious) are intentionally kept — they are
- * surfaced with appropriate warnings via the security badge in the UI.
+ * Returns true when security data flags wash trading or fake volume.
+ */
+const hasManipulatedVolume = (token: TrendingAsset): boolean =>
+  token.securityData?.features?.some((feature) =>
+    MANIPULATED_VOLUME_FEATURE_IDS.has(feature.featureId),
+  ) ?? false;
+
+/**
+ * Filters out tokens that lack a meaningful symbol or name, and tokens whose
+ * security data includes WASH_TRADING or FAKE_VOLUME.
+ * Other risky tokens (Warning/Spam/Malicious) are intentionally kept in case
+ * of false positives — they are surfaced with appropriate warnings via the security badge in the UI.
  */
 export const filterLowQualityTokens = (
   tokens: TrendingAsset[],
-): TrendingAsset[] => tokens.filter((token) => !lacksTickerOrName(token));
+): TrendingAsset[] =>
+  tokens.filter(
+    (token) => !lacksTickerOrName(token) && !hasManipulatedVolume(token),
+  );


### PR DESCRIPTION
## **Description**

Both the Trending list and the Crypto Movers section use 24h volume as a
major input to ranking. Wash-traded tokens — currently equity-ticker
impersonations like NVDA, AAPL, GOOGL — manufacture that volume, so they
sort to the top and stay there. Observed continuously in production for
over a week.

This adds a feature-level check to `filterLowQualityTokens`: a token whose
`securityData.features` includes `WASH_TRADING` or `FAKE_VOLUME` is dropped
from the list. There is a single call site (`useTrendingRequest`, gated on
`filterLowQuality`), and both `TrendingTokensFullView` and `useTokensFeed`
pass `filterLowQuality: true` — so one change covers the Trending list,
the Crypto Movers pills, and the "View all" full view.

**Why feature-level and not `resultType: Warning` wholesale:**

1. Volume manipulation is the actual mechanism corrupting the ranking.
   These tokens are only in the list because their volume is fake, so
   removing them restores the ranking rather than editorializing it.
2. `Warning`/`Spam` verdicts have observed false positives — a token with
   substantial legitimate volume was flagged `Warning/Spam` this week.
   Filtering on the verdict would silently delist legitimate tokens.
   Filtering on manipulation features does not.

Other risky tokens are still surfaced with the security badge — unchanged behavior.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where tokens with manipulated trading volume could appear in Trending and Crypto Movers.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/jira/software/c/projects/PSAFE/boards/1950?selectedIssue=PSAFE-668

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Wash-traded tokens excluded from token discovery rankings

  Scenario: user views the Crypto Movers section
    Given the user is on the Explore > Now tab
    When the Crypto Movers section loads
    Then no token flagged WASH_TRADING or FAKE_VOLUME is listed
    And equity-ticker impersonations (NVDA, AAPL, GOOGL) are absent

  Scenario: user views the Trending list
    Given the user is on the Trending tokens full view
    When the list loads and the user scrolls through all pages
    Then no token flagged WASH_TRADING or FAKE_VOLUME is listed
    And tokens with other Warning/Spam verdicts still render with a
        security badge
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/edae9af3-eb4f-4d06-8936-2af8371eab28


https://github.com/user-attachments/assets/f1747763-dd0a-4a73-b07f-888fc4998d16

<img width="610" height="1033" alt="image" src="https://github.com/user-attachments/assets/a96d095d-cc70-461e-a2c8-66f83f47e97f" />


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/06c7544b-ed53-4e2e-8e73-268741092060


https://github.com/user-attachments/assets/5f092876-0286-46a1-bb0a-82db629e35f3

<img width="593" height="793" alt="image" src="https://github.com/user-attachments/assets/c5b8f1d2-f016-41e8-8775-ac0da87991f3" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to trending list filtering with unit tests; no auth, signing, or payment paths, though incorrect manipulation flags could hide tokens from discovery.
> 
> **Overview**
> **Trending and Crypto Movers** now drop tokens whose security scan reports **`WASH_TRADING`** or **`FAKE_VOLUME`**, in addition to tokens missing a symbol or name.
> 
> `filterLowQualityTokens` adds `hasManipulatedVolume`, which checks `securityData.features` against those feature IDs. Tokens with other warnings (e.g. `UNSTABLE_TOKEN_PRICE`) or broad `Warning`/`Spam` verdicts are **unchanged** and still show with security badges. Tests cover removal for both manipulation features and retention for other risky tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81869ee161adc71f459742feb22df06280b2fda1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->