### PR TITLE
refactor(activity): align activity details cache-first fetching

### DIFF
--- a/app/components/Views/ActivityDetails/ActivityDetails.test.tsx
+++ b/app/components/Views/ActivityDetails/ActivityDetails.test.tsx
@@ -9,8 +9,6 @@ import type { ActivityListItem } from '../../../util/activity-adapters';
 import ActivityDetails from './ActivityDetails';
 import { ActivityDetailsSelectorsIDs } from './ActivityDetails.testIds';
 import { useActivityDetailsItem } from './hooks/useActivityDetailsItem';
-// eslint-disable-next-line import-x/no-restricted-paths -- same query the screen uses
-import { useTransactionsQuery } from '../ActivityList/useTransactionsQuery';
 import { useParams } from '../../../util/navigation/navUtils';
 // eslint-disable-next-line import-x/no-restricted-paths -- test controls the shared speed-up/cancel actions hook
 import { useUnifiedTxActions } from '../ActivityList/useUnifiedTxActions';
@@ -30,14 +28,6 @@ jest.mock('../../../util/navigation/navUtils', () => ({
 
 jest.mock('./hooks/useActivityDetailsItem', () => ({
   useActivityDetailsItem: jest.fn(),
-}));
-
-jest.mock('../ActivityList/useTransactionsQuery', () => ({
-  useTransactionsQuery: jest.fn(() => ({
-    data: { pages: [{ data: [] }] },
-    isPending: false,
-    isFetching: false,
-  })),
 }));
 
 // The title resolves the bridge quote via this selector; the screen test uses a
@@ -113,7 +103,6 @@ jest.mock('../confirmations/components/modals/cancel-speedup-modal', () => {
 
 const useParamsMock = jest.mocked(useParams);
 const useActivityDetailsItemMock = jest.mocked(useActivityDetailsItem);
-const useTransactionsQueryMock = jest.mocked(useTransactionsQuery);
 const useUnifiedTxActionsMock = jest.mocked(useUnifiedTxActions);
 const usePerpsDetailsItemMock = jest.mocked(usePerpsDetailsItem);
 const usePredictDetailsItemMock = jest.mocked(usePredictDetailsItem);
@@ -153,18 +142,16 @@ const sendItem: ActivityListItem = {
 describe('ActivityDetails screen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useTransactionsQueryMock.mockReturnValue({
-      data: { pages: [{ data: [] }] },
-      isPending: false,
-      isFetching: false,
-    } as unknown as ReturnType<typeof useTransactionsQuery>);
     mockIsFocused.mockReturnValue(true);
     useParamsMock.mockReturnValue({
       chainId: 'eip155:1',
       txIdentifier: '0xhash',
     });
     useUnifiedTxActionsMock.mockReturnValue(buildTxActions());
-    useActivityDetailsItemMock.mockReturnValue(undefined);
+    useActivityDetailsItemMock.mockReturnValue({
+      item: undefined,
+      isFetching: false,
+    });
     usePerpsDetailsItemMock.mockReturnValue({
       item: undefined,
       transaction: undefined,
@@ -178,7 +165,10 @@ describe('ActivityDetails screen', () => {
   });
 
   it('renders the template when the transaction resolves', () => {
-    useActivityDetailsItemMock.mockReturnValue(sendItem);
+    useActivityDetailsItemMock.mockReturnValue({
+      item: sendItem,
+      isFetching: false,
+    });
 
     const { getByTestId, queryByTestId } = renderWithProvider(
       <ActivityDetails />,
@@ -190,7 +180,10 @@ describe('ActivityDetails screen', () => {
   });
 
   it('renders a not-found message when the transaction cannot be resolved', () => {
-    useActivityDetailsItemMock.mockReturnValue(undefined);
+    useActivityDetailsItemMock.mockReturnValue({
+      item: undefined,
+      isFetching: false,
+    });
 
     const { getByTestId, queryByTestId } = renderWithProvider(
       <ActivityDetails />,
@@ -206,7 +199,10 @@ describe('ActivityDetails screen', () => {
     useUnifiedTxActionsMock.mockReturnValue(
       buildTxActions({ existingTx: pendingTx, speedUpIsOpen: true }),
     );
-    useActivityDetailsItemMock.mockReturnValue(sendItem);
+    useActivityDetailsItemMock.mockReturnValue({
+      item: sendItem,
+      isFetching: false,
+    });
 
     const { getByTestId, rerender } = renderWithProvider(<ActivityDetails />);
 
@@ -214,19 +210,28 @@ describe('ActivityDetails screen', () => {
     fireEvent.press(getByTestId('mock-speedup-cancel-confirm'));
 
     // Replacement commits: the original tx is dropped and no longer resolves.
-    useActivityDetailsItemMock.mockReturnValue(undefined);
+    useActivityDetailsItemMock.mockReturnValue({
+      item: undefined,
+      isFetching: false,
+    });
     rerender(<ActivityDetails />);
 
     expect(mockGoBack).toHaveBeenCalledTimes(1);
   });
 
   it('does not auto-dismiss when the item disappears without a speed-up/cancel (pending→confirmed flip)', () => {
-    useActivityDetailsItemMock.mockReturnValue(sendItem);
+    useActivityDetailsItemMock.mockReturnValue({
+      item: sendItem,
+      isFetching: false,
+    });
 
     const { rerender } = renderWithProvider(<ActivityDetails />);
 
     // No confirm; the item vanishes on the id→hash flip.
-    useActivityDetailsItemMock.mockReturnValue(undefined);
+    useActivityDetailsItemMock.mockReturnValue({
+      item: undefined,
+      isFetching: false,
+    });
     rerender(<ActivityDetails />);
 
     expect(mockGoBack).not.toHaveBeenCalled();
@@ -236,14 +241,20 @@ describe('ActivityDetails screen', () => {
     useUnifiedTxActionsMock.mockReturnValue(
       buildTxActions({ existingTx: pendingTx, speedUpIsOpen: true }),
     );
-    useActivityDetailsItemMock.mockReturnValue(sendItem);
+    useActivityDetailsItemMock.mockReturnValue({
+      item: sendItem,
+      isFetching: false,
+    });
 
     const { getByTestId, rerender } = renderWithProvider(<ActivityDetails />);
 
     fireEvent.press(getByTestId('mock-speedup-cancel-confirm'));
 
     // Action failed: tx not replaced, item still resolves.
-    useActivityDetailsItemMock.mockReturnValue(sendItem);
+    useActivityDetailsItemMock.mockReturnValue({
+      item: sendItem,
+      isFetching: false,
+    });
     rerender(<ActivityDetails />);
 
     expect(mockGoBack).not.toHaveBeenCalled();
@@ -257,12 +268,18 @@ describe('ActivityDetails screen', () => {
         isQRHardwareAccount: true,
       }),
     );
-    useActivityDetailsItemMock.mockReturnValue(sendItem);
+    useActivityDetailsItemMock.mockReturnValue({
+      item: sendItem,
+      isFetching: false,
+    });
 
     const { getByTestId, rerender } = renderWithProvider(<ActivityDetails />);
 
     fireEvent.press(getByTestId('mock-speedup-cancel-confirm'));
-    useActivityDetailsItemMock.mockReturnValue(undefined);
+    useActivityDetailsItemMock.mockReturnValue({
+      item: undefined,
+      isFetching: false,
+    });
     rerender(<ActivityDetails />);
 
     expect(mockGoBack).not.toHaveBeenCalled();
@@ -272,7 +289,10 @@ describe('ActivityDetails screen', () => {
     useUnifiedTxActionsMock.mockReturnValue(
       buildTxActions({ existingTx: pendingTx, speedUpIsOpen: true }),
     );
-    useActivityDetailsItemMock.mockReturnValue(sendItem);
+    useActivityDetailsItemMock.mockReturnValue({
+      item: sendItem,
+      isFetching: false,
+    });
 
     const { getByTestId, rerender } = renderWithProvider(<ActivityDetails />);
 
@@ -281,19 +301,20 @@ describe('ActivityDetails screen', () => {
     // The screen is backgrounded (another screen pushed on top) when the
     // replacement commits — goBack must not pop whatever is now on top.
     mockIsFocused.mockReturnValue(false);
-    useActivityDetailsItemMock.mockReturnValue(undefined);
+    useActivityDetailsItemMock.mockReturnValue({
+      item: undefined,
+      isFetching: false,
+    });
     rerender(<ActivityDetails />);
 
     expect(mockGoBack).not.toHaveBeenCalled();
   });
 
   it('does not flash not-found while rematch is still loading', () => {
-    useActivityDetailsItemMock.mockReturnValue(undefined);
-    useTransactionsQueryMock.mockReturnValue({
-      data: undefined,
-      isPending: true,
+    useActivityDetailsItemMock.mockReturnValue({
+      item: undefined,
       isFetching: true,
-    } as unknown as ReturnType<typeof useTransactionsQuery>);
+    });
 
     const { queryByTestId } = renderWithProvider(<ActivityDetails />);
 

--- a/app/components/Views/ActivityDetails/ActivityDetails.tsx
+++ b/app/components/Views/ActivityDetails/ActivityDetails.tsx
@@ -35,8 +35,6 @@ import { ActivityDetailsSelectorsIDs } from './ActivityDetails.testIds';
 import type { ActivityDetailsParams } from './ActivityDetails.types';
 import { useActivityDetailsItem } from './hooks/useActivityDetailsItem';
 import { useLocalTransactionMeta } from './hooks/useLocalTransactionMeta';
-/* eslint-disable-next-line import-x/no-restricted-paths */
-import { useTransactionsQuery } from '../ActivityList/useTransactionsQuery';
 import { ActivityDetailsPendingBanner } from './components/ActivityDetailsPendingBanner';
 import { TemplateLoader } from './templates/TemplateLoader';
 
@@ -50,7 +48,8 @@ function ActivityDetailsProviders({ children }: { children: ReactNode }) {
 
 function ActivityDetailsScreen() {
   const { chainId, txIdentifier } = useParams<ActivityDetailsParams>();
-  const activityItem = useActivityDetailsItem(txIdentifier, chainId);
+  const { item: activityItem, isFetching: isActivityFetching } =
+    useActivityDetailsItem(txIdentifier, chainId);
   const { item: perpsItem, isLoading: isPerpsLoading } = usePerpsDetailsItem(
     txIdentifier,
     chainId,
@@ -58,10 +57,9 @@ function ActivityDetailsScreen() {
   const { item: predictItem, isLoading: isPredictLoading } =
     usePredictDetailsItem(activityItem ? undefined : txIdentifier, chainId);
   const item = perpsItem ?? activityItem ?? predictItem;
-  const isLoading = isPerpsLoading || isPredictLoading;
-  const { data: evmTransactions, isFetching } = useTransactionsQuery();
-  const waitingForApi = !item && evmTransactions === undefined && isFetching;
-  const waiting = Boolean(isLoading || waitingForApi);
+  const waiting = Boolean(
+    isPerpsLoading || isPredictLoading || (!item && isActivityFetching),
+  );
   const tw = useTailwind();
   const navigation = useNavigation<AppNavigationProp>();
   const isFocused = useIsFocused();

--- a/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.test.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.test.ts
@@ -11,8 +11,11 @@ import {
 } from '../../../../constants/on-ramp';
 import type { FiatOrder } from '../../../../reducers/fiatOrders/types';
 import { selectSelectedAccountGroupInternalAccounts } from '../../../../selectors/multichainAccounts/accountTreeController';
+import { selectEvmAddress } from '../../../../selectors/accountsController';
+import { selectSelectedAccountGroupEvmInternalAccount } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { useActivityDetailsItem } from './useActivityDetailsItem';
 /* eslint-disable import-x/no-restricted-paths -- TODO(ADR-0020): mirrors the resolver hook's data sources; route-isolation backlog */
+import { useApiTransaction } from '../../ActivityList/hooks/activity/useApiTransaction';
 import { useLocalActivityItems } from '../../ActivityList/hooks/useLocalActivityItems';
 import { useRampActivityItems } from '../../ActivityList/hooks/useRampActivityItems';
 import { useTransactionsQuery } from '../../ActivityList/useTransactionsQuery';
@@ -22,6 +25,7 @@ import { mapNonEvmTransactions } from '../../ActivityList/helpers/transformation
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
+jest.mock('../../ActivityList/hooks/activity/useApiTransaction');
 jest.mock('../../ActivityList/hooks/useLocalActivityItems');
 jest.mock('../../ActivityList/hooks/useRampActivityItems');
 jest.mock('../../ActivityList/useTransactionsQuery');
@@ -35,6 +39,7 @@ jest.mock('../../../UI/Bridge/hooks/useBridgeHistoryItemBySrcTxHash', () => ({
   findBridgeHistoryItemBySrcTxHash: jest.fn(),
 }));
 
+const useApiTransactionMock = jest.mocked(useApiTransaction);
 const useLocalActivityItemsMock = jest.mocked(useLocalActivityItems);
 const useRampActivityItemsMock = jest.mocked(useRampActivityItems);
 const useTransactionsQueryMock = jest.mocked(useTransactionsQuery);
@@ -85,6 +90,7 @@ function setSources({
   useRampActivityItemsMock.mockReturnValue(ramp);
   useTransactionsQueryMock.mockReturnValue({
     data: { pages: [{ data: confirmed }] },
+    isFetching: false,
   } as unknown as ReturnType<typeof useTransactionsQuery>);
   mapNonEvmTransactionsMock.mockReturnValue(nonEvm);
 }
@@ -92,9 +98,19 @@ function setSources({
 describe('useActivityDetailsItem', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    useApiTransactionMock.mockReturnValue({
+      transaction: undefined,
+      isFetching: false,
+    });
     jest.mocked(useSelector).mockImplementation((selector) => {
       if (selector === selectSelectedAccountGroupInternalAccounts) {
         return [];
+      }
+      if (selector === selectSelectedAccountGroupEvmInternalAccount) {
+        return undefined;
+      }
+      if (selector === selectEvmAddress) {
+        return '0x1234567890abcdef1234567890abcdef12345678';
       }
       return { transactions: [] };
     });
@@ -103,7 +119,7 @@ describe('useActivityDetailsItem', () => {
   it('returns undefined when no identifier is provided', () => {
     setSources({});
     const { result } = renderHook(() => useActivityDetailsItem(undefined));
-    expect(result.current).toBeUndefined();
+    expect(result.current.item).toBeUndefined();
   });
 
   it('resolves a local item by hash (case-insensitive)', () => {
@@ -111,7 +127,7 @@ describe('useActivityDetailsItem', () => {
     setSources({ local: [local] });
 
     const { result } = renderHook(() => useActivityDetailsItem('0xabc'));
-    expect(result.current).toBe(local);
+    expect(result.current.item).toBe(local);
   });
 
   it('resolves a non-EVM item when no local/api item matches', () => {
@@ -119,7 +135,7 @@ describe('useActivityDetailsItem', () => {
     setSources({ nonEvm: [nonEvm] });
 
     const { result } = renderHook(() => useActivityDetailsItem('0xsol'));
-    expect(result.current).toBe(nonEvm);
+    expect(result.current.item).toBe(nonEvm);
   });
 
   it('forwards bridge history and subject address into non-EVM mapping', () => {
@@ -153,7 +169,7 @@ describe('useActivityDetailsItem', () => {
     setSources({ local: [local], confirmed: [api] });
 
     const { result } = renderHook(() => useActivityDetailsItem('0xdef'));
-    expect(result.current).toBe(api);
+    expect(result.current.item).toBe(api);
   });
 
   it('prefers the API swap over a local swap whose destination is unresolved on-device', () => {
@@ -166,7 +182,7 @@ describe('useActivityDetailsItem', () => {
     setSources({ local: [local], confirmed: [api] });
 
     const { result } = renderHook(() => useActivityDetailsItem('0xswap'));
-    expect(result.current).toBe(api);
+    expect(result.current.item).toBe(api);
   });
 
   it('falls back to the local swap when there is no API copy', () => {
@@ -178,7 +194,7 @@ describe('useActivityDetailsItem', () => {
     setSources({ local: [local] });
 
     const { result } = renderHook(() => useActivityDetailsItem('0xonly'));
-    expect(result.current).toBe(local);
+    expect(result.current.item).toBe(local);
   });
 
   it('keeps the local spending-cap copy when only it carries the cap amount', () => {
@@ -191,7 +207,7 @@ describe('useActivityDetailsItem', () => {
     setSources({ local: [local], confirmed: [api] });
 
     const { result } = renderHook(() => useActivityDetailsItem('0xcap'));
-    expect(result.current).toBe(local);
+    expect(result.current.item).toBe(local);
   });
 
   it('prefers the API spending-cap copy when the local copy also lacks an amount', () => {
@@ -200,7 +216,7 @@ describe('useActivityDetailsItem', () => {
     setSources({ local: [local], confirmed: [api] });
 
     const { result } = renderHook(() => useActivityDetailsItem('0xnocap'));
-    expect(result.current).toBe(api);
+    expect(result.current.item).toBe(api);
   });
 
   it('keeps the local item when it is already categorized and types differ', () => {
@@ -209,7 +225,7 @@ describe('useActivityDetailsItem', () => {
     setSources({ local: [local], confirmed: [api] });
 
     const { result } = renderHook(() => useActivityDetailsItem('0xfff'));
-    expect(result.current).toBe(local);
+    expect(result.current.item).toBe(local);
   });
 
   it('keeps the local item when only it carries a gas-token fee', () => {
@@ -236,7 +252,7 @@ describe('useActivityDetailsItem', () => {
     setSources({ local: [local], confirmed: [api] });
 
     const { result } = renderHook(() => useActivityDetailsItem('0xgas'));
-    expect(result.current).toBe(local);
+    expect(result.current.item).toBe(local);
   });
 
   it('prefers a richer API send over a local contractInteraction that only has a gas-token fee', () => {
@@ -262,7 +278,7 @@ describe('useActivityDetailsItem', () => {
     setSources({ local: [local], confirmed: [api] });
 
     const { result } = renderHook(() => useActivityDetailsItem('0xdegraded'));
-    expect(result.current).toBe(api);
+    expect(result.current.item).toBe(api);
   });
 
   it('resolves a local item by TransactionMeta id when the display hash changed', () => {
@@ -280,7 +296,7 @@ describe('useActivityDetailsItem', () => {
     setSources({ local: [local] });
 
     const { result } = renderHook(() => useActivityDetailsItem('meta-1'));
-    expect(result.current).toBe(local);
+    expect(result.current.item).toBe(local);
   });
 
   it('returns the API item when there is no local match', () => {
@@ -288,7 +304,48 @@ describe('useActivityDetailsItem', () => {
     setSources({ confirmed: [api] });
 
     const { result } = renderHook(() => useActivityDetailsItem('0xAPI'));
-    expect(result.current).toBe(api);
+    expect(result.current.item).toBe(api);
+  });
+
+  it('resolves a fetched API transaction when it is not in the list query pages', () => {
+    setSources({});
+    useApiTransactionMock.mockReturnValue({
+      transaction: {
+        chainId: 1,
+        hash: '0xfetched',
+        from: '0x1234567890abcdef1234567890abcdef12345678',
+        to: '0x0000000000000000000000000000000000000001',
+      },
+      isFetching: false,
+    });
+
+    const { result } = renderHook(() =>
+      useActivityDetailsItem(
+        '0xfetched',
+        'eip155:1',
+      ),
+    );
+
+    expect(result.current.item?.hash).toBe('0xfetched');
+    expect(result.current.item?.raw?.type).toBe('apiEvmTransaction');
+  });
+
+  it('reports fetching while the single-transaction fallback is loading', () => {
+    setSources({});
+    useApiTransactionMock.mockReturnValue({
+      transaction: undefined,
+      isFetching: true,
+    });
+
+    const { result } = renderHook(() =>
+      useActivityDetailsItem(
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+        'eip155:1',
+      ),
+    );
+
+    expect(result.current.item).toBeUndefined();
+    expect(result.current.isFetching).toBe(true);
   });
 
   it('resolves the item matching the requested chainId when hashes collide across chains', () => {
@@ -307,7 +364,7 @@ describe('useActivityDetailsItem', () => {
     const { result } = renderHook(() =>
       useActivityDetailsItem('0xdup', 'eip155:8453'),
     );
-    expect(result.current).toBe(base);
+    expect(result.current.item).toBe(base);
   });
 
   it('resolves a Ramp item by hash from fiat orders', () => {
@@ -318,7 +375,7 @@ describe('useActivityDetailsItem', () => {
       useActivityDetailsItem('0xramp', 'eip155:59144'),
     );
 
-    expect(result.current).toBe(ramp);
+    expect(result.current.item).toBe(ramp);
   });
 
   it('resolves a Ramp item by order id when a transaction hash is available', () => {
@@ -329,6 +386,6 @@ describe('useActivityDetailsItem', () => {
       useActivityDetailsItem('ramp-order-id', 'eip155:59144'),
     );
 
-    expect(result.current).toBe(ramp);
+    expect(result.current.item).toBe(ramp);
   });
 });

--- a/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
@@ -1,13 +1,21 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { mapApiTransaction } from '@metamask/client-utils';
 import type { CaipChainId } from '@metamask/utils';
 import {
   type ActivityListItem,
+  classifyPooledStakingActivity,
   preferLocalOrApiActivityItem,
 } from '../../../../util/activity-adapters';
+import { selectEvmAddress } from '../../../../selectors/accountsController';
 import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../../selectors/multichain/multichain';
-import { selectSelectedAccountGroupInternalAccounts } from '../../../../selectors/multichainAccounts/accountTreeController';
+import {
+  selectSelectedAccountGroupEvmInternalAccount,
+  selectSelectedAccountGroupInternalAccounts,
+} from '../../../../selectors/multichainAccounts/accountTreeController';
 /* eslint-disable import-x/no-restricted-paths -- TODO(ADR-0020): reuses the activity list's data sources; route-isolation backlog */
+import { useApiTransaction } from '../../ActivityList/hooks/activity/useApiTransaction';
+import { isValidTransactionHash } from '../../ActivityList/hooks/activity/isValidTransactionHash';
 import { useLocalActivityItems } from '../../ActivityList/hooks/useLocalActivityItems';
 import { useRampActivityItems } from '../../ActivityList/hooks/useRampActivityItems';
 import { useTransactionsQuery } from '../../ActivityList/useTransactionsQuery';
@@ -142,15 +150,33 @@ function getPreferredApiItem(
 export function useActivityDetailsItem(
   txIdentifier: string | undefined,
   chainId?: CaipChainId,
-): ActivityListItem | undefined {
+): {
+  item: ActivityListItem | undefined;
+  isFetching: boolean;
+} {
   const localActivityItems = useLocalActivityItems();
   const rampActivityItems = useRampActivityItems();
-  const { data: evmTransactions } = useTransactionsQuery();
+  const { data: evmTransactions, isFetching: isListFetching } =
+    useTransactionsQuery();
+  const groupEvmAccount = useSelector(
+    selectSelectedAccountGroupEvmInternalAccount,
+  );
+  const globalEvmAddress = useSelector(selectEvmAddress);
+  const evmAddress = (groupEvmAccount?.address ?? globalEvmAddress ?? '') || '';
   const nonEvmState = useSelector(
     selectNonEvmTransactionsForSelectedAccountGroup,
   );
   const accounts = useSelector(selectSelectedAccountGroupInternalAccounts);
   const { bridgeHistoryItemsBySrcTxHash } = useBridgeHistoryItemBySrcTxHash();
+
+  const txHash =
+    chainId?.startsWith('eip155:') &&
+    txIdentifier &&
+    isValidTransactionHash(txIdentifier)
+      ? txIdentifier
+      : undefined;
+  const { transaction: apiTransaction, isFetching: isSingleTxFetching } =
+    useApiTransaction({ chainId, txHash });
 
   const confirmedEvmItems = useMemo<ActivityListItem[]>(
     () => evmTransactions?.pages.flatMap((page) => page.data) ?? [],
@@ -191,7 +217,28 @@ export function useActivityDetailsItem(
     [rampActivityItems, chainId],
   );
 
-  return useMemo(() => {
+  const fetchedApiItem = useMemo(() => {
+    if (!apiTransaction || !evmAddress) {
+      return undefined;
+    }
+
+    const activity = {
+      ...mapApiTransaction({
+        subjectAddress: evmAddress,
+        transaction: apiTransaction,
+      }),
+      raw: { type: 'apiEvmTransaction' as const, data: apiTransaction },
+    } as ActivityListItem;
+    const classified = classifyPooledStakingActivity(apiTransaction, activity);
+
+    if (chainId && classified.chainId !== chainId) {
+      return undefined;
+    }
+
+    return classified;
+  }, [apiTransaction, chainId, evmAddress]);
+
+  const item = useMemo(() => {
     const id = txIdentifier?.toLowerCase();
     if (!id) {
       return undefined;
@@ -203,7 +250,9 @@ export function useActivityDetailsItem(
     }
 
     const localItem = localByLookupKey.get(id);
-    const apiItem = getPreferredApiItem(apiByHash, id, localItem);
+    const apiItem =
+      getPreferredApiItem(apiByHash, id, localItem, fetchedApiItem) ??
+      (fetchedApiItem?.hash?.toLowerCase() === id ? fetchedApiItem : undefined);
     const nonEvmItem = nonEvmByHash.get(id);
 
     if (localItem) {
@@ -221,5 +270,20 @@ export function useActivityDetailsItem(
     apiByHash,
     nonEvmByHash,
     rampByIdentifier,
+    fetchedApiItem,
   ]);
+
+  const isFetching = useMemo(() => {
+    if (item) {
+      return false;
+    }
+
+    if (isSingleTxFetching) {
+      return true;
+    }
+
+    return evmTransactions === undefined && isListFetching;
+  }, [item, isSingleTxFetching, evmTransactions, isListFetching]);
+
+  return { item, isFetching };
 }

--- a/app/components/Views/ActivityList/hooks/activity/isValidTransactionHash.ts
+++ b/app/components/Views/ActivityList/hooks/activity/isValidTransactionHash.ts
@@ -1,0 +1,5 @@
+import { isStrictHexString } from '@metamask/utils';
+
+export function isValidTransactionHash(hash: string) {
+  return hash.length === 66 && isStrictHexString(hash);
+}

--- a/app/components/Views/ActivityList/hooks/activity/useApiTransaction.test.ts
+++ b/app/components/Views/ActivityList/hooks/activity/useApiTransaction.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useApiTransaction } from './useApiTransaction';
+import { useCachedEvmTransaction } from './useCachedEvmTransaction';
+import { useTransactionQuery } from './useTransactionQuery';
+
+jest.mock('./useCachedEvmTransaction');
+jest.mock('./useTransactionQuery');
+
+const useCachedEvmTransactionMock = jest.mocked(useCachedEvmTransaction);
+const useTransactionQueryMock = jest.mocked(useTransactionQuery);
+
+describe('useApiTransaction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useTransactionQueryMock.mockReturnValue({
+      data: undefined,
+      isFetching: false,
+    } as ReturnType<typeof useTransactionQuery>);
+  });
+
+  it('returns the cached transaction without fetching', () => {
+    const cached = { chainId: 1, hash: '0xabc' };
+    useCachedEvmTransactionMock.mockReturnValue(cached);
+
+    const { result } = renderHook(() =>
+      useApiTransaction({
+        chainId: 'eip155:1',
+        txHash: '0xabc',
+      }),
+    );
+
+    expect(result.current.transaction).toBe(cached);
+    expect(result.current.isFetching).toBe(false);
+    expect(useTransactionQueryMock).toHaveBeenCalledWith({
+      chainId: 'eip155:1',
+      txHash: '0xabc',
+      enabled: false,
+    });
+  });
+
+  it('fetches when the transaction is not cached', () => {
+    const fetched = { chainId: 1, hash: '0xdef' };
+    useCachedEvmTransactionMock.mockReturnValue(undefined);
+    useTransactionQueryMock.mockReturnValue({
+      data: fetched,
+      isFetching: true,
+    } as ReturnType<typeof useTransactionQuery>);
+
+    const { result } = renderHook(() =>
+      useApiTransaction({
+        chainId: 'eip155:1',
+        txHash: '0xdef',
+      }),
+    );
+
+    expect(result.current.transaction).toBe(fetched);
+    expect(result.current.isFetching).toBe(true);
+    expect(useTransactionQueryMock).toHaveBeenCalledWith({
+      chainId: 'eip155:1',
+      txHash: '0xdef',
+      enabled: true,
+    });
+  });
+});

--- a/app/components/Views/ActivityList/hooks/activity/useApiTransaction.ts
+++ b/app/components/Views/ActivityList/hooks/activity/useApiTransaction.ts
@@ -1,0 +1,22 @@
+import { useCachedEvmTransaction } from './useCachedEvmTransaction';
+import { useTransactionQuery } from './useTransactionQuery';
+
+export function useApiTransaction({
+  chainId,
+  txHash,
+}: {
+  chainId: string | undefined;
+  txHash: string | undefined;
+}) {
+  const cached = useCachedEvmTransaction({ chainId, txHash });
+  const { data: fetched, isFetching } = useTransactionQuery({
+    chainId,
+    txHash,
+    enabled: Boolean(chainId && txHash && !cached),
+  });
+
+  return {
+    transaction: cached ?? fetched,
+    isFetching: Boolean(chainId && txHash && !cached && isFetching),
+  };
+}

--- a/app/components/Views/ActivityList/hooks/activity/useCachedEvmTransaction.test.ts
+++ b/app/components/Views/ActivityList/hooks/activity/useCachedEvmTransaction.test.ts
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react-hooks';
+import type { InfiniteData } from '@tanstack/react-query';
+import type { V4MultiAccountTransactionsResponse } from '@metamask/core-backend';
+import {
+  activityQueryKey,
+  useCachedEvmTransaction,
+} from './useCachedEvmTransaction';
+
+const mockGetQueriesData = jest.fn();
+
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQueryClient: () => ({
+    getQueriesData: mockGetQueriesData,
+  }),
+}));
+
+describe('useCachedEvmTransaction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns undefined for non-EVM chains', () => {
+    const { result } = renderHook(() =>
+      useCachedEvmTransaction({
+        chainId: 'solana:mainnet',
+        txHash: '0xabc',
+      }),
+    );
+
+    expect(result.current).toBeUndefined();
+    expect(mockGetQueriesData).not.toHaveBeenCalled();
+  });
+
+  it('returns a cached transaction from the activity list query cache', () => {
+    const transaction = {
+      chainId: 1,
+      hash: '0xABC',
+    };
+    mockGetQueriesData.mockReturnValue([
+      [
+        ['accounts', 'transactions', 'v4MultiAccount'],
+        {
+          pages: [{ data: [transaction] }],
+        } as InfiniteData<V4MultiAccountTransactionsResponse>,
+      ],
+    ]);
+
+    const { result } = renderHook(() =>
+      useCachedEvmTransaction({
+        chainId: 'eip155:1',
+        txHash: '0xabc',
+      }),
+    );
+
+    expect(mockGetQueriesData).toHaveBeenCalledWith({
+      queryKey: activityQueryKey,
+    });
+    expect(result.current).toBe(transaction);
+  });
+});

--- a/app/components/Views/ActivityList/hooks/activity/useCachedEvmTransaction.ts
+++ b/app/components/Views/ActivityList/hooks/activity/useCachedEvmTransaction.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import { useQueryClient, type InfiniteData } from '@tanstack/react-query';
+import type { V4MultiAccountTransactionsResponse } from '@metamask/core-backend';
+
+export const activityQueryKey = [
+  'accounts',
+  'transactions',
+  'v4MultiAccount',
+] as const;
+
+export function useCachedEvmTransaction({
+  chainId,
+  txHash,
+}: {
+  chainId: string | undefined;
+  txHash: string | undefined;
+}) {
+  const queryClient = useQueryClient();
+
+  return useMemo(() => {
+    if (!chainId?.startsWith('eip155:') || !txHash) {
+      return undefined;
+    }
+
+    const numericChainId = Number(chainId.split(':')[1]);
+    const normalizedHash = txHash.toLowerCase();
+    const cachedQueries = queryClient.getQueriesData<
+      InfiniteData<V4MultiAccountTransactionsResponse>
+    >({
+      queryKey: activityQueryKey,
+    });
+
+    for (const [, cachedData] of cachedQueries) {
+      const transaction = cachedData?.pages
+        .flatMap((page) => page.data)
+        .find(
+          (item) =>
+            item.chainId === numericChainId &&
+            item.hash.toLowerCase() === normalizedHash,
+        );
+
+      if (transaction) {
+        return transaction;
+      }
+    }
+
+    return undefined;
+  }, [chainId, queryClient, txHash]);
+}

--- a/app/components/Views/ActivityList/hooks/activity/useTransactionQuery.test.ts
+++ b/app/components/Views/ActivityList/hooks/activity/useTransactionQuery.test.ts
@@ -1,0 +1,86 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../../../../../core/apiClient';
+import { useTransactionQuery } from './useTransactionQuery';
+
+jest.mock('react-native-i18n', () => ({
+  I18n: {
+    locale: 'en-US',
+  },
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: jest.fn(),
+}));
+
+jest.mock('../../../../../core/apiClient', () => ({
+  apiClient: {
+    accounts: {
+      getV1TransactionByHashQueryOptions: jest.fn(() => ({
+        queryKey: ['accounts', 'transactions', 'v1ByHash'],
+      })),
+    },
+  },
+}));
+
+const useQueryMock = jest.mocked(useQuery);
+
+describe('useTransactionQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useQueryMock.mockReturnValue({
+      data: undefined,
+      isFetching: false,
+    } as ReturnType<typeof useQuery>);
+  });
+
+  it('builds v1 query options and disables the query when inputs are missing', () => {
+    renderHook(() =>
+      useTransactionQuery({
+        chainId: undefined,
+        enabled: true,
+        txHash: undefined,
+      }),
+    );
+
+    expect(
+      apiClient.accounts.getV1TransactionByHashQueryOptions,
+    ).toHaveBeenCalledWith(1, '', {
+      includeLogs: false,
+      includeValueTransfers: true,
+      includeTxMetadata: true,
+      lang: expect.any(String),
+    });
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+        retry: false,
+      }),
+    );
+  });
+
+  it('enables the query for valid EVM chain and hash inputs', () => {
+    renderHook(() =>
+      useTransactionQuery({
+        chainId: 'eip155:8453',
+        enabled: true,
+        txHash: '0xabc',
+      }),
+    );
+
+    expect(
+      apiClient.accounts.getV1TransactionByHashQueryOptions,
+    ).toHaveBeenCalledWith(
+      8453,
+      '0xabc',
+      expect.objectContaining({
+        includeTxMetadata: true,
+      }),
+    );
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+      }),
+    );
+  });
+});

--- a/app/components/Views/ActivityList/hooks/activity/useTransactionQuery.ts
+++ b/app/components/Views/ActivityList/hooks/activity/useTransactionQuery.ts
@@ -1,0 +1,46 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { I18n } from 'react-native-i18n';
+import { apiClient } from '../../../../../core/apiClient';
+
+function getNumericEvmChainId(chainId: string | undefined) {
+  if (!chainId?.startsWith('eip155:')) {
+    return undefined;
+  }
+
+  const numericChainId = Number(chainId.split(':')[1]);
+  return Number.isFinite(numericChainId) ? numericChainId : undefined;
+}
+
+export function useTransactionQuery({
+  chainId,
+  enabled,
+  txHash,
+}: {
+  chainId: string | undefined;
+  enabled: boolean;
+  txHash: string | undefined;
+}) {
+  const numericChainId = useMemo(
+    () => getNumericEvmChainId(chainId),
+    [chainId],
+  );
+
+  const queryOptions = apiClient.accounts.getV1TransactionByHashQueryOptions(
+    numericChainId ?? 1,
+    txHash ?? '',
+    {
+      includeLogs: false,
+      includeValueTransfers: true,
+      includeTxMetadata: true,
+      lang: I18n.locale.split('-')[0],
+    },
+  );
+
+  // @ts-expect-error apiClient returns v5 types, repo still in v4
+  return useQuery({
+    ...queryOptions,
+    enabled: enabled && Boolean(numericChainId && txHash),
+    retry: false,
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Mobile Activity details previously re-scanned only data already loaded by the activity list's infinite query. If a user opened details directly or the transaction lived on an unloaded page, the screen could show "not found" even though the extension resolves the same route via a cache-first lookup followed by a v1 by-hash fetch.

This PR ports the extension's activity details fetching hooks to mobile:

- `useCachedEvmTransaction` — reads the TanStack `v4MultiAccount` infinite-query cache via `getQueriesData` before any network request
- `useTransactionQuery` — fetches a single confirmed EVM transaction by hash when the cache misses
- `useApiTransaction` — orchestrates cache-first resolution (`cached ?? fetched`)

`useActivityDetailsItem` now uses `useApiTransaction` for valid EVM transaction hashes, maps the result with `mapApiTransaction`, and returns `{ item, isFetching }`. `ActivityDetails` uses that loading signal so the screen does not flash "not found" while the single-tx fallback is in flight.

Local, ramp, non-EVM, and `preferLocalOrApiActivityItem` precedence are unchanged.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: Align mobile Activity details fetching with extension cache-first pattern (no linked ticket).

## **Manual testing steps**

```gherkin
Feature: Activity details cache-first EVM resolution

  Scenario: Open details from the activity list (cache hit)
    Given the user has confirmed EVM transactions visible on the Activity tab
    And the activity list has loaded at least one page of transactions

    When the user taps a confirmed EVM transaction row
    Then Activity details opens with the correct transaction
    And no additional v1 by-hash network request is triggered for that hash

  Scenario: Open details via direct navigation when the tx is not in loaded list pages (cache miss)
    Given the user navigates to Activity details with route params `{ chainId: eip155:<id>, txIdentifier: <valid 66-char hex hash> }`
    And that transaction is not present in currently loaded infinite-query pages

    When the details screen mounts
    Then the screen shows a loading state briefly
    And the transaction resolves from the v1 by-hash fetch
    And the correct details template renders

  Scenario: Transaction cannot be resolved
    Given the user navigates to Activity details with an unknown or invalid identifier

    When loading completes
    Then the screen shows the not-found message
```

**Automated tests run:**

```bash
yarn jest app/components/Views/ActivityList/hooks/activity \
  app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.test.ts \
  app/components/Views/ActivityDetails/ActivityDetails.test.tsx
```

## **Screenshots/Recordings**

N/A — internal data-fetching alignment; no UI layout changes. Behavior is covered by unit tests and manual verification of list → details and direct-navigation flows.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3695fa4b-2e4f-43f2-8dd7-adc5b6038a8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3695fa4b-2e4f-43f2-8dd7-adc5b6038a8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


