### PR TITLE
fix: remove call to deleted controller method

### DIFF
--- a/app/components/Views/ActivityList/ActivityList.test.tsx
+++ b/app/components/Views/ActivityList/ActivityList.test.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import type { SharedValue } from 'react-native-reanimated';
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react-native';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { TransactionType } from '@metamask/transaction-controller';
@@ -19,7 +13,6 @@ import { useTransactionsQuery } from './useTransactionsQuery';
 import { useLocalActivityItems } from './hooks/useLocalActivityItems';
 import { useRampActivityItems } from './hooks/useRampActivityItems';
 import { useUnifiedTxActions } from './useUnifiedTxActions';
-import Engine from '../../../core/Engine';
 import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import Routes from '../../../constants/navigation/Routes';
 import {
@@ -320,20 +313,6 @@ jest.mock(
 jest.mock('./useUnifiedTxActions', () => ({
   useUnifiedTxActions: jest.fn(),
 }));
-
-jest.mock('../../../core/Engine', () => ({
-  context: {
-    TransactionController: {
-      updateIncomingTransactions: jest.fn(() => Promise.resolve()),
-    },
-  },
-}));
-
-const updateIncomingTransactions = (
-  Engine.context.TransactionController as unknown as {
-    updateIncomingTransactions: jest.Mock;
-  }
-).updateIncomingTransactions;
 
 jest.mock('../../UI/ActivityListItemRow/ActivityListItemRow', () => ({
   ActivityListItemRow: ({
@@ -814,7 +793,6 @@ describe('ActivityList', () => {
     expect(screen.getByTestId('row-0xconfirmed')).toBeOnTheScreen();
 
     fireEvent.press(screen.getByTestId('mock-refresh'));
-    await waitFor(() => expect(updateIncomingTransactions).toHaveBeenCalled());
     expect(mockRefetch).toHaveBeenCalledTimes(1);
 
     // Scrolling should not throw (drives the UI-thread scroll handler).

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -56,7 +56,6 @@ import {
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import { useTheme } from '../../../util/theme';
-import Engine from '../../../core/Engine';
 import { useStyles } from '../../hooks/useStyles';
 import PriceChartContext, {
   PriceChartProvider,
@@ -144,13 +143,6 @@ type ActivityFlashListProps = FlashListProps<GroupedActivityListItem> & {
 const AnimatedFlashList = Animated.createAnimatedComponent(
   FlashList as unknown as React.ComponentType<ActivityFlashListProps>,
 ) as unknown as React.ComponentType<ActivityFlashListProps>;
-
-const updateIncomingTransactions = () =>
-  (
-    Engine.context.TransactionController as unknown as {
-      updateIncomingTransactions: () => Promise<void>;
-    }
-  ).updateIncomingTransactions();
 
 const generateGroupedKey = (
   item: GroupedActivityListItem,
@@ -825,12 +817,7 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
     const onRefresh = useCallback(async () => {
       setRefreshing(true);
       try {
-        await Promise.all([
-          updateIncomingTransactions(),
-          refetch(),
-          perpsRefetch?.(),
-          predictRefetch?.(),
-        ]);
+        await Promise.all([refetch(), perpsRefetch?.(), predictRefetch?.()]);
       } finally {
         setRefreshing(false);
       }

--- a/app/components/Views/ActivityList/ActivityList.view.test.tsx
+++ b/app/components/Views/ActivityList/ActivityList.view.test.tsx
@@ -6,8 +6,6 @@ import '../../../../tests/component-view/mocks';
  * — local TransactionController outgoing rows; accounts API for incoming/outgoing API paths.
  */
 import { fireEvent, waitFor, within } from '@testing-library/react-native';
-import { RefreshControl } from 'react-native';
-import Engine from '../../../core/Engine';
 import Routes from '../../../constants/navigation/Routes';
 import { describeForPlatforms } from '../../../../tests/component-view/platform';
 import {
@@ -34,11 +32,6 @@ import {
 } from './ActivityList.testIds';
 
 const ACTIVITY_CV_RECIPIENT = '0x80181d3ba89220cdb80234fc7aa19d5cc56229cc';
-
-const transactionControllerWithIncomingSync = Engine.context
-  .TransactionController as unknown as {
-  updateIncomingTransactions: jest.MockedFunction<() => Promise<void>>;
-};
 
 describeForPlatforms('ActivityList', () => {
   it('shows pending and confirmed local rows then opens transaction details from a confirmed row', async () => {
@@ -86,31 +79,6 @@ describeForPlatforms('ActivityList', () => {
     expect(
       await findByTestId(getRouteProbeTestId(Routes.ACTIVITY_DETAILS)),
     ).toBeOnTheScreen();
-  });
-
-  it('pull to refresh on an empty list syncs incoming transactions through Engine', async () => {
-    const updateIncomingSpy = jest
-      .spyOn(
-        transactionControllerWithIncomingSync,
-        'updateIncomingTransactions',
-      )
-      .mockResolvedValue(undefined);
-
-    const { UNSAFE_getByType } = renderActivityListView({
-      overrides: {
-        settings: {
-          basicFunctionalityEnabled: true,
-        },
-      },
-    });
-
-    fireEvent(UNSAFE_getByType(RefreshControl), 'refresh');
-
-    await waitFor(() => {
-      expect(updateIncomingSpy).toHaveBeenCalledTimes(1);
-    });
-
-    updateIncomingSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## **Description**

Removed the `TransactionController.updateIncomingTransactions` call from the Activity refresh handler because the controller method no longer exists. Activity refresh continues to refetch local, Perps, and Predict activity data.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A

## **Manual testing steps**

```gherkin
Feature: Refresh Activity data

  Scenario: Refresh activity without the removed controller method
    Given the Activity view is open
    When the user refreshes the activity list
    Then the activity data refreshes without calling the removed controller method
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Not applicable: this is a JavaScript-only controller-call removal.
- [x] I've tested with a power user scenario
  - Not applicable: this is a JavaScript-only controller-call removal.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Not applicable: this is a JavaScript-only controller-call removal.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Activity refresh wiring and tests; no auth or data-model changes, with refresh behavior otherwise unchanged aside from the removed sync step.
> 
> **Overview**
> **Activity list pull-to-refresh** no longer calls `TransactionController.updateIncomingTransactions`, which was removed from the controller. Refresh still runs `refetch()` plus optional Perps and Predict refetches.
> 
> Tests drop the `Engine` / `TransactionController` mocks and assertions tied to that call, including the component-view case that expected incoming sync on empty-list refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b632710faa17ed6fbb16862c2d92a609f97b024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->