### PR TITLE
chore(activity): refresh perps activity on focus

### DIFF
--- a/app/components/Views/ActivityDetails/hooks/usePerpsActivityQuery.ts
+++ b/app/components/Views/ActivityDetails/hooks/usePerpsActivityQuery.ts
@@ -153,7 +153,6 @@ export function usePerpsActivityQuery(
     initialPageParam: undefined as number | undefined,
     getNextPageParam: (lastPage: PerpsActivityPage) => lastPage.nextCursor,
     enabled,
-    refetchOnMount: 'always',
     retry: (failureCount, error) =>
       error instanceof Error &&
       error.message === providerUnavailableMessage &&

--- a/app/components/Views/ActivityList/hooks/usePerpsActivityItems.test.ts
+++ b/app/components/Views/ActivityList/hooks/usePerpsActivityItems.test.ts
@@ -14,6 +14,10 @@ import {
   type PerpsTransaction,
 } from '../../../UI/Perps/types/transactionHistory';
 
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+}));
+
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));

--- a/app/components/Views/ActivityList/hooks/usePerpsActivityItems.test.ts
+++ b/app/components/Views/ActivityList/hooks/usePerpsActivityItems.test.ts
@@ -1,5 +1,4 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { useFocusEffect } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { InitializationState } from '@metamask/perps-controller';
 import { usePerpsActivityItems } from './usePerpsActivityItems';
@@ -18,10 +17,6 @@ import {
 jest.mock('@react-navigation/native', () => ({
   useFocusEffect: jest.fn(),
 }));
-
-const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
-  typeof useFocusEffect
->;
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -286,21 +281,6 @@ describe('usePerpsActivityItems', () => {
     expect(result.current.error).toBe('boom');
     await result.current.refetch();
     expect(refetch).toHaveBeenCalledTimes(1);
-  });
-
-  it('refetches on focus without cancelling an in-flight initial fetch', () => {
-    const refetch = jest.fn();
-    setQuery([], { refetch });
-
-    renderHook(() => usePerpsActivityItems());
-
-    const focusCallback = mockUseFocusEffect.mock.calls[0][0] as () => void;
-    focusCallback();
-    focusCallback();
-
-    expect(refetch).toHaveBeenCalledTimes(2);
-    expect(refetch).toHaveBeenNthCalledWith(1, { cancelRefetch: false });
-    expect(refetch).toHaveBeenNthCalledWith(2, { cancelRefetch: false });
   });
 
   it('maps funding pagination onto loadMore/hasMore and loadMore fetches the next page', async () => {

--- a/app/components/Views/ActivityList/hooks/usePerpsActivityItems.test.ts
+++ b/app/components/Views/ActivityList/hooks/usePerpsActivityItems.test.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { useFocusEffect } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { InitializationState } from '@metamask/perps-controller';
 import { usePerpsActivityItems } from './usePerpsActivityItems';
@@ -17,6 +18,10 @@ import {
 jest.mock('@react-navigation/native', () => ({
   useFocusEffect: jest.fn(),
 }));
+
+const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
+  typeof useFocusEffect
+>;
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -281,6 +286,21 @@ describe('usePerpsActivityItems', () => {
     expect(result.current.error).toBe('boom');
     await result.current.refetch();
     expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches on focus without cancelling an in-flight initial fetch', () => {
+    const refetch = jest.fn();
+    setQuery([], { refetch });
+
+    renderHook(() => usePerpsActivityItems());
+
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0] as () => void;
+    focusCallback();
+    focusCallback();
+
+    expect(refetch).toHaveBeenCalledTimes(2);
+    expect(refetch).toHaveBeenNthCalledWith(1, { cancelRefetch: false });
+    expect(refetch).toHaveBeenNthCalledWith(2, { cancelRefetch: false });
   });
 
   it('maps funding pagination onto loadMore/hasMore and loadMore fetches the next page', async () => {

--- a/app/components/Views/ActivityList/hooks/usePerpsActivityItems.ts
+++ b/app/components/Views/ActivityList/hooks/usePerpsActivityItems.ts
@@ -42,6 +42,7 @@ export function usePerpsActivityItems({
     refetch,
     transactions,
   } = usePerpsActivityQuery(accountId, enabled && isInitialized);
+
   useFocusEffect(
     useCallback(() => {
       if (!enabled || !isInitialized) {

--- a/app/components/Views/ActivityList/hooks/usePerpsActivityItems.ts
+++ b/app/components/Views/ActivityList/hooks/usePerpsActivityItems.ts
@@ -4,6 +4,7 @@
  * Open orders and unrecognized trades map to `null` and are dropped.
  */
 import { useCallback, useMemo } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { InitializationState } from '@metamask/perps-controller';
 import { selectSelectedAccountCaipId } from '../../../../selectors/activity';
@@ -41,6 +42,15 @@ export function usePerpsActivityItems({
     refetch,
     transactions,
   } = usePerpsActivityQuery(accountId, enabled && isInitialized);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!enabled || !isInitialized) {
+        return;
+      }
+      refetch();
+    }, [enabled, isInitialized, refetch]),
+  );
 
   const items = useMemo(() => {
     const result: ActivityListItem[] = [];

--- a/app/components/Views/ActivityList/hooks/usePerpsActivityItems.ts
+++ b/app/components/Views/ActivityList/hooks/usePerpsActivityItems.ts
@@ -42,13 +42,12 @@ export function usePerpsActivityItems({
     refetch,
     transactions,
   } = usePerpsActivityQuery(accountId, enabled && isInitialized);
-
   useFocusEffect(
     useCallback(() => {
       if (!enabled || !isInitialized) {
         return;
       }
-      refetch();
+      refetch({ cancelRefetch: false });
     }, [enabled, isInitialized, refetch]),
   );
 


### PR DESCRIPTION
## **Description**

- Refresh Perps activity when the Activity List regains focus, instead of on remount

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-only change to when perps activity refetches; no auth, payments, or data-model changes.
> 
> **Overview**
> Perps activity data now **refreshes when the Activity list screen regains focus** instead of on every component remount.
> 
> `usePerpsActivityQuery` drops `refetchOnMount: 'always'`, and `usePerpsActivityItems` uses React Navigation's `useFocusEffect` to call `refetch({ cancelRefetch: false })` when focus returns, only if perps is enabled and initialized. Tests mock `useFocusEffect` so the hook suite stays stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddcf78b83db27c8447716896603b041e3c3af8a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->