### PR TITLE
fix: use default text color for Manage connections header

### DIFF
--- a/app/components/Views/SDK/SDKSessionsManager/SDKSessionsManager.tsx
+++ b/app/components/Views/SDK/SDKSessionsManager/SDKSessionsManager.tsx
@@ -12,7 +12,6 @@ import {
   Button,
   ButtonVariant,
   HeaderStandard,
-  TextColor,
 } from '@metamask/design-system-react-native';
 import Icon, {
   IconName,
@@ -145,7 +144,6 @@ const SDKSessionsManager = () => {
     >
       <HeaderStandard
         title={strings('app_settings.manage_sdk_connections_title')}
-        titleProps={{ color: TextColor.PrimaryDefault }}
         onBack={handleBack}
         includesTopInset
         testID={SDKSelectorsIDs.SESSION_MANAGER_HEADER}


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The "Manage connections" header on the SDK sessions manager screen (`Settings > Manage connections`) rendered its title in the primary brand blue, because `HeaderStandard` was passed an explicit `titleProps={{ color: TextColor.PrimaryDefault }}`.

Every other standard header title in the app uses the default text color, so this screen looked inconsistent and read like a tappable link rather than a screen title. Primary color is reserved for interactive elements.

This removes the `titleProps` override so `HeaderStandard` falls back to its own default (`text-default`), and drops the now-unused `TextColor` import. No other behavior changes.

## **Changelog**

CHANGELOG entry: Fixed the "Manage connections" screen title being rendered in blue instead of the default text color

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Manage connections header styling

  Scenario: user opens the Manage connections screen
    Given the user is on the wallet home screen
    When user opens Settings and taps "Manage connections"
    Then the "Manage connections" header title is rendered in the default text color
    And the title is not rendered in the primary blue color
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

The "Manage connections" header title rendered in primary blue.
<img width="670" height="320" alt="Permissions Header - Before" src="https://github.com/user-attachments/assets/445eadf2-6bd4-4a2d-8808-c35ace591d4d" />

### **After**

The "Manage connections" header title rendered in the default text color, matching every other standard header in the app.
<img width="474" height="372" alt="Permissions Header - After" src="https://github.com/user-attachments/assets/d3aa084d-741d-43ee-b3ba-07753bd73069" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-screen styling change with no logic, auth, or data impact.
> 
> **Overview**
> The **Manage connections** screen (`SDKSessionsManager`) no longer forces the `HeaderStandard` title to **primary blue** via `titleProps={{ color: TextColor.PrimaryDefault }}`. The header now uses the design-system default title color, consistent with other standard headers.
> 
> The unused **`TextColor`** import from `@metamask/design-system-react-native` is removed. No navigation or session-management behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 383d82f1ba4f286ed1542df280a9013defb5459f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->