### PR TITLE
fix(perps): show pending toast while updating TP/SL

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
@@ -45,6 +45,13 @@ jest.mock('../../../../component-library/components/Buttons/Button', () => ({
 }));
 jest.mock('../../../../util/haptics');
 
+interface MockToast {
+  labelOptions?: { label: string }[];
+}
+
+const getToastLabel = (toast: MockToast) =>
+  toast.labelOptions?.[0]?.label ?? 'unknown';
+
 describe('usePerpsTPSLUpdate', () => {
   const mockUpdatePositionTPSL = jest.fn();
   const mockShowToast = jest.fn();
@@ -79,6 +86,18 @@ describe('usePerpsTPSLUpdate', () => {
         },
       },
       tpsl: {
+        updateTPSLInProgress: {
+          variant: 'icon',
+          iconName: 'Loading',
+          hapticsType: 'warning',
+          hasNoTimeout: false,
+          labelOptions: [
+            {
+              label: 'perps.position.tpsl.update_in_progress',
+              isBold: true,
+            },
+          ],
+        },
         updateTPSLSuccess: {
           variant: 'icon',
           iconName: 'CheckBold',
@@ -520,8 +539,8 @@ describe('usePerpsTPSLUpdate', () => {
       mockUpdatePositionTPSLOptimistic.mockImplementation(() => {
         callOrder.push('optimistic');
       });
-      mockShowToast.mockImplementation(() => {
-        callOrder.push('toast');
+      mockShowToast.mockImplementation((toast: MockToast) => {
+        callOrder.push(getToastLabel(toast));
       });
 
       const { result } = renderHookWithToast();
@@ -533,7 +552,78 @@ describe('usePerpsTPSLUpdate', () => {
         await result.current.handleUpdateTPSL(position, '3300', '2700');
       });
 
-      expect(callOrder).toEqual(['optimistic', 'toast']);
+      expect(callOrder).toEqual([
+        'perps.position.tpsl.update_in_progress',
+        'optimistic',
+        'perps.position.tpsl.update_success',
+      ]);
+    });
+  });
+
+  describe('pending toast', () => {
+    it('shows the pending toast before the update request is sent', async () => {
+      // Arrange
+      const callOrder: string[] = [];
+      mockShowToast.mockImplementation((toast: MockToast) => {
+        callOrder.push(getToastLabel(toast));
+      });
+      mockUpdatePositionTPSL.mockImplementation(() => {
+        callOrder.push('request');
+        return Promise.resolve({ success: true });
+      });
+      const { result } = renderHookWithToast();
+      const position = createMockPosition();
+
+      // Act
+      await act(async () => {
+        await result.current.handleUpdateTPSL(position, '3300', '2700');
+      });
+
+      // Assert
+      expect(callOrder[0]).toBe('perps.position.tpsl.update_in_progress');
+      expect(callOrder[1]).toBe('request');
+      expect(mockShowToast).toHaveBeenNthCalledWith(
+        1,
+        mockPerpsToastOptions.positionManagement.tpsl.updateTPSLInProgress,
+      );
+    });
+
+    it('replaces the pending toast with the error toast when the update fails', async () => {
+      // Arrange
+      mockUpdatePositionTPSL.mockResolvedValue({
+        success: false,
+        error: 'Network error',
+      });
+      const { result } = renderHookWithToast();
+      const position = createMockPosition();
+
+      // Act
+      await act(async () => {
+        await result.current.handleUpdateTPSL(position, '3300', '2700');
+      });
+
+      // Assert
+      expect(mockShowToast).toHaveBeenCalledTimes(2);
+      expect(mockShowToast).toHaveBeenNthCalledWith(
+        1,
+        mockPerpsToastOptions.positionManagement.tpsl.updateTPSLInProgress,
+      );
+      expect(getToastLabel(mockShowToast.mock.calls[1][0])).toBe(
+        'perps.position.tpsl.update_failed',
+      );
+    });
+
+    it('shows the pending toast with the in-progress spinner styling', () => {
+      // Arrange
+      const { updateTPSLInProgress } =
+        mockPerpsToastOptions.positionManagement.tpsl;
+
+      // Act
+      const { label } = updateTPSLInProgress.labelOptions[0];
+
+      // Assert
+      expect(label).toBe('perps.position.tpsl.update_in_progress');
+      expect(updateTPSLInProgress.hapticsType).toBe('warning');
     });
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
@@ -54,6 +54,10 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
       setIsUpdating(true);
       DevLogger.log('usePerpsTPSLUpdate: Setting isUpdating to true');
 
+      // The TP/SL screen dismisses on tap, so the pending toast is the only
+      // feedback until the venue confirms. Every path below replaces it.
+      showToast(PerpsToastOptions.positionManagement.tpsl.updateTPSLInProgress);
+
       // Confirmation CUF: ends when the live positions stream delivers the
       // backend-confirmed TP/SL change (that delivery runs the CUF dispatcher).
       // The optimistic cache patch renders sooner but does not end the span, so

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -1311,6 +1311,23 @@ describe('usePerpsToasts', () => {
     });
 
     describe('positionManagement.tpsl', () => {
+      it('returns update TPSL in progress configuration', () => {
+        const { result } = renderHook(() => usePerpsToasts());
+        const config =
+          result.current.PerpsToastOptions.positionManagement.tpsl
+            .updateTPSLInProgress;
+
+        expect(config).toMatchObject({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Loading,
+          hapticsType: NotificationMoment.Warning,
+          hasNoTimeout: false,
+        });
+        expect(config.labelOptions).toEqual([
+          { label: 'Updating TP/SL', isBold: true },
+        ]);
+      });
+
       it('returns update TPSL success configuration', () => {
         const { result } = renderHook(() => usePerpsToasts());
         const config =

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -219,6 +219,7 @@ export interface PerpsToastOptionsConfig {
       };
     };
     tpsl: {
+      updateTPSLInProgress: PerpsToastOptions;
       updateTPSLSuccess: PerpsToastOptions;
       updateTPSLError: (error?: string) => PerpsToastOptions;
     };
@@ -1147,6 +1148,12 @@ const usePerpsToasts = (): {
           },
         },
         tpsl: {
+          updateTPSLInProgress: {
+            ...perpsBaseToastOptions.inProgress,
+            labelOptions: getPerpsToastLabels(
+              strings('perps.position.tpsl.update_in_progress'),
+            ),
+          },
           updateTPSLSuccess: {
             ...perpsBaseToastOptions.success,
             labelOptions: getPerpsToastLabels(

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2395,6 +2395,7 @@
         "unrealized_pnl": "Unrealized P&L"
       },
       "tpsl": {
+        "update_in_progress": "Updating TP/SL",
         "update_success": "TP/SL updated successfully",
         "update_failed": "Failed to update TP/SL"
       },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The TP/SL sheet closes immediately when the user taps **Set**. That dismiss is intentional (it avoids an Android Fabric crash), but it left a 1–2s gap with no UI feedback before the success toast.

This PR adds a **pending** toast (`Updating TP/SL`) at the start of `handleUpdateTPSL`, using the existing in-progress spinner/loading toast style. It is an additional toast, not a replacement of the success/error copy. Because the hook is shared, all three entry points are covered:

- TP/SL screen via PerpsMarketDetailsView
- Pro positions panel
- One-click stop-loss banner (same hook; called out so reviewers know this is slightly broader than the ticket’s Set-button flow)

If the controller resolves in under ~100ms, the pending toast may never paint.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added an "Updating TP/SL" toast while take-profit and stop-loss updates are in progress

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
Refs: https://consensyssoftware.atlassian.net/browse/TAT-3901

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Pending toast while updating TP/SL

  Background:
    Given I am logged into MetaMask Mobile
    And I have an open Perps position

  Scenario: user sets TP/SL from the TP/SL screen
    Given I open Perps market details for that position
    And I open the TP/SL sheet and configure values

    When I tap Set
    Then the sheet closes immediately
    And I see a toast "Updating TP/SL" with the in-progress spinner
    And I then see "TP/SL updated successfully"

  Scenario: user updates TP/SL from the pro positions panel
    Given I am on the Perps pro positions panel
    And I start a TP/SL update for an open position

    When the update request is in flight
    Then I see "Updating TP/SL"
    And I then see the success or error toast

  Scenario: user triggers one-click stop-loss
    Given the one-click stop-loss banner is visible for a position

    When I confirm the one-click stop-loss update
    Then I see "Updating TP/SL" before the result toast
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of this change. -->

### **Before**

N/A — attach a recording of the 1–2s silent gap after Set before marking this PR ready for review.

### **After**

N/A — attach a recording of "Updating TP/SL" followed by the success toast before marking this PR ready for review.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only toast sequencing in the shared TP/SL update hook; no trading or API behavior changes.
> 
> **Overview**
> Shows an **"Updating TP/SL"** in-progress toast (loading spinner + warning haptics) as soon as `handleUpdateTPSL` runs, before the venue request completes. That closes the feedback gap after the TP/SL sheet dismisses on **Set**, while existing success, error, and already-closed toasts still follow on the same paths.
> 
> Adds `updateTPSLInProgress` to Perps toast config (reusing shared in-progress styling), the `perps.position.tpsl.update_in_progress` copy in `en.json`, and hook/toast tests for toast order (pending → request → success/error).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 662dd770a2b6bc5b0f20c802f613d5e25aa3e779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->