### PR TITLE
fix(perps): always show ticker in market row

### DIFF
--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.test.tsx
@@ -81,7 +81,7 @@ describe('PerpsMarketRowItem', () => {
       expect(screen.getByText('50x')).toBeOnTheScreen();
       expect(screen.getByText('$52,000')).toBeOnTheScreen();
       expect(screen.getByText('+4.00%')).toBeOnTheScreen();
-      expect(screen.getByText('$2.5B Vol')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · $2.5B Vol')).toBeOnTheScreen();
     });
 
     it('renders as a touchable component', () => {
@@ -191,7 +191,7 @@ describe('PerpsMarketRowItem', () => {
 
       render(<PerpsMarketRowItem market={customVolumeMarket} />);
 
-      expect(screen.getByText('$150M Vol')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · $150M Vol')).toBeOnTheScreen();
     });
 
     it('handles large price changes', () => {
@@ -228,8 +228,7 @@ describe('PerpsMarketRowItem', () => {
         screen.getByTestId(getPerpsMarketRowItemSelector.assetLabel('BTC')),
       ).toHaveTextContent('BTC');
       expect(screen.queryByText('Bitcoin')).not.toBeOnTheScreen();
-      expect(screen.queryByText('BTC · $2.5B Vol')).not.toBeOnTheScreen();
-      expect(screen.getByText('$2.5B Vol')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · $2.5B Vol')).toBeOnTheScreen();
     });
 
     it('strips the provider prefix from the ticker when the flag is disabled', () => {
@@ -248,7 +247,7 @@ describe('PerpsMarketRowItem', () => {
       ).toHaveTextContent('TSLA');
       expect(screen.queryByText('xyz:TSLA')).not.toBeOnTheScreen();
       expect(screen.queryByText('Tesla')).not.toBeOnTheScreen();
-      expect(screen.queryByText('TSLA · $2.5B Vol')).not.toBeOnTheScreen();
+      expect(screen.getByText('TSLA · $2.5B Vol')).toBeOnTheScreen();
     });
 
     it('shows the full asset name for a provider-prefixed symbol when the flag is enabled', () => {
@@ -269,27 +268,7 @@ describe('PerpsMarketRowItem', () => {
       expect(screen.getByText('TSLA · $2.5B Vol')).toBeOnTheScreen();
     });
 
-    it('does not show ticker suffix when the HIP-3 bare symbol equals the name', () => {
-      mockSelectors(true);
-
-      render(
-        <PerpsMarketRowItem
-          market={{ ...mockMarketData, symbol: 'xyz:AAPL', name: 'AAPL' }}
-        />,
-      );
-
-      // Asset label should show the bare ticker 'AAPL' (name == stripped symbol)
-      expect(
-        screen.getByTestId(
-          getPerpsMarketRowItemSelector.assetLabel('xyz:AAPL'),
-        ),
-      ).toHaveTextContent('AAPL');
-      // No suffix — it would be a duplicate of the asset label
-      expect(screen.queryByText('AAPL · $2.5B Vol')).not.toBeOnTheScreen();
-      expect(screen.getByText('$2.5B Vol')).toBeOnTheScreen();
-    });
-
-    it('falls back to the ticker when the flag is enabled but name is missing', () => {
+    it('falls back to the ticker in the title when the flag is enabled but name is missing', () => {
       mockSelectors(true);
 
       render(<PerpsMarketRowItem market={{ ...mockMarketData, name: '' }} />);
@@ -297,11 +276,29 @@ describe('PerpsMarketRowItem', () => {
       expect(
         screen.getByTestId(getPerpsMarketRowItemSelector.assetLabel('BTC')),
       ).toHaveTextContent('BTC');
-      expect(screen.queryByText('BTC · $2.5B Vol')).not.toBeOnTheScreen();
-      expect(screen.getByText('$2.5B Vol')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · $2.5B Vol')).toBeOnTheScreen();
     });
+  });
 
-    it('does not show a duplicate ticker when the name falls back to the symbol', () => {
+  // Markets with no human-readable name render the ticker as the title, so the
+  // second row has to repeat it rather than treating it as redundant.
+  describe('Ticker In Second Row', () => {
+    it.each([true, false])(
+      'shows the ticker in the second row when the full asset name flag is %s',
+      (showFullAssetNames) => {
+        // Arrange
+        mockSelectors(showFullAssetNames);
+
+        // Act
+        render(<PerpsMarketRowItem market={mockMarketData} />);
+
+        // Assert
+        expect(screen.getByText('BTC · $2.5B Vol')).toBeOnTheScreen();
+      },
+    );
+
+    it('shows the ticker in the second row when the name falls back to the symbol', () => {
+      // Arrange
       mockSelectors(true);
 
       render(
@@ -310,11 +307,78 @@ describe('PerpsMarketRowItem', () => {
         />,
       );
 
-      expect(
-        screen.getByTestId(getPerpsMarketRowItemSelector.assetLabel('BTC')),
-      ).toHaveTextContent('BTC');
-      expect(screen.queryByText('BTC · $2.5B Vol')).not.toBeOnTheScreen();
-      expect(screen.getByText('$2.5B Vol')).toBeOnTheScreen();
+      // Act
+      const assetLabel = screen.getByTestId(
+        getPerpsMarketRowItemSelector.assetLabel('BTC'),
+      );
+
+      // Assert - the ticker is duplicated between the two rows by design
+      expect(assetLabel).toHaveTextContent('BTC');
+      expect(screen.getByText('BTC · $2.5B Vol')).toBeOnTheScreen();
+    });
+
+    it('shows the bare ticker in the second row when the HIP-3 stripped symbol equals the name', () => {
+      // Arrange
+      mockSelectors(true);
+
+      render(
+        <PerpsMarketRowItem
+          market={{ ...mockMarketData, symbol: 'xyz:AAPL', name: 'AAPL' }}
+        />,
+      );
+
+      // Act
+      const assetLabel = screen.getByTestId(
+        getPerpsMarketRowItemSelector.assetLabel('xyz:AAPL'),
+      );
+
+      // Assert - the provider prefix is stripped from both rows
+      expect(assetLabel).toHaveTextContent('AAPL');
+      expect(screen.getByText('AAPL · $2.5B Vol')).toBeOnTheScreen();
+      expect(screen.queryByText('xyz:AAPL · $2.5B Vol')).not.toBeOnTheScreen();
+    });
+
+    it('shows the ticker in the second row when the name is missing', () => {
+      // Arrange
+      mockSelectors(true);
+
+      // Act
+      render(<PerpsMarketRowItem market={{ ...mockMarketData, name: '' }} />);
+
+      // Assert
+      expect(screen.getByText('BTC · $2.5B Vol')).toBeOnTheScreen();
+    });
+
+    it('shows the ticker in the second row for the funding rate metric', () => {
+      // Arrange
+      mockSelectors(false);
+
+      // Act
+      render(
+        <PerpsMarketRowItem
+          market={{ ...mockMarketData, fundingRate: 0.0005 }}
+          displayMetric="fundingRate"
+        />,
+      );
+
+      // Assert
+      expect(screen.getByText('BTC · 0.0500% Funding')).toBeOnTheScreen();
+    });
+
+    it('shows the ticker in the second row for the price change metric, which has no metric label', () => {
+      // Arrange
+      mockSelectors(false);
+
+      // Act
+      render(
+        <PerpsMarketRowItem
+          market={mockMarketData}
+          displayMetric="priceChange"
+        />,
+      );
+
+      // Assert
+      expect(screen.getByText('BTC · +4.00%')).toBeOnTheScreen();
     });
   });
 
@@ -457,7 +521,7 @@ describe('PerpsMarketRowItem', () => {
       // Should show the new live price
       expect(screen.getByText('$55,000')).toBeOnTheScreen();
       // Should show updated volume (2 decimals with formatVolume)
-      expect(screen.getByText('$3.00B Vol')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · $3.00B Vol')).toBeOnTheScreen();
     });
 
     it('does not update when live price matches current price', () => {
@@ -517,7 +581,7 @@ describe('PerpsMarketRowItem', () => {
 
       // Price shows $0, volume shows $0.00 Vol
       expect(screen.getByText('$0')).toBeOnTheScreen();
-      expect(screen.getByText('$0.00 Vol')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · $0.00 Vol')).toBeOnTheScreen();
     });
 
     it('formats different volume ranges correctly', () => {
@@ -528,28 +592,28 @@ describe('PerpsMarketRowItem', () => {
       const { rerender } = render(
         <PerpsMarketRowItem market={mockMarketData} />,
       );
-      expect(screen.getByText('$5.50B Vol')).toBeOnTheScreen(); // B shows 2 decimals
+      expect(screen.getByText('BTC · $5.50B Vol')).toBeOnTheScreen(); // B shows 2 decimals
 
       // Test millions (2 decimals with formatVolume)
       mockUsePerpsLivePrices.mockReturnValue({
         BTC: { price: '50000', volume24h: 750000000 },
       });
       rerender(<PerpsMarketRowItem market={{ ...mockMarketData }} />);
-      expect(screen.getByText('$750.00M Vol')).toBeOnTheScreen(); // M shows 2 decimals
+      expect(screen.getByText('BTC · $750.00M Vol')).toBeOnTheScreen(); // M shows 2 decimals
 
       // Test thousands (0 decimals with formatVolume)
       mockUsePerpsLivePrices.mockReturnValue({
         BTC: { price: '50000', volume24h: 50000 },
       });
       rerender(<PerpsMarketRowItem market={{ ...mockMarketData }} />);
-      expect(screen.getByText('$50K Vol')).toBeOnTheScreen(); // K shows no decimals
+      expect(screen.getByText('BTC · $50K Vol')).toBeOnTheScreen(); // K shows no decimals
 
       // Test small values (2 decimals with formatVolume)
       mockUsePerpsLivePrices.mockReturnValue({
         BTC: { price: '50000', volume24h: 123.45 },
       });
       rerender(<PerpsMarketRowItem market={{ ...mockMarketData }} />);
-      expect(screen.getByText('$123.45 Vol')).toBeOnTheScreen(); // Shows 2 decimals
+      expect(screen.getByText('BTC · $123.45 Vol')).toBeOnTheScreen(); // Shows 2 decimals
     });
 
     it('handles missing live price fields gracefully', () => {
@@ -564,7 +628,7 @@ describe('PerpsMarketRowItem', () => {
       // Should keep original change data when percentChange24h is missing
       expect(screen.getByText('+4.00%')).toBeOnTheScreen();
       // Should keep original volume when volume24h is missing
-      expect(screen.getByText('$2.5B Vol')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · $2.5B Vol')).toBeOnTheScreen();
     });
 
     it('handles live prices for multiple symbols independently', () => {
@@ -652,7 +716,7 @@ describe('PerpsMarketRowItem', () => {
       // With 5 significant digits, this rounds to $100,000,000 (trailing zeros removed)
       expect(screen.getByText('$100,000,000')).toBeOnTheScreen();
       expect(screen.getByText('+2.50%')).toBeOnTheScreen();
-      expect(screen.getByText('$10.00B Vol')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · $10.00B Vol')).toBeOnTheScreen();
     });
   });
 
@@ -729,7 +793,7 @@ describe('PerpsMarketRowItem', () => {
       );
 
       // Should display formatted funding rate using formatFundingRate utility
-      expect(screen.getByText('0.0500% Funding')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · 0.0500% Funding')).toBeOnTheScreen();
     });
 
     it('displays negative funding rate correctly', () => {
@@ -746,7 +810,7 @@ describe('PerpsMarketRowItem', () => {
       );
 
       // Should display negative funding rate
-      expect(screen.getByText('-0.2300% Funding')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · -0.2300% Funding')).toBeOnTheScreen();
     });
 
     it('displays zero funding rate when fundingRate is undefined', () => {
@@ -763,7 +827,7 @@ describe('PerpsMarketRowItem', () => {
       );
 
       // Should display zero funding rate using formatFundingRate utility
-      expect(screen.getByText('0.0000% Funding')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · 0.0000% Funding')).toBeOnTheScreen();
     });
 
     it('displays zero funding rate when fundingRate is null', () => {
@@ -780,7 +844,7 @@ describe('PerpsMarketRowItem', () => {
       );
 
       // Should display zero funding rate
-      expect(screen.getByText('0.0000% Funding')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · 0.0000% Funding')).toBeOnTheScreen();
     });
 
     it('displays zero funding rate when fundingRate is 0', () => {
@@ -797,7 +861,7 @@ describe('PerpsMarketRowItem', () => {
       );
 
       // Should display zero funding rate
-      expect(screen.getByText('0.0000% Funding')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · 0.0000% Funding')).toBeOnTheScreen();
     });
 
     it('updates funding rate from live WebSocket data', () => {
@@ -822,7 +886,7 @@ describe('PerpsMarketRowItem', () => {
       );
 
       // Should display the updated live funding rate
-      expect(screen.getByText('0.0500% Funding')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · 0.0500% Funding')).toBeOnTheScreen();
     });
 
     it('updates funding rate even when price has not changed', () => {
@@ -848,7 +912,7 @@ describe('PerpsMarketRowItem', () => {
       );
 
       // Should display the updated funding rate even though price didn't change
-      expect(screen.getByText('0.1200% Funding')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · 0.1200% Funding')).toBeOnTheScreen();
       // Price should remain the same
       expect(screen.getByText('$52,000')).toBeOnTheScreen();
     });
@@ -876,7 +940,7 @@ describe('PerpsMarketRowItem', () => {
       );
 
       // Should display the original funding rate
-      expect(screen.getByText('0.0500% Funding')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · 0.0500% Funding')).toBeOnTheScreen();
     });
 
     it('handles very small funding rates correctly', () => {
@@ -894,7 +958,7 @@ describe('PerpsMarketRowItem', () => {
       );
 
       // Should display with 4 decimal places
-      expect(screen.getByText('0.0001% Funding')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · 0.0001% Funding')).toBeOnTheScreen();
     });
 
     it('handles large funding rates correctly', () => {
@@ -912,7 +976,7 @@ describe('PerpsMarketRowItem', () => {
       );
 
       // Should display with 4 decimal places
-      expect(screen.getByText('15.7500% Funding')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · 15.7500% Funding')).toBeOnTheScreen();
     });
 
     it('uses formatFundingRate utility for consistent formatting', () => {
@@ -931,7 +995,7 @@ describe('PerpsMarketRowItem', () => {
 
       // Should use formatFundingRate which formats to 4 decimal places
       // This ensures consistency with PerpsMarketStatisticsCard
-      expect(screen.getByText('1.2500% Funding')).toBeOnTheScreen();
+      expect(screen.getByText('BTC · 1.2500% Funding')).toBeOnTheScreen();
     });
 
     it('passes updated funding rate to onPress callback', async () => {

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
@@ -161,23 +161,11 @@ const PerpsMarketRowItem = ({
     return getPerpsDisplaySymbol(label);
   }, [showFullAssetNames, displayMarket.name, displayMarket.symbol]);
 
-  // Only show the ticker alongside the metric text when the row is already
-  // displaying the full name (otherwise the ticker is redundant) and the
-  // name is a genuine name rather than the ticker-fallback value returned
-  // when Terminal API / HyperLiquid name resolution has no real name for
-  // this market.
-  const showTickerSuffix = useMemo(
-    () =>
-      showFullAssetNames &&
-      Boolean(displayMarket.name) &&
-      displayMarket.name !== displayMarket.symbol &&
-      getPerpsDisplaySymbol(displayMarket.symbol) !== displayMarket.name,
-    [showFullAssetNames, displayMarket.name, displayMarket.symbol],
-  );
+  // The ticker always leads the second row, even when it duplicates the title,
+  // so markets with no human-readable name still surface their ticker.
+  const ticker = getPerpsDisplaySymbol(displayMarket.symbol);
 
-  const description = showTickerSuffix
-    ? `${getPerpsDisplaySymbol(displayMarket.symbol)} \u00B7 ${displayText}`
-    : displayText;
+  const description = displayText ? `${ticker} \u00B7 ${displayText}` : ticker;
 
   return (
     <ListItem


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Some Perps market rows showed no ticker at all — the second line was just the metric (`$2.5B Vol`), and the ticker appeared nowhere on the row.

`PerpsMarketRowItem` computed a `showTickerSuffix` flag that suppressed the ticker whenever it would duplicate the title. It required **all** of: the full-asset-names flag on, a non-empty `name`, and `name` differing from both the raw symbol and the prefix-stripped symbol. When HyperLiquid or the Terminal API has no human-readable name for a market, `name` falls back to the ticker — so the title renders the ticker, and the suffix check simultaneously concludes the ticker is redundant and drops it. The row loses the ticker entirely. The same happened with the flag off, where the title is always the ticker.

This PR inverts the premise: **the ticker is unconditional context, not a conditional suffix**. The description row is now always `<ticker> · <metric>`. The `showTickerSuffix` memo and the conditional description are gone (net -12 lines in the component). The provider prefix is still stripped via `getPerpsDisplaySymbol` (`xyz:TSLA` -> `TSLA`), and title logic (full name vs ticker) is untouched.

**Reviewer note — broader visual impact than the bug alone.** The ticket says the ticker should *always* be present, so this now also affects rows that previously looked fine. With the full-asset-names flag off, every row goes from `$2.5B Vol` to `BTC · $2.5B Vol`, duplicating the title on *every* row rather than only nameless ones. That follows the acceptance criteria literally, but it is a broad visual change across the market list, watchlist and trending rows, so it deserves a designer's glance before merge. If the intent was narrower (ticker only when it isn't already the title), say so and the condition can be reintroduced as "title is not the ticker" instead of the old multi-clause check.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Perps market rows missing the ticker for markets with no human-readable name

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
Refs: https://consensyssoftware.atlassian.net/browse/TAT-3842

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Ticker always visible in Perps market rows

  Background:
    Given I am logged into MetaMask Mobile
    And I open the Perps markets list

  Scenario: market with no human-readable name shows its ticker
    Given a market whose name is not resolved by HyperLiquid or the Terminal API
    And the full asset names feature flag is enabled

    When I look at that market's row
    Then the title shows the ticker
    And the second line shows "<ticker> · <metric>"
    And the ticker is never missing from the row

  Scenario: market with a full name shows the ticker next to the metric
    Given a market with a resolved name such as Bitcoin
    And the full asset names feature flag is enabled

    When I look at that market's row
    Then the title shows "Bitcoin"
    And the second line shows "BTC · $2.5B Vol"

  Scenario: full asset names flag disabled
    Given the full asset names feature flag is disabled

    When I look at any market row
    Then the title shows the ticker
    And the second line shows "<ticker> · <metric>"

  Scenario: HIP-3 provider-prefixed market strips the prefix
    Given a market with the symbol "xyz:TSLA"

    When I look at that market's row
    Then both the title and the second line show "TSLA" without the "xyz:" prefix

  Scenario: other metrics keep the ticker prefix
    Given the market list is sorted to display funding rate or 24h price change

    When I look at any market row
    Then the second line still starts with the ticker followed by "·"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no simulator verification was done for this change. Attach a screenshot of a nameless market row showing only `$2.5B Vol` before marking this PR ready for review.

### **After**

N/A — no simulator verification was done for this change. Attach a screenshot of the same row showing `<ticker> · $2.5B Vol`, plus one full market list with the flag off, before marking this PR ready for review.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI copy change in Perps list rows with broad visual impact (ticker repeated on every row when full names are off); no auth, data, or API changes.
> 
> **Overview**
> **Perps market rows** now always prefix the second line with the display ticker (`BTC · $2.5B Vol`, `BTC · 0.0500% Funding`, etc.), fixing rows where only the metric appeared and the ticker was missing when `name` fell back to the symbol.
> 
> `PerpsMarketRowItem` drops the `showTickerSuffix` guard that hid the ticker when it seemed redundant with the title. The description is always `ticker · metric` (or ticker alone if there is no metric text), still using `getPerpsDisplaySymbol` for HIP-3 prefixes. Title behavior (full name vs ticker) is unchanged.
> 
> Tests are updated across rendering, feature flags, live prices, and funding rate; a new **Ticker In Second Row** block documents intentional duplication when the title is also the ticker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3729499ef5b119a302afc585c3d3a46d9b869c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->