### PR TITLE
fix(perps): show deposited amount in success toast

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsDepositStatus.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsDepositStatus.test.ts
@@ -568,7 +568,105 @@ describe('usePerpsDepositStatus', () => {
       });
       expect(
         mockPerpsToastOptions.accountManagement.deposit.success,
-      ).toHaveBeenCalledWith('1500.00');
+      ).toHaveBeenCalledWith('500');
+    });
+
+    it('should pass the credited amount rather than the resulting balance when the account already had funds', () => {
+      // Arrange - account already funded with 50.00 before the deposit settles
+      mockUsePerpsLiveAccount.mockReturnValue({
+        account: {
+          spendableBalance: '50.00',
+          withdrawableBalance: '50.00',
+          marginUsed: '0.00',
+          unrealizedPnl: '0.00',
+          returnOnEquity: '0',
+          totalBalance: '50.00',
+        },
+        isInitialLoading: false,
+      });
+      const { rerender } = renderHook(() => usePerpsDepositStatus());
+
+      // Act - a $1 deposit nets 0.97 after fees
+      act(() => {
+        const transactionHandler = mockSubscribe.mock.calls.find(
+          (call) =>
+            call[0] === 'TransactionController:transactionStatusUpdated',
+        )?.[1];
+        transactionHandler?.({
+          transactionMeta: {
+            id: 'test-tx-id',
+            type: TransactionType.perpsDeposit,
+            status: TransactionStatus.approved,
+          } as TransactionMeta,
+        });
+      });
+
+      mockUsePerpsLiveAccount.mockReturnValue({
+        account: {
+          spendableBalance: '50.97',
+          withdrawableBalance: '50.97',
+          marginUsed: '0.00',
+          unrealizedPnl: '0.00',
+          returnOnEquity: '0',
+          totalBalance: '50.97',
+        },
+        isInitialLoading: false,
+      });
+      rerender({});
+
+      // Assert
+      expect(
+        mockPerpsToastOptions.accountManagement.deposit.success,
+      ).toHaveBeenCalledWith('0.97');
+    });
+
+    it('should compute the credited amount without floating point artifacts', () => {
+      // Arrange - a delta that loses precision under binary subtraction
+      mockUsePerpsLiveAccount.mockReturnValue({
+        account: {
+          spendableBalance: '0.07',
+          withdrawableBalance: '0.07',
+          marginUsed: '0.00',
+          unrealizedPnl: '0.00',
+          returnOnEquity: '0',
+          totalBalance: '0.07',
+        },
+        isInitialLoading: false,
+      });
+      const { rerender } = renderHook(() => usePerpsDepositStatus());
+
+      // Act
+      act(() => {
+        const transactionHandler = mockSubscribe.mock.calls.find(
+          (call) =>
+            call[0] === 'TransactionController:transactionStatusUpdated',
+        )?.[1];
+        transactionHandler?.({
+          transactionMeta: {
+            id: 'test-tx-id',
+            type: TransactionType.perpsDeposit,
+            status: TransactionStatus.approved,
+          } as TransactionMeta,
+        });
+      });
+
+      mockUsePerpsLiveAccount.mockReturnValue({
+        account: {
+          spendableBalance: '1.14',
+          withdrawableBalance: '1.14',
+          marginUsed: '0.00',
+          unrealizedPnl: '0.00',
+          returnOnEquity: '0',
+          totalBalance: '1.14',
+        },
+        isInitialLoading: false,
+      });
+      rerender({});
+
+      // Assert - 1.14 - 0.07 is 1.0699999999999998 in float arithmetic
+      expect(
+        mockPerpsToastOptions.accountManagement.deposit.success,
+      ).toHaveBeenCalledWith('1.07');
     });
 
     it('should not show success toast when balance decreases', () => {

--- a/app/components/UI/Perps/hooks/usePerpsDepositStatus.ts
+++ b/app/components/UI/Perps/hooks/usePerpsDepositStatus.ts
@@ -3,6 +3,7 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
+import { BigNumber } from 'bignumber.js';
 import { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import Engine from '../../../../core/Engine';
@@ -119,8 +120,15 @@ export const usePerpsDepositStatus = () => {
     const previousBalance = Number.parseFloat(prevSpendableBalanceRef.current);
 
     if (currentBalance > previousBalance) {
+      // The toast reports what the deposit credited, so it has to be the
+      // balance delta. Passing the resulting spendable balance made the toast
+      // claim the whole account balance had just been added.
+      const amountAdded = new BigNumber(liveSpendable)
+        .minus(prevSpendableBalanceRef.current)
+        .toFixed();
+
       showToast(
-        PerpsToastOptions.accountManagement.deposit.success(liveSpendable),
+        PerpsToastOptions.accountManagement.deposit.success(amountAdded),
       );
 
       expectingDepositRef.current = false;

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -181,13 +181,17 @@ describe('usePerpsToasts', () => {
 
   describe('PerpsToastOptions configurations', () => {
     describe('accountManagement.deposit', () => {
-      it('returns success configuration with formatted amount', () => {
+      it('returns success configuration reporting the amount added', () => {
+        // Arrange
         const { result } = renderHook(() => usePerpsToasts());
+
+        // Act
         const config =
           result.current.PerpsToastOptions.accountManagement.deposit.success(
-            '100 USDC',
+            '100',
           );
 
+        // Assert
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Confirmation,
@@ -197,9 +201,46 @@ describe('usePerpsToasts', () => {
         expect(config.labelOptions).toEqual([
           { label: 'Your Perps account was funded', isBold: true },
           { label: '\n', isBold: false },
-          { label: '$100 available to trade', isBold: false },
+          { label: '$100 was added to Perps', isBold: false },
         ]);
       });
+
+      it('reports sub-dollar amounts added without rounding them away', () => {
+        // Arrange
+        const { result } = renderHook(() => usePerpsToasts());
+
+        // Act
+        const config =
+          result.current.PerpsToastOptions.accountManagement.deposit.success(
+            '0.97',
+          );
+
+        // Assert
+        expect(config.labelOptions?.[2]).toEqual({
+          label: '$0.97 was added to Perps',
+          isBold: false,
+        });
+      });
+
+      it.each(['', '0', 'not-a-number'])(
+        'falls back to the generic success subtext when the amount added is %p',
+        (amountAdded) => {
+          // Arrange
+          const { result } = renderHook(() => usePerpsToasts());
+
+          // Act
+          const config =
+            result.current.PerpsToastOptions.accountManagement.deposit.success(
+              amountAdded,
+            );
+
+          // Assert
+          expect(config.labelOptions?.[2]).toEqual({
+            label: 'Funds are ready to trade',
+            isBold: false,
+          });
+        },
+      );
 
       it('returns in progress configuration with processing time', () => {
         const { result } = renderHook(() => usePerpsToasts());

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -61,7 +61,8 @@ export type PerpsToastOptions = Omit<ToastOptions, 'labelOptions'> & {
 export interface PerpsToastOptionsConfig {
   accountManagement: {
     deposit: {
-      success: (amount: string) => PerpsToastOptions;
+      /** @param amountAdded - Amount credited to the Perps account, not the resulting balance. */
+      success: (amountAdded: string) => PerpsToastOptions;
       inProgress: (
         processingTimeInSeconds: number | undefined,
         transactionId: string,
@@ -426,12 +427,13 @@ const usePerpsToasts = (): {
     () => ({
       accountManagement: {
         deposit: {
-          success: (amount: string) => {
+          success: (amountAdded: string) => {
+            const numericAmountAdded = Number.parseFloat(amountAdded);
             let subtext = strings('perps.deposit.funds_are_ready_to_trade');
 
-            if (amount && amount !== '0') {
-              subtext = strings('perps.deposit.success_message', {
-                amount: formatPerpsFiat(amount),
+            if (Number.isFinite(numericAmountAdded) && numericAmountAdded > 0) {
+              subtext = strings('perps.deposit.success_amount_added', {
+                amount: formatPerpsFiat(amountAdded),
               });
             }
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1521,7 +1521,7 @@
         "view_transaction": "View transaction"
       },
       "success_toast": "Your Perps account was funded",
-      "success_message": "{{amount}} available to trade",
+      "success_amount_added": "{{amount}} was added to Perps",
       "funds_are_ready_to_trade": "Funds are ready to trade",
       "error_toast": "Transaction failed",
       "error_generic": "Funds have been returned to you",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`usePerpsDepositStatus` detects a settled deposit by watching `spendableBalance` rise, then passed that **resulting balance** into a toast whose copy described the **amount credited**. A $1 deposit ($0.97 net) into a funded account therefore quoted the whole account balance as newly added.

This change passes the balance delta into the toast and updates the copy together (changing only one half would have made the bug worse). Subtraction uses `BigNumber` because float math on decimal balance strings produces artifacts (`1.14 - 0.07 = 1.0699999999999998`).

Copy is **provisional** and still needs product sign-off (ticket cc's Nikki Pham). The locale key is `perps.deposit.success_amount_added` (`"{{amount}} was added to Perps"`), replacing `perps.deposit.success_message`. A new key was used so es/fr/de fall back to correct English instead of a stale, confidently-wrong translation of "available to trade". A wording tweak later should not need code edits.

Known limitations (left out of scope):
- The delta assumes a quiet account: `prevSpendableBalance` is snapshotted at approval, so unrelated activity in that window (a fill releasing margin, a second deposit) skews the figure.
- If the live account stream has not populated at approval time, the snapshot falls back to `'0'` and the delta equals the full balance, reproducing the old symptom. Fixing that would require changing deposit detection.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Perps deposit toast showing total balance instead of amount added

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
Refs: TAT-3917
https://consensyssoftware.atlassian.net/browse/TAT-3917

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps deposit success toast amount

  Background:
    Given I am logged into MetaMask Mobile
    And Perps is enabled for my account

  Scenario: funded account shows the amount credited, not the resulting balance
    Given I already have spendable Perps funds (for example $50.00)
    And I start a $1 Perps deposit that nets about $0.97 after fees

    When the deposit settles
    Then I see a success toast whose subtext is "$0.97 was added to Perps"
    And the toast does not quote my full spendable balance as the amount added

  Scenario: first-time or empty-account deposit
    Given I have no spendable Perps funds
    And I complete a successful Perps deposit

    When the deposit settles
    Then I see a success toast whose subtext reports the amount added to Perps
    And I do not see leftover "available to trade" wording for that amount

  Scenario: unparseable amount falls back to generic copy
    Given a deposit succeeds but the credited amount cannot be shown as a positive number

    When the success toast is shown
    Then the subtext is "Funds are ready to trade"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — device screenshots were not captured in this worktree. Add a recording of a $1 deposit into a funded Perps account before marking Ready for review (old toast quoted the full balance).

### **After**

N/A — same as above; expected after: "$0.97 was added to Perps" (copy still needs product sign-off from Nikki Pham).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing Perps toast copy and amount calculation only; logic is localized to deposit success handling with expanded unit tests.
> 
> **Overview**
> Fixes the Perps deposit success toast so it shows **how much was credited**, not the post-deposit spendable balance. **`usePerpsDepositStatus`** now passes the spendable-balance delta (computed with **`BigNumber`**) into the toast when a deposit settles, which avoids wrong totals on already-funded accounts and float rounding glitches.
> 
> Toast copy is aligned with that behavior: English uses **`perps.deposit.success_amount_added`** (`"{{amount}} was added to Perps"`) instead of the old “available to trade” string. **`usePerpsToasts`** treats the argument as **`amountAdded`**, formats sub-dollar amounts, and falls back to “Funds are ready to trade” when the value isn’t a positive number. Tests cover funded-account deltas, decimal precision, and the new messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ed278299469d152f82123ba7125bac2688a8aa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->