### PR TITLE
fix(confirmations): detect nested predict deposit-order for exact output

### DIFF
--- a/.yarn/patches/@metamask-transaction-pay-controller-npm-27.1.1-predict-deposit-order-exact-output.patch
+++ b/.yarn/patches/@metamask-transaction-pay-controller-npm-27.1.1-predict-deposit-order-exact-output.patch
@@ -1,26 +1,39 @@
 diff --git a/dist/strategy/relay/relay-quotes.cjs b/dist/strategy/relay/relay-quotes.cjs
 --- a/dist/strategy/relay/relay-quotes.cjs
 +++ b/dist/strategy/relay/relay-quotes.cjs
-@@ -196,7 +196,8 @@
+@@ -196,7 +196,10 @@
          }
          const hasTransactions = Boolean(body.txs?.length);
          const requiresExactOutput = hasTransactions ||
 -            transaction.type === transaction_controller_1.TransactionType.perpsDepositAndOrder;
-+            transaction.type === transaction_controller_1.TransactionType.perpsDepositAndOrder ||
-+            transaction.type === transaction_controller_1.TransactionType.predictDepositAndOrder;
++            (0, transaction_controller_1.hasTransactionType)(transaction, [
++                transaction_controller_1.TransactionType.perpsDepositAndOrder,
++                transaction_controller_1.TransactionType.predictDepositAndOrder,
++            ]);
          const finalBody = {
              ...body,
              amount: body.amount ??
 diff --git a/dist/strategy/relay/relay-quotes.mjs b/dist/strategy/relay/relay-quotes.mjs
 --- a/dist/strategy/relay/relay-quotes.mjs
 +++ b/dist/strategy/relay/relay-quotes.mjs
-@@ -193,7 +193,8 @@
+@@ -1,7 +1,7 @@
+ /* eslint-disable require-atomic-updates */
+ import { Interface } from "@ethersproject/abi";
+ import { toHex } from "@metamask/controller-utils";
+-import { TransactionType } from "@metamask/transaction-controller";
++import { hasTransactionType, TransactionType } from "@metamask/transaction-controller";
+ import { createModuleLogger } from "@metamask/utils";
+ import { BigNumber } from "bignumber.js";
+ import { ARBITRUM_USDC_ADDRESS, CHAIN_ID_ARBITRUM, CHAIN_ID_HYPERCORE, CHAIN_ID_POLYGON, HYPERCORE_USDC_ADDRESS, HYPERCORE_USDC_DECIMALS, NATIVE_TOKEN_ADDRESS, PERPS_DEPOSIT_TYPES, USDC_DECIMALS, PaymentOverride } from "../../constants.mjs";
+@@ -192,7 +192,10 @@
          }
          const hasTransactions = Boolean(body.txs?.length);
          const requiresExactOutput = hasTransactions ||
 -            transaction.type === TransactionType.perpsDepositAndOrder;
-+            transaction.type === TransactionType.perpsDepositAndOrder ||
-+            transaction.type === TransactionType.predictDepositAndOrder;
++            hasTransactionType(transaction, [
++                TransactionType.perpsDepositAndOrder,
++                TransactionType.predictDepositAndOrder,
++            ]);
          const finalBody = {
              ...body,
              amount: body.amount ??

--- a/yarn.lock
+++ b/yarn.lock
@@ -12423,7 +12423,7 @@ __metadata:
 
 "@metamask/transaction-pay-controller@patch:@metamask/transaction-pay-controller@npm%3A27.1.1#~/.yarn/patches/@metamask-transaction-pay-controller-npm-27.1.1-predict-deposit-order-exact-output.patch":
   version: 27.1.1
-  resolution: "@metamask/transaction-pay-controller@patch:@metamask/transaction-pay-controller@npm%3A27.1.1#~/.yarn/patches/@metamask-transaction-pay-controller-npm-27.1.1-predict-deposit-order-exact-output.patch::version=27.1.1&hash=56d3b8"
+  resolution: "@metamask/transaction-pay-controller@patch:@metamask/transaction-pay-controller@npm%3A27.1.1#~/.yarn/patches/@metamask-transaction-pay-controller-npm-27.1.1-predict-deposit-order-exact-output.patch::version=27.1.1&hash=2614c1"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
@@ -12446,7 +12446,7 @@ __metadata:
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/431bd1fb0138e8e93a2891d81f0b64586ed6453270f6a377c5afa865a6e2b6190c5745d44d5b5fdc478e59de1408ecfba31e02c414bedaf8ab54ec4e581815b6
+  checksum: 10/e9a3f7a0d846c84b070377843455c71203fa5330c90657f1c2559a49831fb7f322fe0d99875f6d7d921ac4da6a2a11bfd12f39e561ff6ba1a694019ff5ac7fad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Predict deposit-and-order confirmations are submitted through `addTransactionBatch`, so the parent `TransactionMeta` has type `batch` and `predictDepositAndOrder` only ever appears on a nested transaction.

The existing patch on the 8.11.0 release branch compared `transaction.type` directly, so the Predict branch never matched and Relay quotes for deposit-and-order kept requesting `EXACT_INPUT` instead of `EXACT_OUTPUT`.

The patch now uses `hasTransactionType`, which checks the parent type and the nested transaction types. Perps deposit-and-order is a single transaction whose parent type already matches, so its behaviour is unchanged.

## **Changelog**

CHANGELOG entry: Fixed Predict deposit-and-order Relay quotes to preserve exact-output sizing

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/pull/36144

## **Manual testing steps**

```gherkin
Feature: Predict deposit-and-order Relay quotes

  Scenario: request exact output for a batched deposit-and-order
    Given a Predict deposit-and-order confirmation submitted as a transaction batch
    When the Relay quote strategy builds the quote request
    Then it requests EXACT_OUTPUT with targetAmountMinimum
    And plain predictDeposit transactions continue to request EXACT_INPUT
```

## **Screenshots/Recordings**

N/A

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment/Relay quote mode selection for Predict deposit-and-order; wrong logic would mis-size swaps but scope is limited to the patched controller relay path.
> 
> **Overview**
> Updates the **`@metamask/transaction-pay-controller`** Yarn patch so Relay quote building treats **Predict deposit-and-order** the same as perps for **exact-output** sizing.
> 
> Instead of comparing only the parent `transaction.type` to `perpsDepositAndOrder`, `requiresExactOutput` now uses **`hasTransactionType`** against **`perpsDepositAndOrder`** and **`predictDepositAndOrder`**, so batched Predict flows (parent type `batch`, nested `predictDepositAndOrder`) request **EXACT_OUTPUT** with the correct minimum target amount. Perps single-tx behavior stays the same.
> 
> `yarn.lock` is refreshed for the patched package checksum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b0576cddeb2ab4a703eb4c14a33175200e30e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->