### PR TITLE
ci: slim Slack RC notification workflow setup

### DIFF
--- a/.github/workflows/slack-rc-notification-benchmark.yml
+++ b/.github/workflows/slack-rc-notification-benchmark.yml
@@ -1,0 +1,321 @@
+##############################################################################################
+#
+# TEMPORARY: Slack RC notification setup benchmark.
+# Branch-scoped to ci/slim-slack-rc-notification. Delete before merge.
+# Does not call Slack, release, build, comment, or notification workflows.
+# Does not use repository secrets. Uploads only dry-run test outputs.
+#
+##############################################################################################
+name: Slack RC Notification Benchmark
+
+on:
+  push:
+    branches:
+      - ci/slim-slack-rc-notification
+
+# contents: read for checkout. actions: write is only for uploading dry-run
+# payload/timing files used by the compare job. No contents: write.
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: slack-rc-notification-benchmark-${{ github.sha }}-${{ github.run_id }}
+  cancel-in-progress: false
+
+env:
+  FIXTURE_SEMVER: 0.0.0-ci-dry-run
+  FIXTURE_IOS_BUILD_NUMBER: '100'
+  FIXTURE_ANDROID_BUILD_NUMBER: '100'
+  FIXTURE_PR_NUMBER: '1'
+  FIXTURE_PIPELINE_URL: https://github.com/MetaMask/metamask-mobile/actions
+  FIXTURE_ANDROID_PUBLIC_URL: https://example.invalid/android-ci-dry-run
+  FIXTURE_IOS_PUBLIC_URL: https://example.invalid/ios-ci-dry-run
+  SLACK_RC_NOTIFICATION_DRY_RUN: 'true'
+
+jobs:
+  baseline:
+    name: Baseline
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record setup start
+        run: echo "SETUP_START_NS=$(date +%s%N)" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download Android Play Store check report (optional)
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: android-play-store-check-slack
+          path: android-play-store-check-out
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Capture RC, OTA, and production dry-run payloads
+        run: |
+          set -euo pipefail
+          unset SLACK_BOT_TOKEN || true
+          mkdir -p benchmark-out
+          extract_payload() {
+            local stdout_file="$1"
+            local json_file="$2"
+            python3 - "$stdout_file" "$json_file" <<'PY'
+          import pathlib, sys
+          text = pathlib.Path(sys.argv[1]).read_text()
+          start = text.index("--- Slack payload (dry run) ---\n")
+          rest = text[start + len("--- Slack payload (dry run) ---\n"):]
+          end = rest.index("\n--- end dry run ---")
+          payload = rest[:end].lstrip("\n")
+          pathlib.Path(sys.argv[2]).write_text(payload)
+          PY
+          }
+
+          common_env=(
+            "SLACK_RC_NOTIFICATION_DRY_RUN=true"
+            "BUILD_PIPELINE_URL=${FIXTURE_PIPELINE_URL}"
+            "ANDROID_PUBLIC_URL=${FIXTURE_ANDROID_PUBLIC_URL}"
+            "IOS_PUBLIC_URL=${FIXTURE_IOS_PUBLIC_URL}"
+          )
+
+          echo "::group::RC explicit metadata"
+          env "${common_env[@]}" \
+            SEMVER="${FIXTURE_SEMVER}" \
+            IOS_BUILD_NUMBER="${FIXTURE_IOS_BUILD_NUMBER}" \
+            ANDROID_BUILD_NUMBER="${FIXTURE_ANDROID_BUILD_NUMBER}" \
+            PR_NUMBER="${FIXTURE_PR_NUMBER}" \
+            BUILD_KIND=rc \
+            node ./scripts/slack-rc-notification.mjs | tee benchmark-out/rc.stdout.txt
+          extract_payload benchmark-out/rc.stdout.txt benchmark-out/rc.json
+          echo "::endgroup::"
+
+          echo "::group::OTA-style metadata fallback"
+          GITHUB_OUTPUT="${PWD}/benchmark-out/ota-github-output.txt"
+          : > "${GITHUB_OUTPUT}"
+          GITHUB_OUTPUT="${GITHUB_OUTPUT}" ./scripts/get-build-metadata.sh --ci
+          ota_ios=$(sed -n 's/^ios_version_code=//p' "${GITHUB_OUTPUT}" | tail -n 1)
+          ota_android=$(sed -n 's/^android_version_code=//p' "${GITHUB_OUTPUT}" | tail -n 1)
+          if [[ -z "${ota_ios}" || -z "${ota_android}" ]]; then
+            echo "::error::OTA metadata fallback did not emit native build numbers"
+            exit 1
+          fi
+          env "${common_env[@]}" \
+            SEMVER="${FIXTURE_SEMVER}" \
+            IOS_BUILD_NUMBER="${ota_ios}" \
+            ANDROID_BUILD_NUMBER="${ota_android}" \
+            BUILD_KIND=rc \
+            node ./scripts/slack-rc-notification.mjs | tee benchmark-out/ota.stdout.txt
+          extract_payload benchmark-out/ota.stdout.txt benchmark-out/ota.json
+          echo "::endgroup::"
+
+          echo "::group::Production explicit metadata"
+          env "${common_env[@]}" \
+            SEMVER="${FIXTURE_SEMVER}" \
+            IOS_BUILD_NUMBER="${FIXTURE_IOS_BUILD_NUMBER}" \
+            ANDROID_BUILD_NUMBER="${FIXTURE_ANDROID_BUILD_NUMBER}" \
+            BUILD_KIND=production \
+            node ./scripts/slack-rc-notification.mjs | tee benchmark-out/production.stdout.txt
+          extract_payload benchmark-out/production.stdout.txt benchmark-out/production.json
+          echo "::endgroup::"
+
+      - name: Record setup-to-payload duration
+        run: |
+          end_ns=$(date +%s%N)
+          python3 - "$SETUP_START_NS" "$end_ns" baseline <<'PY'
+          import os, pathlib, sys
+          start_ns = int(sys.argv[1])
+          end_ns = int(sys.argv[2])
+          mode = sys.argv[3]
+          elapsed_ms = (end_ns - start_ns) // 1_000_000
+          out = pathlib.Path("benchmark-out")
+          out.mkdir(exist_ok=True)
+          (out / "timing-ms.txt").write_text(f"{elapsed_ms}\n")
+          minutes, ms = divmod(elapsed_ms, 60_000)
+          seconds, millis = divmod(ms, 1000)
+          summary = f"{mode} setup-to-payload: {elapsed_ms} ms ({minutes}m {seconds}s {millis}ms)\n"
+          with pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as handle:
+              handle.write(summary)
+          print(summary, end="")
+          PY
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: slack-rc-benchmark-baseline
+          path: benchmark-out/
+          if-no-files-found: error
+          retention-days: 7
+
+  candidate:
+    name: Candidate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record setup start
+        run: echo "SETUP_START_NS=$(date +%s%N)" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download Android Play Store check report (optional)
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: android-play-store-check-slack
+          path: android-play-store-check-out
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Capture RC, OTA, and production dry-run payloads
+        run: |
+          set -euo pipefail
+          unset SLACK_BOT_TOKEN || true
+          mkdir -p benchmark-out
+          extract_payload() {
+            local stdout_file="$1"
+            local json_file="$2"
+            python3 - "$stdout_file" "$json_file" <<'PY'
+          import pathlib, sys
+          text = pathlib.Path(sys.argv[1]).read_text()
+          start = text.index("--- Slack payload (dry run) ---\n")
+          rest = text[start + len("--- Slack payload (dry run) ---\n"):]
+          end = rest.index("\n--- end dry run ---")
+          payload = rest[:end].lstrip("\n")
+          pathlib.Path(sys.argv[2]).write_text(payload)
+          PY
+          }
+
+          common_env=(
+            "SLACK_RC_NOTIFICATION_DRY_RUN=true"
+            "BUILD_PIPELINE_URL=${FIXTURE_PIPELINE_URL}"
+            "ANDROID_PUBLIC_URL=${FIXTURE_ANDROID_PUBLIC_URL}"
+            "IOS_PUBLIC_URL=${FIXTURE_IOS_PUBLIC_URL}"
+          )
+
+          echo "::group::RC explicit metadata"
+          env "${common_env[@]}" \
+            SEMVER="${FIXTURE_SEMVER}" \
+            IOS_BUILD_NUMBER="${FIXTURE_IOS_BUILD_NUMBER}" \
+            ANDROID_BUILD_NUMBER="${FIXTURE_ANDROID_BUILD_NUMBER}" \
+            PR_NUMBER="${FIXTURE_PR_NUMBER}" \
+            BUILD_KIND=rc \
+            node ./scripts/slack-rc-notification.mjs | tee benchmark-out/rc.stdout.txt
+          extract_payload benchmark-out/rc.stdout.txt benchmark-out/rc.json
+          echo "::endgroup::"
+
+          echo "::group::OTA-style metadata fallback"
+          GITHUB_OUTPUT="${PWD}/benchmark-out/ota-github-output.txt"
+          : > "${GITHUB_OUTPUT}"
+          GITHUB_OUTPUT="${GITHUB_OUTPUT}" ./scripts/get-build-metadata.sh --ci
+          ota_ios=$(sed -n 's/^ios_version_code=//p' "${GITHUB_OUTPUT}" | tail -n 1)
+          ota_android=$(sed -n 's/^android_version_code=//p' "${GITHUB_OUTPUT}" | tail -n 1)
+          if [[ -z "${ota_ios}" || -z "${ota_android}" ]]; then
+            echo "::error::OTA metadata fallback did not emit native build numbers"
+            exit 1
+          fi
+          env "${common_env[@]}" \
+            SEMVER="${FIXTURE_SEMVER}" \
+            IOS_BUILD_NUMBER="${ota_ios}" \
+            ANDROID_BUILD_NUMBER="${ota_android}" \
+            BUILD_KIND=rc \
+            node ./scripts/slack-rc-notification.mjs | tee benchmark-out/ota.stdout.txt
+          extract_payload benchmark-out/ota.stdout.txt benchmark-out/ota.json
+          echo "::endgroup::"
+
+          echo "::group::Production explicit metadata"
+          env "${common_env[@]}" \
+            SEMVER="${FIXTURE_SEMVER}" \
+            IOS_BUILD_NUMBER="${FIXTURE_IOS_BUILD_NUMBER}" \
+            ANDROID_BUILD_NUMBER="${FIXTURE_ANDROID_BUILD_NUMBER}" \
+            BUILD_KIND=production \
+            node ./scripts/slack-rc-notification.mjs | tee benchmark-out/production.stdout.txt
+          extract_payload benchmark-out/production.stdout.txt benchmark-out/production.json
+          echo "::endgroup::"
+
+      - name: Record setup-to-payload duration
+        run: |
+          end_ns=$(date +%s%N)
+          python3 - "$SETUP_START_NS" "$end_ns" candidate <<'PY'
+          import os, pathlib, sys
+          start_ns = int(sys.argv[1])
+          end_ns = int(sys.argv[2])
+          mode = sys.argv[3]
+          elapsed_ms = (end_ns - start_ns) // 1_000_000
+          out = pathlib.Path("benchmark-out")
+          out.mkdir(exist_ok=True)
+          (out / "timing-ms.txt").write_text(f"{elapsed_ms}\n")
+          minutes, ms = divmod(elapsed_ms, 60_000)
+          seconds, millis = divmod(ms, 1000)
+          summary = f"{mode} setup-to-payload: {elapsed_ms} ms ({minutes}m {seconds}s {millis}ms)\n"
+          with pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as handle:
+              handle.write(summary)
+          print(summary, end="")
+          PY
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: slack-rc-benchmark-candidate
+          path: benchmark-out/
+          if-no-files-found: error
+          retention-days: 7
+
+  compare:
+    name: Compare payloads
+    needs: [baseline, candidate]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: slack-rc-benchmark-baseline
+          path: baseline-out
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: slack-rc-benchmark-candidate
+          path: candidate-out
+
+      - name: Compare dry-run payloads byte-for-byte
+        run: |
+          set -euo pipefail
+          failed=0
+          for name in rc.json ota.json production.json; do
+            echo "::group::diff ${name}"
+            if cmp -s "baseline-out/${name}" "candidate-out/${name}"; then
+              echo "OK ${name} identical ($(wc -c < "baseline-out/${name}") bytes)"
+            else
+              echo "::error::Payload mismatch for ${name}"
+              diff -u "baseline-out/${name}" "candidate-out/${name}" || true
+              failed=1
+            fi
+            echo "::endgroup::"
+          done
+          baseline_ms=$(tr -d '[:space:]' < baseline-out/timing-ms.txt)
+          candidate_ms=$(tr -d '[:space:]' < candidate-out/timing-ms.txt)
+          {
+            echo "## Slack RC notification benchmark"
+            echo ""
+            echo "| Mode | setup-to-payload (ms) |"
+            echo "| --- | ---: |"
+            echo "| baseline | ${baseline_ms} |"
+            echo "| candidate | ${candidate_ms} |"
+            echo ""
+            echo "Payloads compared: rc.json, ota.json, production.json"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice title=Benchmark timings::baseline_ms=${baseline_ms} candidate_ms=${candidate_ms}"
+          if [[ "${failed}" -ne 0 ]]; then
+            exit 1
+          fi

--- a/.github/workflows/slack-rc-notification.yml
+++ b/.github/workflows/slack-rc-notification.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.source_branch }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Download Android Play Store check report (optional)
         id: download-play-store-check
@@ -67,13 +67,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: yarn
       - name: Read build metadata from repo
         if: inputs.semver == '' || inputs.ios_build_number == '' || inputs.android_build_number == ''
         id: build-meta
         run: ./scripts/get-build-metadata.sh --ci
-      - name: Install dependencies
-        run: yarn install --immutable
       - name: Post Slack notification
         run: |
           if node ./scripts/slack-rc-notification.mjs; then

--- a/docs/specs/spec-001-rc-slack.md
+++ b/docs/specs/spec-001-rc-slack.md
@@ -1,0 +1,154 @@
+# spec-001: Slim Slack release notifications
+
+## Summary
+
+Slim `.github/workflows/slack-rc-notification.yml` in place: shallow checkout, no Yarn cache, no `yarn install`. Callers, the Node script, metadata fallback, and the dormant Play Store download stay. Success is identical dry-run payloads and a ≥60% faster median setup-to-payload time across three paired GitHub Actions runs. Independent Slack or RC-comment dispatch is out of scope (`docs/specs/spec-002-rc-comment.md`).
+
+## Copy Prompt for Implementation
+
+```text
+- Implement only docs/specs/spec-001-rc-slack.md.
+- Change production YAML in .github/workflows/slack-rc-notification.yml only (fetch-depth 1, drop cache: yarn, drop yarn install).
+- Add the temporary branch-scoped benchmark workflow, push, run it three times, paste run URLs and median timings, then delete the benchmark from the PR.
+- Do not edit callers, post to Slack, cut an RC, or dispatch Slack or the RC comment as independent workflows.
+- Ask any questions needed if anything ambiguous.
+```
+
+## Context
+
+`.github/workflows/slack-rc-notification.yml` is a reusable GitHub Actions workflow that posts RC or production build notifications. It is called by:
+
+- `.github/workflows/build-rc-auto.yml`
+- `.github/workflows/runway-rc-builds.yml`
+- `.github/workflows/runway-ota-rc.yml`
+- `.github/workflows/runway-production-builds.yml`
+
+The Auto RC Actions usage view attributes approximately 2 minutes 46 seconds to the Slack notification job. This duration is billed job time, not an equivalent addition to Auto RC wall-clock time: the Slack job runs in parallel with the longer RC comment job after the platform builds succeed. Reducing it still lowers runner usage and shortens the notification job itself.
+
+The current setup includes a full-history checkout, Yarn cache restoration, and `yarn install --immutable` before executing `scripts/slack-rc-notification.mjs`.
+
+Git history explains why these steps were introduced:
+
+- `yarn install --immutable` was added in commit `4973b2f3d27` when the notification script imported `parseChangelog` from `@metamask/auto-changelog`.
+- `fetch-depth: 0` was added in commit `96ee8a516af` so the script could derive RC notes using `git merge-base` and `git log`.
+- Commit `d57c51141b1` removed the changelog dependency and all git-history processing when Slack was changed to link to the release PR comment. The install and full-history checkout remained.
+- The optional Android Play Store report download was introduced in commit `b09b78f442d`. Its environment-variable handoff has been commented out since commit `f4808a7545`, but this spec deliberately preserves the dormant integration.
+
+The current script imports only Node's `fs` module and uses the global `fetch` API. It does not import an installed package. The script remains necessary because it constructs Slack Block Kit payloads, selects RC or production behavior, validates URLs, derives the release channel, and calls Slack's API. `actions/setup-node` also remains necessary to honor the repository's Node 24.16.0 requirement from `.nvmrc`.
+
+Checkout remains necessary because the workflow executes the checked-out script and because the Runway OTA RC caller supplies `semver` without iOS or Android build numbers. That path intentionally invokes `scripts/get-build-metadata.sh`, which reads `package.json`, `android/app/build.gradle`, and `ios/MetaMask.xcodeproj/project.pbxproj`.
+
+This specification covers only the low-impact in-place optimization. Dispatching Slack and the RC comment as independent workflows is deferred.
+
+## Hypothesis
+
+If the reusable Slack workflow stops installing dependencies, stops restoring the Yarn cache, and performs a shallow checkout, then its median setup-to-payload duration will decrease by at least 60% without changing notification payloads for RC, OTA RC, or production callers.
+
+The hypothesis is wrong if any tested payload differs, metadata fallback stops working, the candidate median improves by less than 60% across three paired GitHub-hosted runner executions, or an existing caller can no longer invoke the workflow successfully.
+
+## Decisions
+
+- Change `actions/checkout` from `fetch-depth: 0` to `fetch-depth: 1`.
+- Keep checkout pinned to `inputs.source_branch`.
+- Keep `actions/setup-node@v4` with `node-version-file: '.nvmrc'`.
+- Remove `cache: yarn` from `actions/setup-node`; no package-manager operation remains to benefit from the restored cache.
+- Remove the `Install dependencies` step and its `yarn install --immutable` command.
+- Keep `scripts/slack-rc-notification.mjs`; replacing it with shell, `curl`, or another Slack action would increase behavioral and security risk without addressing the measured setup cost.
+- Keep the conditional `scripts/get-build-metadata.sh --ci` fallback unchanged so the Runway OTA RC caller continues to obtain native build numbers.
+- Keep the optional Android Play Store report download and the `actions: read` permission in this change. Its consumer is currently disabled, but removing the dormant integration is independent cleanup.
+- Do not modify the four caller workflows.
+- Do not add permanent benchmark or pull-request jobs.
+- Validate on GitHub-hosted runners using a temporary, branch-scoped workflow that cannot build or publish.
+- Require three paired baseline/candidate runs. Payloads must be byte-for-byte identical, and candidate median duration must be at least 60% lower than baseline.
+- Defer independent Slack and RC-comment dispatch to a later change.
+
+## Implementation Details
+
+Modify `.github/workflows/slack-rc-notification.yml` only for the production change:
+
+1. Set checkout `fetch-depth` to `1`.
+2. Remove `cache: yarn` from the setup-node configuration.
+3. Remove the dependency installation step.
+4. Leave step ordering, inputs, fallback metadata logic, environment variables, permissions, failure-open behavior, and callers unchanged.
+
+Do not remove setup-node. Although GitHub-hosted Ubuntu runners include Node, the repository explicitly requires Node 24.16.0, and the script relies on the global `fetch` API. Keeping setup-node avoids coupling the notification to changes in the runner image.
+
+Do not remove checkout or the metadata fallback. Auto RC, Runway RC, and Runway production currently pass all build metadata. Runway OTA RC passes only `semver`, so its missing build numbers are read from the checked-out source tree.
+
+For pre-merge performance validation, temporarily add `.github/workflows/slack-rc-notification-benchmark.yml` on a dedicated implementation branch. The temporary workflow must:
+
+- Trigger only on pushes to that exact implementation branch.
+- Request no write permissions.
+- Receive or inherit no secrets.
+- Never call another release, build, upload, deployment, comment, or notification workflow.
+- Run a `baseline` and `candidate` job in parallel on the same GitHub-hosted runner class.
+- Reproduce the current setup in the baseline: full checkout, setup-node with Yarn caching, optional artifact-download attempt, metadata fallback as applicable, and `yarn install --immutable`.
+- Reproduce the proposed setup in the candidate: shallow checkout, setup-node without Yarn caching, the preserved optional artifact-download attempt, metadata fallback as applicable, and no dependency install.
+- Set `SLACK_RC_NOTIFICATION_DRY_RUN=true` and omit `SLACK_BOT_TOKEN` in every script invocation.
+- Use non-release fixture values for semantic versions, build numbers, PR number, URLs, and channel derivation.
+- Exercise these cases after setup:
+  - RC metadata supplied explicitly, including PR number.
+  - OTA-style invocation with semantic version supplied and native build numbers obtained through `scripts/get-build-metadata.sh --ci`.
+  - Production metadata supplied explicitly with `BUILD_KIND=production`.
+- Capture each dry-run payload to a file, upload only those test outputs, and compare corresponding baseline and candidate outputs byte-for-byte.
+- Record setup-to-payload elapsed time in the job summary or a benchmark artifact.
+
+Run the paired benchmark three times. Use the median elapsed duration for each mode rather than the fastest run, because checkout, action download, and Yarn cache behavior vary between runners. Preserve the three run URLs and measured values as pull-request evidence.
+
+Delete `.github/workflows/slack-rc-notification-benchmark.yml` from the implementation branch before the final change is merged. Its absence from the final diff is mandatory.
+
+The benchmark compares behavior and runner setup cost; it does not contact Slack. A real release notification remains covered by existing release execution after merge.
+
+## Open Questions
+
+_None._
+
+## Acceptance Criteria
+
+- [ ] `.github/workflows/slack-rc-notification.yml` uses `fetch-depth: 1`.
+- [ ] The workflow still configures Node from `.nvmrc`.
+- [ ] The workflow no longer configures a Yarn cache.
+- [ ] The workflow no longer runs `yarn install --immutable`.
+- [ ] The metadata fallback condition and `scripts/get-build-metadata.sh --ci` invocation are unchanged.
+- [ ] The optional Android Play Store report download and its required permission remain unchanged.
+- [ ] All four existing caller workflows remain unchanged and valid.
+- [ ] Three paired GitHub-hosted benchmark runs complete without access to release or Slack secrets.
+- [ ] RC, OTA-style, and production dry-run payloads are byte-for-byte identical between baseline and candidate in every run.
+- [ ] The candidate median setup-to-payload duration is at least 60% lower than the baseline median.
+- [ ] No benchmark run builds binaries, publishes artifacts intended for users, uploads to TestFlight or Play Store, pushes an EAS update, comments on a PR, or contacts Slack.
+- [ ] The temporary benchmark workflow is absent from the final merge diff.
+- [ ] Repository GitHub Actions validation passes.
+
+## How to Test
+
+1. Confirm the notification script requires no installed dependency:
+
+   ```bash
+   rg "^import|from '" scripts/slack-rc-notification.mjs
+   ```
+
+   Only Node built-ins may be imported.
+
+2. Run an explicit-metadata RC dry run without a Slack token:
+
+   ```bash
+   SEMVER=0.0.0-ci-dry-run \
+   IOS_BUILD_NUMBER=100 \
+   ANDROID_BUILD_NUMBER=100 \
+   PR_NUMBER=1 \
+   BUILD_PIPELINE_URL=https://github.com/MetaMask/metamask-mobile/actions \
+   SLACK_RC_NOTIFICATION_DRY_RUN=true \
+   node scripts/slack-rc-notification.mjs
+   ```
+
+3. Run the OTA-style metadata fallback in a temporary shell with `GITHUB_OUTPUT` set, then pass its outputs to the dry-run script. Verify semantic version and both native build numbers are populated from the repository tree.
+
+4. Run a production dry run with explicit metadata and `BUILD_KIND=production`. Verify production copy is generated and no Slack request is made.
+
+5. Push the temporary benchmark workflow to its exact branch and complete three paired runs. Verify payload equality for all three scenarios and calculate median baseline and candidate durations.
+
+6. Remove the temporary benchmark workflow and verify it is absent from the final diff.
+
+7. Run or await the repository's existing actionlint-based GitHub Actions validation on the pull request.
+
+8. Review the final diff and verify only the intended production workflow and this specification remain changed for this work.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The reusable Slack RC/production notification job still did a full-history checkout, restored the Yarn cache, and ran `yarn install --immutable` even though `scripts/slack-rc-notification.mjs` only uses Node built-ins and `fetch`. That leftover setup was the bulk of billed runner time on the Slack job (about 2m46s in Auto RC usage), which runs in parallel with the longer RC comment job.

This PR slims `.github/workflows/slack-rc-notification.yml` in place: `fetch-depth: 1`, no Yarn cache, no `yarn install`. Callers, Node from `.nvmrc`, metadata fallback, dormant Play Store download, and the notification script stay. A temporary branch-scoped dry-run benchmark compared baseline vs candidate payloads, then was deleted so it is not in the merge diff. Spec: `docs/specs/spec-001-rc-slack.md`.

Paired GitHub-hosted dry runs (payloads identical; no Slack token):

| Run | Baseline wall | Candidate wall | URL |
| --- | --- | --- | --- |
| 1 | 167s | 22s | https://github.com/MetaMask/metamask-mobile/actions/runs/34493573798 |
| 2 | 177s | 20s | https://github.com/MetaMask/metamask-mobile/actions/runs/34492536292 |
| 3 | 163s | 21s | https://github.com/MetaMask/metamask-mobile/actions/runs/34492061677 |

Median setup-to-payload wall clock: **167s → 21s (~87% lower)**, above the spec's 60% bar.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: internal CI optimization; no GitHub issue

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — CI-only workflow change. Dry-run payloads were compared on GitHub-hosted runners (links in Description). App UI is unchanged.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no UI change. Previous Slack job setup: full checkout, Yarn cache, `yarn install`.

### **After**

N/A — no UI change. Benchmark evidence (identical dry-run payloads; no Slack token):

- https://github.com/MetaMask/metamask-mobile/actions/runs/34493573798 (167s → 22s)
- https://github.com/MetaMask/metamask-mobile/actions/runs/34492536292 (177s → 20s)
- https://github.com/MetaMask/metamask-mobile/actions/runs/34492061677 (163s → 21s)

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android (N/A — CI-only workflow)
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario (N/A — CI-only workflow)
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics (N/A — CI-only workflow)
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
